### PR TITLE
Add compression level to save image

### DIFF
--- a/backend/src/nodes/nodes/image/save_image.py
+++ b/backend/src/nodes/nodes/image/save_image.py
@@ -18,6 +18,7 @@ from ...properties.inputs import (
     DirectoryInput,
     TextInput,
     ImageExtensionDropdown,
+    SliderInput,
 )
 from ...utils.pil_utils import *
 from ...utils.utils import get_h_w_c
@@ -34,6 +35,9 @@ class ImWriteNode(NodeBase):
             TextInput("Subdirectory Path").make_optional(),
             TextInput("Image Name"),
             ImageExtensionDropdown(),
+            SliderInput(
+                "Compression Level", minimum=0, maximum=100, default=30, slider_step=1
+            ),
         ]
         self.category = ImageCategory
         self.name = "Save Image"
@@ -50,6 +54,7 @@ class ImWriteNode(NodeBase):
         relative_path: Union[str, None],
         filename: str,
         extension: str,
+        compression: int,
     ) -> None:
         """Write an image to the specified path and return write status"""
 
@@ -82,17 +87,29 @@ class ImWriteNode(NodeBase):
             with Image.fromarray(img) as image:
                 image.save(full_path)
         else:
+            if extension == "png":
+                # opencv compresses png from 0-9 (higher is more compression). 3 is default
+                params = [cv2.IMWRITE_PNG_COMPRESSION, int(compression / 10) - 1]
+            elif extension == "jpg":
+                # opencv compresses jpg from 0-100 (higher is better). 95 is default
+                params = [cv2.IMWRITE_JPEG_QUALITY, 100 - compression]
+            elif extension == "webp":
+                # opencv compresses webp from 0-100 (higher is better)
+                params = [cv2.IMWRITE_WEBP_QUALITY, 100 - compression]
+            else:
+                params = []
+
             # Write image with opencv if path is ascii, since imwrite doesn't support unicode
             # This saves us from having to keep the image buffer in memory, if possible
             if full_path.isascii():
-                cv2.imwrite(full_path, img)
+                cv2.imwrite(full_path, img, params)
             else:
                 try:
                     temp_filename = f'temp-{"".join(random.choices(string.ascii_letters, k=16))}.{extension}'
                     full_temp_path = full_path.replace(full_file, temp_filename)
-                    cv2.imwrite(full_temp_path, img)
+                    cv2.imwrite(full_temp_path, img, params)
                     os.rename(full_temp_path, full_path)
                 except:
-                    _, buf_img = cv2.imencode(f".{extension}", img)
+                    _, buf_img = cv2.imencode(f".{extension}", img, params)
                     with open(full_path, "wb") as outf:
                         outf.write(buf_img)

--- a/backend/src/nodes/nodes/image/save_image.py
+++ b/backend/src/nodes/nodes/image/save_image.py
@@ -36,7 +36,7 @@ class ImWriteNode(NodeBase):
             TextInput("Image Name"),
             ImageExtensionDropdown(),
             SliderInput(
-                "Compression Level", minimum=0, maximum=100, default=30, slider_step=1
+                "Quality (JPEG/WEBP)", minimum=0, maximum=100, default=95, slider_step=1
             ),
         ]
         self.category = ImageCategory
@@ -54,7 +54,7 @@ class ImWriteNode(NodeBase):
         relative_path: Union[str, None],
         filename: str,
         extension: str,
-        compression: int,
+        quality: int,
     ) -> None:
         """Write an image to the specified path and return write status"""
 
@@ -87,15 +87,10 @@ class ImWriteNode(NodeBase):
             with Image.fromarray(img) as image:
                 image.save(full_path)
         else:
-            if extension == "png":
-                # opencv compresses png from 0-9 (higher is more compression). 3 is default
-                params = [cv2.IMWRITE_PNG_COMPRESSION, min(int(compression / 10), 9)]
-            elif extension == "jpg":
-                # opencv compresses jpg from 0-100 (higher is better). 95 is default
-                params = [cv2.IMWRITE_JPEG_QUALITY, 100 - compression]
+            if extension == "jpg":
+                params = [cv2.IMWRITE_JPEG_QUALITY, quality]
             elif extension == "webp":
-                # opencv compresses webp from 0-100 (higher is better)
-                params = [cv2.IMWRITE_WEBP_QUALITY, 100 - compression]
+                params = [cv2.IMWRITE_WEBP_QUALITY, quality]
             else:
                 params = []
 

--- a/backend/src/nodes/nodes/image/save_image.py
+++ b/backend/src/nodes/nodes/image/save_image.py
@@ -89,7 +89,7 @@ class ImWriteNode(NodeBase):
         else:
             if extension == "png":
                 # opencv compresses png from 0-9 (higher is more compression). 3 is default
-                params = [cv2.IMWRITE_PNG_COMPRESSION, int(compression / 10) - 1]
+                params = [cv2.IMWRITE_PNG_COMPRESSION, min(int(compression / 10), 9)]
             elif extension == "jpg":
                 # opencv compresses jpg from 0-100 (higher is better). 95 is default
                 params = [cv2.IMWRITE_JPEG_QUALITY, 100 - compression]


### PR DESCRIPTION
The default is 30 because that translates to 3, which we determined was the fastest for png compression. It also translates to 70% quality for jpeg and webp, which I think makes sense enough.

It's a bit odd the way it is, since ideally it would change depending on what format was selected, but we all know we cant do that right now. This was the best solution I had.

![image](https://user-images.githubusercontent.com/34788790/197373265-c42f897d-db45-4bda-8bce-22f5b5576826.png)
