### PR TITLE
New tiling options

### DIFF
--- a/backend/src/nodes/nodes/ncnn/upscale_image.py
+++ b/backend/src/nodes/nodes/ncnn/upscale_image.py
@@ -16,7 +16,8 @@ from ...properties.inputs import NcnnModelInput, ImageInput, TileSizeDropdown
 from ...properties.outputs import ImageOutput
 from ...properties import expression
 from ...utils.exec_options import get_execution_options
-from ...utils.auto_split import estimate_tile_size
+from ...utils.auto_split import MaxTileSize
+from ...utils.auto_split_tiles import estimate_tile_size, parse_tile_size_input
 from ...utils.ncnn_auto_split import ncnn_auto_split
 from ...utils.ncnn_model import NcnnModel
 from ...utils.ncnn_session import get_ncnn_net
@@ -73,20 +74,19 @@ class NcnnUpscaleImageNode(NodeBase):
         model: NcnnModel,
         input_name: str,
         output_name: str,
-        tile_size: Union[int, None],
+        tile_size: int,
     ):
         exec_options = get_execution_options()
         net = get_ncnn_net(model, exec_options)
         # Try/except block to catch errors
         try:
             vkdev = ncnn.get_gpu_device(exec_options.ncnn_gpu_index)
-            heap_budget = vkdev.get_heap_budget() * 1024 * 1024 * 0.8
 
-            max_tile_size = (
-                tile_size
-                if tile_size is not None
-                else estimate_tile_size(heap_budget, model.bin_length, img, 4)
-            )
+            def estimate():
+                heap_budget = vkdev.get_heap_budget() * 1024 * 1024 * 0.8
+                return MaxTileSize(
+                    estimate_tile_size(heap_budget, model.bin_length, img, 4)
+                )
 
             with ncnn_allocators(vkdev) as (
                 blob_vkallocator,
@@ -99,7 +99,7 @@ class NcnnUpscaleImageNode(NodeBase):
                     output_name=output_name,
                     blob_vkallocator=blob_vkallocator,
                     staging_vkallocator=staging_vkallocator,
-                    max_tile_size=max_tile_size,
+                    tiler=parse_tile_size_input(tile_size, estimate),
                 )
         except (RuntimeError, ValueError):
             raise
@@ -122,7 +122,7 @@ class NcnnUpscaleImageNode(NodeBase):
                 model,
                 model.layer_list[0].outputs[0],
                 model.layer_list[-1].outputs[0],
-                tile_size if tile_size > 0 else None,
+                tile_size,
             )
             if ic == 3:
                 i = cv2.cvtColor(i, cv2.COLOR_RGB2BGR)

--- a/backend/src/nodes/properties/inputs/generic_inputs.py
+++ b/backend/src/nodes/properties/inputs/generic_inputs.py
@@ -332,10 +332,14 @@ def FillColorDropdown() -> DropDownInput:
     )
 
 
-def TileSizeDropdown(label="Tile Size") -> DropDownInput:
-    options = [
-        {"option": "Auto", "value": 0},
-    ]
+def TileSizeDropdown(label="Tile Size", estimate=True) -> DropDownInput:
+    options = []
+    if estimate:
+        options.append({"option": "Auto (estimate)", "value": 0})
+
+    options.append({"option": "Maximum", "value": 2**31})
+    options.append({"option": "No Tiling", "value": -1})
+
     for size in [128, 192, 256, 384, 512, 768, 1024, 2048, 4096]:
         options.append({"option": str(size), "value": size})
 

--- a/backend/src/nodes/utils/auto_split.py
+++ b/backend/src/nodes/utils/auto_split.py
@@ -32,7 +32,7 @@ class NoTiling(Tiler):
 
 
 class MaxTileSize(Tiler):
-    def __init__(self, tile_size: int) -> None:
+    def __init__(self, tile_size: int = 2**31) -> None:
         self.tile_size: int = tile_size
 
     def starting_tile_size(self, width: int, height: int, _channels: int) -> int:
@@ -179,28 +179,3 @@ def auto_split(
 
     assert result is not None
     return result
-
-
-def estimate_tile_size(
-    budget: int,
-    model_size: int,
-    img: np.ndarray,
-    img_element_size: int = 4,
-) -> int:
-    h, w, c = get_h_w_c(img)
-    img_bytes = h * w * c * img_element_size
-    mem_required_estimation = (model_size / (1024 * 52)) * img_bytes
-
-    tile_pixels = w * h * budget / mem_required_estimation
-    # the largest power-of-2 tile_size such that tile_size**2 < tile_pixels
-    tile_size = 2 ** (int(tile_pixels**0.5).bit_length() - 1)
-
-    GB_AMT = 1024**3
-    required_mem = f"{mem_required_estimation/GB_AMT:.2f}"
-    budget_mem = f"{budget/GB_AMT:.2f}"
-    logger.info(
-        f"Estimating memory required: {required_mem} GB, {budget_mem} GB free."
-        f" Estimated tile size: {tile_size}"
-    )
-
-    return tile_size

--- a/backend/src/nodes/utils/auto_split_tiles.py
+++ b/backend/src/nodes/utils/auto_split_tiles.py
@@ -1,0 +1,41 @@
+from typing import Callable
+import numpy as np
+from sanic.log import logger
+
+from .utils import get_h_w_c
+from .auto_split import Tiler, MaxTileSize, NoTiling
+
+
+def estimate_tile_size(
+    budget: int,
+    model_size: int,
+    img: np.ndarray,
+    img_element_size: int = 4,
+) -> int:
+    h, w, c = get_h_w_c(img)
+    img_bytes = h * w * c * img_element_size
+    mem_required_estimation = (model_size / (1024 * 52)) * img_bytes
+
+    tile_pixels = w * h * budget / mem_required_estimation
+    # the largest power-of-2 tile_size such that tile_size**2 < tile_pixels
+    tile_size = 2 ** (int(tile_pixels**0.5).bit_length() - 1)
+
+    GB_AMT = 1024**3
+    required_mem = f"{mem_required_estimation/GB_AMT:.2f}"
+    budget_mem = f"{budget/GB_AMT:.2f}"
+    logger.info(
+        f"Estimating memory required: {required_mem} GB, {budget_mem} GB free."
+        f" Estimated tile size: {tile_size}"
+    )
+
+    return tile_size
+
+
+def parse_tile_size_input(tile_size: int, estimate: Callable[[], Tiler]) -> Tiler:
+    if tile_size == 0:
+        return estimate()
+    if tile_size == -1:
+        return NoTiling()
+
+    assert tile_size > 0
+    return MaxTileSize(tile_size)

--- a/backend/src/nodes/utils/ncnn_auto_split.py
+++ b/backend/src/nodes/utils/ncnn_auto_split.py
@@ -93,4 +93,4 @@ def ncnn_auto_split(
                 # Re-raise the exception if not an OOM error
                 raise
 
-    return auto_split(img, upscale, tiling_mode)
+    return auto_split(img, upscale, tiler)

--- a/backend/src/nodes/utils/ncnn_auto_split.py
+++ b/backend/src/nodes/utils/ncnn_auto_split.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import gc
-from typing import Union
 
 import numpy as np
 from ncnn_vulkan import ncnn
 from sanic.log import logger
 
-from .auto_split import auto_split, Split
+from .auto_split import auto_split, Split, Tiler
 from .utils import get_h_w_c
 
 
@@ -33,7 +32,7 @@ def ncnn_auto_split(
     output_name: str,
     blob_vkallocator,
     staging_vkallocator,
-    max_tile_size: Union[int, None] = None,
+    tiler: Tiler,
 ) -> np.ndarray:
     def upscale(img: np.ndarray):
         ex = net.create_extractor()
@@ -79,4 +78,4 @@ def ncnn_auto_split(
                 # Re-raise the exception if not an OOM error
                 raise
 
-    return auto_split(img, upscale, max_tile_size)
+    return auto_split(img, upscale, tiling_mode)

--- a/backend/src/nodes/utils/onnx_auto_split.py
+++ b/backend/src/nodes/utils/onnx_auto_split.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 import gc
-from typing import Union
 
 import numpy as np
 import onnxruntime as ort
 
-from .auto_split import auto_split
+from .auto_split import auto_split, Tiler
 from .utils import np2nptensor, nptensor2np
 
 
@@ -14,7 +13,7 @@ def onnx_auto_split(
     img: np.ndarray,
     session: ort.InferenceSession,
     change_shape: bool,
-    max_tile_size: Union[int, None] = None,
+    tiler: Tiler,
 ) -> np.ndarray:
     input_name = session.get_inputs()[0].name
     output_name = session.get_outputs()[0].name
@@ -52,6 +51,6 @@ def onnx_auto_split(
                 raise
 
     try:
-        return auto_split(img, upscale, max_tile_size)
+        return auto_split(img, upscale, tiling_mode)
     finally:
         gc.collect()

--- a/backend/src/nodes/utils/onnx_auto_split.py
+++ b/backend/src/nodes/utils/onnx_auto_split.py
@@ -51,6 +51,6 @@ def onnx_auto_split(
                 raise
 
     try:
-        return auto_split(img, upscale, tiling_mode)
+        return auto_split(img, upscale, tiler)
     finally:
         gc.collect()

--- a/backend/src/nodes/utils/pytorch_auto_split.py
+++ b/backend/src/nodes/utils/pytorch_auto_split.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import gc
-from typing import Union
 
 import torch
 import numpy as np
 
 from .torch_types import PyTorchModel
 
-from .auto_split import auto_split, Split
+from .auto_split import auto_split, Split, Tiler
 from .pytorch_utils import tensor2np, np2tensor
 
 
@@ -18,7 +17,7 @@ def pytorch_auto_split(
     model: PyTorchModel,
     device: torch.device,
     use_fp16: bool,
-    max_tile_size: Union[int, None] = None,
+    tiler: Tiler,
 ) -> np.ndarray:
     model = model.to(device)
     model = model.half() if use_fp16 else model.float()
@@ -55,7 +54,7 @@ def pytorch_auto_split(
                 raise
 
     try:
-        return auto_split(img, upscale, max_tile_size)
+        return auto_split(img, upscale, tiling_mode)
     finally:
         del model
         del device

--- a/backend/src/nodes/utils/pytorch_auto_split.py
+++ b/backend/src/nodes/utils/pytorch_auto_split.py
@@ -54,7 +54,7 @@ def pytorch_auto_split(
                 raise
 
     try:
-        return auto_split(img, upscale, tiling_mode)
+        return auto_split(img, upscale, tiler)
     finally:
         del model
         del device


### PR DESCRIPTION
This implements the tiling options we've been talking about on discord.

The main new abstraction is a `Tiler` (I'm not too keen on the name btw). This interface defines (1) the initial tile size and (2) how splits are implemented (=how the tile size decreases).  This makes it trivial to implement something like a no tiling mode. The interface will also allow us to implement tile size memorization.

![image](https://user-images.githubusercontent.com/20878432/195663919-54cb7284-ed70-4356-b8e0-127e10773603.png)

Notes:
- I implemented the "Maximum" as just a very large tile size (2**31).
- If CUDA isn't available, pytorch will default to "Maximum" in "Auto (estimate)" mode.
- Since the Tile Size dropdown now contains 2 magic numbers, I added a method to parse this number into a tiler.
