### PR TITLE
Minor improvements around type tags

### DIFF
--- a/src/common/types/util.ts
+++ b/src/common/types/util.ts
@@ -1,13 +1,17 @@
-import { IntIntervalType, NumericLiteralType, StructType, Type, UnionType } from '@chainner/navi';
-
-export const isNumericLiteral = (type: Type): type is NumericLiteralType => {
-    return type.type === 'literal' && type.underlying === 'number';
-};
+import {
+    IntIntervalType,
+    NonNeverType,
+    NumericLiteralType,
+    StructType,
+    Type,
+    UnionType,
+} from '@chainner/navi';
 
 export type IntNumberType =
     | NumericLiteralType
     | IntIntervalType
     | UnionType<NumericLiteralType | IntIntervalType>;
+
 export const isImage = (
     type: Type
 ): type is StructType & {
@@ -19,4 +23,8 @@ export const isImage = (
     ];
 } => {
     return type.type === 'struct' && type.name === 'Image' && type.fields.length === 3;
+};
+
+export const getField = (struct: StructType, field: string): NonNeverType | undefined => {
+    return struct.fields.find((f) => f.name === field)?.type;
 };

--- a/src/renderer/components/TypeTag.tsx
+++ b/src/renderer/components/TypeTag.tsx
@@ -1,7 +1,7 @@
-import { StructType, Type, without } from '@chainner/navi';
+import { NeverType, StructType, Type, isNumericLiteral, without } from '@chainner/navi';
 import { Tag } from '@chakra-ui/react';
 import React, { memo } from 'react';
-import { isImage, isNumericLiteral } from '../../common/types/util';
+import { getField, isImage } from '../../common/types/util';
 
 const getColorMode = (channels: number) => {
     switch (channels) {
@@ -36,10 +36,10 @@ const getTypeText = (type: Type): string[] => {
             }
         }
 
-        if (type.name === 'PyTorchModel' && type.fields.length === 3) {
-            const [scale] = type.fields;
-            if (isNumericLiteral(scale.type)) {
-                tags.push(`${scale.type.toString()}x`);
+        if (type.name === 'PyTorchModel' || type.name === 'NcnnNetwork') {
+            const scale = getField(type, 'scale') ?? NeverType.instance;
+            if (isNumericLiteral(scale)) {
+                tags.push(`${scale.toString()}x`);
             }
         }
     }


### PR DESCRIPTION
Changes:
- Use Navi's `isNumericLiteral` function.
- New `getField` function to get fields without having to worry about field order.
- Show scale of NCNN networks.