### PR TITLE
Always convert outputs to list

### DIFF
--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -32,6 +32,30 @@ from chain.input import InputMap, EdgeInput
 from nodes.node_base import NodeBase
 from nodes.utils.image_utils import get_h_w_c
 
+
+Output = List[Any]
+
+
+def to_output(raw_output: Any, node: NodeBase) -> Output:
+    l = len(node.outputs)
+
+    output: Output
+    if l == 0:
+        assert raw_output is None
+        output = []
+    elif l == 1:
+        output = [raw_output]
+    else:
+        output = list(raw_output)
+
+    # make outputs readonly
+    for o in output:
+        if isinstance(o, np.ndarray):
+            o.setflags(write=False)
+
+    return output
+
+
 T = TypeVar("T")
 
 
@@ -138,7 +162,7 @@ class IteratorContext:
             )
 
 
-def timed_supplier(supplier: Callable[[], Any]) -> Callable[[], Tuple[Any, float]]:
+def timed_supplier(supplier: Callable[[], T]) -> Callable[[], Tuple[T, float]]:
     def wrapper():
         start = time.time()
         result = supplier()
@@ -167,7 +191,7 @@ class Executor:
         loop: asyncio.AbstractEventLoop,
         queue: EventQueue,
         pool: ThreadPoolExecutor,
-        parent_cache: Optional[OutputCache] = None,
+        parent_cache: Optional[OutputCache[Output]] = None,
         parent_executor: Optional[Executor] = None,
     ):
         assert not (
@@ -177,7 +201,7 @@ class Executor:
         self.execution_id: str = uuid.uuid4().hex
         self.chain = chain
         self.inputs = inputs
-        self.cache: OutputCache = OutputCache(
+        self.cache: OutputCache[Output] = OutputCache(
             parent=parent_executor.cache if parent_executor else parent_cache
         )
         self.__broadcast_tasks: List[asyncio.Task[None]] = []
@@ -198,7 +222,7 @@ class Executor:
             else get_cache_strategies(chain)
         )
 
-    async def process(self, node_id: NodeId) -> Any:
+    async def process(self, node_id: NodeId) -> Output:
         node = self.chain.nodes[node_id]
         try:
             return await self.__process(node)
@@ -209,7 +233,7 @@ class Executor:
         except Exception as e:
             raise NodeExecutionError(node, str(e), {}) from e
 
-    async def __process(self, node: Node) -> Any:
+    async def __process(self, node: Node) -> Output:
         """Process a single node"""
 
         logger.debug(f"node: {node}")
@@ -229,10 +253,8 @@ class Executor:
             if isinstance(node_input, EdgeInput):
                 # Recursively get the value of the input
                 processed_input = await self.process(node_input.id)
-                # Split the output if necessary and grab the right index from the output
-                if type(processed_input) in [list, tuple]:
-                    processed_input = processed_input[node_input.index]
-                inputs.append(processed_input)
+                # Grab the right index from the output
+                inputs.append(processed_input[node_input.index])
                 await self.progress.suspend()
             # Otherwise, just use the given input (number, string, etc)
             else:
@@ -257,16 +279,18 @@ class Executor:
             run_func = functools.partial(
                 node_instance.run, *enforced_inputs, context=context
             )
-            output, execution_time = await timed_supplier_async(run_func)
+            raw_output, execution_time = await timed_supplier_async(run_func)
+            output = to_output(raw_output, node_instance)
             del run_func
             await self.__broadcast_data(node_instance, node.id, execution_time, output)
         else:
             try:
                 # Run the node and pass in inputs as args
                 run_func = functools.partial(node_instance.run, *enforced_inputs)
-                output, execution_time = await self.loop.run_in_executor(
+                raw_output, execution_time = await self.loop.run_in_executor(
                     self.pool, timed_supplier(run_func)
                 )
+                output = to_output(raw_output, node_instance)
                 del run_func
             except Aborted:
                 raise
@@ -308,7 +332,7 @@ class Executor:
         node_instance: NodeBase,
         node_id: NodeId,
         execution_time: float,
-        output: Any,
+        output: Output,
     ):
         node_outputs = node_instance.outputs
         finished = list(self.cache.keys())
@@ -317,11 +341,10 @@ class Executor:
 
         def compute_broadcast_data():
             broadcast_data: Dict[OutputId, Any] = dict()
-            output_list: List[Any] = [output] if len(node_outputs) == 1 else output
             for index, node_output in enumerate(node_outputs):
                 try:
                     broadcast_data[node_output.id] = node_output.get_broadcast_data(
-                        output_list[index]
+                        output[index]
                     )
                 except Exception as e:
                     logger.error(f"Error broadcasting output: {e}")

--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -41,12 +41,15 @@ def to_output(raw_output: Any, node: NodeBase) -> Output:
 
     output: Output
     if l == 0:
-        assert raw_output is None
+        assert raw_output is None, f"Expected all {node.name} nodes to return None."
         output = []
     elif l == 1:
         output = [raw_output]
     else:
         output = list(raw_output)
+        assert (
+            len(output) == l
+        ), f"Expected all {node.name} nodes to have {l} output(s) but found {len(output)}."
 
     # make outputs readonly
     for o in output:


### PR DESCRIPTION
Broadcasts and the executor were using 2 different methods to convert the raw outputs of a node into a list. This previously created problems when Joey tried to return a tuple value in NCNN nodes.

To prevent this from happening again, I made it so that outputs are now always converted by looking at the number of `.outputs` a node has. I also added assertions to make sure that nodes actually return what their `.outputs` say they return. At least, the number of outputs is checked, right now. We should probably also have some kind of output validation to check the correctness of node implementations at runtime. We already had the Canny edge detection node that returned an image with the wrong number of channels. If we also give `ImageOutput`s a `channels` parameters like for inputs, we'll be able to detect such errors in the future.

Other changes:
- Set images to readonly.
- Made the cache class generic over its items. I did this to decouple the cache implementation from the `Output` type.