### PR TITLE
Replace current video functionality with FFMPEG

### DIFF
--- a/backend/src/nodes/nodes/image/video_frame_iterator.py
+++ b/backend/src/nodes/nodes/image/video_frame_iterator.py
@@ -21,6 +21,7 @@ from ...properties.inputs import (
     VideoFileInput,
 )
 from ...properties.outputs import ImageOutput, NumberOutput, TextOutput, DirectoryOutput
+from ...properties import expression
 from ...utils.image_utils import normalize
 from ...utils.utils import get_h_w_c
 
@@ -45,7 +46,13 @@ class VideoFrameIteratorFrameLoaderNode(NodeBase):
         self.description = ""
         self.inputs = [IteratorInput().make_optional()]
         self.outputs = [
-            ImageOutput("Frame Image", broadcast_type=True),
+            ImageOutput(
+                "Frame Image",
+                image_type=expression.Image(
+                    channels=3,
+                ),
+                broadcast_type=True,
+            ),
             NumberOutput("Frame Index"),
             DirectoryOutput("Video Directory"),
             TextOutput("Video Name"),
@@ -191,7 +198,6 @@ class SimpleVideoFrameIteratorNode(IteratorNodeBase):
         context.inputs.set_append_values(output_node_id, [writer, fps])
 
         def before(_: int, index: int):
-            # TODO: Determine if it's true that video will always be 3-channel
             in_bytes = ffmpeg_reader.stdout.read(width * height * 3)
             if not in_bytes:
                 print("Can't receive frame (stream end?). Exiting ...")

--- a/backend/src/nodes/nodes/image/video_frame_iterator.py
+++ b/backend/src/nodes/nodes/image/video_frame_iterator.py
@@ -111,11 +111,9 @@ class VideoFrameIteratorFrameWriterNode(NodeBase):
                         format="rawvideo",
                         pix_fmt="rgb24",
                         s=f"{w}x{h}",
-                        # f=video_type,
                         r=fps,
-                        # movflags="faststart",
                     )
-                    .output(video_save_path, pix_fmt="yuv420p")
+                    .output(video_save_path, pix_fmt="yuv420p", r=fps, crf=0)
                     .overwrite_output()
                     .run_async(pipe_stdin=True)
                 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 appdirs
 black
 facexlib
+ffmpeg-python
 ncnn_vulkan
 numpy
 onnx
@@ -16,5 +17,6 @@ pytest
 pywin32 ; sys_platform=="win32"
 sanic
 sanic_cors
+static_ffmpeg
 torch
 torchvision

--- a/src/common/dependencies.ts
+++ b/src/common/dependencies.ts
@@ -116,6 +116,21 @@ export const requiredDependencies: Dependency[] = [
         name: 'appdirs',
         packages: [{ packageName: 'appdirs', version: '1.4.4', sizeEstimate: 13.5 * KB }],
     },
+    {
+        name: 'FFMPEG',
+        packages: [
+            {
+                packageName: 'ffmpeg-python',
+                version: '0.2.0',
+                sizeEstimate: 25 * KB,
+            },
+            {
+                packageName: 'static-ffmpeg',
+                version: '2.3.0',
+                sizeEstimate: 7 * KB,
+            },
+        ],
+    },
 ];
 
 if (isMac && !isM1) {


### PR DESCRIPTION
This is a drop-in replacement of the existing video functionality. No changes to any node schemas have been made.

This PR adds two more dependencies: `ffmpeg-python` and `static-ffmpeg`. `static-ffmpeg` will only be used if ffmpeg is not installed on the system, otherwise it will use the system's ffmpeg. 

This PR should resolve any issues with codecs being unavailable during video processing. Hopefully, no new issues will be introduced by this. One unfortunate thing is that we are unable to run this in "quiet" mode due to [this issue](https://github.com/kkroening/ffmpeg-python/issues/195), so this will spam our logs a bit during processing. As far as I know there is no way to avoid this.

More video formats, codec selection, and other stuff can be added in a future PR.

Side note, apparently AVI sucks as an ffmpeg format, so we should consider removing it

Closes #823