### PR TITLE
Remove weird white outline on nodes

### DIFF
--- a/src/renderer/global.scss
+++ b/src/renderer/global.scss
@@ -22,6 +22,12 @@ body {
     display: none;
 }
 
+.react-flow__node:focus,
+:focus-visible,
+:focus-within {
+    outline: none;
+}
+
 @keyframes logo-dashdraw {
     from {
         stroke-dashoffset: 10;


### PR DESCRIPTION
This fixes that outline showing up when you press `t` on a node.