### PR TITLE
Round half up

### DIFF
--- a/backend/src/nodes/nodes/image_dimension/resize_factor.py
+++ b/backend/src/nodes/nodes/image_dimension/resize_factor.py
@@ -10,7 +10,7 @@ from ...properties.inputs import ImageInput, NumberInput, InterpolationInput
 from ...properties.outputs import ImageOutput
 from ...properties import expression
 from ...utils.pil_utils import resize
-from ...utils.utils import get_h_w_c
+from ...utils.utils import get_h_w_c, round_half_up
 
 
 @NodeFactory.register("chainner:image:resize_factor")
@@ -53,8 +53,8 @@ class ImResizeByFactorNode(NodeBase):
 
         h, w, _ = get_h_w_c(img)
         out_dims = (
-            max(round(w * (scale / 100)), 1),
-            max(round(h * (scale / 100)), 1),
+            max(round_half_up(w * (scale / 100)), 1),
+            max(round_half_up(h * (scale / 100)), 1),
         )
 
         return resize(img, out_dims, interpolation)

--- a/backend/src/nodes/nodes/image_utility/stack.py
+++ b/backend/src/nodes/nodes/image_utility/stack.py
@@ -9,7 +9,7 @@ from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import ImageInput, StackOrientationDropdown
 from ...properties.outputs import ImageOutput
-from ...utils.utils import get_h_w_c
+from ...utils.utils import get_h_w_c, round_half_up
 
 
 @NodeFactory.register("chainner:image:stack")
@@ -109,14 +109,14 @@ class StackNode(NodeBase):
                 if h < max_h:
                     fixed_img = cv2.resize(
                         img,
-                        (round(w * max_h / h), max_h),
+                        (round_half_up(w * max_h / h), max_h),
                         interpolation=cv2.INTER_NEAREST,
                     )
             elif orientation == "vertical":
                 if w < max_w:
                     fixed_img = cv2.resize(
                         img,
-                        (max_w, round(h * max_w / w)),
+                        (max_w, round_half_up(h * max_w / w)),
                         interpolation=cv2.INTER_NEAREST,
                     )
             else:

--- a/backend/src/nodes/properties/inputs/numeric_inputs.py
+++ b/backend/src/nodes/properties/inputs/numeric_inputs.py
@@ -1,6 +1,7 @@
 from typing import Union, Tuple, List
 
 from .base_input import BaseInput, InputKind
+from ...utils.utils import round_half_up
 from .. import expression
 
 
@@ -11,7 +12,7 @@ def clampNumber(
     max_value: Union[float, int, None],
 ) -> Union[float, int]:
     # Convert proper number type
-    value = round(value, precision)
+    value = round_half_up(value) if precision == 0 else round(value, precision)
 
     # Clamp to max and min, correcting for max/min not aligning with offset + n * step
     if max_value is not None:

--- a/backend/src/nodes/utils/utils.py
+++ b/backend/src/nodes/utils/utils.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from typing import Callable, List, Tuple, Type, Union
-import decimal
 import re
 import cv2
 
@@ -33,9 +32,7 @@ def round_half_up(number: Union[float, int]) -> int:
 
     https://en.wikipedia.org/wiki/Rounding#Rounding_to_the_nearest_integer
     """
-    return int(
-        decimal.Decimal(str(number)).to_integral_value(rounding=decimal.ROUND_HALF_UP)
-    )
+    return int(number + 0.5)
 
 
 def get_h_w_c(image: np.ndarray) -> Tuple[int, int, int]:

--- a/backend/src/nodes/utils/utils.py
+++ b/backend/src/nodes/utils/utils.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 from typing import Callable, List, Tuple, Type, Union
-import cv2
+import decimal
 import re
+import cv2
 
 import numpy as np
 from sanic.log import logger
@@ -21,6 +22,20 @@ MAX_VALUES_BY_DTYPE = {
     np.dtype("float64"): 1.0,
 }
 NUMBERS = re.compile(r"(\d+)")
+
+
+def round_half_up(number: Union[float, int]) -> int:
+    """
+    Python's `round` method implements round-half-to-even rounding which is very unintuitive.
+    This function implements round-half-up rounding.
+
+    Round half up is consistent with JavaScript's `Math.round`.
+
+    https://en.wikipedia.org/wiki/Rounding#Rounding_to_the_nearest_integer
+    """
+    return int(
+        decimal.Decimal(str(number)).to_integral_value(rounding=decimal.ROUND_HALF_UP)
+    )
 
 
 def get_h_w_c(image: np.ndarray) -> Tuple[int, int, int]:
@@ -276,14 +291,14 @@ def resize_to_side_conditional(
             h_new = h
         else:
             w_new = target
-            h_new = max(round((target / w) * h), 1)
+            h_new = max(round_half_up((target / w) * h), 1)
 
     elif side == "height":
         if compare_conditions(h):
             w_new = w
             h_new = h
         else:
-            w_new = max(round((target / h) * w), 1)
+            w_new = max(round_half_up((target / h) * w), 1)
             h_new = target
 
     elif side == "shorter side":
@@ -291,16 +306,16 @@ def resize_to_side_conditional(
             w_new = w
             h_new = h
         else:
-            w_new = max(round((target / min(h, w)) * w), 1)
-            h_new = max(round((target / min(h, w)) * h), 1)
+            w_new = max(round_half_up((target / min(h, w)) * w), 1)
+            h_new = max(round_half_up((target / min(h, w)) * h), 1)
 
     elif side == "longer side":
         if compare_conditions(max(h, w)):
             w_new = w
             h_new = h
         else:
-            w_new = max(round((target / max(h, w)) * w), 1)
-            h_new = max(round((target / max(h, w)) * h), 1)
+            w_new = max(round_half_up((target / max(h, w)) * w), 1)
+            h_new = max(round_half_up((target / max(h, w)) * h), 1)
 
     else:
         raise RuntimeError(f"Unknown side selection {side}")


### PR DESCRIPTION
Python, being the intuitive programming that it is, uses [round half to even](https://en.wikipedia.org/wiki/Rounding#Round_half_to_even) in its built-in [`round` function](https://docs.python.org/3/library/functions.html#round). This is at odds (pun intended) with both JavaScript's `Math.round` and common sense. Our users can observe this rounding behavior because results from the Math node (and other nodes producing non-integer values) are rounded by number inputs.

This PR changes all uses of `round` that are observable by the user or are at odds with the type system (which uses JS's `Math.round`) to `round_half_up`. `round_half_up` is a new function I added that implements the same rounding method JS also uses.

We are going to have to be careful about using which rounding method in the future.