### PR TITLE
Fix clipboard paste crash

### DIFF
--- a/src/renderer/helpers/copyAndPaste.ts
+++ b/src/renderer/helpers/copyAndPaste.ts
@@ -87,22 +87,22 @@ export const pasteFromClipboard = (
         }
     } else {
         availableFormats.forEach((format) => {
-            log.info('Clipboard format', format);
+            log.debug('Clipboard format', format);
             switch (format) {
                 case 'text/plain':
-                    log.info('Clipboard text', clipboard.readText());
+                    log.debug('Clipboard text', clipboard.readText());
                     break;
                 case 'text/html':
-                    log.info('Clipboard html', clipboard.readHTML());
+                    log.debug('Clipboard html', clipboard.readHTML());
                     break;
                 case 'text/rtf':
-                    log.info('Clipboard rtf', clipboard.readRTF());
+                    log.debug('Clipboard rtf', clipboard.readRTF());
                     break;
                 case 'image/png':
-                    log.info('Clipboard image', clipboard.readImage().toPNG());
+                    log.debug('Clipboard image', clipboard.readImage().toPNG());
                     break;
                 default:
-                    log.info('Clipboard data', clipboard.readBuffer(format));
+                    log.debug('Clipboard data', clipboard.readBuffer(format));
             }
         });
     }

--- a/src/renderer/helpers/copyAndPaste.ts
+++ b/src/renderer/helpers/copyAndPaste.ts
@@ -1,4 +1,5 @@
 import { clipboard } from 'electron';
+import log from 'electron-log';
 import { Edge, Node } from 'reactflow';
 import { EdgeData, NodeData } from '../../common/common-types';
 import { createUniqueId, deriveUniqueId } from '../../common/util';
@@ -55,27 +56,54 @@ export const pasteFromClipboard = (
     setNodes: SetState<Node<NodeData>[]>,
     setEdges: SetState<Edge<EdgeData>[]>
 ) => {
-    const chain = JSON.parse(
-        clipboard.readBuffer('application/chainner.chain').toString()
-    ) as ClipboardChain;
+    const availableFormats = clipboard.availableFormats();
+    if (availableFormats.length === 0) {
+        try {
+            const chain = JSON.parse(
+                clipboard.readBuffer('application/chainner.chain').toString()
+            ) as ClipboardChain;
 
-    const duplicationId = createUniqueId();
-    const deriveId = (oldId: string) => deriveUniqueId(duplicationId + oldId);
+            const duplicationId = createUniqueId();
+            const deriveId = (oldId: string) => deriveUniqueId(duplicationId + oldId);
 
-    setNodes((nodes) => {
-        const currentIds = new Set(nodes.map((n) => n.id));
-        const newIds = new Set(chain.nodes.map((n) => n.id));
+            setNodes((nodes) => {
+                const currentIds = new Set(nodes.map((n) => n.id));
+                const newIds = new Set(chain.nodes.map((n) => n.id));
 
-        const newNodes = copyNodes(chain.nodes, deriveId, (oldId) => {
-            if (newIds.has(oldId)) return deriveId(oldId);
-            if (currentIds.has(oldId)) return oldId;
-            return undefined;
+                const newNodes = copyNodes(chain.nodes, deriveId, (oldId) => {
+                    if (newIds.has(oldId)) return deriveId(oldId);
+                    if (currentIds.has(oldId)) return oldId;
+                    return undefined;
+                });
+
+                return [...setSelected(nodes, false), ...setSelected(newNodes, true)];
+            });
+            setEdges((edges) => {
+                const newEdges = copyEdges(chain.edges, deriveId);
+                return [...setSelected(edges, false), ...setSelected(newEdges, true)];
+            });
+        } catch (e) {
+            log.error('Invalid clipboard data', e);
+        }
+    } else {
+        availableFormats.forEach((format) => {
+            log.info('Clipboard format', format);
+            switch (format) {
+                case 'text/plain':
+                    log.info('Clipboard text', clipboard.readText());
+                    break;
+                case 'text/html':
+                    log.info('Clipboard html', clipboard.readHTML());
+                    break;
+                case 'text/rtf':
+                    log.info('Clipboard rtf', clipboard.readRTF());
+                    break;
+                case 'image/png':
+                    log.info('Clipboard image', clipboard.readImage().toPNG());
+                    break;
+                default:
+                    log.info('Clipboard data', clipboard.readBuffer(format));
+            }
         });
-
-        return [...setSelected(nodes, false), ...setSelected(newNodes, true)];
-    });
-    setEdges((edges) => {
-        const newEdges = copyEdges(chain.edges, deriveId);
-        return [...setSelected(edges, false), ...setSelected(newEdges, true)];
-    });
+    }
 };


### PR DESCRIPTION
I will eventually make the image handler write a temp file and make a new node referencing it. However, for now I just fixed the crash and added some boilerplate for standard pasting formats.

Basically, I'll work on the image stuff tomorrow, but figured I'd just PR my crash fix now