### PR TITLE
Updated Navi and used newly exported functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPLv3",
       "dependencies": {
         "@babel/plugin-transform-react-jsx": "^7.17.12",
-        "@chainner/navi": "^0.1.0",
+        "@chainner/navi": "^0.2.0",
         "@chakra-ui/icons": "^2.0.11",
         "@chakra-ui/react": "^2.3.5",
         "@emotion/react": "^11.9.0",
@@ -858,9 +858,9 @@
       "dev": true
     },
     "node_modules/@chainner/navi": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@chainner/navi/-/navi-0.1.0.tgz",
-      "integrity": "sha512-esLeO6UiaKqqfjYggMo3BrUyXizZtQK78qks0dAlGnOEt5HAdoqvIigvK4TIFBjrEGYNsyQNHHaFZwQfkuv4Hw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@chainner/navi/-/navi-0.2.0.tgz",
+      "integrity": "sha512-nn67Oiib/Z3YToharJ/mRpEKJ6TMr5sbjGGuyNon3L1NfiN4lYNVPTb7OydrUHRDGtqgRq7Xcp7IVJJSwvCiFw==",
       "dependencies": {
         "antlr4": "^4.11.0"
       }
@@ -26311,9 +26311,9 @@
       "dev": true
     },
     "@chainner/navi": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@chainner/navi/-/navi-0.1.0.tgz",
-      "integrity": "sha512-esLeO6UiaKqqfjYggMo3BrUyXizZtQK78qks0dAlGnOEt5HAdoqvIigvK4TIFBjrEGYNsyQNHHaFZwQfkuv4Hw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@chainner/navi/-/navi-0.2.0.tgz",
+      "integrity": "sha512-nn67Oiib/Z3YToharJ/mRpEKJ6TMr5sbjGGuyNon3L1NfiN4lYNVPTb7OydrUHRDGtqgRq7Xcp7IVJJSwvCiFw==",
       "requires": {
         "antlr4": "^4.11.0"
       }

--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
   },
   "dependencies": {
     "@babel/plugin-transform-react-jsx": "^7.17.12",
-    "@chainner/navi": "^0.1.0",
+    "@chainner/navi": "^0.2.0",
     "@chakra-ui/icons": "^2.0.11",
     "@chakra-ui/react": "^2.3.5",
     "@emotion/react": "^11.9.0",


### PR DESCRIPTION
The new stuff is mainly for built-in functions. v0.2.0 also includes support for type assertions, so you can now write `let foo: int = bar();` to write more correct types.