### PR TITLE
Added simple output validation

### DIFF
--- a/backend/src/nodes/properties/outputs/base_output.py
+++ b/backend/src/nodes/properties/outputs/base_output.py
@@ -46,3 +46,6 @@ class BaseOutput:
 
     def get_broadcast_data(self, _value):
         return None
+
+    def validate(self, value) -> None:
+        assert value is not None

--- a/backend/src/nodes/properties/outputs/file_outputs.py
+++ b/backend/src/nodes/properties/outputs/file_outputs.py
@@ -17,6 +17,9 @@ class FileOutput(BaseOutput):
     def get_broadcast_data(self, value: str):
         return value
 
+    def validate(self, value) -> None:
+        assert isinstance(value, str)
+
 
 def ImageFileOutput() -> FileOutput:
     """Output for saving a local image file"""

--- a/backend/src/nodes/properties/outputs/generic_outputs.py
+++ b/backend/src/nodes/properties/outputs/generic_outputs.py
@@ -2,9 +2,16 @@ from .base_output import BaseOutput, OutputKind
 from .. import expression
 
 
-def NumberOutput(label: str, output_type: expression.ExpressionJson = "number"):
-    """Output for arbitrary number"""
-    return BaseOutput(expression.intersect("number", output_type), label)
+class NumberOutput(BaseOutput):
+    def __init__(
+        self,
+        label: str,
+        output_type: expression.ExpressionJson = "number",
+    ):
+        super().__init__(expression.intersect("number", output_type), label)
+
+    def validate(self, value) -> None:
+        assert isinstance(value, (int, float))
 
 
 class TextOutput(BaseOutput):
@@ -18,3 +25,6 @@ class TextOutput(BaseOutput):
 
     def get_broadcast_data(self, value: str):
         return value
+
+    def validate(self, value) -> None:
+        assert isinstance(value, str)

--- a/backend/src/nodes/properties/outputs/numpy_outputs.py
+++ b/backend/src/nodes/properties/outputs/numpy_outputs.py
@@ -1,5 +1,7 @@
+from typing import List, Optional, Union
 import numpy as np
 
+from ...utils.format import format_image_with_channels
 from ...utils.image_utils import preview_encode
 from ...utils.utils import get_h_w_c
 from .base_output import BaseOutput, OutputKind
@@ -17,6 +19,9 @@ class NumPyOutput(BaseOutput):
         has_handle: bool = True,
     ):
         super().__init__(output_type, label, kind=kind, has_handle=has_handle)
+
+    def validate(self, value) -> None:
+        assert isinstance(value, np.ndarray)
 
 
 def AudioOutput():
@@ -53,6 +58,9 @@ class ImageOutput(NumPyOutput):
             "width": w,
             "channels": c,
         }
+
+    def validate(self, value) -> None:
+        assert isinstance(value, np.ndarray)
 
 
 class LargeImageOutput(ImageOutput):

--- a/backend/src/nodes/properties/outputs/numpy_outputs.py
+++ b/backend/src/nodes/properties/outputs/numpy_outputs.py
@@ -1,7 +1,5 @@
-from typing import List, Optional, Union
 import numpy as np
 
-from ...utils.format import format_image_with_channels
 from ...utils.image_utils import preview_encode
 from ...utils.utils import get_h_w_c
 from .base_output import BaseOutput, OutputKind

--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -56,6 +56,10 @@ def to_output(raw_output: Any, node: NodeBase) -> Output:
         if isinstance(o, np.ndarray):
             o.setflags(write=False)
 
+    # output-specific validations
+    for i, o in enumerate(node.outputs):
+        o.validate(output[i])
+
     return output
 
 


### PR DESCRIPTION
This PR adds the output validation I teased in #1085. Basically, each `BaseOutput` now has a `validate` method it can use to verify that the value returned by the node actually conforms to the guarantees of the output. Right now, they just do simple type checks, but even that is enough to catch certain bugs. We may wish to expand those checks in the future to ensure the correctness of our nodes as the code base grows.