### PR TITLE
Added support other type models (-1..1) for ONXX

### DIFF
--- a/backend/src/nodes/onnx_nodes.py
+++ b/backend/src/nodes/onnx_nodes.py
@@ -141,6 +141,85 @@ class OnnxImageUpscaleNode(NodeBase):
         )
 
 
+@NodeFactory.register("chainner:onnx:upscale_image_other")
+class OnnxImageUpscaleOtherNode(NodeBase):
+    def __init__(self):
+        super().__init__()
+        self.description = "Other processing for models like ArmorLab (0..1 → -1..1)"
+        self.inputs = [
+            OnnxModelInput(),
+            ImageInput(),
+            TileModeDropdown(has_auto=False),
+        ]
+        self.outputs = [
+            ImageOutput(
+                "Upscaled Image",
+                image_type=expression.Image(channels="Input1.channels"),
+            )
+        ]
+
+        self.category = ONNXCategory
+        self.name = "Upscale Image (other)"
+        self.icon = "ONNX"
+        self.sub = "Processing"
+
+    def upscale(
+        self,
+        img: np.ndarray,
+        session: ort.InferenceSession,
+        tile_mode: Union[int, None],
+        change_shape: bool,
+    ) -> np.ndarray:
+        logger.info("Upscaling image")
+        is_fp16_model = session.get_inputs()[0].type == "tensor(float16)"
+        img = np2nptensor(img, change_range=False)
+        logger.info(img.shape)
+        out, _ = onnx_auto_split_process(
+            img.astype(np.float16) if is_fp16_model else img,
+            session,
+            max_depth=tile_mode,
+            change_shape=change_shape,
+        )
+        logger.info(out.shape)
+        out = nptensor2np(out, change_range=False, imtype=np.float32)
+
+        # Like ArmorLab models, where from -1 to 1.
+        np.multiply(out, 0.5, out=out)
+        np.add(out, 0.5, out=out)
+
+        del session
+        logger.info("Done upscaling")
+        return out
+
+    def run(
+        self,
+        model: OnnxModel,
+        img: np.ndarray,
+        tile_mode: Union[int, None],
+    ) -> np.ndarray:
+        # Like ArmorLab models, where from -1 to 1.
+        np.subtract(img, 0.5, out=img)
+        np.divide(img, 0.5, out=img)
+
+        """Upscales an image with a pretrained model"""
+        session = get_onnx_session(model, get_execution_options())
+        shape = session.get_inputs()[0].shape
+        if isinstance(shape[1], int) and shape[1] <= 4:
+            in_nc = shape[1]
+            change_shape = False
+        else:
+            in_nc = shape[3]
+            change_shape = True
+
+        h, w, c = get_h_w_c(img)
+        logger.debug(f"Image is {h}x{w}x{c}")
+        return convenient_upscale(
+            img,
+            in_nc,
+            lambda i: self.upscale(i, session, tile_mode, change_shape),
+        )
+
+
 @NodeFactory.register("chainner:onnx:interpolate_models")
 class OnnxInterpolateModelsNode(NodeBase):
     def __init__(self):


### PR DESCRIPTION
Added new node "Upscale Image (other)" with color transformation from 0..1 (chaiNNer) to -1..1 (like ArmorLab) and back to 0..1 (chaiNNer).