### PR TITLE
Make Sharpen consistent with blur nodes

### DIFF
--- a/backend/src/nodes/nodes/image_filter/sharpen.py
+++ b/backend/src/nodes/nodes/image_filter/sharpen.py
@@ -17,7 +17,7 @@ class SharpenNode(NodeBase):
         self.description = "Apply sharpening to an image using an unsharp mask."
         self.inputs = [
             ImageInput(),
-            NumberInput("Amount"),
+            NumberInput("Amount", default=1, minimum=1),
         ]
         self.outputs = [ImageOutput(image_type="Input0")]
         self.category = ImageFilterCategory

--- a/backend/src/nodes/nodes/image_filter/sharpen.py
+++ b/backend/src/nodes/nodes/image_filter/sharpen.py
@@ -17,7 +17,7 @@ class SharpenNode(NodeBase):
         self.description = "Apply sharpening to an image using an unsharp mask."
         self.inputs = [
             ImageInput(),
-            NumberInput("Amount", default=1, minimum=1),
+            NumberInput("Amount", precision=1, controls_step=1),
         ]
         self.outputs = [ImageOutput(image_type="Input0")]
         self.category = ImageFilterCategory
@@ -31,6 +31,9 @@ class SharpenNode(NodeBase):
         amount: float,
     ) -> np.ndarray:
         """Adjusts the sharpening of an image"""
+
+        if amount == 0:
+            return img
 
         blurred = cv2.GaussianBlur(img, (0, 0), amount)
         img = cv2.addWeighted(img, 2.0, blurred, -1.0, 0)


### PR DESCRIPTION
Fixes #1148.

Just like our blur nodes, Sharpen will now return the image as is if the amount is 0. Decimal amounts are also possible now.