### PR TITLE
Improved output type for crop content node

### DIFF
--- a/backend/src/nodes/nodes/image_dimension/crop_content.py
+++ b/backend/src/nodes/nodes/image_dimension/crop_content.py
@@ -33,7 +33,11 @@ class ContentCropNode(NodeBase):
                 image_type="""
                 match Input0.channels {
                     ..3 => Input0,
-                    _ => Image { channels: Input0.channels }
+                    _ => Image {
+                        width: min(uint, Input0.width) & 1..,
+                        height: min(uint, Input0.height) & 1..,
+                        channels: Input0.channels
+                    }
                 }
                 """
             )


### PR DESCRIPTION
Very small PR. Before this PR, the Crop Content node said that the output image can be of any size. However, we can more precise because the output size is going to be at least 1 and at most the input size. The new output types reflects that.

While the improved type won't allow us to display the size range of the output image in chainner, the improved estimate may catch a few runtime errors.