### PR TITLE
Enforce channel requirements are runtime

### DIFF
--- a/backend/src/nodes/nodes/image_adjustment/hue_and_saturation.py
+++ b/backend/src/nodes/nodes/image_adjustment/hue_and_saturation.py
@@ -8,7 +8,6 @@ from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import ImageInput, SliderInput
 from ...properties.outputs import ImageOutput
-from ...properties import expression
 from ...utils.utils import get_h_w_c
 
 
@@ -18,7 +17,7 @@ class HueAndSaturationNode(NodeBase):
         super().__init__()
         self.description = "Adjust the hue and saturation of an image. This is performed in the HSV color-space."
         self.inputs = [
-            ImageInput(image_type=expression.Image(channels=[1, 3, 4])),
+            ImageInput(channels=[1, 3, 4]),
             SliderInput(
                 "Hue",
                 minimum=-180,

--- a/backend/src/nodes/nodes/image_adjustment/threshold_adaptive.py
+++ b/backend/src/nodes/nodes/image_adjustment/threshold_adaptive.py
@@ -14,7 +14,6 @@ from ...properties.inputs import (
     NumberInput,
 )
 from ...properties.outputs import ImageOutput
-from ...properties import expression
 
 
 @NodeFactory.register("chainner:image:threshold_adaptive")
@@ -23,7 +22,7 @@ class AdaptiveThresholdNode(NodeBase):
         super().__init__()
         self.description = "Similar to regular threshold, but determines the threshold for a pixel based on a small region around it."
         self.inputs = [
-            ImageInput(image_type=expression.Image(channels=1)),
+            ImageInput(channels=1),
             SliderInput(
                 "Maximum Value",
                 maximum=100,
@@ -52,10 +51,6 @@ class AdaptiveThresholdNode(NodeBase):
         c: int,
     ) -> np.ndarray:
         """Takes an image and applies an adaptive threshold to it"""
-
-        assert (
-            img.ndim == 2
-        ), "Image must be grayscale (single channel) to apply an adaptive threshold"
 
         # Adaptive threshold requires uint8 input
         img = (img * 255).astype("uint8")

--- a/backend/src/nodes/nodes/image_channel/combine_rgba.py
+++ b/backend/src/nodes/nodes/image_channel/combine_rgba.py
@@ -21,12 +21,10 @@ class CombineRgbaNode(NodeBase):
             " All channel images must be a single channel image."
         )
         self.inputs = [
-            ImageInput("R Channel", image_type=expression.Image(channels=1)),
-            ImageInput("G Channel", image_type=expression.Image(channels=1)),
-            ImageInput("B Channel", image_type=expression.Image(channels=1)),
-            ImageInput(
-                "A Channel", image_type=expression.Image(channels=1)
-            ).make_optional(),
+            ImageInput("R Channel", channels=1),
+            ImageInput("G Channel", channels=1),
+            ImageInput("B Channel", channels=1),
+            ImageInput("A Channel", channels=1).make_optional(),
         ]
         self.outputs = [
             ImageOutput(

--- a/backend/src/nodes/nodes/image_channel/combine_rgba.py
+++ b/backend/src/nodes/nodes/image_channel/combine_rgba.py
@@ -9,7 +9,6 @@ from ...node_factory import NodeFactory
 from ...properties.inputs import ImageInput
 from ...properties.outputs import ImageOutput
 from ...properties import expression
-from ...utils.utils import get_h_w_c
 
 
 @NodeFactory.register("chainner:image:combine_rgba")
@@ -57,23 +56,11 @@ class CombineRgbaNode(NodeBase):
                     im.shape[:2] == start_shape
                 ), "All channel images must have the same resolution"
 
-        def get_channel(img: np.ndarray) -> np.ndarray:
-            if img.ndim == 2:
-                return img
-
-            c = get_h_w_c(img)[2]
-            assert c == 1, (
-                "All channel images must only have exactly one channel."
-                " Suggestion: Convert to grayscale first."
-            )
-
-            return img[:, :, 0]
-
         channels = [
-            get_channel(img_b),
-            get_channel(img_g),
-            get_channel(img_r),
-            get_channel(img_a) if img_a is not None else np.ones(start_shape),
+            img_b,
+            img_g,
+            img_r,
+            img_a if img_a is not None else np.ones(start_shape),
         ]
 
         return np.stack(channels, axis=2)

--- a/backend/src/nodes/nodes/image_channel/fill_alpha.py
+++ b/backend/src/nodes/nodes/image_channel/fill_alpha.py
@@ -13,7 +13,6 @@ from ...utils.fill_alpha import (
     fill_alpha_fragment_blur,
     fill_alpha_edge_extend,
 )
-from ...utils.utils import get_h_w_c
 
 
 @NodeFactory.register("chainner:image:fill_alpha")
@@ -24,7 +23,7 @@ class FillAlphaNode(NodeBase):
             "Fills the transparent pixels of an image with nearby colors."
         )
         self.inputs = [
-            ImageInput("RGBA", expression.Image(channels=4)),
+            ImageInput("RGBA", channels=4),
             AlphaFillMethodInput(),
         ]
         self.outputs = [
@@ -40,9 +39,6 @@ class FillAlphaNode(NodeBase):
 
     def run(self, img: np.ndarray, method: int) -> np.ndarray:
         """Fills transparent holes in the given image"""
-
-        _, _, c = get_h_w_c(img)
-        assert c == 4, "The image has to be an RGBA image to fill its alpha."
 
         if method == AlphaFillMethod.EXTEND_TEXTURE:
             # Preprocess to convert the image into binary alpha

--- a/backend/src/nodes/nodes/image_channel/transparency_split.py
+++ b/backend/src/nodes/nodes/image_channel/transparency_split.py
@@ -19,7 +19,7 @@ class TransparencySplitNode(NodeBase):
         self.description = (
             "Split image channels into RGB and Alpha (transparency) channels."
         )
-        self.inputs = [ImageInput(image_type=expression.Image(channels=[1, 3, 4]))]
+        self.inputs = [ImageInput(channels=[1, 3, 4])]
         self.outputs = [
             ImageOutput("RGB Channels", expression.Image(size_as="Input0", channels=3)),
             ImageOutput(

--- a/backend/src/nodes/nodes/image_channel/transprency_merge.py
+++ b/backend/src/nodes/nodes/image_channel/transprency_merge.py
@@ -19,7 +19,7 @@ class TransparencyMergeNode(NodeBase):
         self.description = "Merge RGB and Alpha (transparency) image channels into 4-channel RGBA channels."
         self.inputs = [
             ImageInput("RGB Channels"),
-            ImageInput("Alpha Channel", expression.Image(channels=1)),
+            ImageInput("Alpha Channel", channels=1),
         ]
         self.outputs = [
             ImageOutput(

--- a/backend/src/nodes/nodes/image_filter/avg_color_fix.py
+++ b/backend/src/nodes/nodes/image_filter/avg_color_fix.py
@@ -66,8 +66,6 @@ class AverageColorFixNode(NodeBase):
         assert (
             ref_w < input_w and ref_h < input_h
         ), "Image must be larger than Reference Image"
-        assert input_c in (3, 4), "The input image must be an RGB or RGBA image"
-        assert ref_c in (3, 4), "The reference image must be an RGB or RGBA image"
 
         # adjust channels
         alpha = None

--- a/backend/src/nodes/nodes/image_filter/avg_color_fix.py
+++ b/backend/src/nodes/nodes/image_filter/avg_color_fix.py
@@ -10,7 +10,6 @@ from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import ImageInput, NumberInput
 from ...properties.outputs import ImageOutput
-from ...properties import expression
 from ...utils.utils import get_h_w_c
 
 
@@ -25,8 +24,8 @@ class AverageColorFixNode(NodeBase):
          Using significant downscaling increases generalization of averaging effect
          and can reduce artifacts in the output."""
         self.inputs = [
-            ImageInput("Image", image_type=expression.Image(channels=[3, 4])),
-            ImageInput("Reference Image", image_type=expression.Image(channels=[3, 4])),
+            ImageInput("Image", channels=[3, 4]),
+            ImageInput("Reference Image", channels=[3, 4]),
             NumberInput(
                 "Reference Image Scale Factor",
                 precision=4,

--- a/backend/src/nodes/nodes/image_filter/color_transfer.py
+++ b/backend/src/nodes/nodes/image_filter/color_transfer.py
@@ -33,7 +33,7 @@ class ColorTransferNode(NodeBase):
             different images. Try multiple setting combinations to find
             best results."""
         self.inputs = [
-            ImageInput("Image", channels=[3, 4]),
+            ImageInput("Image", channels=[1, 3, 4]),
             ImageInput("Reference Image", channels=[3, 4]),
             ColorspaceInput(),
             OverflowMethodInput(),
@@ -58,11 +58,6 @@ class ColorTransferNode(NodeBase):
         """
 
         _, _, img_c = get_h_w_c(img)
-        _, _, ref_c = get_h_w_c(ref_img)
-
-        # Make sure target has at least 3 channels
-        if img_c == 1:
-            img = cv2.cvtColor(img, cv2.COLOR_GRAY2BGR)
 
         # Preserve alpha
         alpha = None

--- a/backend/src/nodes/nodes/image_filter/color_transfer.py
+++ b/backend/src/nodes/nodes/image_filter/color_transfer.py
@@ -13,7 +13,6 @@ from ...properties.inputs import (
     ReciprocalScalingFactorInput,
 )
 from ...properties.outputs import ImageOutput
-from ...properties import expression
 from ...utils.color_transfer import color_transfer
 from ...utils.utils import get_h_w_c
 
@@ -34,8 +33,8 @@ class ColorTransferNode(NodeBase):
             different images. Try multiple setting combinations to find
             best results."""
         self.inputs = [
-            ImageInput("Image", expression.Image(channels=[3, 4])),
-            ImageInput("Reference Image", expression.Image(channels=[3, 4])),
+            ImageInput("Image", channels=[3, 4]),
+            ImageInput("Reference Image", channels=[3, 4]),
             ColorspaceInput(),
             OverflowMethodInput(),
             ReciprocalScalingFactorInput(),
@@ -60,8 +59,6 @@ class ColorTransferNode(NodeBase):
 
         _, _, img_c = get_h_w_c(img)
         _, _, ref_c = get_h_w_c(ref_img)
-
-        assert ref_c >= 3, "Reference image should be RGB or RGBA"
 
         # Make sure target has at least 3 channels
         if img_c == 1:

--- a/backend/src/nodes/nodes/image_filter/color_transfer.py
+++ b/backend/src/nodes/nodes/image_filter/color_transfer.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import cv2
 import numpy as np
 
 from . import category as ImageFilterCategory

--- a/backend/src/nodes/nodes/image_filter/normal_addition.py
+++ b/backend/src/nodes/nodes/image_filter/normal_addition.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import cv2
 import numpy as np
 
-from sanic.log import logger
-
 from . import category as ImageFilterCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
@@ -22,9 +20,9 @@ class NormalAdditionNode(NodeBase):
             channels of the input image will be used. The output normal map
             is guaranteed to be normalized."""
         self.inputs = [
-            ImageInput("Normal Map 1", expression.Image(channels=[3, 4])),
+            ImageInput("Normal Map 1", channels=[3, 4]),
             SliderInput("Strength 1", maximum=100, default=100),
-            ImageInput("Normal Map 2", expression.Image(channels=[3, 4])),
+            ImageInput("Normal Map 2", channels=[3, 4]),
             SliderInput("Strength 2", maximum=100, default=100),
         ]
         self.outputs = [
@@ -61,11 +59,6 @@ class NormalAdditionNode(NodeBase):
         on the added heightmaps. Practically, this is unnecessary, as adding
         the slopes together is equivalent to adding the heightmaps.
         """
-
-        logger.info(f"Adding normal maps")
-        assert (
-            n.ndim == 3 and m.ndim == 3
-        ), "The input images must be RGB or RGBA images"
 
         n_norm_strength = n_strength / 100
         m_norm_strength = m_strength / 100

--- a/backend/src/nodes/nodes/image_filter/normalize_normal_map.py
+++ b/backend/src/nodes/nodes/image_filter/normalize_normal_map.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import cv2
 import numpy as np
 
-from sanic.log import logger
-
 from . import category as ImageFilterCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
@@ -21,7 +19,7 @@ class NormalizeNode(NodeBase):
         self.description = """Normalizes the given normal map.
             Only the R and G channels of the input image will be used to compute the unit vectors."""
         self.inputs = [
-            ImageInput("Normal Map", expression.Image(channels=[3, 4])),
+            ImageInput("Normal Map", channels=[3, 4]),
         ]
         self.outputs = [
             ImageOutput("Normal Map", expression.Image(size_as="Input0", channels=3)),
@@ -33,9 +31,6 @@ class NormalizeNode(NodeBase):
 
     def run(self, img: np.ndarray) -> np.ndarray:
         """Takes a normal map and normalizes it"""
-
-        logger.info(f"Normalizing image")
-        assert img.ndim == 3, "The input image must be an RGB or RGBA image"
 
         # Convert BGR to XY
         x = img[:, :, 2] * 2 - 1

--- a/backend/src/nodes/nodes/image_utility/blend.py
+++ b/backend/src/nodes/nodes/image_utility/blend.py
@@ -24,14 +24,8 @@ class ImBlend(NodeBase):
         self.description = """Blends overlay image onto base image using
             specified mode."""
         self.inputs = [
-            ImageInput(
-                "Base Layer",
-                image_type=expression.Image(channels=[1, 3, 4]),
-            ),
-            ImageInput(
-                "Overlay Layer",
-                image_type=expression.Image(channels=[1, 3, 4]),
-            ),
+            ImageInput("Base Layer", channels=[1, 3, 4]),
+            ImageInput("Overlay Layer", channels=[1, 3, 4]),
             BlendModeDropdown(),
         ]
         self.outputs = [

--- a/backend/src/nodes/utils/format.py
+++ b/backend/src/nodes/utils/format.py
@@ -1,0 +1,43 @@
+from typing import Callable, Iterable, List, Literal, TypeVar
+
+T = TypeVar("T")
+Conj = Literal["and", "or"]
+
+
+def join_english(
+    items: Iterable[T],
+    to_str: Callable[[T], str] = str,
+    conj: Conj = "and",
+) -> str:
+    s = list(map(to_str, items))
+
+    l = len(s)
+    assert l > 0
+
+    if l == 1:
+        return s[0]
+    if l == 2:
+        return f"{s[0]} {conj} {s[1]}"
+    return ", ".join(s[:-1]) + f", {conj} " + s[-1]
+
+
+def format_image_with_channels(
+    channels: List[int],
+    conj: Conj = "and",
+    plural: bool = False,
+) -> str:
+    assert len(channels) > 0
+
+    named = {1: "grayscale", 3: "RGB", 4: "RGBA"}
+    if all([x in named for x in channels]):
+        if plural:
+            return join_english(channels, lambda c: named[c], conj=conj) + " images"
+        else:
+            return (
+                "a " + join_english(channels, lambda c: named[c], conj=conj) + " image"
+            )
+
+    if plural:
+        return f"images with {join_english(channels, conj=conj)} channel(s)"
+    else:
+        return f"an image with {join_english(channels, conj=conj)} channel(s)"


### PR DESCRIPTION
A lot of nodes require images with a certain number of channels, but they all validate the number of channels in the input image differently. Some throw nice errors, some only partially validate the input image, and some don't verify the number of channels at runtime at all.

This PR adds a new optional `channels` parameter to `ImageInput`s. This parameter is used to both derive a type for the input and to validate the input image at runtime.

This should make the behavior of nodes more consistent and prevent confusing OpenCV error messages because of missing input validation.