### PR TITLE
Fixed image iterator sort

### DIFF
--- a/backend/src/nodes/nodes/image/image_file_iterator.py
+++ b/backend/src/nodes/nodes/image/image_file_iterator.py
@@ -19,7 +19,7 @@ from ...properties.outputs import (
     NumberOutput,
 )
 from ...utils.image_utils import get_available_image_formats
-from ...utils.utils import numerical_sort
+from ...utils.utils import alphanumeric_sort
 
 IMAGE_ITERATOR_NODE_ID = "chainner:image:file_iterator_load"
 
@@ -95,8 +95,8 @@ class ImageFileIteratorNode(IteratorNodeBase):
         ):
             await context.progress.suspend()
 
-            dirs.sort(key=numerical_sort)
-            for name in sorted(files, key=numerical_sort):
+            dirs.sort(key=alphanumeric_sort)
+            for name in sorted(files, key=alphanumeric_sort):
                 filepath = os.path.join(root, name)
                 _base, ext = os.path.splitext(filepath)
                 if ext.lower() in supported_filetypes:

--- a/backend/src/nodes/utils/utils.py
+++ b/backend/src/nodes/utils/utils.py
@@ -308,10 +308,11 @@ def resize_to_side_conditional(
     return w_new, h_new
 
 
-def numerical_sort(value: str) -> List[Union[str, int]]:
+def alphanumeric_sort(value: str) -> List[Union[str, int]]:
     """Key function to sort strings containing numbers by proper
     numerical order."""
 
-    parts = NUMBERS.split(value)
+    lcase_value = value.lower()
+    parts = NUMBERS.split(lcase_value)
     parts[1::2] = map(int, parts[1::2])
     return parts  # type: ignore


### PR DESCRIPTION
Python by default does an ASCII-like sort, so upper and lowercase letters get separated. Added .lower() to the key method so that case would be ignored when sorting alphanumerically.