### PR TITLE
Added `useMemoArray` and `useMemoObject`

### DIFF
--- a/src/renderer/components/ReactFlowBox.tsx
+++ b/src/renderer/components/ReactFlowBox.tsx
@@ -25,6 +25,7 @@ import { GlobalContext, GlobalVolatileContext } from '../contexts/GlobalNodeStat
 import { SettingsContext } from '../contexts/SettingsContext';
 import { DataTransferProcessorOptions, dataTransferProcessors } from '../helpers/dataTransfer';
 import { expandSelection, isSnappedToGrid, snapToGrid } from '../helpers/reactFlowUtil';
+import { useMemoArray } from '../hooks/useMemo';
 import { usePaneNodeSearchMenu } from '../hooks/usePaneNodeSearchMenu';
 
 const compareById = (a: Edge | Node, b: Edge | Node) => a.id.localeCompare(b.id);
@@ -319,7 +320,7 @@ const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlowBoxPro
                 minZoom={0.125}
                 nodeTypes={nodeTypes}
                 nodes={displayNodes}
-                snapGrid={useMemo(() => [snapToGridAmount, snapToGridAmount], [snapToGridAmount])}
+                snapGrid={useMemoArray<[number, number]>([snapToGridAmount, snapToGridAmount])}
                 snapToGrid={isSnapToGrid}
                 style={{
                     zIndex: 0,

--- a/src/renderer/components/node/IteratorNodeBody.tsx
+++ b/src/renderer/components/node/IteratorNodeBody.tsx
@@ -1,11 +1,12 @@
 import { Box, useColorModeValue } from '@chakra-ui/react';
 import { Resizable } from 're-resizable';
-import { memo, useLayoutEffect, useMemo, useState } from 'react';
+import { memo, useLayoutEffect, useState } from 'react';
 import { useContext, useContextSelector } from 'use-context-selector';
 import { IteratorSize } from '../../../common/common-types';
 import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { SettingsContext } from '../../contexts/SettingsContext';
 import { noContextMenu } from '../../hooks/useContextMenu';
+import { useMemoArray } from '../../hooks/useMemo';
 
 const createGridDotsPath = (size: number, fill: string) => (
     <circle
@@ -104,9 +105,8 @@ const IteratorNodeBody = memo(
                     bottomLeft: false,
                     topLeft: false,
                 }}
-                grid={useMemo(
-                    () => (isSnapToGrid ? [snapToGridAmount, snapToGridAmount] : [1, 1]),
-                    [isSnapToGrid, snapToGridAmount]
+                grid={useMemoArray<[number, number]>(
+                    isSnapToGrid ? [snapToGridAmount, snapToGridAmount] : [1, 1]
                 )}
                 minHeight={maxHeight}
                 minWidth={maxWidth}

--- a/src/renderer/contexts/AlertBoxContext.tsx
+++ b/src/renderer/contexts/AlertBoxContext.tsx
@@ -16,6 +16,7 @@ import { app, clipboard } from 'electron';
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createContext, useContext } from 'use-context-selector';
 import { assertNever, noop } from '../../common/util';
+import { useMemoObject } from '../hooks/useMemo';
 import { ContextMenuContext } from './ContextMenuContext';
 
 interface AlertBox {
@@ -209,9 +210,7 @@ export const AlertBoxProvider = memo(({ children }: React.PropsWithChildren<unkn
         [toast]
     );
 
-    // eslint-disable-next-line react/jsx-no-constructed-context-values
-    let value: AlertBox = { sendAlert, showAlert, sendToast };
-    value = useMemo(() => value, Object.values(value));
+    const value = useMemoObject<AlertBox>({ sendAlert, showAlert, sendToast });
 
     return (
         <AlertBoxContext.Provider value={value}>

--- a/src/renderer/contexts/ContextMenuContext.tsx
+++ b/src/renderer/contexts/ContextMenuContext.tsx
@@ -1,8 +1,9 @@
 import { Menu, MenuButton, Portal } from '@chakra-ui/react';
-import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { memo, useCallback, useEffect, useState } from 'react';
 import { createContext } from 'use-context-selector';
 import { noop } from '../../common/util';
 import { useIpcRendererListener } from '../hooks/useIpcRendererListener';
+import { useMemoObject } from '../hooks/useMemo';
 
 type RenderFn = () => JSX.Element;
 
@@ -124,14 +125,12 @@ export const ContextMenuProvider = memo(({ children }: React.PropsWithChildren<u
 
     useIpcRendererListener('window-blur', closeContextMenu, [closeContextMenu]);
 
-    // eslint-disable-next-line react/jsx-no-constructed-context-values
-    let value: ContentMenu = {
+    const value = useMemoObject<ContentMenu>({
         registerContextMenu,
         unregisterContextMenu,
         openContextMenu,
         closeContextMenu,
-    };
-    value = useMemo(() => value, Object.values(value));
+    });
 
     const currentRender = current !== undefined ? menus.map.get(current) : undefined;
 

--- a/src/renderer/contexts/DependencyContext.tsx
+++ b/src/renderer/contexts/DependencyContext.tsx
@@ -37,6 +37,7 @@ import { getPythonInfo } from '../../common/python';
 import { ipcRenderer } from '../../common/safeIpc';
 import { noop } from '../../common/util';
 import { useAsyncEffect } from '../hooks/useAsyncEffect';
+import { useMemoObject } from '../hooks/useMemo';
 import { AlertBoxContext, AlertType } from './AlertBoxContext';
 import { ExecutionContext } from './ExecutionContext';
 import { SettingsContext } from './SettingsContext';
@@ -201,12 +202,10 @@ export const DependencyProvider = memo(({ children }: React.PropsWithChildren<un
         ).length;
     }, [pipList, availableDeps]);
 
-    // eslint-disable-next-line react/jsx-no-constructed-context-values
-    let value: DependencyContextValue = {
+    const value = useMemoObject<DependencyContextValue>({
         openDependencyManager: onOpen,
         availableUpdates,
-    };
-    value = useMemo(() => value, Object.values(value));
+    });
 
     return (
         <DependencyContext.Provider value={value}>

--- a/src/renderer/contexts/ExecutionContext.tsx
+++ b/src/renderer/contexts/ExecutionContext.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useMemo, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { Edge, Node, useReactFlow } from 'react-flow-renderer';
 import { createContext, useContext } from 'use-context-selector';
 import { useThrottledCallback } from 'use-debounce';
@@ -15,6 +15,7 @@ import {
     useBackendEventSource,
     useBackendEventSourceListener,
 } from '../hooks/useBackendEventSource';
+import { useMemoObject } from '../hooks/useMemo';
 import { AlertBoxContext, AlertType } from './AlertBoxContext';
 import { GlobalContext } from './GlobalNodeState';
 import { SettingsContext } from './SettingsContext';
@@ -319,9 +320,14 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
         setStatus(ExecutionStatus.READY);
     };
 
-    // eslint-disable-next-line react/jsx-no-constructed-context-values
-    let value = { run, pause, kill, status, isBackendKilled, setIsBackendKilled };
-    value = useMemo(() => value, Object.values(value));
+    const value = useMemoObject<ExecutionContextValue>({
+        run,
+        pause,
+        kill,
+        status,
+        isBackendKilled,
+        setIsBackendKilled,
+    });
 
     return <ExecutionContext.Provider value={value}>{children}</ExecutionContext.Provider>;
 });

--- a/src/renderer/contexts/SettingsContext.tsx
+++ b/src/renderer/contexts/SettingsContext.tsx
@@ -1,7 +1,8 @@
-import React, { memo, useMemo } from 'react';
+import React, { memo } from 'react';
 import { createContext } from 'use-context-selector';
 import { SchemaId } from '../../common/common-types';
 import useLocalStorage from '../hooks/useLocalStorage';
+import { useMemoArray, useMemoObject } from '../hooks/useMemo';
 
 interface Settings {
     // Global settings
@@ -35,62 +36,30 @@ export const SettingsContext = createContext<Readonly<Settings>>({} as Settings)
 export const SettingsProvider = memo(
     ({ children, port }: React.PropsWithChildren<{ port: number }>) => {
         // Global Settings
-        const [isCpu, setIsCpu] = useLocalStorage('is-cpu', false);
-        const [isFp16, setIsFp16] = useLocalStorage('is-fp16', false);
-        const [isSystemPython, setIsSystemPython] = useLocalStorage('use-system-python', false);
+        const useIsCpu = useMemoArray(useLocalStorage('is-cpu', false));
+        const useIsFp16 = useMemoArray(useLocalStorage('is-fp16', false));
+        const useIsSystemPython = useMemoArray(useLocalStorage('use-system-python', false));
+        const useDisHwAccel = useMemoArray(useLocalStorage('disable-hw-accel', false));
+        const useStartupTemplate = useMemoArray(useLocalStorage('startup-template', ''));
+        const useIsDarkMode = useMemoArray(useLocalStorage('use-dark-mode', true));
+        const useAnimateChain = useMemoArray(useLocalStorage('animate-chain', true));
+
+        // Snap to grid
         const [isSnapToGrid, setIsSnapToGrid] = useLocalStorage('snap-to-grid', false);
         const [snapToGridAmount, setSnapToGridAmount] = useLocalStorage('snap-to-grid-amount', 15);
-        const [isDisHwAccel, setIsDisHwAccel] = useLocalStorage('disable-hw-accel', false);
-        const [startupTemplate, setStartupTemplate] = useLocalStorage('startup-template', '');
-        const [isDarkMode, setIsDarkMode] = useLocalStorage('use-dark-mode', true);
-        const [animateChain, setAnimateChain] = useLocalStorage('animate-chain', true);
-
-        const useIsCpu = useMemo(() => [isCpu, setIsCpu] as const, [isCpu, setIsCpu]);
-        const useIsFp16 = useMemo(() => [isFp16, setIsFp16] as const, [isFp16, setIsFp16]);
-        const useIsSystemPython = useMemo(
-            () => [isSystemPython, setIsSystemPython] as const,
-            [isSystemPython, setIsSystemPython]
-        );
-        const useSnapToGrid = useMemo(
-            () =>
-                [
-                    isSnapToGrid,
-                    setIsSnapToGrid,
-                    snapToGridAmount || 1,
-                    setSnapToGridAmount,
-                ] as const,
-            [isSnapToGrid, setIsSnapToGrid, snapToGridAmount, setSnapToGridAmount]
-        );
-        const useDisHwAccel = useMemo(
-            () => [isDisHwAccel, setIsDisHwAccel] as const,
-            [isDisHwAccel, setIsDisHwAccel]
-        );
-        const useStartupTemplate = useMemo(
-            () => [startupTemplate, setStartupTemplate] as const,
-            [startupTemplate, setStartupTemplate]
-        );
-        const useIsDarkMode = useMemo(
-            () => [isDarkMode, setIsDarkMode] as const,
-            [isDarkMode, setIsDarkMode]
-        );
-        const useAnimateChain = useMemo(
-            () => [animateChain, setAnimateChain] as const,
-            [animateChain, setAnimateChain]
-        );
+        const useSnapToGrid = useMemoArray([
+            isSnapToGrid,
+            setIsSnapToGrid,
+            snapToGridAmount || 1,
+            setSnapToGridAmount,
+        ] as const);
 
         // Node Settings
-        const [favorites, setFavorites] = useLocalStorage<readonly SchemaId[]>(
-            'node-favorites',
-            []
+        const useNodeFavorites = useMemoArray(
+            useLocalStorage<readonly SchemaId[]>('node-favorites', [])
         );
 
-        const useNodeFavorites = useMemo(
-            () => [favorites, setFavorites] as const,
-            [favorites, setFavorites]
-        );
-
-        // eslint-disable-next-line react/jsx-no-constructed-context-values
-        let contextValue: Readonly<Settings> = {
+        const contextValue = useMemoObject<Settings>({
             // Globals
             useIsCpu,
             useIsFp16,
@@ -106,8 +75,7 @@ export const SettingsProvider = memo(
 
             // Port
             port,
-        };
-        contextValue = useMemo(() => contextValue, Object.values(contextValue));
+        });
 
         return <SettingsContext.Provider value={contextValue}>{children}</SettingsContext.Provider>;
     }

--- a/src/renderer/hooks/useContextMenu.ts
+++ b/src/renderer/hooks/useContextMenu.ts
@@ -1,7 +1,8 @@
-import { MouseEvent, MouseEventHandler, useCallback, useEffect, useMemo, useState } from 'react';
+import { MouseEvent, MouseEventHandler, useCallback, useEffect, useState } from 'react';
 import { useContext } from 'use-context-selector';
 import { createUniqueId } from '../../common/util';
 import { ContextMenuContext } from '../contexts/ContextMenuContext';
+import { useMemoObject } from './useMemo';
 
 export interface UseContextMenu {
     readonly id: string;
@@ -58,10 +59,12 @@ export const useContextMenu = (
         [openContextMenu]
     );
 
-    let value: UseContextMenu = { id, onContextMenu, onClick, manuallyOpenContextMenu };
-    value = useMemo(() => value, Object.values(value));
-
-    return value;
+    return useMemoObject<UseContextMenu>({
+        id,
+        onContextMenu,
+        onClick,
+        manuallyOpenContextMenu,
+    });
 };
 
 export const noContextMenu = (e: MouseEvent): void => {

--- a/src/renderer/hooks/useDisabled.ts
+++ b/src/renderer/hooks/useDisabled.ts
@@ -1,8 +1,9 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 import { useContext, useContextSelector } from 'use-context-selector';
 import { NodeData } from '../../common/common-types';
 import { GlobalContext, GlobalVolatileContext } from '../contexts/GlobalNodeState';
 import { DisabledStatus, getDisabledStatus } from '../helpers/disabled';
+import { useMemoObject } from './useMemo';
 
 export interface UseDisabled {
     readonly canDisable: boolean;
@@ -22,7 +23,7 @@ export const useDisabled = (data: NodeData): UseDisabled => {
 
     const schema = schemata.get(schemaId);
 
-    const value: UseDisabled = {
+    return useMemoObject<UseDisabled>({
         canDisable: schema.hasSideEffects || schema.outputs.length > 0,
         isDirectlyDisabled: isDisabled ?? false,
         status: getDisabledStatus(data, effectivelyDisabledNodes),
@@ -30,7 +31,5 @@ export const useDisabled = (data: NodeData): UseDisabled => {
             () => setNodeDisabled(id, !isDisabled),
             [setNodeDisabled, id, isDisabled]
         ),
-    };
-
-    return useMemo(() => value, Object.values(value));
+    });
 };

--- a/src/renderer/hooks/useMemo.ts
+++ b/src/renderer/hooks/useMemo.ts
@@ -1,0 +1,16 @@
+import { useMemo } from 'react';
+
+/**
+ * A `useMemo` variant that compares the array items for reference equality.
+ */
+export const useMemoArray = <T extends readonly unknown[]>(array: T): T =>
+    useMemo(() => array, array);
+
+/**
+ * A `useMemo` variant that compares the object values (using `Object.values`) for reference
+ * equality.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const useMemoObject = <T extends Readonly<Record<string | number, any>>>(
+    obj: T
+): Readonly<T> => useMemo(() => obj, Object.values(obj));

--- a/src/renderer/hooks/useNodeFavorites.ts
+++ b/src/renderer/hooks/useNodeFavorites.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from 'react';
 import { useContextSelector } from 'use-context-selector';
 import { SchemaId } from '../../common/common-types';
 import { SettingsContext } from '../contexts/SettingsContext';
+import { useMemoObject } from './useMemo';
 
 export interface UseNodeFavorites {
     readonly favorites: ReadonlySet<SchemaId>;
@@ -30,8 +31,5 @@ export const useNodeFavorites = () => {
         [setFavorites]
     );
 
-    let value: UseNodeFavorites = { favorites, addFavorites, removeFavorite };
-    value = useMemo(() => value, Object.values(value));
-
-    return value;
+    return useMemoObject<UseNodeFavorites>({ favorites, addFavorites, removeFavorite });
 };

--- a/src/renderer/hooks/useSystemUsage.ts
+++ b/src/renderer/hooks/useSystemUsage.ts
@@ -1,9 +1,10 @@
 import { exec as _exec } from 'child_process';
 import os from 'os-utils';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import util from 'util';
 import { ipcRenderer } from '../../common/safeIpc';
 import { useAsyncInterval } from './useInterval';
+import { useMemoObject } from './useMemo';
 
 const exec = util.promisify(_exec);
 
@@ -50,7 +51,7 @@ const useSystemUsage = (delay: number): SystemUsage => {
 
     useAsyncInterval({ supplier: getSystemUsage, successEffect: setUsage }, delay);
 
-    return useMemo(() => usage, [usage.cpu, usage.ram, usage.vram]);
+    return useMemoObject(usage);
 };
 
 export default useSystemUsage;


### PR DESCRIPTION
This adds 2 new hooks that are like `useMemo` but they derive the deps array from the passed value. This simplifies a lot of code that previously used `useMemo` (around half of all uses of `useMemo`).