### PR TITLE
Brightness changes

### DIFF
--- a/backend/src/nodes/nodes/image_adjustment/brightness_and_contrast.py
+++ b/backend/src/nodes/nodes/image_adjustment/brightness_and_contrast.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import cv2
 import numpy as np
 
 from . import category as ImageAdjustmentCategory

--- a/backend/src/nodes/nodes/image_adjustment/brightness_and_contrast.py
+++ b/backend/src/nodes/nodes/image_adjustment/brightness_and_contrast.py
@@ -8,6 +8,7 @@ from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import ImageInput, SliderInput
 from ...properties.outputs import ImageOutput
+from ...utils.utils import get_h_w_c
 
 
 @NodeFactory.register("chainner:image:brightness_and_contrast")
@@ -40,42 +41,31 @@ class BrightnessAndContrastNode(NodeBase):
         self.icon = "ImBrightnessContrast"
         self.sub = "Adjustments"
 
-    def run(self, img: np.ndarray, b_amount: float, c_amount: float) -> np.ndarray:
+    def run(self, img: np.ndarray, brightness: float, contrast: float) -> np.ndarray:
         """Adjusts the brightness and contrast of an image"""
 
-        b_norm_amount = b_amount / 100
-        c_norm_amount = c_amount / 100
+        brightness /= 100
+        contrast /= 100
 
-        # Pass through unadjusted image
-        if b_norm_amount == 0 and c_norm_amount == 0:
+        if brightness == 0 and contrast == 0:
             return img
 
-        # Calculate brightness adjustment
-        if b_norm_amount > 0:
-            shadow = b_norm_amount
-            highlight = 1
+        _, _, c = get_h_w_c(img)
+
+        # Contrast correction factor
+        max_c = 259 / 255
+        factor: float = (max_c * (contrast + 1)) / (max_c - contrast)
+        add: float = factor * brightness + 0.5 * (1 - factor)
+
+        if c <= 3:
+            img = factor * img + add
         else:
-            shadow = 0
-            highlight = 1 + b_norm_amount
-        alpha_b = highlight - shadow
-        if img.ndim == 2:
-            img = cv2.addWeighted(img, alpha_b, img, 0, shadow)
-        else:
-            img[:, :, :3] = cv2.addWeighted(
-                img[:, :, :3], alpha_b, img[:, :, :3], 0, shadow
+            img = np.concatenate(
+                [
+                    factor * img[:, :, :3] + add,
+                    img[:, :, 3:],
+                ],
+                axis=2,
             )
 
-        # Calculate contrast adjustment
-        alpha_c = ((259 / 255) * (c_norm_amount + 1)) / (
-            (259 / 255) - c_norm_amount
-        )  # Contrast correction factor
-        gamma_c = 0.5 * (1 - alpha_c)
-        if img.ndim == 2:
-            img = cv2.addWeighted(img, alpha_c, img, 0, gamma_c)
-        else:
-            img[:, :, :3] = cv2.addWeighted(
-                img[:, :, :3], alpha_c, img[:, :, :3], 0, gamma_c
-            )
-        img = np.clip(img, 0, 1).astype("float32")
-
-        return img
+        return np.clip(img, 0, 1)

--- a/tests/common/__snapshots__/SaveFile.test.ts.snap
+++ b/tests/common/__snapshots__/SaveFile.test.ts.snap
@@ -1100,7 +1100,19 @@ Object {
 
 exports[`Read save file image-adjustments.chn 1`] = `
 Object {
-  "edges": Array [],
+  "edges": Array [
+    Object {
+      "animated": false,
+      "data": Object {},
+      "id": "c81954e2-9045-5b49-8da5-2eafb8987096",
+      "source": "4b37d9ad-cd4f-568b-ba0c-973fae2f4cc7",
+      "sourceHandle": "4b37d9ad-cd4f-568b-ba0c-973fae2f4cc7-0",
+      "target": "59b0e388-685e-4b7b-8ffe-c64bc98a350f",
+      "targetHandle": "59b0e388-685e-4b7b-8ffe-c64bc98a350f-0",
+      "type": "main",
+      "zIndex": 49,
+    },
+  ],
   "nodes": Array [
     Object {
       "data": Object {
@@ -1127,7 +1139,7 @@ Object {
       "data": Object {
         "id": "59b0e388-685e-4b7b-8ffe-c64bc98a350f",
         "inputData": Object {
-          "1": 24,
+          "1": 0,
           "2": 43,
         },
         "schemaId": "chainner:image:brightness_and_contrast",
@@ -1184,6 +1196,27 @@ Object {
       "selected": false,
       "type": "regularNode",
       "width": 262,
+      "zIndex": 50,
+    },
+    Object {
+      "data": Object {
+        "id": "4b37d9ad-cd4f-568b-ba0c-973fae2f4cc7",
+        "inputData": Object {
+          "1": 0,
+          "2": 0,
+          "3": 24,
+        },
+        "schemaId": "chainner:image:hue_and_saturation",
+      },
+      "height": 356,
+      "id": "4b37d9ad-cd4f-568b-ba0c-973fae2f4cc7",
+      "position": Object {
+        "x": 291.33284813944954,
+        "y": 143.52957902171042,
+      },
+      "selected": false,
+      "type": "regularNode",
+      "width": 242,
       "zIndex": 50,
     },
   ],
@@ -4421,9 +4454,21 @@ Object {
 
 exports[`Write save file image-adjustments.chn 1`] = `
 Object {
-  "checksum": "d2a7d8b3d214413add0c229ac3d8be32",
+  "checksum": "d7993cfe78e77bd592ca208a8c64f4f2",
   "content": Object {
-    "edges": Array [],
+    "edges": Array [
+      Object {
+        "animated": false,
+        "data": Object {},
+        "id": "c81954e2-9045-5b49-8da5-2eafb8987096",
+        "source": "4b37d9ad-cd4f-568b-ba0c-973fae2f4cc7",
+        "sourceHandle": "4b37d9ad-cd4f-568b-ba0c-973fae2f4cc7-0",
+        "target": "59b0e388-685e-4b7b-8ffe-c64bc98a350f",
+        "targetHandle": "59b0e388-685e-4b7b-8ffe-c64bc98a350f-0",
+        "type": "main",
+        "zIndex": 49,
+      },
+    ],
     "nodes": Array [
       Object {
         "data": Object {
@@ -4450,7 +4495,7 @@ Object {
         "data": Object {
           "id": "59b0e388-685e-4b7b-8ffe-c64bc98a350f",
           "inputData": Object {
-            "1": 24,
+            "1": 0,
             "2": 43,
           },
           "schemaId": "chainner:image:brightness_and_contrast",
@@ -4507,6 +4552,27 @@ Object {
         "selected": false,
         "type": "regularNode",
         "width": 262,
+        "zIndex": 50,
+      },
+      Object {
+        "data": Object {
+          "id": "4b37d9ad-cd4f-568b-ba0c-973fae2f4cc7",
+          "inputData": Object {
+            "1": 0,
+            "2": 0,
+            "3": 24,
+          },
+          "schemaId": "chainner:image:hue_and_saturation",
+        },
+        "height": 356,
+        "id": "4b37d9ad-cd4f-568b-ba0c-973fae2f4cc7",
+        "position": Object {
+          "x": 291.33284813944954,
+          "y": 143.52957902171042,
+        },
+        "selected": false,
+        "type": "regularNode",
+        "width": 242,
         "zIndex": 50,
       },
     ],


### PR DESCRIPTION
This changes how Brightness in Brightness & Contrast works. It's now a flat value added to all RGB channels of the image.

I also simplified the contrast formula and added brightness into it. It's not quite simple and really efficient.

The migration works as follows: The input image edge of each B&C nodes is changes to link to a H&S nodes. We use the H&S node to adjust the lightness of the image (old brightness) and then feed that output image into the new B&C nodes with its brightness input set to 0. In practice, it looks like this:

![image](https://user-images.githubusercontent.com/20878432/194948321-33132c57-a787-40f0-af93-88e177a2a20a.png)
