### PR TITLE
Replace most "info" logs with "debug" logs

### DIFF
--- a/backend/src/chain/optimize.py
+++ b/backend/src/chain/optimize.py
@@ -30,7 +30,7 @@ def __outline_child_nodes(chain: Chain) -> bool:
             if can_outline:
                 node.parent = None
                 changed = True
-                logger.info(
+                logger.debug(
                     f"Chain optimization: Outlined {node.schema_id} node {node.id}"
                 )
 
@@ -48,7 +48,7 @@ def __removed_dead_nodes(chain: Chain) -> bool:
         if is_dead:
             chain.remove_node(node.id)
             changed = True
-            logger.info(f"Chain optimization: Removed {node.schema_id} node {node.id}")
+            logger.debug(f"Chain optimization: Removed {node.schema_id} node {node.id}")
 
     return changed
 

--- a/backend/src/nodes/nodes/image/image_file_iterator.py
+++ b/backend/src/nodes/nodes/image/image_file_iterator.py
@@ -78,7 +78,7 @@ class ImageFileIteratorNode(IteratorNodeBase):
 
     # pylint: disable=invalid-overridden-method
     async def run(self, directory: str, context: IteratorContext) -> None:
-        logger.info(f"Iterating over images in directory: {directory}")
+        logger.debug(f"Iterating over images in directory: {directory}")
 
         img_path_node_id = context.get_helper(IMAGE_ITERATOR_NODE_ID).id
 

--- a/backend/src/nodes/nodes/image/video_frame_iterator.py
+++ b/backend/src/nodes/nodes/image/video_frame_iterator.py
@@ -188,7 +188,7 @@ class SimpleVideoFrameIteratorNode(IteratorNodeBase):
 
     # pylint: disable=invalid-overridden-method
     async def run(self, path: str, context: IteratorContext) -> None:
-        logger.info(f"Iterating over frames in video file: {path}")
+        logger.debug(f"Iterating over frames in video file: {path}")
 
         input_node_id = context.get_helper(VIDEO_ITERATOR_INPUT_NODE_ID).id
         output_node_id = context.get_helper(VIDEO_ITERATOR_OUTPUT_NODE_ID).id

--- a/backend/src/nodes/nodes/image_adjustment/threshold.py
+++ b/backend/src/nodes/nodes/image_adjustment/threshold.py
@@ -45,12 +45,12 @@ class ThresholdNode(NodeBase):
     ) -> np.ndarray:
         """Takes an image and applies a threshold to it"""
 
-        logger.info(f"thresh {thresh}, maxval {maxval}, type {thresh_type}")
+        logger.debug(f"thresh {thresh}, maxval {maxval}, type {thresh_type}")
 
         real_thresh = thresh / 100
         real_maxval = maxval / 100
 
-        logger.info(f"real_thresh {real_thresh}, real_maxval {real_maxval}")
+        logger.debug(f"real_thresh {real_thresh}, real_maxval {real_maxval}")
 
         _, result = cv2.threshold(img, real_thresh, real_maxval, thresh_type)
 

--- a/backend/src/nodes/nodes/image_channel/transprency_merge.py
+++ b/backend/src/nodes/nodes/image_channel/transprency_merge.py
@@ -41,10 +41,10 @@ class TransparencyMergeNode(NodeBase):
         """Combine separate channels into a multi-chanel image"""
 
         start_shape = rgb.shape[:2]
-        logger.info(start_shape)
+        logger.debug(start_shape)
 
         for im in rgb, a:
-            logger.info(im.shape[:2])
+            logger.debug(im.shape[:2])
             assert (
                 im.shape[:2] == start_shape
             ), "All images to be merged must be the same resolution"
@@ -64,7 +64,7 @@ class TransparencyMergeNode(NodeBase):
 
         imgs = [rgb, a]
         for img in imgs:
-            logger.info(img.shape)
+            logger.debug(img.shape)
         img = np.concatenate(imgs, axis=2)
 
         return img

--- a/backend/src/nodes/nodes/image_dimension/resize_factor.py
+++ b/backend/src/nodes/nodes/image_dimension/resize_factor.py
@@ -49,7 +49,7 @@ class ImResizeByFactorNode(NodeBase):
     def run(self, img: np.ndarray, scale: float, interpolation: int) -> np.ndarray:
         """Takes an image and resizes it"""
 
-        logger.info(f"Resizing image by {scale} via {interpolation}")
+        logger.debug(f"Resizing image by {scale} via {interpolation}")
 
         h, w, _ = get_h_w_c(img)
         out_dims = (

--- a/backend/src/nodes/nodes/image_dimension/resize_resolution.py
+++ b/backend/src/nodes/nodes/image_dimension/resize_resolution.py
@@ -45,7 +45,7 @@ class ImResizeToResolutionNode(NodeBase):
     ) -> np.ndarray:
         """Takes an image and resizes it"""
 
-        logger.info(f"Resizing image to {width}x{height} via {interpolation}")
+        logger.debug(f"Resizing image to {width}x{height} via {interpolation}")
 
         out_dims = (width, height)
 

--- a/backend/src/nodes/nodes/image_dimension/resize_to_side.py
+++ b/backend/src/nodes/nodes/image_dimension/resize_to_side.py
@@ -113,7 +113,7 @@ class ImResizeToSide(NodeBase):
     ) -> np.ndarray:
         """Takes an image and resizes it"""
 
-        logger.info(f"Resizing image to {side} via {interpolation}")
+        logger.debug(f"Resizing image to {side} via {interpolation}")
 
         h, w, _ = get_h_w_c(img)
         out_dims = resize_to_side_conditional(w, h, target, side, condition)

--- a/backend/src/nodes/nodes/ncnn/save_model.py
+++ b/backend/src/nodes/nodes/ncnn/save_model.py
@@ -35,6 +35,6 @@ class NcnnSaveNode(NodeBase):
         full_bin_path = os.path.join(directory, full_bin)
         full_param_path = os.path.join(directory, full_param)
 
-        logger.info(f"Writing NCNN model to paths: {full_bin_path} {full_param_path}")
+        logger.debug(f"Writing NCNN model to paths: {full_bin_path} {full_param_path}")
         net.write_bin(full_bin_path)
         net.write_param(full_param_path)

--- a/backend/src/nodes/nodes/onnx/interpolate_models.py
+++ b/backend/src/nodes/nodes/onnx/interpolate_models.py
@@ -114,7 +114,7 @@ class OnnxInterpolateModelsNode(NodeBase):
             model_b_weights
         ), "Models must have same number of weights"
 
-        logger.info(f"Interpolating models...")
+        logger.debug(f"Interpolating models...")
         interp_weights_list = self.perform_interp(
             model_a_weights, model_b_weights, amount
         )

--- a/backend/src/nodes/nodes/onnx/load_model.py
+++ b/backend/src/nodes/nodes/onnx/load_model.py
@@ -43,7 +43,7 @@ class OnnxLoadModelNode(NodeBase):
 
         assert os.path.isfile(path), f"Path {path} is not a file"
 
-        logger.info(f"Reading onnx model from path: {path}")
+        logger.debug(f"Reading onnx model from path: {path}")
         model = onnx.load_model(path)
 
         model_as_string = model.SerializeToString()  # type: ignore

--- a/backend/src/nodes/nodes/onnx/save_model.py
+++ b/backend/src/nodes/nodes/onnx/save_model.py
@@ -33,6 +33,6 @@ class OnnxSaveModelNode(NodeBase):
 
     def run(self, model: OnnxModel, directory: str, model_name: str) -> None:
         full_path = f"{os.path.join(directory, model_name)}.onnx"
-        logger.info(f"Writing file to path: {full_path}")
+        logger.debug(f"Writing file to path: {full_path}")
         with open(full_path, "wb") as f:
             f.write(model.bytes)

--- a/backend/src/nodes/nodes/onnx/upscale_image.py
+++ b/backend/src/nodes/nodes/onnx/upscale_image.py
@@ -49,7 +49,7 @@ class OnnxImageUpscaleNode(NodeBase):
         tile_size: TileSize,
         change_shape: bool,
     ) -> np.ndarray:
-        logger.info("Upscaling image")
+        logger.debug("Upscaling image")
 
         def estimate():
             raise ValueError

--- a/backend/src/nodes/nodes/pytorch/interpolate_models.py
+++ b/backend/src/nodes/nodes/pytorch/interpolate_models.py
@@ -97,7 +97,7 @@ class InterpolateNode(NodeBase):
         state_a = model_a.state
         state_b = model_b.state
 
-        logger.info(f"Interpolating models...")
+        logger.debug(f"Interpolating models...")
         if not self.check_can_interp(state_a, state_b):
             raise ValueError(
                 "These models are not compatible and not able to be interpolated together"

--- a/backend/src/nodes/nodes/pytorch/load_model.py
+++ b/backend/src/nodes/nodes/pytorch/load_model.py
@@ -48,7 +48,7 @@ class LoadModelNode(NodeBase):
         exec_options = to_pytorch_execution_options(get_execution_options())
 
         try:
-            logger.info(f"Reading state dict from path: {path}")
+            logger.debug(f"Reading state dict from path: {path}")
             state_dict = torch.load(
                 path, map_location=torch.device(exec_options.device)
             )

--- a/backend/src/nodes/nodes/pytorch/model_file_iterator.py
+++ b/backend/src/nodes/nodes/pytorch/model_file_iterator.py
@@ -70,7 +70,7 @@ class ModelFileIteratorNode(IteratorNodeBase):
 
     # pylint: disable=invalid-overridden-method
     async def run(self, directory: str, context: IteratorContext) -> None:
-        logger.info(f"Iterating over models in directory: {directory}")
+        logger.debug(f"Iterating over models in directory: {directory}")
 
         model_path_node_id = context.get_helper(PYTORCH_ITERATOR_NODE_ID).id
 

--- a/backend/src/nodes/nodes/pytorch/save_model.py
+++ b/backend/src/nodes/nodes/pytorch/save_model.py
@@ -34,5 +34,5 @@ class PthSaveNode(NodeBase):
     def run(self, model: PyTorchModel, directory: str, name: str) -> None:
         full_file = f"{name}.pth"
         full_path = os.path.join(directory, full_file)
-        logger.info(f"Writing model to path: {full_path}")
+        logger.debug(f"Writing model to path: {full_path}")
         torch.save(model.state, full_path)

--- a/backend/src/nodes/utils/color/convert.py
+++ b/backend/src/nodes/utils/color/convert.py
@@ -95,7 +95,7 @@ def convert(img: np.ndarray, input_: ColorSpace, output: ColorSpace) -> np.ndarr
     if path is None:
         raise ValueError(f"Conversion {input_.name} -> {output.name} is not possible.")
 
-    logger.info(
+    logger.debug(
         f"Converting color using the path {' -> '.join(map(lambda x: x.name, path))}"
     )
 

--- a/backend/src/nodes/utils/exec_options.py
+++ b/backend/src/nodes/utils/exec_options.py
@@ -50,7 +50,7 @@ __global_exec_options = ExecutionOptions("cpu", False, 0, 0, 0, "CPUExecutionPro
 
 def get_execution_options() -> ExecutionOptions:
     logger.info(
-        f"Execution options: fp16: {__global_exec_options.fp16}, device: {__global_exec_options.device}"
+        f"PyTorch execution options: fp16: {__global_exec_options.fp16}, device: {__global_exec_options.device} | NCNN execution options: gpu_index: {__global_exec_options.ncnn_gpu_index} | ONNX execution options: gpu_index: {__global_exec_options.onnx_gpu_index}, execution_provider: {__global_exec_options.onnx_execution_provider}"
     )
     return __global_exec_options
 

--- a/backend/src/nodes/utils/ncnn_auto_split.py
+++ b/backend/src/nodes/utils/ncnn_auto_split.py
@@ -82,7 +82,7 @@ def ncnn_auto_split(
             # Check to see if its actually the NCNN out of memory error
             if "failed" in str(e):
                 # clear VRAM
-                logger.info(f"NCNN out of VRAM, clearing VRAM and splitting.")
+                logger.debug(f"NCNN out of VRAM, clearing VRAM and splitting.")
                 ex = None
                 del ex
                 gc.collect()

--- a/backend/src/nodes/utils/onnx_to_ncnn.py
+++ b/backend/src/nodes/utils/onnx_to_ncnn.py
@@ -2468,9 +2468,9 @@ class Onnx2NcnnConverter:
 
     def convert(self, is_fp16: bool = False, include_mem_data: bool = True):
         if is_fp16:
-            logger.info("NCNN mode: fp16")
+            logger.debug("NCNN mode: fp16")
         else:
-            logger.info("NCNN mode: fp32")
+            logger.debug("NCNN mode: fp32")
 
         # Topological sort
         i = 0
@@ -2747,7 +2747,7 @@ class Onnx2NcnnConverter:
             + splitncnn_blob_count
         )
         ncnn_model = NcnnModel(ncnn_node_count, ncnn_blob_count)
-        logger.info(
+        logger.debug(
             f"Node count: {ncnn_model.node_count}, Blob count: {ncnn_model.blob_count}"
         )
 

--- a/backend/src/nodes/utils/pytorch_model_loading.py
+++ b/backend/src/nodes/utils/pytorch_model_loading.py
@@ -11,7 +11,7 @@ from .torch_types import PyTorchModel
 
 
 def load_state_dict(state_dict) -> PyTorchModel:
-    logger.info(f"Loading state dict into pytorch model arch")
+    logger.debug(f"Loading state dict into pytorch model arch")
 
     state_dict_keys = list(state_dict.keys())
 

--- a/backend/src/nodes/utils/utils.py
+++ b/backend/src/nodes/utils/utils.py
@@ -190,7 +190,7 @@ def convenient_upscale(
         # Ignore single-color alpha
         unique = np.unique(img[:, :, 3])
         if len(unique) == 1:
-            logger.info("Single color alpha channel, ignoring.")
+            logger.debug("Single color alpha channel, ignoring.")
             if input_channels == 1:
                 logger.warning("Converting image to grayscale.")
                 img = np.expand_dims(cv2.cvtColor(img, cv2.COLOR_BGRA2GRAY), axis=2)

--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -444,13 +444,13 @@ class Executor:
         await self.__process_nodes(self.__get_iterator_output_nodes(sub))
 
     def resume(self):
-        logger.info(f"Resuming executor {self.execution_id}")
+        logger.debug(f"Resuming executor {self.execution_id}")
         self.progress.resume()
 
     def pause(self):
-        logger.info(f"Pausing executor {self.execution_id}")
+        logger.debug(f"Pausing executor {self.execution_id}")
         self.progress.pause()
 
     def kill(self):
-        logger.info(f"Killing executor {self.execution_id}")
+        logger.debug(f"Killing executor {self.execution_id}")
         self.progress.abort()

--- a/backend/src/run.py
+++ b/backend/src/run.py
@@ -195,7 +195,7 @@ async def run(request: Request):
         await runIndividualCounter.wait_zero()
 
         full_data: RunRequest = dict(request.json)  # type: ignore
-        logger.info(full_data)
+        logger.debug(full_data)
         chain, inputs = parse_json(full_data["data"])
         optimize(chain)
 
@@ -209,7 +209,7 @@ async def run(request: Request):
             onnx_execution_provider=full_data["onnxExecutionProvider"],
         )
         set_execution_options(exec_opts)
-        logger.info(f"Using device: {exec_opts.device}")
+        logger.debug(f"Using device: {exec_opts.device}")
         executor = Executor(
             chain,
             inputs,
@@ -271,7 +271,7 @@ async def run_individual(request: Request):
         full_data: RunIndividualRequest = dict(request.json)  # type: ignore
         if ctx.cache.get(full_data["id"], None) is not None:
             del ctx.cache[full_data["id"]]
-        logger.info(full_data)
+        logger.debug(full_data)
         exec_opts = ExecutionOptions(
             device="cpu" if full_data["isCpu"] else "cuda",
             fp16=full_data["isFp16"],
@@ -281,7 +281,7 @@ async def run_individual(request: Request):
             onnx_execution_provider=full_data["onnxExecutionProvider"],
         )
         set_execution_options(exec_opts)
-        logger.info(f"Using device: {exec_opts.device}")
+        logger.debug(f"Using device: {exec_opts.device}")
         # Create node based on given category/name information
         node_instance = NodeFactory.get_node(full_data["schemaId"])
 


### PR DESCRIPTION
For one, using an iterator spams out logs with useless garbage. Also, regular execution spams our logs with useless garbage.

We don't need to announce that actions are happening. Info logs should be useful. Maybe some of these shouldn't be changed, but for the most part they should IMO.

Also, I added the other execution options to that log. It confused people previously since it wasn't labeled that it was pytorch's options only.