### PR TITLE
Use while/break instead of for loop for video iterator

### DIFF
--- a/backend/src/nodes/nodes/image/video_frame_iterator.py
+++ b/backend/src/nodes/nodes/image/video_frame_iterator.py
@@ -213,7 +213,7 @@ class SimpleVideoFrameIteratorNode(IteratorNodeBase):
 
         context.inputs.set_append_values(output_node_id, [writer, fps])
 
-        def before(_: int, index: int):
+        def before(index: int):
             in_bytes = ffmpeg_reader.stdout.read(width * height * 3)
             if not in_bytes:
                 print("Can't receive frame (stream end?). Exiting ...")
@@ -225,4 +225,4 @@ class SimpleVideoFrameIteratorNode(IteratorNodeBase):
                 input_node_id, [in_frame, index, video_dir, video_name]
             )
 
-        await context.run(range(frame_count), before)
+        await context.run_while(frame_count, before)

--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -179,9 +179,9 @@ class IteratorContext:
             try:
                 await self.progress.suspend()
 
-                if index < length_estimate:
-                    index += 1
-                else:
+                index += 1
+
+                if index > length_estimate:
                     length_estimate = int(length_estimate * 1.1)
 
                 result = before(index)

--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -181,15 +181,13 @@ class IteratorContext:
 
                 index += 1
 
-                if index > length_estimate:
-                    length_estimate = int(length_estimate * 1.1)
-
                 result = before(index)
                 if result is False:
                     break
 
-                await self.run_iteration(index, length_estimate)
-
+                await self.run_iteration(
+                    min(index, length_estimate - 1), length_estimate
+                )
             except Aborted:
                 raise
             except Exception as e:


### PR DESCRIPTION
Relies on reading the stream until its end rather than on the frame count. The frame count of a video can be inaccurate as it's just metadata encoded onto a video rather than an actual computed value. It is however a good enough estimate that we can still use it for progress. 