### PR TITLE
Added pseudo-variable-length inputs using new group

### DIFF
--- a/backend/src/nodes/nodes/utility/text_append.py
+++ b/backend/src/nodes/nodes/utility/text_append.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Union
+from typing import List, Union
 
 from . import category as UtilityCategory
 
@@ -32,12 +32,13 @@ class TextAppendNode(NodeBase):
             TextOutput(
                 "Output Text",
                 output_type="""
+                let sep = toString(Input0);
                 concat(
                     toString(Input1),
-                    toString(Input0),
+                    sep,
                     toString(Input2),
-                    match Input3 { null => "", _ as s => concat(toString(Input0), toString(s)) },
-                    match Input4 { null => "", _ as s => concat(toString(Input0), toString(s)) }
+                    match Input3 { null => "", _ as s => concat(sep, toString(s)) },
+                    match Input4 { null => "", _ as s => concat(sep, toString(s)) }
                 )
                 """,
             )
@@ -56,5 +57,5 @@ class TextAppendNode(NodeBase):
         str3: Union[str, None],
         str4: Union[str, None],
     ) -> str:
-        strings = [str(x) for x in [str1, str2, str3, str4] if x is not None]
-        return separator.join(strings)
+        inputs: List[Union[str, None]] = [str1, str2, str3, str4]
+        return separator.join([x for x in inputs if x is not None])

--- a/backend/src/nodes/nodes/utility/text_append.py
+++ b/backend/src/nodes/nodes/utility/text_append.py
@@ -4,7 +4,7 @@ from typing import List, Union
 
 from . import category as UtilityCategory
 
-from ...node_base import NodeBase
+from ...node_base import NodeBase, group
 from ...node_factory import NodeFactory
 from ...properties.inputs import TextInput
 from ...properties.outputs import TextOutput
@@ -25,8 +25,10 @@ class TextAppendNode(NodeBase):
             ),
             TextInput("Text A"),
             TextInput("Text B"),
-            TextInput("Text C").make_optional(),
-            TextInput("Text D").make_optional(),
+            group("optional-list")(
+                TextInput("Text C").make_optional(),
+                TextInput("Text D").make_optional(),
+            ),
         ]
         self.outputs = [
             TextOutput(

--- a/backend/src/nodes/nodes/utility/text_pattern.py
+++ b/backend/src/nodes/nodes/utility/text_pattern.py
@@ -4,7 +4,7 @@ from typing import Union
 
 from . import category as UtilityCategory
 
-from ...node_base import NodeBase
+from ...node_base import NodeBase, group
 from ...node_factory import NodeFactory
 from ...properties.inputs import TextInput
 from ...properties.outputs import TextOutput
@@ -20,8 +20,10 @@ class TextPatternNode(NodeBase):
             TextInput("Pattern", has_handle=False, placeholder='E.g. "{1} and {2}"'),
             TextInput("{1}").make_optional(),
             TextInput("{2}").make_optional(),
-            TextInput("{3}").make_optional(),
-            TextInput("{4}").make_optional(),
+            group("optional-list")(
+                TextInput("{3}").make_optional(),
+                TextInput("{4}").make_optional(),
+            ),
         ]
         self.outputs = [
             TextOutput(

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -137,8 +137,12 @@ interface FromToDropdownsGroup extends GroupBase {
     readonly kind: 'from-to-dropdowns';
     readonly options: Readonly<Record<string, never>>;
 }
+interface OptionalListGroup extends GroupBase {
+    readonly kind: 'optional-list';
+    readonly options: Readonly<Record<string, never>>;
+}
 export type GroupKind = Group['kind'];
-export type Group = NcnnFileInputGroup | FromToDropdownsGroup;
+export type Group = NcnnFileInputGroup | FromToDropdownsGroup | OptionalListGroup;
 
 export type OfKind<T, Kind extends string> = T extends { readonly kind: Kind } ? T : never;
 

--- a/src/common/group-inputs.ts
+++ b/src/common/group-inputs.ts
@@ -6,6 +6,7 @@ type InputGuarantees<T extends Record<GroupKind, readonly Input[]>> = T;
 type DeclaredGroupInputs = InputGuarantees<{
     'from-to-dropdowns': readonly [DropDownInput, DropDownInput];
     'ncnn-file-inputs': readonly [FileInput, FileInput];
+    'optional-list': readonly [Input, ...Input[]];
 }>;
 
 // A bit hacky, but this ensures that GroupInputs covers exactly all group types, no more and no less
@@ -29,5 +30,8 @@ export const groupInputsChecks: {
     },
     'ncnn-file-inputs': (inputs) => {
         return inputs.length === 2 && inputs.every((i) => i.kind === 'file');
+    },
+    'optional-list': (inputs) => {
+        return inputs.length >= 1 && inputs.every((i) => i.optional);
     },
 };

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -23,6 +23,26 @@ export const assertType: <T>(_: T) => void = noop;
 
 export const deepCopy = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
 
+export const findLastIndex = <T>(
+    array: readonly T[],
+    predicate: (value: T, index: number, obj: readonly T[]) => unknown
+): number => {
+    for (let i = array.length - 1; i >= 0; i -= 1) {
+        if (predicate(array[i], i, array)) {
+            return i;
+        }
+    }
+    return -1;
+};
+export const findLast = <T>(
+    array: readonly T[],
+    predicate: (value: T, index: number, obj: readonly T[]) => unknown
+): T | undefined => {
+    const index = findLastIndex(array, predicate);
+    if (index === -1) return undefined;
+    return array[index];
+};
+
 export interface ParsedSourceHandle {
     nodeId: string;
     outputId: OutputId;

--- a/src/renderer/components/groups/Group.tsx
+++ b/src/renderer/components/groups/Group.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../../common/common-types';
 import { FromToDropdownsGroup } from './FromToDropdownsGroup';
 import { NcnnFileInputsGroup } from './NcnnFileInputsGroup';
+import { OptionalInputsGroup } from './OptionalInputsGroup';
 import { GroupProps } from './props';
 
 const GroupComponents: {
@@ -16,6 +17,7 @@ const GroupComponents: {
 } = {
     'from-to-dropdowns': FromToDropdownsGroup,
     'ncnn-file-inputs': NcnnFileInputsGroup,
+    'optional-list': OptionalInputsGroup,
 };
 
 interface GroupElementProps {

--- a/src/renderer/components/groups/OptionalInputsGroup.tsx
+++ b/src/renderer/components/groups/OptionalInputsGroup.tsx
@@ -1,0 +1,87 @@
+import { Box, Button, Center, Icon } from '@chakra-ui/react';
+import { memo, useEffect, useMemo, useState } from 'react';
+import { IoAddOutline } from 'react-icons/io5';
+import { useContext, useContextSelector } from 'use-context-selector';
+import { findLastIndex } from '../../../common/util';
+import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
+import { SchemaInput } from '../inputs/SchemaInput';
+import { GroupProps } from './props';
+
+export const OptionalInputsGroup = memo(
+    ({ inputs, inputData, inputSize, isLocked, nodeId, schemaId }: GroupProps<'optional-list'>) => {
+        const { getNodeInputValue } = useContext(GlobalContext);
+        const isNodeInputLocked = useContextSelector(
+            GlobalVolatileContext,
+            (c) => c.isNodeInputLocked
+        );
+
+        // number of edges that need to be uncovered due to either having a value or an edge
+        const uncoveredDueToValue = useMemo(() => {
+            return (
+                findLastIndex(inputs, (i) => {
+                    const value = getNodeInputValue(i.id, inputData);
+                    if (value !== undefined) {
+                        return true;
+                    }
+                    if (isNodeInputLocked(nodeId, i.id)) {
+                        return true;
+                    }
+                    return false;
+                }) + 1
+            );
+        }, [inputs, inputData, nodeId, getNodeInputValue, isNodeInputLocked]);
+
+        // number of inputs the user set to be uncovered
+        const [userUncovered, setUserUncovered] = useState(0);
+
+        useEffect(() => {
+            setUserUncovered(Math.max(userUncovered, uncoveredDueToValue));
+        }, [userUncovered, uncoveredDueToValue]);
+
+        const uncovered = Math.max(uncoveredDueToValue, userUncovered);
+        const showMoreButton = uncovered < inputs.length;
+
+        return (
+            <>
+                {inputs.slice(0, uncovered).map((i) => (
+                    <SchemaInput
+                        input={i}
+                        inputData={inputData}
+                        inputSize={inputSize}
+                        isLocked={isLocked}
+                        key={i.id}
+                        nodeId={nodeId}
+                        schemaId={schemaId}
+                    />
+                ))}
+                {showMoreButton && (
+                    <Box
+                        bg="var(--bg-700)"
+                        w="full"
+                    >
+                        <Center>
+                            <Button
+                                _hover={{
+                                    background: 'var(--bg-600)',
+                                }}
+                                aria-label="Add Input"
+                                bg="var(--bg-700)"
+                                height="auto"
+                                m={1}
+                                minWidth={0}
+                                p={1}
+                                onClick={() => setUserUncovered(uncovered + 1)}
+                            >
+                                <Icon
+                                    as={IoAddOutline}
+                                    boxSize="1rem"
+                                    color="var(--fg-700)"
+                                />
+                            </Button>
+                        </Center>
+                    </Box>
+                )}
+            </>
+        );
+    }
+);


### PR DESCRIPTION
This PR adds a new group kind: optional list. This group contains some number of optional inputs that will be hidden by default and can be revealed/uncovered one after the other. The reveal/uncover process is communicated to the user as adding inputs.

![image](https://user-images.githubusercontent.com/20878432/200180928-314e6f5a-9cf4-467c-84f3-9cf5c4c50fb3.png)

Right now, only the Text Append and Text Pattern nodes use this group.

About the design of the "Add Input" button: I don't like it, but it's functional. I'm not a good designer, so I hoped that some else (speak: Joey) will come along and give it a sensible design.

One thing to note is that the state of the group (= how many inputs are currently uncovered) is not persisted. So if you reveal n inputs and don't do anything with them, they will be hidden again when you reload the chain (or press Ctrl+R). I don't think that this necessarily a problem. Users can't unreveal/remove inputs, so chainner automatically cleaning up unused inputs could even be seen as a good feature.

---

We may now choose to add more inputs to Text Append and Text Pattern, as they don't unnecessarily make the node taller now. However, that should be its own PR.