### PR TITLE
Change default CRF value to 23

### DIFF
--- a/backend/src/nodes/nodes/image/video_frame_iterator.py
+++ b/backend/src/nodes/nodes/image/video_frame_iterator.py
@@ -87,7 +87,7 @@ class VideoFrameIteratorFrameWriterNode(NodeBase):
                 slider_step=1,
                 minimum=0,
                 maximum=51,
-                default=0,
+                default=23,
                 ends=("Best", "Worst"),
             ),
         ]


### PR DESCRIPTION
This is FFMPEG's default, so we should probably default to it.