### PR TITLE
Prevent context node selector cross-iterator connections (& more)

### DIFF
--- a/src/renderer/hooks/usePaneNodeSearchMenu.tsx
+++ b/src/renderer/hooks/usePaneNodeSearchMenu.tsx
@@ -473,16 +473,30 @@ export const usePaneNodeSearchMenu = (
                     ? firstClass.slice('iterator-editor='.length)
                     : undefined;
 
-            if (isStoppedOnPane || stoppedIteratorId) {
-                const fromNode = getNode(connectingFrom?.nodeId ?? '');
-                if (
-                    // Handle case of dragging from inside iterator to outside
-                    !(fromNode && fromNode.parentNode && isStoppedOnPane) &&
-                    // Handle case of dragging from one iterator to another
-                    !(fromNode?.parentNode && fromNode.parentNode !== stoppedIteratorId)
-                ) {
-                    menu.manuallyOpenContextMenu(event.pageX, event.pageY);
-                }
+            const fromNode = getNode(connectingFrom?.nodeId ?? '');
+            const fromParent = fromNode?.parentNode;
+            const fromHandleType = connectingFrom?.handleType;
+
+            const isFreeNodeToPane = isStoppedOnPane && fromParent === undefined;
+            const isIteratorToPane = isStoppedOnPane && fromParent;
+            const isPaneToIterator = !isStoppedOnPane && stoppedIteratorId;
+            const isIteratorToSelf =
+                stoppedIteratorId && fromParent && stoppedIteratorId === fromParent;
+            const isIteratorToOtherIterator =
+                stoppedIteratorId && fromParent && stoppedIteratorId !== fromParent;
+
+            const isIteratorSourceToPaneTarget = isIteratorToPane && fromHandleType === 'source';
+            const isIteratorTargetToPaneSource = isIteratorToPane && fromHandleType === 'target';
+            const isPaneSourceToIteratorTarget = isPaneToIterator && fromHandleType === 'source';
+
+            if (
+                (isFreeNodeToPane ||
+                    isIteratorToSelf ||
+                    isPaneSourceToIteratorTarget ||
+                    isIteratorTargetToPaneSource) &&
+                !(isIteratorSourceToPaneTarget || isIteratorToOtherIterator)
+            ) {
+                menu.manuallyOpenContextMenu(event.pageX, event.pageY);
                 if (stoppedIteratorId) {
                     setStoppedOnIterator(stoppedIteratorId);
                 }

--- a/src/renderer/hooks/usePaneNodeSearchMenu.tsx
+++ b/src/renderer/hooks/usePaneNodeSearchMenu.tsx
@@ -475,8 +475,12 @@ export const usePaneNodeSearchMenu = (
 
             if (isStoppedOnPane || stoppedIteratorId) {
                 const fromNode = getNode(connectingFrom?.nodeId ?? '');
-                // Handle case of dragging from inside iterator to outside
-                if (!(fromNode && fromNode.parentNode && isStoppedOnPane)) {
+                if (
+                    // Handle case of dragging from inside iterator to outside
+                    !(fromNode && fromNode.parentNode && isStoppedOnPane) &&
+                    // Handle case of dragging from one iterator to another
+                    !(fromNode?.parentNode && fromNode.parentNode !== stoppedIteratorId)
+                ) {
                     menu.manuallyOpenContextMenu(event.pageX, event.pageY);
                 }
                 if (stoppedIteratorId) {


### PR DESCRIPTION
Closes #1028

~~Just realized this only covers the cross-iterator portion. will also fix input connections~~

I think I handled every condition. I had to split these up into so many boolean variables just to keep everything straight. It seems to work correctly now.

Note that this doesn't handle condition 2 of the issue, which is making the node validity checks check for this. But TBH I don't really think that's necessary so long as we handle preventing those cases correctly.