### PR TITLE
Add NCNN VRAM usage estimation

### DIFF
--- a/backend/src/nodes/nodes/ncnn/load_model.py
+++ b/backend/src/nodes/nodes/ncnn/load_model.py
@@ -26,8 +26,7 @@ class NcnnLoadModelNode(NodeBase):
         self.sub = "Input & Output"
 
     def run(self, param_path: str, bin_path: str) -> Tuple[NcnnModel, str]:
-        model = NcnnModel()
-        model.load_from_file(param_path, bin_path)
+        model = NcnnModel.load_from_file(param_path, bin_path)
         model_name = os.path.splitext(os.path.basename(param_path))[0]
 
         return model, model_name

--- a/backend/src/nodes/nodes/ncnn/load_model.py
+++ b/backend/src/nodes/nodes/ncnn/load_model.py
@@ -26,7 +26,8 @@ class NcnnLoadModelNode(NodeBase):
         self.sub = "Input & Output"
 
     def run(self, param_path: str, bin_path: str) -> Tuple[NcnnModel, str]:
-        model = NcnnModel.load_from_file(param_path, bin_path)
+        model = NcnnModel()
+        model.load_from_file(param_path, bin_path)
         model_name = os.path.splitext(os.path.basename(param_path))[0]
 
         return model, model_name

--- a/backend/src/nodes/nodes/ncnn/upscale_image.py
+++ b/backend/src/nodes/nodes/ncnn/upscale_image.py
@@ -80,14 +80,12 @@ class NcnnUpscaleImageNode(NodeBase):
         # Try/except block to catch errors
         try:
             vkdev = ncnn.get_gpu_device(exec_options.ncnn_gpu_index)
-            heap_budget = vkdev.get_heap_budget() * 1024 * 1024
+            heap_budget = vkdev.get_heap_budget() * 1024 * 1024 * 0.8
 
             max_tile_size = (
                 tile_size
                 if tile_size is not None
-                else estimate_tile_size(
-                    heap_budget, heap_budget, model.bin_length, img, 4, 0.8
-                )
+                else estimate_tile_size(heap_budget, model.bin_length, img, 4)
             )
 
             with ncnn_allocators(vkdev) as (

--- a/backend/src/nodes/nodes/ncnn/upscale_image.py
+++ b/backend/src/nodes/nodes/ncnn/upscale_image.py
@@ -80,9 +80,6 @@ class NcnnUpscaleImageNode(NodeBase):
         try:
             vkdev = ncnn.get_gpu_device(exec_options.ncnn_gpu_index)
             heap_budget = vkdev.get_heap_budget() * 1024 * 1024
-            logger.info(heap_budget)
-            logger.info(f"{model.blob_count=}, {model.node_count=}")
-            logger.info(model.bin_length)
 
             def estimate_tile_size() -> Union[int, None]:
                 free = heap_budget
@@ -113,7 +110,6 @@ class NcnnUpscaleImageNode(NodeBase):
 
                 return tile_size
 
-            # logger.info(vkdev.get_heap_budget())
             with ncnn_allocators(vkdev) as (
                 blob_vkallocator,
                 staging_vkallocator,
@@ -130,6 +126,8 @@ class NcnnUpscaleImageNode(NodeBase):
                     else estimate_tile_size(),
                 )
         except ValueError as e:
+            raise e
+        except RuntimeError as e:
             raise e
         except Exception as e:
             logger.error(e)

--- a/backend/src/nodes/nodes/ncnn/upscale_image.py
+++ b/backend/src/nodes/nodes/ncnn/upscale_image.py
@@ -101,10 +101,8 @@ class NcnnUpscaleImageNode(NodeBase):
                     staging_vkallocator=staging_vkallocator,
                     max_tile_size=max_tile_size,
                 )
-        except ValueError as e:
-            raise e
-        except RuntimeError as e:
-            raise e
+        except (RuntimeError, ValueError):
+            raise
         except Exception as e:
             logger.error(e)
             # pylint: disable=raise-missing-from

--- a/backend/src/nodes/nodes/pytorch/upscale_image.py
+++ b/backend/src/nodes/nodes/pytorch/upscale_image.py
@@ -13,6 +13,7 @@ from ...properties.inputs import ModelInput, ImageInput, TileSizeDropdown
 from ...properties.outputs import ImageOutput
 from ...utils.exec_options import get_execution_options, ExecutionOptions
 from ...utils.torch_types import PyTorchModel
+from ...utils.auto_split import estimate_tile_size
 from ...utils.pytorch_utils import to_pytorch_execution_options
 from ...utils.pytorch_auto_split import pytorch_auto_split
 from ...utils.utils import get_h_w_c, convenient_upscale
@@ -64,47 +65,23 @@ class ImageUpscaleNode(NodeBase):
             use_fp16 = options.fp16 and model.supports_fp16
             device = torch.device(options.device)
 
-            def estimate_tile_size() -> Union[int, None]:
-                if "cuda" in options.device:
-                    mem_info: Tuple[int, int] = torch.cuda.mem_get_info(device)  # type: ignore
-                    free, total = mem_info
+            max_tile_size = tile_size
+            if "cuda" in options.device and tile_size is not None:
+                mem_info: Tuple[int, int] = torch.cuda.mem_get_info(device)  # type: ignore
+                free, total = mem_info
+                element_size = 2 if use_fp16 else 4
+                model_bytes = sum(p.numel() * element_size for p in model.parameters())
 
-                    element_size = 2 if use_fp16 else 4
-
-                    h, w, c = get_h_w_c(img)
-                    img_bytes = h * w * c * element_size
-                    model_bytes = sum(
-                        p.numel() * element_size for p in model.parameters()
-                    )
-                    mem_required_estimation = (model_bytes / (1024 * 52)) * img_bytes
-
-                    # Attempt to avoid using too much vram at once
-                    free_allowed_usage = 0.6
-                    tile_pixels = (
-                        w * h * (free * free_allowed_usage) / mem_required_estimation
-                    )
-                    # the largest power-of-2 tile_size such that tile_size**2 < tile_pixels
-                    tile_size = 2 ** (int(tile_pixels**0.5).bit_length() - 1)
-
-                    GB_AMT = 1024**3
-                    required_mem = f"{mem_required_estimation/GB_AMT:.2f}"
-                    free_mem = f"{free/GB_AMT:.2f}"
-                    total_mem = f"{total/GB_AMT:.2f}"
-                    logger.info(
-                        f"Estimating memory required: {required_mem} GB, {free_mem} GB free, {total_mem} GB total."
-                        f" Estimated tile size: {tile_size}"
-                    )
-
-                    return tile_size
+                max_tile_size = estimate_tile_size(
+                    free, total, model_bytes, img, element_size, 0.6
+                )
 
             img_out = pytorch_auto_split(
                 img,
                 model=model,
                 device=device,
                 use_fp16=use_fp16,
-                max_tile_size=tile_size
-                if tile_size is not None
-                else estimate_tile_size(),
+                max_tile_size=max_tile_size,
             )
             logger.debug("Done upscaling")
 

--- a/backend/src/nodes/nodes/pytorch/upscale_image.py
+++ b/backend/src/nodes/nodes/pytorch/upscale_image.py
@@ -68,12 +68,16 @@ class ImageUpscaleNode(NodeBase):
             max_tile_size = tile_size
             if "cuda" in options.device and tile_size is not None:
                 mem_info: Tuple[int, int] = torch.cuda.mem_get_info(device)  # type: ignore
-                free, total = mem_info
+                free, _total = mem_info
                 element_size = 2 if use_fp16 else 4
                 model_bytes = sum(p.numel() * element_size for p in model.parameters())
+                budget = int(free * 0.6)
 
                 max_tile_size = estimate_tile_size(
-                    free, total, model_bytes, img, element_size, 0.6
+                    budget,
+                    model_bytes,
+                    img,
+                    element_size,
                 )
 
             img_out = pytorch_auto_split(

--- a/backend/src/nodes/utils/auto_split.py
+++ b/backend/src/nodes/utils/auto_split.py
@@ -12,6 +12,34 @@ class Split:
     pass
 
 
+def estimate_tile_size(
+    free: int,
+    total: int,
+    model_size: int,
+    img: np.ndarray,
+    img_element_size: int = 4,
+    allowed_usage: float = 0.8,
+) -> Union[int, None]:
+    h, w, c = get_h_w_c(img)
+    img_bytes = h * w * c * img_element_size
+    mem_required_estimation = (model_size / (1024 * 52)) * img_bytes
+
+    tile_pixels = w * h * (free * allowed_usage) / mem_required_estimation
+    # the largest power-of-2 tile_size such that tile_size**2 < tile_pixels
+    tile_size = 2 ** (int(tile_pixels**0.5).bit_length() - 1)
+
+    GB_AMT = 1024**3
+    required_mem = f"{mem_required_estimation/GB_AMT:.2f}"
+    free_mem = f"{free/GB_AMT:.2f}"
+    total_mem = f"{total/GB_AMT:.2f}"
+    logger.info(
+        f"Estimating memory required: {required_mem} GB, {free_mem} GB free, {total_mem} GB total."
+        f" Estimated tile size: {tile_size}"
+    )
+
+    return tile_size
+
+
 def auto_split(
     img: np.ndarray,
     upscale: Callable[[np.ndarray], Union[np.ndarray, Split]],

--- a/backend/src/nodes/utils/auto_split.py
+++ b/backend/src/nodes/utils/auto_split.py
@@ -13,27 +13,24 @@ class Split:
 
 
 def estimate_tile_size(
-    free: int,
-    total: int,
+    budget: int,
     model_size: int,
     img: np.ndarray,
     img_element_size: int = 4,
-    allowed_usage: float = 0.8,
-) -> Union[int, None]:
+) -> int:
     h, w, c = get_h_w_c(img)
     img_bytes = h * w * c * img_element_size
     mem_required_estimation = (model_size / (1024 * 52)) * img_bytes
 
-    tile_pixels = w * h * (free * allowed_usage) / mem_required_estimation
+    tile_pixels = w * h * budget / mem_required_estimation
     # the largest power-of-2 tile_size such that tile_size**2 < tile_pixels
     tile_size = 2 ** (int(tile_pixels**0.5).bit_length() - 1)
 
     GB_AMT = 1024**3
     required_mem = f"{mem_required_estimation/GB_AMT:.2f}"
-    free_mem = f"{free/GB_AMT:.2f}"
-    total_mem = f"{total/GB_AMT:.2f}"
+    budget_mem = f"{budget/GB_AMT:.2f}"
     logger.info(
-        f"Estimating memory required: {required_mem} GB, {free_mem} GB free, {total_mem} GB total."
+        f"Estimating memory required: {required_mem} GB, {budget_mem} GB free."
         f" Estimated tile size: {tile_size}"
     )
 

--- a/backend/src/nodes/utils/ncnn_auto_split.py
+++ b/backend/src/nodes/utils/ncnn_auto_split.py
@@ -65,8 +65,14 @@ def ncnn_auto_split(
             del ex, mat_in, mat_out
             gc.collect()
             # Clear VRAM
+            blob_vkallocator.clear()
+            staging_vkallocator.clear()
             return result
         except Exception as e:
+            if "vkQueueSubmit" in str(e):
+                raise RuntimeError(
+                    "A critical error has occurred. You may need to restart chaiNNer in order for NCNN upscaling to start working again."
+                ) from e
             # Check to see if its actually the NCNN out of memory error
             if "failed" in str(e):
                 # clear VRAM
@@ -74,6 +80,8 @@ def ncnn_auto_split(
                 ex = None
                 del ex
                 gc.collect()
+                blob_vkallocator.clear()
+                staging_vkallocator.clear()
                 return Split()
             else:
                 # Re-raise the exception if not an OOM error

--- a/backend/src/nodes/utils/ncnn_auto_split.py
+++ b/backend/src/nodes/utils/ncnn_auto_split.py
@@ -70,6 +70,13 @@ def ncnn_auto_split(
             return result
         except Exception as e:
             if "vkQueueSubmit" in str(e):
+                ex = None
+                del ex
+                gc.collect()
+                blob_vkallocator.clear()
+                staging_vkallocator.clear()
+                # TODO: Have someone running into this issue enable this and see if it fixes anything
+                # ncnn.destroy_gpu_instance()
                 raise RuntimeError(
                     "A critical error has occurred. You may need to restart chaiNNer in order for NCNN upscaling to start working again."
                 ) from e

--- a/backend/src/nodes/utils/ncnn_model.py
+++ b/backend/src/nodes/utils/ncnn_model.py
@@ -305,29 +305,31 @@ class NcnnModel:
     def magic(self):
         return "7767517"
 
-    def load_from_file(self, param_path: str = "", bin_path: str = "") -> "NcnnModel":
+    @staticmethod
+    def load_from_file(param_path: str = "", bin_path: str = "") -> "NcnnModel":
         if bin_path == "":
             bin_path = param_path.replace(".param", ".bin")
         elif param_path == "":
             param_path = bin_path.replace(".bin", ".param")
 
+        model = NcnnModel()
         with open(param_path, "r", encoding="utf-8") as paramf:
             with open(bin_path, "rb") as binf:
                 paramf.readline()
                 counts = paramf.readline().strip().split(" ")
-                self.node_count = int(counts[0])
-                self.blob_count = int(counts[1])
+                model.node_count = int(counts[0])
+                model.blob_count = int(counts[1])
 
                 for line in paramf:
-                    op_type, layer = self.parse_param_layer(line)
-                    layer.weight_data = self.load_layer_weights(binf, op_type, layer)
-                    self.add_layer(layer)
+                    op_type, layer = model.parse_param_layer(line)
+                    layer.weight_data = model.load_layer_weights(binf, op_type, layer)
+                    model.add_layer(layer)
 
                 binf.seek(0)
-                self.weights_bin = binf.read()
-                self.bin_length = len(self.weights_bin)
+                model.weights_bin = binf.read()
+                model.bin_length = len(model.weights_bin)
 
-        return self
+        return model
 
     @staticmethod
     def interp_layers(

--- a/backend/src/nodes/utils/ncnn_model.py
+++ b/backend/src/nodes/utils/ncnn_model.py
@@ -299,35 +299,35 @@ class NcnnModel:
         self.blob_count: int = blob_count
         self.layer_list: List[NcnnLayer] = []
         self.weights_bin: bytes = b""
+        self.bin_length = 0
 
     @property
     def magic(self):
         return "7767517"
 
-    @staticmethod
-    def load_from_file(param_path: str = "", bin_path: str = "") -> "NcnnModel":
+    def load_from_file(self, param_path: str = "", bin_path: str = "") -> "NcnnModel":
         if bin_path == "":
             bin_path = param_path.replace(".param", ".bin")
         elif param_path == "":
             param_path = bin_path.replace(".bin", ".param")
 
-        model = NcnnModel()
         with open(param_path, "r", encoding="utf-8") as paramf:
             with open(bin_path, "rb") as binf:
                 paramf.readline()
                 counts = paramf.readline().strip().split(" ")
-                model.node_count = int(counts[0])
-                model.blob_count = int(counts[1])
+                self.node_count = int(counts[0])
+                self.blob_count = int(counts[1])
 
                 for line in paramf:
-                    op_type, layer = model.parse_param_layer(line)
-                    layer.weight_data = model.load_layer_weights(binf, op_type, layer)
-                    model.add_layer(layer)
+                    op_type, layer = self.parse_param_layer(line)
+                    layer.weight_data = self.load_layer_weights(binf, op_type, layer)
+                    self.add_layer(layer)
 
                 binf.seek(0)
-                model.weights_bin = binf.read()
+                self.weights_bin = binf.read()
+                self.bin_length = len(self.weights_bin)
 
-        return model
+        return self
 
     @staticmethod
     def interp_layers(
@@ -619,3 +619,7 @@ class NcnnModel:
         interp_model.weights_bin = b"".join(weight_bytes_list)
 
         return interp_model
+
+    @property
+    def bin(self) -> bytes:
+        return self.weights_bin


### PR DESCRIPTION
Similar to the PyTorch estimation, this gets the heap budget (a built-in NCNN property, they use it for tile size estimation in realesrgan-ncnn-vulkan) and the size of the image and returns a tile size for it.

This should hopefully reduce vkQueueSubmit errors (like in #861, #913, and #1057) since that error seems to mainly happen whenever an OOM error happens.

I used 80% as the "max allowed" value because the heap budget is already smaller than the actual total VRAM, and because it's what I remembered realesrgan-ncnn-vulkan using.

From my tests, it seems to work pretty well, but @theflyingzamboni should probably test it first before we merge this.

Also, I added a special except case for vkQueueSubmit while I was at it.