### PR TITLE
Replaced weights_bin with serialize method

### DIFF
--- a/backend/src/nodes/utils/ncnn_model.py
+++ b/backend/src/nodes/utils/ncnn_model.py
@@ -295,7 +295,7 @@ class NcnnLayer:
         data: Union[float, int, np.ndarray, TensorProto],  # type: ignore
         weight_name: str,
         quantize_tag: bytes = b"",
-    ) -> bytes:
+    ) -> int:
         if isinstance(data, TensorProto):  # type: ignore
             data_array = onph.to_array(data)  # type: ignore
         elif isinstance(data, float):
@@ -309,7 +309,7 @@ class NcnnLayer:
             data_array = data_array.astype(np.float16)
         self.weight_data[weight_name] = NcnnWeight(data_array, quantize_tag)
 
-        return quantize_tag + data_array.tobytes()
+        return len(quantize_tag) + len(data_array.tobytes())
 
 
 class NcnnModel:

--- a/backend/src/nodes/utils/ncnn_session.py
+++ b/backend/src/nodes/utils/ncnn_session.py
@@ -21,9 +21,6 @@ def create_ncnn_net(
     net.load_param_mem(model.model.write_param())
     net.load_model_mem(model.model.bin)
 
-    # Attribute not needed anymore, save memory
-    model.model.weights_bin = b""
-
     return net
 
 


### PR DESCRIPTION
Fixes bug where interpolating ncnn models would cause an empty bin file to be saved due to clearing the weights_bin attribute. Resolved this by discarding the attribute entirely and replacing it with a serialize method to be called to convert the weights to a byte string when needed. Any performance overhead seems to be indistinguishable in terms of runtime, and regardless is only incurred when saving or the first time an upscale is run using a model. Also prevents the need for the full byte string to be stored in RAM in the model object in the first place.