### PR TITLE
Add more encoding options to video frame iterator

### DIFF
--- a/backend/src/nodes/nodes/image/video_frame_iterator.py
+++ b/backend/src/nodes/nodes/image/video_frame_iterator.py
@@ -19,6 +19,8 @@ from ...properties.inputs import (
     TextInput,
     VideoTypeDropdown,
     VideoFileInput,
+    VideoPresetDropdown,
+    SliderInput,
 )
 from ...properties.outputs import ImageOutput, NumberOutput, TextOutput, DirectoryOutput
 from ...utils.image_utils import normalize
@@ -76,6 +78,17 @@ class VideoFrameIteratorFrameWriterNode(NodeBase):
             DirectoryInput("Output Video Directory"),
             TextInput("Output Video Name"),
             VideoTypeDropdown(),
+            VideoPresetDropdown(),
+            SliderInput(
+                "Quality (CRF)",
+                precision=0,
+                controls_step=1,
+                slider_step=1,
+                minimum=0,
+                maximum=51,
+                default=0,
+                ends=("100%", "0%"),
+            ),
         ]
         self.outputs = []
 
@@ -94,6 +107,8 @@ class VideoFrameIteratorFrameWriterNode(NodeBase):
         save_dir: str,
         video_name: str,
         video_type: str,
+        video_preset: str,
+        crf: int,
         writer,
         fps: float,
     ) -> None:
@@ -113,7 +128,13 @@ class VideoFrameIteratorFrameWriterNode(NodeBase):
                         s=f"{w}x{h}",
                         r=fps,
                     )
-                    .output(video_save_path, pix_fmt="yuv420p", r=fps, crf=0)
+                    .output(
+                        video_save_path,
+                        pix_fmt="yuv420p",
+                        r=fps,
+                        crf=crf,
+                        preset=video_preset if video_preset != "none" else None,
+                    )
                     .overwrite_output()
                     .run_async(pipe_stdin=True)
                 )

--- a/backend/src/nodes/nodes/image/video_frame_iterator.py
+++ b/backend/src/nodes/nodes/image/video_frame_iterator.py
@@ -87,7 +87,7 @@ class VideoFrameIteratorFrameWriterNode(NodeBase):
                 minimum=0,
                 maximum=51,
                 default=0,
-                ends=("100%", "0%"),
+                ends=("Best", "Worst"),
             ),
         ]
         self.outputs = []

--- a/backend/src/nodes/properties/inputs/generic_inputs.py
+++ b/backend/src/nodes/properties/inputs/generic_inputs.py
@@ -223,8 +223,28 @@ def VideoTypeDropdown() -> DropDownInput:
         label="Video Type",
         options=[
             {"option": "MP4", "value": "mp4"},
+            {"option": "MKV", "value": "mkv"},
+            {"option": "Webm", "value": "webm"},
             {"option": "AVI", "value": "avi"},
             {"option": "None", "value": "none"},
+        ],
+    )
+
+
+def VideoPresetDropdown() -> DropDownInput:
+    """Video Type option dropdown"""
+    return DropDownInput(
+        input_type="VideoPreset",
+        label="Preset",
+        options=[
+            {"option": "ultrafast", "value": "ultrafast"},
+            {"option": "superfast", "value": "superfast"},
+            {"option": "veryfast", "value": "veryfast"},
+            {"option": "fast", "value": "fast"},
+            {"option": "medium", "value": "medium"},
+            {"option": "slow", "value": "slow"},
+            {"option": "slower", "value": "slower"},
+            {"option": "veryslow", "value": "veryslow"},
         ],
     )
 

--- a/src/common/types/chainner-scope.ts
+++ b/src/common/types/chainner-scope.ts
@@ -73,6 +73,7 @@ struct ThresholdType;
 struct TileMode;
 struct TransferColorspace;
 struct VideoType;
+struct VideoPreset;
 
 enum BorderType { ReflectMirror, Wrap, Replicate, Black, Transparent }
 enum FillColor { Auto, Black, Transparent }


### PR DESCRIPTION
Adds MKV and Webm as types. Also adds the encoding presets as well as a CRF slider

![image](https://user-images.githubusercontent.com/34788790/196583263-87925614-30b7-4083-b902-50cc494d9f3c.png)
