### PR TITLE
Improve the Nvidia-SMI check

### DIFF
--- a/src/main/nvidiaSmi.ts
+++ b/src/main/nvidiaSmi.ts
@@ -28,13 +28,10 @@ const hasOutput = (command: string): Promise<boolean> => {
 };
 
 const getNvidiaSmiCommandFromPath = async (): Promise<string | undefined> => {
-    if (
-        platform === 'win32' &&
-        ((await hasOutput('where nvidia-smi')) || (await hasOutput('nvidia-smi')))
-    ) {
+    if (await hasOutput(`${platform === 'win32' ? 'where' : 'which'} nvidia-smi`)) {
         return 'nvidia-smi';
     }
-    if ((await hasOutput('which nvidia-smi')) || (await hasOutput('nvidia-smi'))) {
+    if (await hasOutput('nvidia-smi')) {
         return 'nvidia-smi';
     }
     return undefined;

--- a/src/main/nvidiaSmi.ts
+++ b/src/main/nvidiaSmi.ts
@@ -28,7 +28,10 @@ const hasOutput = (command: string): Promise<boolean> => {
 };
 
 const getNvidiaSmiCommandFromPath = async (): Promise<string | undefined> => {
-    if (platform === 'win32' && (await hasOutput('where nvidia-smi'))) {
+    if (
+        platform === 'win32' &&
+        ((await hasOutput('where nvidia-smi')) || (await hasOutput('nvidia-smi')))
+    ) {
         return 'nvidia-smi';
     }
     if ((await hasOutput('which nvidia-smi')) || (await hasOutput('nvidia-smi'))) {
@@ -71,6 +74,11 @@ const getNvidiaSmiCommand = async (): Promise<string | undefined> => {
 
         if (targetDir) {
             return path.join(basePath, targetDir, 'nvidia-smi.exe');
+        }
+        // check if smi is in System32
+        const smiPath = `${WINDIR}\\System32\\nvidia-smi.exe`;
+        if ((await fs.stat(smiPath)).isFile()) {
+            return smiPath;
         }
     }
     return undefined;


### PR DESCRIPTION
- On windows, we weren't just checking if running `nvidia-smi` worked. I think that's because the `where nvidia-smi` command should only work if `nvidia-smi` works, but might as well check anyway.
- Added a check for if nvidia-smi.exe is in System32. We've seen cases where this is true, so might as well check for it.