### PR TITLE
Text Append separator requirement

### DIFF
--- a/backend/src/nodes/nodes/utility/text_append.py
+++ b/backend/src/nodes/nodes/utility/text_append.py
@@ -16,7 +16,13 @@ class TextAppendNode(NodeBase):
         super().__init__()
         self.description = "Append different text together using a separator string."
         self.inputs = [
-            TextInput("Separator", has_handle=False, max_length=3),
+            TextInput(
+                "Separator",
+                has_handle=False,
+                min_length=0,
+                max_length=3,
+                default="-",
+            ),
             TextInput("Text A"),
             TextInput("Text B"),
             TextInput("Text C").make_optional(),

--- a/backend/src/nodes/properties/inputs/generic_inputs.py
+++ b/backend/src/nodes/properties/inputs/generic_inputs.py
@@ -46,6 +46,7 @@ class TextInput(BaseInput):
         max_length: Union[int, None] = None,
         placeholder: Union[str, None] = None,
         allow_numbers: bool = True,
+        default: Union[str, None] = None,
     ):
         super().__init__(
             ["string", "number"] if allow_numbers else "string",
@@ -56,6 +57,7 @@ class TextInput(BaseInput):
         self.min_length = min_length
         self.max_length = max_length
         self.placeholder = placeholder
+        self.default = default
 
     def enforce(self, value) -> str:
         if isinstance(value, float) and int(value) == value:
@@ -69,6 +71,7 @@ class TextInput(BaseInput):
             "minLength": self.min_length,
             "maxLength": self.max_length,
             "placeholder": self.placeholder,
+            "def": self.default,
         }
 
 

--- a/src/renderer/components/inputs/TextInput.tsx
+++ b/src/renderer/components/inputs/TextInput.tsx
@@ -15,6 +15,7 @@ interface TextInputProps extends InputProps {
     minLength: number;
     maxLength?: number;
     placeholder?: string;
+    def?: string | null;
 }
 
 export const TextInput = memo(
@@ -27,6 +28,7 @@ export const TextInput = memo(
         minLength,
         maxLength,
         placeholder,
+        def,
     }: TextInputProps) => {
         const isInputLocked = useContextSelector(GlobalVolatileContext, (c) => c.isNodeInputLocked)(
             id,
@@ -37,8 +39,12 @@ export const TextInput = memo(
         const [tempText, setTempText] = useState(input ?? '');
 
         useEffect(() => {
-            if (input === undefined && minLength === 0) {
-                setInput('');
+            if (input === undefined) {
+                if (def != null) {
+                    setInput(def);
+                } else if (minLength === 0) {
+                    setInput('');
+                }
             }
         }, []);
 


### PR DESCRIPTION
As discussed on Discord. Changes to Text Append:

- `-` is now the default value for the Separator input.
- The Separator input now allows the empty string.