### PR TITLE
Added Version type

### DIFF
--- a/src/common/SaveFile.ts
+++ b/src/common/SaveFile.ts
@@ -2,9 +2,9 @@ import { createHash } from 'crypto';
 import log from 'electron-log';
 import { readFile, writeFile } from 'fs/promises';
 import { Edge, Node, Viewport } from 'react-flow-renderer';
-import semver from 'semver';
-import { EdgeData, FileOpenResult, NodeData } from './common-types';
+import { EdgeData, FileOpenResult, NodeData, Version } from './common-types';
 import { currentMigration, migrate } from './migrations';
+import { versionGt } from './version';
 
 export interface SaveData {
     nodes: Node<NodeData>[];
@@ -17,7 +17,7 @@ export interface ParsedSaveData extends SaveData {
 }
 
 export interface RawSaveFile {
-    version: string;
+    version: Version;
     content: SaveData;
     timestamp?: string;
     checksum?: string;
@@ -48,7 +48,7 @@ export class SaveFile {
             } else {
                 // checksum was added after v0.6.1, so any saves >0.6.1 without a checksum have
                 // been tampered with
-                tamperedWith = semver.gt(version, '0.6.1') || (migration ?? 0) > 4;
+                tamperedWith = versionGt(version, '0.6.1') || (migration ?? 0) > 4;
             }
 
             data = migrate(version, content, migration) as SaveData;
@@ -67,7 +67,7 @@ export class SaveFile {
         return SaveFile.parse(await readFile(path, { encoding: 'utf-8' }));
     }
 
-    static stringify(content: SaveData, version: string): string {
+    static stringify(content: SaveData, version: Version): string {
         const { nodes, edges, viewport } = content;
         const sanitizedNodes = nodes.map<Node<NodeData>>((n) => ({
             data: {
@@ -100,7 +100,7 @@ export class SaveFile {
         return JSON.stringify(data);
     }
 
-    static async write(path: string, saveData: SaveData, version: string): Promise<void> {
+    static async write(path: string, saveData: SaveData, version: Version): Promise<void> {
         await writeFile(path, SaveFile.stringify(saveData, version), 'utf-8');
     }
 }

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -111,6 +111,9 @@ export interface EdgeData {
     readonly complete?: boolean;
 }
 
+/**
+ * A valid semantic version or a string that can be coerced into one.
+ */
 export type Version =
     | `${number}.${number}.${number}`
     | `${number}.${number}.${number}${'+' | '-'}${string}`

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -111,9 +111,14 @@ export interface EdgeData {
     readonly complete?: boolean;
 }
 
+export type Version =
+    | `${number}.${number}.${number}`
+    | `${number}.${number}.${number}${'+' | '-'}${string}`
+    | (string & { readonly __coerceableVersionString: undefined });
+
 export interface PythonInfo {
     readonly python: string;
-    readonly version: string;
+    readonly version: Version;
 }
 
 export type FileSaveResult = FileSaveSuccess | FileSaveCanceled;

--- a/src/common/dependencies.ts
+++ b/src/common/dependencies.ts
@@ -1,3 +1,4 @@
+import { Version } from './common-types';
 import { isM1, isMac, isWindows } from './env';
 
 const KB = 1024 ** 1;
@@ -6,7 +7,7 @@ const GB = 1024 ** 3;
 
 export interface PyPiPackage {
     packageName: string;
-    version: string;
+    version: Version;
     findLink?: string;
     /**
      * A size estimate (in bytes) for the whl file to download.
@@ -125,6 +126,6 @@ if (isMac && !isM1) {
 } else if (isWindows) {
     requiredDependencies.push({
         name: 'Pywin32',
-        packages: [{ packageName: 'pywin32', version: '304', sizeEstimate: 12 * MB }],
+        packages: [{ packageName: 'pywin32', version: '304' as Version, sizeEstimate: 12 * MB }],
     });
 }

--- a/src/common/pip.ts
+++ b/src/common/pip.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-param-reassign */
 import { spawn } from 'child_process';
 import log from 'electron-log';
-import { PythonInfo } from './common-types';
+import { PythonInfo, Version } from './common-types';
 import { Dependency } from './dependencies';
 import { sanitizedEnv } from './env';
 import { pipInstallWithProgress } from './pipInstallWithProgress';
@@ -58,14 +58,14 @@ export const runPip = async (
     });
 };
 
-export type PipList = { [packageName: string]: string | undefined };
+export type PipList = { [packageName: string]: Version | undefined };
 
 export const runPipList = async (info: PythonInfo, onStdio?: OnStdio): Promise<PipList> => {
     const output = await runPip(info, ['list', '--format=json'], onStdio);
 
     interface ListEntry {
         name: string;
-        version: string;
+        version: Version;
     }
     const list = JSON.parse(output) as ListEntry[];
 

--- a/src/common/safeIpc.ts
+++ b/src/common/safeIpc.ts
@@ -9,7 +9,7 @@ import {
     ipcRenderer as unsafeIpcRenderer,
 } from 'electron';
 import { Systeminformation } from 'systeminformation';
-import { FileOpenResult, FileSaveResult, PythonInfo } from './common-types';
+import { FileOpenResult, FileSaveResult, PythonInfo, Version } from './common-types';
 import { ParsedSaveData, SaveData } from './SaveFile';
 
 interface ChannelInfo<ReturnType, Args extends unknown[] = []> {
@@ -25,7 +25,7 @@ export interface InvokeChannels {
     'get-python': ChannelInfo<PythonInfo>;
     'get-port': ChannelInfo<number>;
     'get-localstorage-location': ChannelInfo<string>;
-    'get-app-version': ChannelInfo<string>;
+    'get-app-version': ChannelInfo<Version>;
     'get-vram-usage': ChannelInfo<number | null>;
     'dir-select': ChannelInfo<Electron.OpenDialogReturnValue, [dirPath: string]>;
     'file-select': ChannelInfo<

--- a/src/common/version.ts
+++ b/src/common/version.ts
@@ -1,0 +1,42 @@
+import semver from 'semver';
+import { Version } from './common-types';
+
+export const parse = (v: string): Version => {
+    const version = semver.coerce(v);
+    if (!version) {
+        throw new SyntaxError(`Invalid version '${v}'`);
+    }
+    return version.version as Version;
+};
+
+export const versionLt = (lhs: Version, rhs: Version): boolean => {
+    try {
+        return semver.lt(parse(lhs), parse(rhs));
+    } catch {
+        return false;
+    }
+};
+
+export const versionLte = (lhs: Version, rhs: Version): boolean => {
+    try {
+        return semver.lte(parse(lhs), parse(rhs));
+    } catch {
+        return false;
+    }
+};
+
+export const versionGt = (lhs: Version, rhs: Version): boolean => {
+    try {
+        return semver.gt(parse(lhs), parse(rhs));
+    } catch {
+        return false;
+    }
+};
+
+export const versionGte = (lhs: Version, rhs: Version): boolean => {
+    try {
+        return semver.gte(parse(lhs), parse(rhs));
+    } catch {
+        return false;
+    }
+};

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -8,14 +8,14 @@ import { LocalStorage } from 'node-localstorage';
 import os from 'os';
 import path from 'path';
 import portfinder from 'portfinder';
-import semver from 'semver';
-import { PythonInfo, WindowSize } from '../common/common-types';
+import { PythonInfo, Version, WindowSize } from '../common/common-types';
 import { Dependency, getOptionalDependencies, requiredDependencies } from '../common/dependencies';
 import { sanitizedEnv } from '../common/env';
 import { runPipInstall, runPipList } from '../common/pip';
 import { BrowserWindowWithSafeIpc, ipcMain } from '../common/safeIpc';
 import { SaveFile, openSaveFile } from '../common/SaveFile';
 import { lazy } from '../common/util';
+import { versionGt } from '../common/version';
 import { getArguments } from './arguments';
 import { MenuData, setMainMenu } from './menu';
 import { createNvidiaSmiVRamChecker, getNvidiaGpuNames, getNvidiaSmi } from './nvidiaSmi';
@@ -29,6 +29,8 @@ import { hasUpdate } from './update';
 if (require('electron-squirrel-startup')) {
     app.quit();
 }
+
+const version = app.getVersion() as Version;
 
 const localStorageLocation = path.join(app.getPath('userData'), 'settings');
 ipcMain.handle('get-localstorage-location', () => localStorageLocation);
@@ -80,7 +82,7 @@ process.env.ELECTRON_DISABLE_SECURITY_WARNINGS = 'true';
 // Check for update
 const checkUpdateOnStartup = localStorage.getItem('check-upd-on-strtup') === 'true';
 if (app.isPackaged && checkUpdateOnStartup) {
-    hasUpdate(app.getVersion())
+    hasUpdate(version)
         .then(async (latest) => {
             if (!latest) return;
 
@@ -93,7 +95,7 @@ if (app.isPackaged && checkUpdateOnStartup) {
                 type: 'info',
                 title: 'An update is available for chaiNNer!',
                 message: `Version ${latest.version} is available for download from GitHub.`,
-                detail: `Currently installed: ${app.getVersion()}\n\nRelease notes:\n\n${changelogItems.join(
+                detail: `Currently installed: ${version}\n\nRelease notes:\n\n${changelogItems.join(
                     '\n'
                 )}`,
                 buttons: [`Get version ${latest.version}`, 'Ok'],
@@ -134,7 +136,7 @@ const registerEventHandlers = (mainWindow: BrowserWindowWithSafeIpc) => {
                 defaultPath,
             });
             if (!canceled && filePath) {
-                await SaveFile.write(filePath, saveData, app.getVersion());
+                await SaveFile.write(filePath, saveData, version);
                 return { kind: 'Success', path: filePath };
             }
             return { kind: 'Canceled' };
@@ -146,7 +148,7 @@ const registerEventHandlers = (mainWindow: BrowserWindowWithSafeIpc) => {
 
     ipcMain.handle('file-save-json', async (event, saveData, savePath) => {
         try {
-            await SaveFile.write(savePath, saveData, app.getVersion());
+            await SaveFile.write(savePath, saveData, version);
         } catch (error) {
             log.error(error);
             throw error;
@@ -164,7 +166,7 @@ const registerEventHandlers = (mainWindow: BrowserWindowWithSafeIpc) => {
 
     ipcMain.handle('get-gpu-info', getGpuInfo);
 
-    ipcMain.handle('get-app-version', () => app.getVersion());
+    ipcMain.handle('get-app-version', () => version);
 
     let blockerId: number | undefined;
     ipcMain.on('start-sleep-blocker', () => {
@@ -275,15 +277,6 @@ const checkPythonEnv = async (splashWindow: BrowserWindowWithSafeIpc) => {
     return pythonInfo;
 };
 
-const checkSemverGt = (v1: string, v2: string) => {
-    try {
-        return semver.gt(semver.coerce(v1)!.version, semver.coerce(v2)!.version);
-    } catch (error) {
-        log.error(error);
-        return false;
-    }
-};
-
 const checkPythonDeps = async (
     splashWindow: BrowserWindowWithSafeIpc,
     pythonInfo: PythonInfo,
@@ -308,7 +301,7 @@ const checkPythonDeps = async (
             if (!installedVersion) {
                 return false;
             }
-            return checkSemverGt(packageInfo.version, installedVersion);
+            return versionGt(packageInfo.version, installedVersion);
         });
 
         // CASE 3: An optional package is installed, set to auto update, and is not the latest version
@@ -317,7 +310,7 @@ const checkPythonDeps = async (
             if (!installedVersion) {
                 return false;
             }
-            return packageInfo.autoUpdate && checkSemverGt(packageInfo.version, installedVersion);
+            return packageInfo.autoUpdate && versionGt(packageInfo.version, installedVersion);
         });
 
         const allPackagesThatNeedToBeInstalled = [

--- a/src/main/python/version.ts
+++ b/src/main/python/version.ts
@@ -1,12 +1,13 @@
 import { exec as _exec } from 'child_process';
-import semver from 'semver';
 import util from 'util';
+import { Version } from '../../common/common-types';
+import { parse, versionGte } from '../../common/version';
 
 const exec = util.promisify(_exec);
 
 export const getPythonVersion = async (python: string) => {
     const { stdout } = await exec(`"${python}" --version`);
-    return semver.coerce(stdout)!.version;
+    return parse(stdout);
 };
 
-export const isSupportedPythonVersion = (version: string) => semver.gte(version, '3.7.0');
+export const isSupportedPythonVersion = (version: Version) => versionGte(version, '3.7.0');

--- a/src/main/update.ts
+++ b/src/main/update.ts
@@ -1,8 +1,9 @@
 import https from 'https';
-import semver from 'semver';
+import { Version } from '../common/common-types';
+import { parse, versionGt } from '../common/version';
 
 export interface LatestVersion {
-    version: string;
+    version: Version;
     releaseUrl: string;
     body: string;
 }
@@ -34,10 +35,10 @@ export const getLatestVersion = () =>
                     };
 
                     const releaseUrl = latest.html_url;
-                    const latestVersionNum = semver.coerce(latest.tag_name)!;
+                    const latestVersionNum = parse(latest.tag_name);
                     const { body } = latest;
                     resolve({
-                        version: latestVersionNum.version,
+                        version: latestVersionNum,
                         releaseUrl,
                         body,
                     });
@@ -54,9 +55,9 @@ export const getLatestVersion = () =>
         req.end();
     });
 
-export const hasUpdate = async (currentVersion: string): Promise<LatestVersion | undefined> => {
+export const hasUpdate = async (currentVersion: Version): Promise<LatestVersion | undefined> => {
     const latest = await getLatestVersion();
-    if (!semver.gt(latest.version, currentVersion)) {
+    if (!versionGt(latest.version, currentVersion)) {
         return undefined;
     }
     return latest;

--- a/tests/common/SaveFile.test.ts
+++ b/tests/common/SaveFile.test.ts
@@ -13,10 +13,10 @@ for (const file of fs.readdirSync(dataDir)) {
         expect(parsed).toMatchSnapshot();
     });
     test(`Write save file ${file}`, async () => {
-        const json = SaveFile.stringify(await SaveFile.read(filePath), '');
+        const json = SaveFile.stringify(await SaveFile.read(filePath), '0.0.0-test');
         const obj = JSON.parse(json) as RawSaveFile;
         delete obj.migration;
-        obj.timestamp = '';
+        delete obj.timestamp;
         expect(obj).toMatchSnapshot();
     });
 }

--- a/tests/common/__snapshots__/SaveFile.test.ts.snap
+++ b/tests/common/__snapshots__/SaveFile.test.ts.snap
@@ -3328,8 +3328,7 @@ Object {
       "zoom": 1,
     },
   },
-  "timestamp": "",
-  "version": "",
+  "version": "0.0.0-test",
 }
 `;
 
@@ -3397,8 +3396,7 @@ Object {
       "zoom": 1,
     },
   },
-  "timestamp": "",
-  "version": "",
+  "version": "0.0.0-test",
 }
 `;
 
@@ -3492,8 +3490,7 @@ Object {
       "zoom": 1,
     },
   },
-  "timestamp": "",
-  "version": "",
+  "version": "0.0.0-test",
 }
 `;
 
@@ -3589,8 +3586,7 @@ Object {
       "zoom": 1,
     },
   },
-  "timestamp": "",
-  "version": "",
+  "version": "0.0.0-test",
 }
 `;
 
@@ -4012,8 +4008,7 @@ Object {
       "zoom": 1,
     },
   },
-  "timestamp": "",
-  "version": "",
+  "version": "0.0.0-test",
 }
 `;
 
@@ -4106,8 +4101,7 @@ Object {
       "zoom": 0.6263322193120638,
     },
   },
-  "timestamp": "",
-  "version": "",
+  "version": "0.0.0-test",
 }
 `;
 
@@ -4170,8 +4164,7 @@ Object {
       "zoom": 0.8705505632961259,
     },
   },
-  "timestamp": "",
-  "version": "",
+  "version": "0.0.0-test",
 }
 `;
 
@@ -4388,8 +4381,7 @@ Object {
       "zoom": 1,
     },
   },
-  "timestamp": "",
-  "version": "",
+  "version": "0.0.0-test",
 }
 `;
 
@@ -4423,8 +4415,7 @@ Object {
       "zoom": 1,
     },
   },
-  "timestamp": "",
-  "version": "",
+  "version": "0.0.0-test",
 }
 `;
 
@@ -4525,8 +4516,7 @@ Object {
       "zoom": 1,
     },
   },
-  "timestamp": "",
-  "version": "",
+  "version": "0.0.0-test",
 }
 `;
 
@@ -4686,8 +4676,7 @@ Object {
       "zoom": 1,
     },
   },
-  "timestamp": "",
-  "version": "",
+  "version": "0.0.0-test",
 }
 `;
 
@@ -4827,8 +4816,7 @@ Object {
       "zoom": 1,
     },
   },
-  "timestamp": "",
-  "version": "",
+  "version": "0.0.0-test",
 }
 `;
 
@@ -5059,8 +5047,7 @@ Object {
       "zoom": 1,
     },
   },
-  "timestamp": "",
-  "version": "",
+  "version": "0.0.0-test",
 }
 `;
 
@@ -5176,8 +5163,7 @@ Object {
       "zoom": 1,
     },
   },
-  "timestamp": "",
-  "version": "",
+  "version": "0.0.0-test",
 }
 `;
 
@@ -5304,8 +5290,7 @@ Object {
       "zoom": 1,
     },
   },
-  "timestamp": "",
-  "version": "",
+  "version": "0.0.0-test",
 }
 `;
 
@@ -5339,8 +5324,7 @@ Object {
       "zoom": 1,
     },
   },
-  "timestamp": "",
-  "version": "",
+  "version": "0.0.0-test",
 }
 `;
 
@@ -5695,8 +5679,7 @@ Object {
       "zoom": 1,
     },
   },
-  "timestamp": "",
-  "version": "",
+  "version": "0.0.0-test",
 }
 `;
 
@@ -5761,8 +5744,7 @@ Object {
       "zoom": 1,
     },
   },
-  "timestamp": "",
-  "version": "",
+  "version": "0.0.0-test",
 }
 `;
 
@@ -5896,8 +5878,7 @@ Object {
       "zoom": 1,
     },
   },
-  "timestamp": "",
-  "version": "",
+  "version": "0.0.0-test",
 }
 `;
 
@@ -5934,8 +5915,7 @@ Object {
       "zoom": 1,
     },
   },
-  "timestamp": "",
-  "version": "",
+  "version": "0.0.0-test",
 }
 `;
 
@@ -5971,8 +5951,7 @@ Object {
       "zoom": 1,
     },
   },
-  "timestamp": "",
-  "version": "",
+  "version": "0.0.0-test",
 }
 `;
 
@@ -6107,8 +6086,7 @@ Object {
       "zoom": 1,
     },
   },
-  "timestamp": "",
-  "version": "",
+  "version": "0.0.0-test",
 }
 `;
 
@@ -6322,8 +6300,7 @@ Object {
       "zoom": 1,
     },
   },
-  "timestamp": "",
-  "version": "",
+  "version": "0.0.0-test",
 }
 `;
 
@@ -6420,8 +6397,7 @@ Object {
       "zoom": 1,
     },
   },
-  "timestamp": "",
-  "version": "",
+  "version": "0.0.0-test",
 }
 `;
 
@@ -6606,8 +6582,7 @@ Object {
       "zoom": 1,
     },
   },
-  "timestamp": "",
-  "version": "",
+  "version": "0.0.0-test",
 }
 `;
 
@@ -6685,7 +6660,6 @@ Object {
       "zoom": 1,
     },
   },
-  "timestamp": "",
-  "version": "",
+  "version": "0.0.0-test",
 }
 `;


### PR DESCRIPTION
I never liked the `checkSemverGt` functions (3) we had, so I finally got rid of them. 

I added a new type called `Version` which represents either a valid semantic version or a string that can be coerced into one. This makes our functions handling versions way more descriptive, because we can now take/return a version instead of just a string.