### PR TITLE
Implement handling for converting fp16 ONNX to NCNN

### DIFF
--- a/backend/src/nodes/nodes/onnx/convert_to_ncnn.py
+++ b/backend/src/nodes/nodes/onnx/convert_to_ncnn.py
@@ -13,6 +13,8 @@ from ...utils.ncnn_model import NcnnModelWrapper
 from ...utils.onnx_model import OnnxModel
 from ...utils.onnx_to_ncnn import Onnx2NcnnConverter
 
+FP_MODE_32 = 0
+
 
 @NodeFactory.register("chainner:onnx:convert_to_ncnn")
 class ConvertOnnxToNcnnNode(NodeBase):
@@ -22,13 +24,7 @@ class ConvertOnnxToNcnnNode(NodeBase):
         self.inputs = [OnnxModelInput("ONNX Model"), OnnxFpDropdown()]
         self.outputs = [
             NcnnModelOutput(label="NCNN Model"),
-            TextOutput(
-                "FP Mode",
-                """match Input1 {
-                        FpMode::fp32 => "fp32",
-                        FpMode::fp16 => "fp16",
-                }""",
-            ),
+            TextOutput("FP Mode", "FpMode::toString(Input1)"),
         ]
 
         self.category = ONNXCategory

--- a/backend/src/nodes/nodes/pytorch/convert_to_ncnn.py
+++ b/backend/src/nodes/nodes/pytorch/convert_to_ncnn.py
@@ -48,7 +48,7 @@ class ConvertTorchToNCNNNode(NodeBase):
             )
 
         # Set final to False so intermediate conversion to ONNX is always fp32
-        onnx_model = ConvertTorchToONNXNode().run(model, final=False)[0]
+        onnx_model = ConvertTorchToONNXNode().run(model)[0]
         ncnn_model, fp_mode = ConvertOnnxToNcnnNode().run(onnx_model, is_fp16)
 
         return ncnn_model, fp_mode

--- a/backend/src/nodes/nodes/pytorch/convert_to_ncnn.py
+++ b/backend/src/nodes/nodes/pytorch/convert_to_ncnn.py
@@ -48,7 +48,7 @@ class ConvertTorchToNCNNNode(NodeBase):
             )
 
         # Set final to False so intermediate conversion to ONNX is always fp32
-        onnx_model = ConvertTorchToONNXNode().run(model, False)
+        onnx_model = ConvertTorchToONNXNode().run(model, final=False)
         ncnn_model, fp_mode = ConvertOnnxToNcnnNode().run(onnx_model, is_fp16)
 
         return ncnn_model, fp_mode

--- a/backend/src/nodes/nodes/pytorch/convert_to_ncnn.py
+++ b/backend/src/nodes/nodes/pytorch/convert_to_ncnn.py
@@ -48,7 +48,7 @@ class ConvertTorchToNCNNNode(NodeBase):
             )
 
         # Set final to False so intermediate conversion to ONNX is always fp32
-        onnx_model = ConvertTorchToONNXNode().run(model, final=False)
+        onnx_model = ConvertTorchToONNXNode().run(model, final=False)[0]
         ncnn_model, fp_mode = ConvertOnnxToNcnnNode().run(onnx_model, is_fp16)
 
         return ncnn_model, fp_mode

--- a/backend/src/nodes/nodes/pytorch/convert_to_ncnn.py
+++ b/backend/src/nodes/nodes/pytorch/convert_to_ncnn.py
@@ -12,7 +12,7 @@ from ...utils.torch_types import PyTorchModel
 from .convert_to_onnx import ConvertTorchToONNXNode
 
 try:
-    from ..onnx.convert_to_ncnn import ConvertOnnxToNcnnNode
+    from ..onnx.convert_to_ncnn import ConvertOnnxToNcnnNode, FP_MODE_32
 except:
     ConvertOnnxToNcnnNode = None
 
@@ -25,13 +25,7 @@ class ConvertTorchToNCNNNode(NodeBase):
         self.inputs = [ModelInput("PyTorch Model"), OnnxFpDropdown()]
         self.outputs = [
             NcnnModelOutput(label="NCNN Model"),
-            TextOutput(
-                "FP Mode",
-                """match Input1 {
-                        FpMode::fp32 => "fp32",
-                        FpMode::fp16 => "fp16",
-                }""",
-            ),
+            TextOutput("FP Mode", "FpMode::toString(Input1)"),
         ]
 
         self.category = PyTorchCategory
@@ -47,8 +41,8 @@ class ConvertTorchToNCNNNode(NodeBase):
                 manager to use this node."
             )
 
-        # Set final to False so intermediate conversion to ONNX is always fp32
-        onnx_model = ConvertTorchToONNXNode().run(model)[0]
+        # Intermediate conversion to ONNX is always fp32
+        onnx_model = ConvertTorchToONNXNode().run(model, FP_MODE_32)[0]
         ncnn_model, fp_mode = ConvertOnnxToNcnnNode().run(onnx_model, is_fp16)
 
         return ncnn_model, fp_mode

--- a/backend/src/nodes/nodes/pytorch/convert_to_ncnn.py
+++ b/backend/src/nodes/nodes/pytorch/convert_to_ncnn.py
@@ -46,7 +46,9 @@ class ConvertTorchToNCNNNode(NodeBase):
                 and therefore requires the ONNX dependency to be installed. Please install ONNX through the dependency \
                 manager to use this node."
             )
-        onnx_model = ConvertTorchToONNXNode().run(model)
+
+        # Set final to False so intermediate conversion to ONNX is always fp32
+        onnx_model = ConvertTorchToONNXNode().run(model, False)
         ncnn_model, fp_mode = ConvertOnnxToNcnnNode().run(onnx_model, is_fp16)
 
         return ncnn_model, fp_mode

--- a/backend/src/nodes/nodes/pytorch/convert_to_onnx.py
+++ b/backend/src/nodes/nodes/pytorch/convert_to_onnx.py
@@ -36,7 +36,7 @@ class ConvertTorchToONNXNode(NodeBase):
         self.icon = "ONNX"
         self.sub = "Utility"
 
-    def run(self, model: PyTorchModel, is_fp16: int = 0) -> Tuple[OnnxModel, str]:
+    def run(self, model: PyTorchModel, is_fp16: int) -> Tuple[OnnxModel, str]:
         fp16 = bool(is_fp16)
         exec_options = to_pytorch_execution_options(get_execution_options())
         if fp16:

--- a/backend/src/nodes/nodes/pytorch/convert_to_onnx.py
+++ b/backend/src/nodes/nodes/pytorch/convert_to_onnx.py
@@ -87,4 +87,4 @@ class ConvertTorchToONNXNode(NodeBase):
 
         fp_mode = "fp16" if fp16 else "fp32"
 
-        return OnnxModel(onnx_model_bytes), "fp32"
+        return OnnxModel(onnx_model_bytes), fp_mode

--- a/backend/src/nodes/nodes/pytorch/convert_to_onnx.py
+++ b/backend/src/nodes/nodes/pytorch/convert_to_onnx.py
@@ -21,27 +21,25 @@ class ConvertTorchToONNXNode(NodeBase):
     def __init__(self):
         super().__init__()
         self.description = """Convert a PyTorch model to ONNX."""
-        if to_pytorch_execution_options(get_execution_options()).fp16:
-            self.inputs = [
-                ModelInput("PyTorch Model"),
-                OnnxFpDropdown(),
-            ]
-            self.outputs = [
+        is_fp16 = to_pytorch_execution_options(get_execution_options()).fp16
+        self.inputs = [
+            ModelInput("PyTorch Model"),
+            *([OnnxFpDropdown()] if is_fp16 else []),
+        ]
+        self.outputs = [
+            *(
                 OnnxModelOutput(label="ONNX Model"),
                 TextOutput(
                     "FP Mode",
                     """match Input1 {
                         FpMode::fp32 => "fp32",
                         FpMode::fp16 => "fp16",
-                }""",
-                ),
-            ]
-        else:
-            self.inputs = [ModelInput("PyTorch Model")]
-            self.outputs = [
-                OnnxModelOutput(label="ONNX Model"),
-                TextOutput("FP Mode", "Fp32"),
-            ]
+                    }""",
+                )
+                if is_fp16
+                else TextOutput("FP Mode", '"fp32"'),
+            )
+        ]
 
         self.category = PyTorchCategory
         self.name = "Convert To ONNX"

--- a/backend/src/nodes/nodes/pytorch/convert_to_onnx.py
+++ b/backend/src/nodes/nodes/pytorch/convert_to_onnx.py
@@ -28,7 +28,7 @@ class ConvertTorchToONNXNode(NodeBase):
         self.icon = "ONNX"
         self.sub = "Utility"
 
-    def run(self, model: PyTorchModel) -> OnnxModel:
+    def run(self, model: PyTorchModel, final: bool = True) -> OnnxModel:
         exec_options = to_pytorch_execution_options(get_execution_options())
 
         model = model.eval()
@@ -41,7 +41,7 @@ class ConvertTorchToONNXNode(NodeBase):
         dummy_input = torch.rand(1, model.in_nc, 64, 64)  # type: ignore
         dummy_input = dummy_input.to(torch.device(exec_options.device))
 
-        should_use_fp16 = exec_options.fp16 and model.supports_fp16
+        should_use_fp16 = exec_options.fp16 and model.supports_fp16 and final
         if should_use_fp16:
             model = model.half()
             dummy_input = dummy_input.half()

--- a/backend/src/nodes/utils/ncnn_model.py
+++ b/backend/src/nodes/utils/ncnn_model.py
@@ -15,8 +15,6 @@ except:
     TensorProto = None
     onph = None
 
-from .onnx_tensor_utils import TensorProtoTypes as TPT
-
 param_schema_file = os.path.join(
     os.path.dirname(os.path.realpath(__file__)), "ncnn_param_schema.json"
 )

--- a/backend/src/nodes/utils/ncnn_model.py
+++ b/backend/src/nodes/utils/ncnn_model.py
@@ -309,12 +309,9 @@ class NcnnLayer:
 
         if quantize_tag == DTYPE_FP16:
             data_array = data_array.astype(np.float16)
-        elif (
-            data_array.dtype == np.float16
-            and TPT.FLOAT16
-            not in param_schema[self.op_type]["weightOrder"][weight_name]
-        ):
-            # Convert invalid fp16 from ONNX model weights to fp32
+        else:
+            # Since int8 not supported, all data that is not fp16 is fp32.
+            # This covers issues caused by converting fp16 ONNX models.
             data_array = data_array.astype(np.float32)
         self.weight_data[weight_name] = NcnnWeight(data_array, quantize_tag)
 

--- a/backend/src/nodes/utils/ncnn_param_schema.json
+++ b/backend/src/nodes/utils/ncnn_param_schema.json
@@ -1,6 +1,6 @@
 {
   "AbsVal": {
-    "weightOrder": []
+    "weightOrder": {}
   },
   "ArgMax": {
     "0": {
@@ -13,7 +13,7 @@
       "paramPhase": "topk",
       "defaultValue": 1
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "BatchNorm": {
     "0": {
@@ -26,12 +26,12 @@
       "paramPhase": "eps",
       "defaultValue": 0
     },
-    "weightOrder": [
-      "slope",
-      "mean",
-      "variance",
-      "bias"
-    ]
+    "weightOrder": {
+      "slope": [1],
+      "mean": [1],
+      "variance": [1],
+      "bias": [1]
+    }
   },
   "Bias": {
     "0": {
@@ -39,9 +39,9 @@
       "paramPhase": "bias_data_size",
       "defaultValue": 0
     },
-    "weightOrder": [
-      "channels"
-    ]
+    "weightOrder": {
+      "channels": [1]
+    }
   },
   "BinaryOp": {
     "0": {
@@ -59,10 +59,10 @@
       "paramPhase": "b",
       "defaultValue": 0
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "BNLL": {
-    "weightOrder": []
+    "weightOrder": {}
   },
   "Cast": {
     "0": {
@@ -75,7 +75,7 @@
       "paramPhase": "type_to",
       "defaultValue": 0
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "Clip": {
     "0": {
@@ -88,7 +88,7 @@
       "paramPhase": "max",
       "defaultValue": "FLT_MAX"
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "Concat": {
     "0": {
@@ -96,7 +96,7 @@
       "paramPhase": "axis",
       "defaultValue": 0
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "Convolution": {
     "0": {
@@ -194,10 +194,10 @@
       "paramPhase": "dynamic_weight",
       "defaultValue": 0
     },
-    "weightOrder": [
-      "weight",
-      "bias"
-    ]
+    "weightOrder": {
+      "weight": [1, 3, 10],
+      "bias": [1]
+    }
   },
   "Convolution1D": {
     "0": {
@@ -260,10 +260,10 @@
       "paramPhase": "dynamic_weight",
       "defaultValue": 0
     },
-    "weightOrder": [
-      "weight",
-      "bias"
-    ]
+    "weightOrder": {
+      "weight": [1, 3, 10],
+      "bias": [1]
+    }
   },
   "ConvolutionDepthWise": {
     "0": {
@@ -361,10 +361,10 @@
       "paramPhase": "dynamic_weight",
       "defaultValue": 0
     },
-    "weightOrder": [
-      "weight",
-      "bias"
-    ]
+    "weightOrder": {
+      "weight": [1, 3, 10],
+      "bias": [1]
+    }
   },
   "Crop": {
     "0": {
@@ -427,7 +427,7 @@
       "paramPhase": "axes",
       "defaultValue": []
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "Deconvolution": {
     "0": {
@@ -525,10 +525,10 @@
       "paramPhase": "output_h",
       "defaultValue": "output_w"
     },
-    "weightOrder": [
-      "weight",
-      "bias"
-    ]
+    "weightOrder": {
+      "weight": [1, 3, 10],
+      "bias": [1]
+    }
   },
   "DeconvolutionDepthWise": {
     "0": {
@@ -631,10 +631,10 @@
       "paramPhase": "output_h",
       "defaultValue": "output_w"
     },
-    "weightOrder": [
-      "weight",
-      "bias"
-    ]
+    "weightOrder": {
+      "weight": [1, 3, 10],
+      "bias": [1]
+    }
   },
   "Dequantize": {
     "0": {
@@ -652,9 +652,10 @@
       "paramPhase": "bias_data_size",
       "defaultValue": 0
     },
-    "weightOrder": [
-      "bias"
-    ]
+    "weightOrder": {
+      "scale": [1],
+      "bias": [1]
+    }
   },
   "DetectionOutput": {
     "0": {
@@ -702,7 +703,7 @@
       "paramPhase": "variances[3]",
       "defaultValue": 0.2
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "Dropout": {
     "0": {
@@ -710,7 +711,7 @@
       "paramPhase": "scale",
       "defaultValue": 1
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "Eltwise": {
     "0": {
@@ -723,7 +724,7 @@
       "paramPhase": "coeffs",
       "defaultValue": []
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "ELU": {
     "0": {
@@ -731,7 +732,7 @@
       "paramPhase": "alpha",
       "defaultValue": 0.1
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "Embed": {
     "0": {
@@ -754,10 +755,10 @@
       "paramPhase": "weight_data_size",
       "defaultValue": 0
     },
-    "weightOrder": [
-      "weight",
-      "bias"
-    ]
+    "weightOrder": {
+      "weight": [1, 3, 10],
+      "bias": [1]
+    }
   },
   "Exp": {
     "0": {
@@ -775,7 +776,7 @@
       "paramPhase": "shift",
       "defaultValue": 0
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "ExpandDims": {
     "0": {
@@ -798,10 +799,10 @@
       "paramPhase": "axes",
       "defaultValue": []
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "Flatten": {
-    "weightOrder": []
+    "weightOrder": {}
   },
   "GRU": {
     "0": {
@@ -819,11 +820,11 @@
       "paramPhase": "direction",
       "defaultValue": 0
     },
-    "weightOrder": [
-      "weight_xc",
-      "bias",
-      "weight_hc"
-    ]
+    "weightOrder": {
+      "weight_xc": [1, 3, 10],
+      "bias": [1, 3, 10],
+      "weight_hc": [1, 3, 10]
+    }
   },
   "HardSigmoid": {
     "0": {
@@ -836,7 +837,7 @@
       "paramPhase": "beta",
       "defaultValue": 0.5
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "HardSwish": {
     "0": {
@@ -849,7 +850,7 @@
       "paramPhase": "beta",
       "defaultValue": 0.5
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "InnerProduct": {
     "0": {
@@ -882,10 +883,10 @@
       "paramPhase": "activation_params",
       "defaultValue": []
     },
-    "weightOrder": [
-      "weight",
-      "bias"
-    ]
+    "weightOrder": {
+      "weight": [1, 3, 10],
+      "bias": [1]
+    }
   },
   "Input": {
     "0": {
@@ -903,7 +904,7 @@
       "paramPhase": "c",
       "defaultValue": 0
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "InstanceNorm": {
     "0": {
@@ -921,10 +922,10 @@
       "paramPhase": "affine",
       "defaultValue": 1
     },
-    "weightOrder": [
-      "gamma",
-      "bias"
-    ]
+    "weightOrder": {
+      "gamma": [1],
+      "bias": [1]
+    }
   },
   "Interp": {
     "0": {
@@ -962,7 +963,7 @@
       "paramPhase": "align_corner",
       "defaultValue": 0
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "Log": {
     "0": {
@@ -980,7 +981,7 @@
       "paramPhase": "shift",
       "defaultValue": 0
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "LRN": {
     "0": {
@@ -1008,7 +1009,7 @@
       "paramPhase": "bias",
       "defaultValue": 1
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "LSTM": {
     "0": {
@@ -1026,7 +1027,7 @@
       "paramPhase": "direction",
       "defaultValue": 0
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "MemoryData": {
     "0": {
@@ -1044,10 +1045,10 @@
       "paramPhase": "c",
       "defaultValue": 0
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "Mish": {
-    "weightOrder": []
+    "weightOrder": {}
   },
   "MVN": {
     "0": {
@@ -1065,10 +1066,10 @@
       "paramPhase": "eps",
       "defaultValue": 0.0001
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "Noop": {
-    "weightOrder": []
+    "weightOrder": {}
   },
   "Normalize": {
     "0": {
@@ -1101,9 +1102,9 @@
       "paramPhase": "eps_mode",
       "defaultValue": 0
     },
-    "weightOrder": [
-      "scale"
-    ]
+    "weightOrder": {
+      "scale": [1]
+    }
   },
   "Packing": {
     "0": {
@@ -1136,7 +1137,7 @@
       "paramPhase": "storage_type_to",
       "defaultValue": 0
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "Padding": {
     "0": {
@@ -1184,9 +1185,9 @@
       "paramPhase": "behind",
       "defaultValue": 0
     },
-    "weightOrder": [
-      "per_channel_pad_data"
-    ]
+    "weightOrder": {
+      "per_channel_pad_data": [1]
+    }
   },
   "Permute": {
     "0": {
@@ -1194,7 +1195,7 @@
       "paramPhase": "order_type",
       "defaultValue": 0
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "PixelShuffle": {
     "0": {
@@ -1207,7 +1208,7 @@
       "paramPhase": "mode",
       "defaultValue": 0
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "Pooling": {
     "0": {
@@ -1285,7 +1286,7 @@
       "paramPhase": "out_h",
       "defaultValue": "out_w"
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "Pooling1D": {
     "0": {
@@ -1338,7 +1339,7 @@
       "paramPhase": "pad_right",
       "defaultValue": "pad_left"
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "Power": {
     "0": {
@@ -1356,7 +1357,7 @@
       "paramPhase": "shift",
       "defaultValue": 0
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "PReLU": {
     "0": {
@@ -1364,9 +1365,9 @@
       "paramPhase": "num_slope",
       "defaultValue": 0
     },
-    "weightOrder": [
-      "slope"
-    ]
+    "weightOrder": {
+      "slope": [1]
+    }
   },
   "PriorBox": {
     "0": {
@@ -1449,9 +1450,9 @@
       "paramPhase": "center_mmdetection",
       "defaultValue": 0
     },
-    "weightOrder": [
-      "slope"
-    ]
+    "weightOrder": {
+      "slope": [1]
+    }
   },
   "Proposal": {
     "0": {
@@ -1484,7 +1485,7 @@
       "paramPhase": "min_size",
       "defaultValue": 16
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "PSROIPooling": {
     "0": {
@@ -1507,7 +1508,7 @@
       "paramPhase": "output_dim",
       "defaultValue": 0
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "Quantize": {
     "0": {
@@ -1515,7 +1516,9 @@
       "paramPhase": "scale",
       "defaultValue": 1
     },
-    "weightOrder": []
+    "weightOrder": {
+      "scale": [1]
+    }
   },
   "Reduction": {
     "0": {
@@ -1548,7 +1551,7 @@
       "paramPhase": "UNKNOWN",
       "defaultValue": 0
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "ReLU": {
     "0": {
@@ -1556,7 +1559,7 @@
       "paramPhase": "slope",
       "defaultValue": 0
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "Reorg": {
     "0": {
@@ -1564,7 +1567,7 @@
       "paramPhase": "stride",
       "defaultValue": 0
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "Requantize": {
     "0": {
@@ -1592,9 +1595,11 @@
       "paramPhase": "fusion_relu",
       "defaultValue": 0
     },
-    "weightOrder": [
-      "bias"
-    ]
+    "weightOrder": {
+      "scale_in": [1],
+      "scale_out": [1],
+      "bias": [1]
+    }
   },
   "Reshape": {
     "0": {
@@ -1617,7 +1622,7 @@
       "paramPhase": "permute",
       "defaultValue": 0
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "ROIAlign": {
     "0": {
@@ -1650,7 +1655,7 @@
       "paramPhase": "version",
       "defaultValue": 0
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "ROIPooling": {
     "0": {
@@ -1668,7 +1673,7 @@
       "paramPhase": "spatial_scale",
       "defaultValue": 1
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "Scale": {
     "0": {
@@ -1681,10 +1686,10 @@
       "paramPhase": "bias_term",
       "defaultValue": 0
     },
-    "weightOrder": [
-      "scale",
-      "bias"
-    ]
+    "weightOrder": {
+      "scale": [1],
+      "bias": [1]
+    }
   },
   "SELU": {
     "0": {
@@ -1709,7 +1714,7 @@
       "paramPhase": "reverse",
       "defaultValue": 0
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "Sigmoid": {},
   "Slice": {
@@ -1723,7 +1728,7 @@
       "paramPhase": "axis",
       "defaultValue": 0
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "Softmax": {
     "0": {
@@ -1736,10 +1741,10 @@
       "paramPhase": "fixbug0",
       "defaultValue": 0
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "Split": {
-    "weightOrder": []
+    "weightOrder": {}
   },
   "SPP": {
     "0": {
@@ -1752,7 +1757,7 @@
       "paramPhase": "pyramid_height",
       "defaultValue": 1
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "Squeeze": {
     "0": {
@@ -1775,7 +1780,7 @@
       "paramPhase": "axes",
       "defaultValue": []
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "StatisticsPooling": {
     "0": {
@@ -1783,13 +1788,13 @@
       "paramPhase": "include_stddev",
       "defaultValue": 0
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "Swish": {
-    "weightOrder": []
+    "weightOrder": {}
   },
   "TanH": {
-    "weightOrder": []
+    "weightOrder": {}
   },
   "Threshold": {
     "0": {
@@ -1797,7 +1802,7 @@
       "paramPhase": "threshold",
       "defaultValue": 0
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "Tile": {
     "0": {
@@ -1810,7 +1815,7 @@
       "paramPhase": "tiles",
       "defaultValue": 1
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "UnaryOp": {
     "0": {
@@ -1818,7 +1823,7 @@
       "paramPhase": "op_type",
       "defaultValue": 0
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "YoloDetectionOutput": {
     "0": {
@@ -1846,7 +1851,7 @@
       "paramPhase": "biases",
       "defaultValue": []
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "Yolov3DetectionOutput": {
     "0": {
@@ -1884,7 +1889,7 @@
       "paramPhase": "anchors_scale",
       "defaultValue": []
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "RNN": {
     "0": {
@@ -1902,7 +1907,7 @@
       "paramPhase": "direction",
       "defaultValue": 0
     },
-    "weightOrder": []
+    "weightOrder": {}
   },
   "MultiHeadAttention": {
     "0": {
@@ -1920,6 +1925,6 @@
       "paramPhase": "weight_data_size",
       "defaultValue": 0
     },
-    "weightOrder": []
+    "weightOrder": {}
   }
 }

--- a/backend/src/nodes/utils/ncnn_param_schema.json
+++ b/backend/src/nodes/utils/ncnn_param_schema.json
@@ -40,7 +40,7 @@
       "defaultValue": 0
     },
     "weightOrder": {
-      "channels": [1]
+      "bias": [1]
     }
   },
   "BinaryOp": {
@@ -1027,7 +1027,12 @@
       "paramPhase": "direction",
       "defaultValue": 0
     },
-    "weightOrder": {}
+    "weightOrder": {
+      "weight_xc": [1, 3, 10],
+      "bias_c": [1, 3, 10],
+      "weight_hc": [1, 3, 10],
+      "weight_hr": [1, 3, 10]
+    }
   },
   "MemoryData": {
     "0": {
@@ -1045,7 +1050,9 @@
       "paramPhase": "c",
       "defaultValue": 0
     },
-    "weightOrder": {}
+    "weightOrder": {
+      "data": [1]
+    }
   },
   "Mish": {
     "weightOrder": {}
@@ -1907,7 +1914,11 @@
       "paramPhase": "direction",
       "defaultValue": 0
     },
-    "weightOrder": {}
+    "weightOrder": {
+      "weight_xc": [1, 3, 10],
+      "bias_c": [1, 3, 10],
+      "weight_hc": [1, 3, 10]
+    }
   },
   "MultiHeadAttention": {
     "0": {
@@ -1925,6 +1936,15 @@
       "paramPhase": "weight_data_size",
       "defaultValue": 0
     },
-    "weightOrder": {}
+    "weightOrder": {
+      "q_weight": [1, 3, 10],
+      "q_bias": [1],
+      "k_weight": [1, 3, 10], 
+      "k_bias": [1],
+      "v_weight": [1, 3, 10],
+      "v_bias": [1],
+      "out_weight": [1, 3, 10],
+      "out_bias": [1]
+    }
   }
 }

--- a/backend/src/nodes/utils/onnx_tensor_utils.py
+++ b/backend/src/nodes/utils/onnx_tensor_utils.py
@@ -103,7 +103,7 @@ def get_node_attr_tensor(node: onnx.NodeProto, key: str) -> onnx.TensorProto:
 def get_node_attr_from_input_f(tp: onnx.TensorProto) -> float:
     shape_data = onph.to_array(tp)
 
-    if tp.data_type in (TPT.FLOAT, TPT.DOUBLE, TPT.INT32):
+    if tp.data_type in (TPT.FLOAT, TPT.FLOAT16, TPT.DOUBLE, TPT.INT32):
         f = shape_data.item(0)
     elif tp.data_type == TPT.INT64:
         f = max(min(shape_data.item(0), INT64_MAX), INT64_MIN)
@@ -134,7 +134,7 @@ def get_node_attr_from_input_ai(tp: onnx.TensorProto) -> np.ndarray:
 
 
 def get_node_attr_from_input_af(tp: onnx.TensorProto) -> np.ndarray:
-    if tp.data_type == TPT.FLOAT or tp.data_type == TPT.DOUBLE:
+    if tp.data_type in (TPT.FLOAT, TPT.FLOAT16, TPT.DOUBLE):
         shape_data = onph.to_array(tp)
         return np.array([val for val in shape_data], shape_data.dtype)
     else:

--- a/backend/src/nodes/utils/onnx_tensor_utils.py
+++ b/backend/src/nodes/utils/onnx_tensor_utils.py
@@ -143,10 +143,12 @@ def get_node_attr_from_input_af(tp: onnx.TensorProto) -> np.ndarray:
     return np.empty(0, np.float32)
 
 
-def get_tensor_proto_data_size(tp: onnx.TensorProto) -> int:
+def get_tensor_proto_data_size(tp: onnx.TensorProto, fpmode: int = TPT.FLOAT) -> int:
     if tp.raw_data:
+        if fpmode == TPT.FLOAT16:
+            return len(tp.raw_data) // 2
         return len(tp.raw_data) // 4
-    elif tp.data_type == TPT.FLOAT:
+    elif tp.data_type == TPT.FLOAT or tp.data_type == TPT.FLOAT16:
         return len(tp.float_data)
 
     return 0

--- a/backend/src/nodes/utils/onnx_to_ncnn.py
+++ b/backend/src/nodes/utils/onnx_to_ncnn.py
@@ -334,7 +334,7 @@ class Onnx2NcnnConverter:
                 add_three = self.weights[node.input[1]]
                 if (
                     len(add_three.dims) != 0
-                    or get_tensor_proto_data_size(add_three) != 1
+                    or get_tensor_proto_data_size(add_three, add_three.data_type) != 1
                 ):
                     continue
 
@@ -379,7 +379,10 @@ class Onnx2NcnnConverter:
                     continue
 
                 div_six = self.weights[node4.input[1]]
-                if len(div_six.dims) != 0 or get_tensor_proto_data_size(div_six) != 1:
+                if (
+                    len(div_six.dims) != 0
+                    or get_tensor_proto_data_size(div_six, div_six.data_type) != 1
+                ):
                     continue
 
                 constant_div_six = get_node_attr_from_input_f(div_six)
@@ -483,7 +486,7 @@ class Onnx2NcnnConverter:
                 add_three = self.weights[node.input[1]]
                 if (
                     len(add_three.dims) != 0
-                    or get_tensor_proto_data_size(add_three) != 1
+                    or get_tensor_proto_data_size(add_three, add_three.data_type) != 1
                 ):
                     continue
 
@@ -522,7 +525,10 @@ class Onnx2NcnnConverter:
                     continue
 
                 div_six = self.weights[node3.input[1]]
-                if len(div_six.dims) != 0 or get_tensor_proto_data_size(div_six) != 1:
+                if (
+                    len(div_six.dims) != 0
+                    or get_tensor_proto_data_size(div_six, div_six.data_type) != 1
+                ):
                     continue
 
                 constant_div_six = get_node_attr_from_input_f(div_six)
@@ -951,7 +957,10 @@ class Onnx2NcnnConverter:
                     continue
 
                 pow_two = self.weights[node3.input[1]]
-                if len(pow_two.dims) != 0 or get_tensor_proto_data_size(pow_two) != 1:
+                if (
+                    len(pow_two.dims) != 0
+                    or get_tensor_proto_data_size(pow_two, pow_two.data_type) != 1
+                ):
                     continue
 
                 constant_pow_two = get_node_attr_from_input_f(pow_two)
@@ -972,7 +981,10 @@ class Onnx2NcnnConverter:
                     continue
 
                 add_eps = self.weights[node5.input[1]]
-                if len(add_eps.dims) != 0 or get_tensor_proto_data_size(add_eps) != 1:
+                if (
+                    len(add_eps.dims) != 0
+                    or get_tensor_proto_data_size(add_eps, add_eps.data_type) != 1
+                ):
                     continue
 
                 eps = get_node_attr_from_input_f(add_eps)
@@ -2203,7 +2215,10 @@ class Onnx2NcnnConverter:
                     continue
 
                 scalar_b = self.weights[node.input[0]]
-                if len(scalar_b.dims) != 0 or get_tensor_proto_data_size(scalar_b) != 1:
+                if (
+                    len(scalar_b.dims) != 0
+                    or get_tensor_proto_data_size(scalar_b, scalar_b.data_type) != 1
+                ):
                     continue
 
                 if node.op_type == "Sub":
@@ -2236,7 +2251,10 @@ class Onnx2NcnnConverter:
                     continue
 
                 scalar_b = self.weights[node.input[1]]
-                if len(scalar_b.dims) != 0 or get_tensor_proto_data_size(scalar_b) != 1:
+                if (
+                    len(scalar_b.dims) != 0
+                    or get_tensor_proto_data_size(scalar_b, scalar_b.data_type) != 1
+                ):
                     continue
 
                 b = get_node_attr_from_input_f(scalar_b)
@@ -2576,7 +2594,7 @@ class Onnx2NcnnConverter:
 
                     M_dims_size = len(M.dims)
                     if M_dims_size == 0:
-                        layer.add_param(0, get_tensor_proto_data_size(M))
+                        layer.add_param(0, get_tensor_proto_data_size(M, M.data_type))
                     elif M_dims_size == 1:
                         layer.add_param(0, M.dims[0])
                     elif M_dims_size == 2:
@@ -2922,7 +2940,7 @@ class Onnx2NcnnConverter:
                 B = self.weights[node.input[2]]
                 mean = self.weights[node.input[3]]
                 var = self.weights[node.input[4]]
-                channels = get_tensor_proto_data_size(scale)
+                channels = get_tensor_proto_data_size(scale, scale.data_type)
 
                 layer.add_param(0, channels)
 
@@ -2937,7 +2955,7 @@ class Onnx2NcnnConverter:
             elif op == "BiasGelu":
                 B = self.weights[node.input[1]]
 
-                layer.add_param(0, get_tensor_proto_data_size(B))
+                layer.add_param(0, get_tensor_proto_data_size(B, B.data_type))
 
                 bin_length += layer.add_weight(B, "bias")
             elif op == "Ceil":
@@ -3016,7 +3034,7 @@ class Onnx2NcnnConverter:
 
                 layer.add_param(5, has_bias)
 
-                layer.add_param(6, get_tensor_proto_data_size(W))
+                layer.add_param(6, get_tensor_proto_data_size(W, W.data_type))
 
                 if group > 1:
                     layer.add_param(7, group)
@@ -3092,7 +3110,7 @@ class Onnx2NcnnConverter:
 
                 layer.add_param(5, has_bias)
 
-                weight_data_size = get_tensor_proto_data_size(W)
+                weight_data_size = get_tensor_proto_data_size(W, W.data_type)
                 layer.add_param(6, weight_data_size)
 
                 if group > 1:
@@ -3139,9 +3157,11 @@ class Onnx2NcnnConverter:
                 W = self.weights[node.input[5]]
                 B = self.weights[node.input[6]]
 
-                layer.add_param(0, get_tensor_proto_data_size(B))
-                layer.add_param(1, get_tensor_proto_data_size(words))
-                layer.add_param(2, get_tensor_proto_data_size(positions))
+                layer.add_param(0, get_tensor_proto_data_size(B, B.data_type))
+                layer.add_param(1, get_tensor_proto_data_size(words, words.data_type))
+                layer.add_param(
+                    2, get_tensor_proto_data_size(positions, positions.data_type)
+                )
 
                 quantize_tag = DTYPE_FP16 if is_fp16 else DTYPE_FP32
                 bin_length += layer.add_weight(words, "words", DTYPE_FP32)
@@ -3169,9 +3189,9 @@ class Onnx2NcnnConverter:
                     B = self.weights[node.input[1]]
                     C = self.weights[node.input[2]]
 
-                    layer.add_param(0, get_tensor_proto_data_size(C))
+                    layer.add_param(0, get_tensor_proto_data_size(C, C.data_type))
                     layer.add_param(1, 1)
-                    layer.add_param(2, get_tensor_proto_data_size(B))
+                    layer.add_param(2, get_tensor_proto_data_size(B, B.data_type))
 
                     bin_length += layer.add_weight(B, "B", DTYPE_FP32)
                     bin_length += layer.add_weight(C, "C")
@@ -3376,7 +3396,7 @@ class Onnx2NcnnConverter:
                 if node.input[1] in self.weights:
                     # InnerProduct
                     B = self.weights[node.input[1]]
-                    weight_data_size = get_tensor_proto_data_size(B)
+                    weight_data_size = get_tensor_proto_data_size(B, B.data_type)
                     num_output = B.dims[-1]
 
                     layer.add_param(0, num_output)
@@ -3467,7 +3487,7 @@ class Onnx2NcnnConverter:
                 layer.add_param(0, get_node_attr_i(node, "scale_factor", 1))
             elif op == "PRelu":
                 slope = self.weights[node.input[1]]
-                num_slope = get_tensor_proto_data_size(slope)
+                num_slope = get_tensor_proto_data_size(slope, slope.data_type)
 
                 layer.add_param(0, num_slope)
 
@@ -3636,7 +3656,7 @@ class Onnx2NcnnConverter:
                 else:
                     direction_type = GRU.FORWARD
 
-                weight_data_size = get_tensor_proto_data_size(W)
+                weight_data_size = get_tensor_proto_data_size(W, W.data_type)
 
                 layer.add_param(0, hidden_size)
                 layer.add_param(1, weight_data_size)
@@ -3663,7 +3683,7 @@ class Onnx2NcnnConverter:
                 B = self.weights[node.input[3]]
                 B2 = self.weights[node.input[4]]
 
-                layer.add_param(0, get_tensor_proto_data_size(B))
+                layer.add_param(0, get_tensor_proto_data_size(B, B.data_type))
 
                 quantize_tag = DTYPE_FP16 if is_fp16 else DTYPE_FP32
                 bin_length += layer.add_weight(W, "weight", quantize_tag)

--- a/src/common/types/chainner-scope.ts
+++ b/src/common/types/chainner-scope.ts
@@ -57,6 +57,7 @@ struct NcnnNetwork {
 
 struct OnnxFile;
 struct OnnxModel;
+let Fp32 = "fp32";
 
 struct IteratorAuto;
 

--- a/src/common/types/chainner-scope.ts
+++ b/src/common/types/chainner-scope.ts
@@ -102,6 +102,12 @@ def BorderType::getOutputChannels(type: BorderType, channels: uint) {
         _ => channels
     }
 }
+def FpMode::toString(mode: FpMode) {
+    match mode {
+        FpMode::fp32 => "fp32",
+        FpMode::fp16 => "fp16",
+    }
+}
 `;
 
 export const getChainnerScope = lazy((): Scope => {

--- a/src/common/types/chainner-scope.ts
+++ b/src/common/types/chainner-scope.ts
@@ -57,7 +57,6 @@ struct NcnnNetwork {
 
 struct OnnxFile;
 struct OnnxModel;
-let Fp32 = "fp32";
 
 struct IteratorAuto;
 


### PR DESCRIPTION
As discussed on discord. Main features are:
1. PyTorch to NCNN will now always use fp32 when converting to ONNX intermediately. 
2. Converting raw data in tensors to floats now handles fp16.
3. If fp16 is used in ONNX model where not supported in NCNN, data type converted to fp32.
4. Fp mode is now selectable for Convert to ONNX (though fp16 will error if pytorch fp16 mode not on/supported).