### PR TITLE
Use `not` instead of `invStrSet` in user-facing error messages

### DIFF
--- a/src/common/checkNodeValidity.ts
+++ b/src/common/checkNodeValidity.ts
@@ -133,8 +133,10 @@ const prettyPrintType = (type: Type): string => {
         case 'number':
         case 'string':
         case 'interval':
-        case 'inverted-set':
             return type.toString();
+
+        case 'inverted-set':
+            return `not(${[...type.excluded].map((s) => JSON.stringify(s)).join(' | ')})`;
 
         case 'int-interval':
             if (type.min === -Infinity && type.max === Infinity) {
@@ -151,7 +153,6 @@ const prettyPrintType = (type: Type): string => {
         case 'struct':
             if (type.fields.length === 0) return type.name;
             return `${type.name} { ${type.fields
-
                 .map((f) => `${f.name}: ${prettyPrintType(f.type)}`)
                 .join(', ')} }`;
 


### PR DESCRIPTION
So users will now see `not("foo")` instead of `invStrSet("foo")`. This will hopefully make it easier to understand error messages.