### PR TITLE
RGB-like color conversion

### DIFF
--- a/backend/src/nodes/nodes/image_utility/convert_color.py
+++ b/backend/src/nodes/nodes/image_utility/convert_color.py
@@ -11,7 +11,11 @@ from ...properties.inputs import (
 )
 from ...properties.outputs import ImageOutput
 from ...properties import expression
-from ...utils.color.convert import convert, color_space_from_id
+from ...utils.color.convert import (
+    convert,
+    color_space_from_id,
+    color_space_or_detector_from_id,
+)
 
 
 @NodeFactory.register("chainner:image:change_colorspace")
@@ -24,7 +28,7 @@ class ColorConvertNode(NodeBase):
         )
         self.inputs = [
             ImageInput(image_type=expression.Image(channels="Input1.channels")),
-            ColorSpaceInput(label="From"),
+            ColorSpaceInput(label="From", detector=True),
             ColorSpaceInput(label="To"),
         ]
         self.outputs = [
@@ -43,4 +47,8 @@ class ColorConvertNode(NodeBase):
     def run(self, img: np.ndarray, input_: int, output: int) -> np.ndarray:
         """Takes an image and changes the color mode it"""
 
-        return convert(img, color_space_from_id(input_), color_space_from_id(output))
+        return convert(
+            img,
+            color_space_or_detector_from_id(input_),
+            color_space_from_id(output),
+        )

--- a/backend/src/nodes/properties/expression.py
+++ b/backend/src/nodes/properties/expression.py
@@ -41,6 +41,8 @@ ExpressionJson = Union[
     "FunctionCallExpressionJson",
     "MatchExpressionJson",
     List["ExpressionJson"],
+    List[int],
+    List[str],
 ]
 
 

--- a/backend/src/nodes/properties/inputs/image_dropdown_inputs.py
+++ b/backend/src/nodes/properties/inputs/image_dropdown_inputs.py
@@ -4,12 +4,16 @@ import cv2
 from ...utils.image_utils import BorderType
 from ...utils.pil_utils import InterpolationMethod, RotateExpandCrop
 from ...utils.tile_util import TileMode
-from ...utils.color.convert_data import color_spaces
+from ...utils.color.convert_data import color_spaces, color_spaces_or_detectors
 from ..expression import named
 from .generic_inputs import DropDownInput
 
 
-def ColorSpaceInput(label: str = "Color Space") -> DropDownInput:
+def ColorSpaceInput(
+    label: str = "Color Space",
+    detector: bool = False,
+) -> DropDownInput:
+    l = color_spaces_or_detectors if detector else color_spaces
     return DropDownInput(
         input_type="ColorSpace",
         label=label,
@@ -19,7 +23,7 @@ def ColorSpaceInput(label: str = "Color Space") -> DropDownInput:
                 "value": c.id,
                 "type": named("ColorSpace", {"channels": c.channels}),
             }
-            for c in color_spaces
+            for c in l
         ],
     )
 

--- a/backend/src/nodes/properties/inputs/numpy_inputs.py
+++ b/backend/src/nodes/properties/inputs/numpy_inputs.py
@@ -25,7 +25,7 @@ class ImageInput(BaseInput):
     ):
         image_type = expression.intersect(
             image_type,
-            expression.Image(channels=channels),  # type: ignore
+            expression.Image(channels=channels),
         )
         super().__init__(image_type, label)
 

--- a/backend/src/nodes/utils/color/convert.py
+++ b/backend/src/nodes/utils/color/convert.py
@@ -88,9 +88,13 @@ for conversion in conversions:
     l.append(conversion)
 
 
-def convert(img: np.ndarray, input_: Union[ColorSpace, ColorSpaceDetector], output: ColorSpace) -> np.ndarray:
+def convert(
+    img: np.ndarray,
+    input_: Union[ColorSpace, ColorSpaceDetector],
+    output: ColorSpace,
+) -> np.ndarray:
     if isinstance(input_, ColorSpaceDetector):
-        input_= input_.detect(img)
+        input_ = input_.detect(img)
 
     assert_input_channels(img, input_, output)
 

--- a/backend/src/nodes/utils/color/convert.py
+++ b/backend/src/nodes/utils/color/convert.py
@@ -3,9 +3,10 @@ from typing import Callable, Dict, Generic, Iterable, List, Set, Tuple, TypeVar,
 import numpy as np
 from sanic.log import logger
 
-from .convert_data import conversions, color_spaces
+from .convert_data import conversions, color_spaces, color_spaces_or_detectors
 from .convert_model import (
     ColorSpace,
+    ColorSpaceDetector,
     Conversion,
     assert_input_channels,
     assert_output_channels,
@@ -14,6 +15,13 @@ from .convert_model import (
 
 def color_space_from_id(id_: int) -> ColorSpace:
     for c in color_spaces:
+        if c.id == id_:
+            return c
+    raise ValueError(f"There is no color space with the id {id_}.")
+
+
+def color_space_or_detector_from_id(id_: int) -> Union[ColorSpace, ColorSpaceDetector]:
+    for c in color_spaces_or_detectors:
         if c.id == id_:
             return c
     raise ValueError(f"There is no color space with the id {id_}.")
@@ -80,7 +88,10 @@ for conversion in conversions:
     l.append(conversion)
 
 
-def convert(img: np.ndarray, input_: ColorSpace, output: ColorSpace) -> np.ndarray:
+def convert(img: np.ndarray, input_: Union[ColorSpace, ColorSpaceDetector], output: ColorSpace) -> np.ndarray:
+    if isinstance(input_, ColorSpaceDetector):
+        input_= input_.detect(img)
+
     assert_input_channels(img, input_, output)
 
     if input_ == output:

--- a/backend/src/nodes/utils/color/convert_data.py
+++ b/backend/src/nodes/utils/color/convert_data.py
@@ -14,7 +14,7 @@ HSV = ColorSpace(4, "HSV", 3)
 HSL = ColorSpace(5, "HSL", 3)
 CMYK = ColorSpace(6, "CMYK", 4)
 
-RGB_LIKE = ColorSpaceDetector(0, "Gray/RGB/RGBA", [GRAY, RGB, RGBA])
+RGB_LIKE = ColorSpaceDetector(1000, "Gray/RGB/RGBA", [GRAY, RGB, RGBA])
 
 color_spaces: List[ColorSpace] = [
     RGB,
@@ -27,9 +27,6 @@ color_spaces: List[ColorSpace] = [
 ]
 color_spaces_or_detectors: List[Union[ColorSpace, ColorSpaceDetector]] = [
     RGB_LIKE,
-    RGB,
-    RGBA,
-    GRAY,
     YUV,
     HSV,
     HSL,

--- a/backend/src/nodes/utils/color/convert_data.py
+++ b/backend/src/nodes/utils/color/convert_data.py
@@ -1,8 +1,8 @@
-from typing import List
+from typing import List, Union
 import numpy as np
 import cv2
 
-from .convert_model import ColorSpace, Conversion
+from .convert_model import ColorSpace, ColorSpaceDetector, Conversion
 from ..utils import get_h_w_c
 
 
@@ -14,7 +14,27 @@ HSV = ColorSpace(4, "HSV", 3)
 HSL = ColorSpace(5, "HSL", 3)
 CMYK = ColorSpace(6, "CMYK", 4)
 
-color_spaces = [RGB, RGBA, GRAY, YUV, HSV, HSL, CMYK]
+RGB_LIKE = ColorSpaceDetector(0, "Gray/RGB/RGBA", [GRAY, RGB, RGBA])
+
+color_spaces: List[ColorSpace] = [
+    RGB,
+    RGBA,
+    GRAY,
+    YUV,
+    HSV,
+    HSL,
+    CMYK,
+]
+color_spaces_or_detectors: List[Union[ColorSpace, ColorSpaceDetector]] = [
+    RGB_LIKE,
+    RGB,
+    RGBA,
+    GRAY,
+    YUV,
+    HSV,
+    HSL,
+    CMYK,
+]
 
 
 def __rev3(image: np.ndarray) -> np.ndarray:

--- a/backend/src/nodes/utils/color/convert_model.py
+++ b/backend/src/nodes/utils/color/convert_model.py
@@ -15,8 +15,8 @@ class ColorSpace:
 
 class ColorSpaceDetector:
     def __init__(self, id_: int, name: str, color_spaces: Iterable[ColorSpace]) -> None:
-        assert 0 <= id_ and id_ < 256
-        self.id = 1000 + id_
+        assert 1000 <= id_ and id_ < 2000
+        self.id = id_
         self.name = name
         self.channel_map: Dict[int, ColorSpace] = {}
         for cs in color_spaces:

--- a/backend/src/nodes/utils/color/convert_model.py
+++ b/backend/src/nodes/utils/color/convert_model.py
@@ -1,4 +1,4 @@
-from typing import Callable, Tuple
+from typing import Callable, Dict, Iterable, Tuple
 import numpy as np
 
 from ..format import format_image_with_channels
@@ -11,6 +11,30 @@ class ColorSpace:
         self.id = id_
         self.name = name
         self.channels = channels
+
+
+class ColorSpaceDetector:
+    def __init__(self, id_: int, name: str, color_spaces: Iterable[ColorSpace]) -> None:
+        assert 0 <= id_ and id_ < 256
+        self.id = 1000 + id_
+        self.name = name
+        self.channel_map: Dict[int, ColorSpace] = {}
+        for cs in color_spaces:
+            assert cs.channels not in self.channel_map
+            self.channel_map[cs.channels] = cs
+        self.channels = list(self.channel_map.keys())
+
+    def detect(self, image: np.ndarray) -> ColorSpace:
+        c = get_h_w_c(image)[2]
+        cs = self.channel_map.get(c, None)
+        if cs is not None:
+            return cs
+
+        raise ValueError(
+            f"Expected the input image for {self.name}"
+            f" to be {format_image_with_channels(self.channels)}"
+            f" but found {format_image_with_channels([c])}."
+        )
 
 
 def assert_input_channels(img: np.ndarray, input_: ColorSpace, output: ColorSpace):

--- a/src/common/migrations.js
+++ b/src/common/migrations.js
@@ -794,6 +794,28 @@ const convertColorSpaceFromTo = (data) => {
     return data;
 };
 
+const convertColorRGBLikeDetector = (data) => {
+    const GRAY = 0;
+    const RGB = 1;
+    const RGBA = 2;
+    const RGB_LIKE = 1000;
+
+    /** @type {Partial<Record<number, number>>} */
+    const mapping = {
+        [GRAY]: RGB_LIKE,
+        [RGB]: RGB_LIKE,
+        [RGBA]: RGB_LIKE,
+    };
+    data.nodes.forEach((node) => {
+        if (node.data.schemaId === 'chainner:image:change_colorspace') {
+            const from = node.data.inputData[1];
+            node.data.inputData[1] = mapping[from] ?? from;
+        }
+    });
+
+    return data;
+};
+
 // ==============
 
 const versionToMigration = (version) => {
@@ -835,6 +857,7 @@ const migrations = [
     addTargetTileSizeAgain,
     brightnessImplementationChange,
     convertColorSpaceFromTo,
+    convertColorRGBLikeDetector,
 ];
 
 export const currentMigration = migrations.length;

--- a/tests/common/__snapshots__/SaveFile.test.ts.snap
+++ b/tests/common/__snapshots__/SaveFile.test.ts.snap
@@ -2270,7 +2270,7 @@ Object {
       "data": Object {
         "id": "ad24cc0b-36ac-415f-9347-c6da40edec4e",
         "inputData": Object {
-          "1": 2,
+          "1": 1000,
           "2": 1,
         },
         "schemaId": "chainner:image:change_colorspace",
@@ -5397,7 +5397,7 @@ Object {
 
 exports[`Write save file image-utilities.chn 1`] = `
 Object {
-  "checksum": "7d07b6fd8fc6799a5ec6bea0256d540b",
+  "checksum": "cf7e625f9cddef513ad512266184591d",
   "content": Object {
     "edges": Array [
       Object {
@@ -5648,7 +5648,7 @@ Object {
         "data": Object {
           "id": "ad24cc0b-36ac-415f-9347-c6da40edec4e",
           "inputData": Object {
-            "1": 2,
+            "1": 1000,
             "2": 1,
           },
           "schemaId": "chainner:image:change_colorspace",


### PR DESCRIPTION
I recently had to upscale a set of mixed grayscale and RGB images. It was quite annoying because there as no single-node way to convert a grayscale or RGB image to RGB. So I added one.

This PR adds the Gray/RGB/RGBA color space detector. The "From" direction of Change Colorspace now allows color space detectors. These detectors look at the number of channels of an image and deduce the color space from that. Right now, there is only one detector, but we may expand this in the future for things like HSLA.

Note that detectors are only available for the "From" input.

![image](https://user-images.githubusercontent.com/20878432/197521195-74fe5025-1bd3-4673-8805-cf04ee284185.png)
![image](https://user-images.githubusercontent.com/20878432/197521274-e5261b48-f462-4496-99da-0e1ad9de8806.png)

---

Open questions:

I made Gray/RGB/RGBA the new default for the "From" direction. Should it be?
![image](https://user-images.githubusercontent.com/20878432/197521764-ad9154ba-004a-4631-98a9-c7a2f06a1c0f.png)

Since Gray/RGB/RGBA is a super set of the members, should we remove Gray, RGB, and RGBA from the "From" input? I tend towards keeping them for consistency, but they also feel a bit like dead weight now.
