### PR TITLE
Add flatpak building, ensure correct use of icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,9 @@
         {
           "name": "@electron-forge/maker-squirrel",
           "config": {
-            "name": "chainner"
+            "name": "chainner",
+            "iconUrl": "./src/public/icons/win/icon.ico",
+            "setupIcon": "./src/public/icons/win/icon.ico"
           }
         },
         {
@@ -70,7 +72,8 @@
           "name": "@electron-forge/maker-dmg",
           "config": {
             "format": "ULFO",
-            "name": "chaiNNer"
+            "name": "chaiNNer",
+            "icon": "./src/public/icons/mac/icon.icns"
           }
         },
         {
@@ -88,6 +91,17 @@
             "name": "chainner",
             "options": {
               "icon": "./src/public/icons/cross_platform/icon.png"
+            }
+          }
+        },
+        {
+          "name": "@electron-forge/maker-flatpak",
+          "config": {
+            "options": {
+              "name": "chainner",
+              "options": {
+                "icon": "./src/public/icons/cross_platform/icon.png"
+              }
             }
           }
         }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -521,7 +521,7 @@ const doSplashScreenChecks = async (mainWindow: BrowserWindowWithSafeIpc) =>
                 nodeIntegration: true,
                 contextIsolation: false,
             },
-            // icon: `${__dirname}/public/icons/cross_platform/icon`,
+            icon: `${__dirname}/../public/icons/cross_platform/icon`,
             show: false,
         }) as BrowserWindowWithSafeIpc;
         if (!splash.isDestroyed()) {
@@ -604,7 +604,7 @@ const createWindow = lazy(async () => {
             nodeIntegrationInWorker: true,
             contextIsolation: false,
         },
-        // icon: `${__dirname}/public/icons/cross_platform/icon`,
+        icon: `${__dirname}/../public/icons/cross_platform/icon`,
         show: false,
     }) as BrowserWindowWithSafeIpc;
 


### PR DESCRIPTION
Set up as defined here: https://www.electronforge.io/config/makers/flatpak

While I was there, I also changed some things noticed on this page: https://www.electronforge.io/guides/create-and-add-icons since I don't know if the icons truly work on other platforms (plus the installers never had icons)