### PR TITLE
Change Colorspace from to

### DIFF
--- a/backend/src/nodes/nodes/image_filter/color_transfer.py
+++ b/backend/src/nodes/nodes/image_filter/color_transfer.py
@@ -7,7 +7,7 @@ from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import (
     ImageInput,
-    ColorspaceInput,
+    TransferColorspaceInput,
     OverflowMethodInput,
     ReciprocalScalingFactorInput,
 )
@@ -34,7 +34,7 @@ class ColorTransferNode(NodeBase):
         self.inputs = [
             ImageInput("Image", channels=[1, 3, 4]),
             ImageInput("Reference Image", channels=[3, 4]),
-            ColorspaceInput(),
+            TransferColorspaceInput(),
             OverflowMethodInput(),
             ReciprocalScalingFactorInput(),
         ]

--- a/backend/src/nodes/nodes/image_utility/convert_color.py
+++ b/backend/src/nodes/nodes/image_utility/convert_color.py
@@ -40,7 +40,7 @@ class ColorConvertNode(NodeBase):
         self.icon = "MdColorLens"
         self.sub = "Miscellaneous"
 
-    def run(self, img: np.ndarray, input: int, output: int) -> np.ndarray:
+    def run(self, img: np.ndarray, input_: int, output: int) -> np.ndarray:
         """Takes an image and changes the color mode it"""
 
-        return convert(img, color_space_from_id(input), color_space_from_id(output))
+        return convert(img, color_space_from_id(input_), color_space_from_id(output))

--- a/backend/src/nodes/properties/inputs/generic_inputs.py
+++ b/backend/src/nodes/properties/inputs/generic_inputs.py
@@ -242,9 +242,9 @@ def FlipAxisInput() -> DropDownInput:
     )
 
 
-def ColorspaceInput() -> DropDownInput:
+def TransferColorspaceInput() -> DropDownInput:
     return DropDownInput(
-        input_type="Colorspace",
+        input_type="TransferColorspace",
         label="Colorspace",
         options=[
             {"option": "L*a*b*", "value": "L*a*b*"},

--- a/backend/src/nodes/properties/inputs/image_dropdown_inputs.py
+++ b/backend/src/nodes/properties/inputs/image_dropdown_inputs.py
@@ -4,65 +4,22 @@ import cv2
 from ...utils.image_utils import BorderType
 from ...utils.pil_utils import InterpolationMethod, RotateExpandCrop
 from ...utils.tile_util import TileMode
+from ...utils.color.convert_data import color_spaces
+from ..expression import named
 from .generic_inputs import DropDownInput
 
 
-def ColorModeInput() -> DropDownInput:
-    """Converting color mode dropdown"""
+def ColorSpaceInput(label: str = "Color Space") -> DropDownInput:
     return DropDownInput(
-        input_type="ColorMode",
-        label="Color Mode",
+        input_type="ColorSpace",
+        label=label,
         options=[
             {
-                "option": "RGB -> Gray",
-                "value": cv2.COLOR_BGR2GRAY,
-                "type": "ColorMode { inputChannels: 3, outputChannels: 1 }",
-            },
-            {
-                "option": "Gray -> RGB",
-                "value": cv2.COLOR_GRAY2BGR,
-                "type": "ColorMode { inputChannels: 1, outputChannels: 3 }",
-            },
-            {
-                "option": "RGB -> RGBA",
-                "value": cv2.COLOR_BGR2BGRA,
-                "type": "ColorMode { inputChannels: 3, outputChannels: 4 }",
-            },
-            {
-                "option": "RGBA -> RGB",
-                "value": cv2.COLOR_BGRA2BGR,
-                "type": "ColorMode { inputChannels: 4, outputChannels: 3 }",
-            },
-            {
-                "option": "RGBA -> Gray",
-                "value": cv2.COLOR_BGRA2GRAY,
-                "type": "ColorMode { inputChannels: 4, outputChannels: 1 }",
-            },
-            {
-                "option": "Gray -> RGBA",
-                "value": cv2.COLOR_GRAY2BGRA,
-                "type": "ColorMode { inputChannels: 1, outputChannels: 4 }",
-            },
-            {
-                "option": "RGB -> YUV",
-                "value": cv2.COLOR_BGR2YUV,
-                "type": "ColorMode { inputChannels: 3, outputChannels: 3 }",
-            },
-            {
-                "option": "YUV -> RGB",
-                "value": cv2.COLOR_YUV2BGR,
-                "type": "ColorMode { inputChannels: 3, outputChannels: 3 }",
-            },
-            {
-                "option": "RGB -> HSV",
-                "value": cv2.COLOR_BGR2HSV,
-                "type": "ColorMode { inputChannels: 3, outputChannels: 3 }",
-            },
-            {
-                "option": "HSV -> RGB",
-                "value": cv2.COLOR_HSV2BGR,
-                "type": "ColorMode { inputChannels: 3, outputChannels: 3 }",
-            },
+                "option": c.name,
+                "value": c.id,
+                "type": named("ColorSpace", {"channels": c.channels}),
+            }
+            for c in color_spaces
         ],
     )
 

--- a/backend/src/nodes/utils/color/convert.py
+++ b/backend/src/nodes/utils/color/convert.py
@@ -1,0 +1,116 @@
+from dataclasses import dataclass, field
+from typing import Callable, Dict, Generic, Iterable, List, Set, Tuple, TypeVar, Union
+import numpy as np
+from sanic.log import logger
+
+from .convert_data import conversions, color_spaces
+from .convert_model import (
+    ColorSpace,
+    Conversion,
+    assert_input_channels,
+    assert_output_channels,
+)
+
+
+def color_space_from_id(id: int) -> ColorSpace:
+    for c in color_spaces:
+        if c.id == id:
+            return c
+    raise ValueError(f"There is no color space with the id {id}.")
+
+
+T = TypeVar("T")
+
+
+@dataclass(order=True)
+class __ProcessingItem(Generic[T]):
+    cost: int
+    path: List[T] = field(compare=False)
+
+
+def get_shortest_path(
+    start: T,
+    is_destination: Callable[[T], bool],
+    get_next: Callable[[T], Iterable[Tuple[int, T]]],
+) -> Union[List[T], None]:
+    """A simple implementation of Dijkstra's"""
+
+    processed: Set[T] = set()
+    front: Dict[T, __ProcessingItem] = {
+        start: __ProcessingItem(cost=0, path=[start]),
+    }
+
+    while len(front) > 0:
+        min = None
+        for x in front.values():
+            if min is None:
+                min = x
+            elif x.cost < min.cost:
+                min = x
+        assert min is not None
+
+        current = min.path[-1]
+        del front[current]
+        processed.add(current)
+
+        if is_destination(current):
+            return min.path
+
+        for cost, to in get_next(current):
+            cost = min.cost + cost
+            old = front.get(to, None)
+            if old is None:
+                if to not in processed:
+                    new_path = min.path.copy()
+                    new_path.append(to)
+                    front[to] = __ProcessingItem(cost=cost, path=new_path)
+            else:
+                if old.cost > cost:
+                    old.cost = cost
+                    old.path.clear()
+                    old.path.extend(min.path)
+                    old.path.append(to)
+
+
+__conversions_map: Dict[ColorSpace, List[Conversion]] = {}
+for conv in conversions:
+    l = __conversions_map.get(conv.input, [])
+    if len(l) == 0:
+        __conversions_map[conv.input] = l
+    l.append(conv)
+
+
+def convert(img: np.ndarray, input: ColorSpace, output: ColorSpace) -> np.ndarray:
+    assert_input_channels(img, input, output)
+
+    if input == output:
+        return img
+
+    path = get_shortest_path(
+        input,
+        is_destination=lambda i: i == output,
+        get_next=lambda i: [(c.cost, c.output) for c in __conversions_map.get(i, [])],
+    )
+
+    if path is None:
+        raise ValueError(f"Conversion {input.name} -> {output.name} is not possible.")
+
+    logger.info(
+        f"Converting color using the path {' -> '.join(map(lambda x: x.name, path))}"
+    )
+
+    for i in range(1, len(path)):
+        curr_in = path[i - 1]
+        curr_out = path[i]
+
+        conv = None
+        for c in __conversions_map.get(curr_in, []):
+            if c.output == curr_out:
+                conv = c
+                break
+        assert conv is not None
+
+        img = conv.convert(img)
+
+    assert_output_channels(img, input, output)
+    return img

--- a/backend/src/nodes/utils/color/convert.py
+++ b/backend/src/nodes/utils/color/convert.py
@@ -41,34 +41,34 @@ def get_shortest_path(
     }
 
     while len(front) > 0:
-        min = None
+        best = None
         for x in front.values():
-            if min is None:
-                min = x
-            elif x.cost < min.cost:
-                min = x
-        assert min is not None
+            if best is None:
+                best = x
+            elif x.cost < best.cost:
+                best = x
+        assert best is not None
 
-        current = min.path[-1]
+        current = best.path[-1]
         del front[current]
         processed.add(current)
 
         if is_destination(current):
-            return min.path
+            return best.path
 
         for cost, to in get_next(current):
-            cost = min.cost + cost
+            cost = best.cost + cost
             old = front.get(to, None)
             if old is None:
                 if to not in processed:
-                    new_path = min.path.copy()
+                    new_path = best.path.copy()
                     new_path.append(to)
                     front[to] = __ProcessingItem(cost=cost, path=new_path)
             else:
                 if old.cost > cost:
                     old.cost = cost
                     old.path.clear()
-                    old.path.extend(min.path)
+                    old.path.extend(best.path)
                     old.path.append(to)
 
 

--- a/backend/src/nodes/utils/color/convert.py
+++ b/backend/src/nodes/utils/color/convert.py
@@ -12,11 +12,11 @@ from .convert_model import (
 )
 
 
-def color_space_from_id(id: int) -> ColorSpace:
+def color_space_from_id(id_: int) -> ColorSpace:
     for c in color_spaces:
-        if c.id == id:
+        if c.id == id_:
             return c
-    raise ValueError(f"There is no color space with the id {id}.")
+    raise ValueError(f"There is no color space with the id {id_}.")
 
 
 T = TypeVar("T")
@@ -73,27 +73,27 @@ def get_shortest_path(
 
 
 __conversions_map: Dict[ColorSpace, List[Conversion]] = {}
-for conv in conversions:
-    l = __conversions_map.get(conv.input, [])
+for conversion in conversions:
+    l = __conversions_map.get(conversion.input, [])
     if len(l) == 0:
-        __conversions_map[conv.input] = l
-    l.append(conv)
+        __conversions_map[conversion.input] = l
+    l.append(conversion)
 
 
-def convert(img: np.ndarray, input: ColorSpace, output: ColorSpace) -> np.ndarray:
-    assert_input_channels(img, input, output)
+def convert(img: np.ndarray, input_: ColorSpace, output: ColorSpace) -> np.ndarray:
+    assert_input_channels(img, input_, output)
 
-    if input == output:
+    if input_ == output:
         return img
 
     path = get_shortest_path(
-        input,
+        input_,
         is_destination=lambda i: i == output,
         get_next=lambda i: [(c.cost, c.output) for c in __conversions_map.get(i, [])],
     )
 
     if path is None:
-        raise ValueError(f"Conversion {input.name} -> {output.name} is not possible.")
+        raise ValueError(f"Conversion {input_.name} -> {output.name} is not possible.")
 
     logger.info(
         f"Converting color using the path {' -> '.join(map(lambda x: x.name, path))}"
@@ -112,5 +112,5 @@ def convert(img: np.ndarray, input: ColorSpace, output: ColorSpace) -> np.ndarra
 
         img = conv.convert(img)
 
-    assert_output_channels(img, input, output)
+    assert_output_channels(img, input_, output)
     return img

--- a/backend/src/nodes/utils/color/convert_data.py
+++ b/backend/src/nodes/utils/color/convert_data.py
@@ -1,0 +1,91 @@
+from typing import List
+import numpy as np
+import cv2
+
+from .convert_model import ColorSpace, Conversion
+from ..utils import get_h_w_c
+
+
+GRAY = ColorSpace(0, "Gray", 1)
+RGB = ColorSpace(1, "RGB", 3)
+RGBA = ColorSpace(2, "RGBA", 4)
+YUV = ColorSpace(3, "YUV", 3)
+HSV = ColorSpace(4, "HSV", 3)
+
+color_spaces = [RGB, RGBA, GRAY, YUV, HSV]
+
+
+def __rev3(image: np.ndarray) -> np.ndarray:
+    c = get_h_w_c(image)[2]
+    assert c == 3, "Expected a 3-channel image"
+    return np.stack([image[:, :, 2], image[:, :, 1], image[:, :, 0]], axis=2)
+
+
+def __rgb_to_hsv(img: np.ndarray) -> np.ndarray:
+    img = cv2.cvtColor(img, cv2.COLOR_BGR2HSV)
+    img[:, :, 0] /= 360  # type: ignore
+    return __rev3(img)
+
+
+def __hsv_to_rgb(img: np.ndarray) -> np.ndarray:
+    img = __rev3(img)
+    img[:, :, 0] *= 360
+    return cv2.cvtColor(img, cv2.COLOR_HSV2BGR)
+
+
+# The conversion loses one channel of information (e.g. the alpha channel, or a color channel)
+__CHANNEL_LOST = 1000
+# The conversion loses hue/chroma information in certain edge cases
+__CHROMA_LOST = 100
+
+
+conversions: List[Conversion] = [
+    # RGB and grayscale
+    Conversion(
+        direction=(RGB, GRAY),
+        convert=lambda i: cv2.cvtColor(i, cv2.COLOR_BGR2GRAY),
+        cost=__CHANNEL_LOST * 2,
+    ),
+    Conversion(
+        direction=(GRAY, RGB),
+        convert=lambda i: cv2.cvtColor(i, cv2.COLOR_GRAY2BGR),
+    ),
+    Conversion(
+        direction=(RGB, RGBA),
+        convert=lambda i: cv2.cvtColor(i, cv2.COLOR_BGR2BGRA),
+    ),
+    Conversion(
+        direction=(RGBA, RGB),
+        convert=lambda i: cv2.cvtColor(i, cv2.COLOR_BGRA2BGR),
+        cost=__CHANNEL_LOST,
+    ),
+    Conversion(
+        direction=(RGBA, GRAY),
+        convert=lambda i: cv2.cvtColor(i, cv2.COLOR_BGRA2GRAY),
+        cost=__CHANNEL_LOST * 3,
+    ),
+    Conversion(
+        direction=(GRAY, RGBA),
+        convert=lambda i: cv2.cvtColor(i, cv2.COLOR_GRAY2BGRA),
+    ),
+    # YUV
+    Conversion(
+        direction=(RGB, YUV),
+        convert=lambda i: __rev3(cv2.cvtColor(i, cv2.COLOR_BGR2YUV)),
+    ),
+    Conversion(
+        direction=(YUV, RGB),
+        convert=lambda i: cv2.cvtColor(__rev3(i), cv2.COLOR_YUV2BGR),
+        cost=__CHROMA_LOST,
+    ),
+    # HSV
+    Conversion(
+        direction=(RGB, HSV),
+        convert=__rgb_to_hsv,
+    ),
+    Conversion(
+        direction=(HSV, RGB),
+        convert=__hsv_to_rgb,
+        cost=__CHROMA_LOST,
+    ),
+]

--- a/backend/src/nodes/utils/color/convert_model.py
+++ b/backend/src/nodes/utils/color/convert_model.py
@@ -6,28 +6,28 @@ from ..utils import get_h_w_c
 
 
 class ColorSpace:
-    def __init__(self, id: int, name: str, channels: int):
-        assert 0 <= id and id < 256
-        self.id = id
+    def __init__(self, id_: int, name: str, channels: int):
+        assert 0 <= id_ and id_ < 256
+        self.id = id_
         self.name = name
         self.channels = channels
 
 
-def assert_input_channels(img: np.ndarray, input: ColorSpace, output: ColorSpace):
+def assert_input_channels(img: np.ndarray, input_: ColorSpace, output: ColorSpace):
     c = get_h_w_c(img)[2]
-    if c != input.channels:
+    if c != input_.channels:
         raise ValueError(
-            f"Expected the input image for a {input.name} -> {output.name} conversion"
-            f" to be {format_image_with_channels([input.channels])}"
+            f"Expected the input image for a {input_.name} -> {output.name} conversion"
+            f" to be {format_image_with_channels([input_.channels])}"
             f" but found {format_image_with_channels([c])}."
         )
 
 
-def assert_output_channels(result: np.ndarray, input: ColorSpace, output: ColorSpace):
+def assert_output_channels(result: np.ndarray, input_: ColorSpace, output: ColorSpace):
     c = get_h_w_c(result)[2]
     if c != output.channels:
         raise ValueError(
-            f"Expected the output image for a {input.name} -> {output.name} conversion"
+            f"Expected the output image for a {input_.name} -> {output.name} conversion"
             f" to be {format_image_with_channels([output.channels])}"
             f" but found {format_image_with_channels([c])}."
             f" This is an internal implementation error."
@@ -45,9 +45,9 @@ class Conversion:
         convert: ConvertFn,
         cost: int = 1,
     ):
-        input, output = direction
-        assert input != output
-        self.input: ColorSpace = input
+        input_, output = direction
+        assert input_ != output
+        self.input: ColorSpace = input_
         self.output: ColorSpace = output
         self.__convert = convert
         assert cost >= 1

--- a/backend/src/nodes/utils/color/convert_model.py
+++ b/backend/src/nodes/utils/color/convert_model.py
@@ -1,0 +1,60 @@
+from typing import Callable, Tuple
+import numpy as np
+
+from ..format import format_image_with_channels
+from ..utils import get_h_w_c
+
+
+class ColorSpace:
+    def __init__(self, id: int, name: str, channels: int):
+        assert 0 <= id and id < 256
+        self.id = id
+        self.name = name
+        self.channels = channels
+
+
+def assert_input_channels(img: np.ndarray, input: ColorSpace, output: ColorSpace):
+    c = get_h_w_c(img)[2]
+    if c != input.channels:
+        raise ValueError(
+            f"Expected the input image for a {input.name} -> {output.name} conversion"
+            f" to be {format_image_with_channels([input.channels])}"
+            f" but found {format_image_with_channels([c])}."
+        )
+
+
+def assert_output_channels(result: np.ndarray, input: ColorSpace, output: ColorSpace):
+    c = get_h_w_c(result)[2]
+    if c != output.channels:
+        raise ValueError(
+            f"Expected the output image for a {input.name} -> {output.name} conversion"
+            f" to be {format_image_with_channels([output.channels])}"
+            f" but found {format_image_with_channels([c])}."
+            f" This is an internal implementation error."
+            f" Please report this as a bug."
+        )
+
+
+ConvertFn = Callable[[np.ndarray], np.ndarray]
+
+
+class Conversion:
+    def __init__(
+        self,
+        direction: Tuple[ColorSpace, ColorSpace],
+        convert: ConvertFn,
+        cost: int = 1,
+    ):
+        input, output = direction
+        assert input != output
+        self.input: ColorSpace = input
+        self.output: ColorSpace = output
+        self.__convert = convert
+        assert cost >= 1
+        self.cost: int = cost
+
+    def convert(self, img: np.ndarray) -> np.ndarray:
+        assert_input_channels(img, self.input, self.output)
+        result = self.__convert(img)
+        assert_output_channels(result, self.input, self.output)
+        return result

--- a/src/common/migrations.js
+++ b/src/common/migrations.js
@@ -763,6 +763,37 @@ const brightnessImplementationChange = (data) => {
     return data;
 };
 
+const convertColorSpaceFromTo = (data) => {
+    const GRAY = 0;
+    const RGB = 1;
+    const RGBA = 2;
+    const YUV = 3;
+    const HSV = 4;
+
+    /** @type {Partial<Record<number, [number, number]>>} */
+    const mapping = {
+        6: [RGB, GRAY],
+        8: [GRAY, RGB],
+        0: [RGB, RGBA],
+        1: [RGBA, RGB],
+        10: [RGBA, GRAY],
+        9: [GRAY, RGBA],
+        82: [RGB, YUV],
+        84: [YUV, RGB],
+        40: [RGB, HSV],
+        54: [HSV, RGB],
+    };
+    data.nodes.forEach((node) => {
+        if (node.data.schemaId === 'chainner:image:change_colorspace') {
+            const [from, to] = mapping[node.data.inputData[1]] ?? [RGB, RGB];
+            node.data.inputData[1] = from;
+            node.data.inputData[2] = to;
+        }
+    });
+
+    return data;
+};
+
 // ==============
 
 const versionToMigration = (version) => {
@@ -803,6 +834,7 @@ const migrations = [
     removeTargetTileSize,
     addTargetTileSizeAgain,
     brightnessImplementationChange,
+    convertColorSpaceFromTo,
 ];
 
 export const currentMigration = migrations.length;

--- a/src/common/types/chainner-scope.ts
+++ b/src/common/types/chainner-scope.ts
@@ -58,8 +58,7 @@ struct AdaptiveMethod;
 struct AdaptiveThresholdType;
 struct BlendMode;
 struct CaptionPosition;
-struct ColorMode { inputChannels: 1 | 3 | 4, outputChannels: 1 | 3 | 4 }
-struct Colorspace;
+struct ColorSpace { channels: 1 | 3 | 4 }
 struct FillMethod;
 struct FlipAxis;
 struct GammaOption;
@@ -71,6 +70,7 @@ struct ReciprocalScalingFactor;
 struct RotateInterpolationMode;
 struct ThresholdType;
 struct TileMode;
+struct TransferColorspace;
 struct VideoType;
 
 enum Orientation { Horizontal, Vertical }

--- a/tests/common/__snapshots__/SaveFile.test.ts.snap
+++ b/tests/common/__snapshots__/SaveFile.test.ts.snap
@@ -2270,7 +2270,8 @@ Object {
       "data": Object {
         "id": "ad24cc0b-36ac-415f-9347-c6da40edec4e",
         "inputData": Object {
-          "1": 1,
+          "1": 2,
+          "2": 1,
         },
         "schemaId": "chainner:image:change_colorspace",
       },
@@ -5396,7 +5397,7 @@ Object {
 
 exports[`Write save file image-utilities.chn 1`] = `
 Object {
-  "checksum": "a7c4e684d6cfa3eb6a22c33238923ff2",
+  "checksum": "7d07b6fd8fc6799a5ec6bea0256d540b",
   "content": Object {
     "edges": Array [
       Object {
@@ -5647,7 +5648,8 @@ Object {
         "data": Object {
           "id": "ad24cc0b-36ac-415f-9347-c6da40edec4e",
           "inputData": Object {
-            "1": 1,
+            "1": 2,
+            "2": 1,
           },
           "schemaId": "chainner:image:change_colorspace",
         },


### PR DESCRIPTION
This replaces the old dropdown with 2 dropdowns where users can select a source and target color space. The `convert` method will then determine the best conversion path to arrive at the target color space.

![image](https://user-images.githubusercontent.com/20878432/195339165-344ca4c7-1025-4fc2-aa8d-f680f1c18d53.png)
![image](https://user-images.githubusercontent.com/20878432/195340062-d4424238-d36a-4c3a-abab-a7c8c44c895a.png)


Other changes:
- Added a migration for old chains.
- Renamed Transfer Color's "Colorspace" to "TransferColorspace".

---

It would be nice to simplify the dropdowns into something like this in the future.

![image](https://user-images.githubusercontent.com/20878432/195339912-018fbac3-a1ff-41d0-9ba3-cd7af125a27f.png)
