### PR TITLE
Increase PyTorch's VRAM estimation budget

### DIFF
--- a/backend/src/nodes/nodes/pytorch/upscale_image.py
+++ b/backend/src/nodes/nodes/pytorch/upscale_image.py
@@ -78,7 +78,7 @@ class ImageUpscaleNode(NodeBase):
                     model_bytes = sum(
                         p.numel() * element_size for p in model.parameters()
                     )
-                    budget = int(free * 0.6)
+                    budget = int(free * 0.8)
 
                     return MaxTileSize(
                         estimate_tile_size(


### PR DESCRIPTION
I think 0.6 is just a bit too low