### PR TITLE
Added X and Y offsets to created View Image nodes

### DIFF
--- a/src/renderer/components/outputs/DefaultImageOutput.tsx
+++ b/src/renderer/components/outputs/DefaultImageOutput.tsx
@@ -11,6 +11,7 @@ import {
     stringifySourceHandle,
     stringifyTargetHandle,
 } from '../../../common/util';
+import { BackendContext } from '../../contexts/BackendContext';
 import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { TypeTags } from '../TypeTag';
 import { OutputProps } from './props';
@@ -23,136 +24,153 @@ interface ImageBroadcastData {
     channels: number;
 }
 
-export const DefaultImageOutput = memo(({ label, id, outputId, useOutputData }: OutputProps) => {
-    const type = useContextSelector(GlobalVolatileContext, (c) =>
-        c.typeState.functions.get(id)?.outputs.get(outputId)
-    );
+export const DefaultImageOutput = memo(
+    ({ label, id, outputId, schemaId, useOutputData }: OutputProps) => {
+        const type = useContextSelector(GlobalVolatileContext, (c) =>
+            c.typeState.functions.get(id)?.outputs.get(outputId)
+        );
 
-    const createNode = useContextSelector(GlobalVolatileContext, (c) => c.createNode);
-    const createConnection = useContextSelector(GlobalVolatileContext, (c) => c.createConnection);
+        const createNode = useContextSelector(GlobalVolatileContext, (c) => c.createNode);
+        const createConnection = useContextSelector(
+            GlobalVolatileContext,
+            (c) => c.createConnection
+        );
 
-    const { selectNode, setManualOutputType } = useContext(GlobalContext);
+        const { selectNode, setManualOutputType } = useContext(GlobalContext);
 
-    const inputHash = useContextSelector(GlobalVolatileContext, (c) => c.inputHashes.get(id));
-    const [value, valueInputHash] = useOutputData<ImageBroadcastData>(outputId);
-    useEffect(() => {
-        if (value && valueInputHash === inputHash) {
-            setManualOutputType(
-                id,
-                outputId,
-                new NamedExpression('Image', [
-                    new NamedExpressionField('width', literal(value.width)),
-                    new NamedExpressionField('height', literal(value.height)),
-                    new NamedExpressionField('channels', literal(value.channels)),
-                ])
-            );
-        } else {
-            setManualOutputType(id, outputId, undefined);
-        }
-    }, [id, outputId, value]);
+        const outputIndex = useContextSelector(BackendContext, (c) =>
+            c.schemata.get(schemaId).outputs.findIndex((o) => o.id === outputId)
+        );
 
-    const { getNodes, getEdges } = useReactFlow<NodeData, EdgeData>();
+        const inputHash = useContextSelector(GlobalVolatileContext, (c) => c.inputHashes.get(id));
+        const [value, valueInputHash] = useOutputData<ImageBroadcastData>(outputId);
+        useEffect(() => {
+            if (value && valueInputHash === inputHash) {
+                setManualOutputType(
+                    id,
+                    outputId,
+                    new NamedExpression('Image', [
+                        new NamedExpressionField('width', literal(value.width)),
+                        new NamedExpressionField('height', literal(value.height)),
+                        new NamedExpressionField('channels', literal(value.channels)),
+                    ])
+                );
+            } else {
+                setManualOutputType(id, outputId, undefined);
+            }
+        }, [id, outputId, value]);
 
-    return (
-        <Flex
-            h="full"
-            minH="2rem"
-            verticalAlign="middle"
-            w="full"
-        >
-            <Center
-                cursor="pointer"
-                h="2rem"
-                w="2rem"
-                onClick={() => {
-                    const byId = new Map(getNodes().map((n) => [n.id, n]));
+        const { getNodes, getEdges } = useReactFlow<NodeData, EdgeData>();
 
-                    // check whether there already is a view node
-                    const viewId = getEdges()
-                        .filter(
-                            (e) =>
-                                e.source === id &&
-                                e.sourceHandle &&
-                                parseSourceHandle(e.sourceHandle).outputId === outputId
-                        )
-                        .map((e) => e.target)
-                        .find((i) => byId.get(i)?.data.schemaId === VIEW_SCHEMA_ID);
-                    if (viewId !== undefined) {
-                        // select view node
-                        selectNode(viewId);
-                        return;
-                    }
-
-                    const containingNode = byId.get(id);
-                    if (containingNode) {
-                        const nodeId = createUniqueId();
-                        // TODO: This is a bit of hardcoding, but it works
-                        createNode(
-                            {
-                                id: nodeId,
-                                position: {
-                                    x: containingNode.position.x + (containingNode.width ?? 0) + 75,
-                                    y: containingNode.position.y,
-                                },
-                                data: {
-                                    schemaId: VIEW_SCHEMA_ID,
-                                },
-                                nodeType: 'regularNode',
-                            },
-                            containingNode.parentNode
-                        );
-                        createConnection({
-                            source: id,
-                            sourceHandle: stringifySourceHandle({ nodeId: id, outputId }),
-                            target: nodeId,
-                            targetHandle: stringifyTargetHandle({ nodeId, inputId: 0 as InputId }),
-                        });
-                    }
-                }}
-            >
-                <Center
-                    _hover={{
-                        backgroundColor: 'var(--node-image-preview-button-bg-hover)',
-                    }}
-                    bgColor="var(--node-image-preview-button-bg)"
-                    borderRadius="md"
-                    cursor="pointer"
-                    h="1.75rem"
-                    maxH="1.75rem"
-                    maxW="1.75rem"
-                    minH="1.75rem"
-                    minW="1.75rem"
-                    overflow="hidden"
-                    transition="0.15s ease-in-out"
-                    w="1.75rem"
-                >
-                    <Icon
-                        as={BsEyeFill}
-                        color="var(--node-image-preview-button-fg)"
-                    />
-                </Center>
-            </Center>
-            <Spacer />
-            {type && (
-                <Center
-                    h="2rem"
-                    verticalAlign="middle"
-                >
-                    <TypeTags
-                        isOptional={false}
-                        type={type}
-                    />
-                </Center>
-            )}
-            <Text
+        return (
+            <Flex
                 h="full"
-                lineHeight="2rem"
-                marginInlineEnd="0.5rem"
-                ml={1}
-                textAlign="right"
+                minH="2rem"
+                verticalAlign="middle"
+                w="full"
             >
-                {label}
-            </Text>
-        </Flex>
-    );
-});
+                <Center
+                    cursor="pointer"
+                    h="2rem"
+                    w="2rem"
+                    onClick={() => {
+                        const byId = new Map(getNodes().map((n) => [n.id, n]));
+
+                        // check whether there already is a view node
+                        const viewId = getEdges()
+                            .filter(
+                                (e) =>
+                                    e.source === id &&
+                                    e.sourceHandle &&
+                                    parseSourceHandle(e.sourceHandle).outputId === outputId
+                            )
+                            .map((e) => e.target)
+                            .find((i) => byId.get(i)?.data.schemaId === VIEW_SCHEMA_ID);
+                        if (viewId !== undefined) {
+                            // select view node
+                            selectNode(viewId);
+                            return;
+                        }
+
+                        const containingNode = byId.get(id);
+                        if (containingNode) {
+                            const nodeId = createUniqueId();
+
+                            // TODO: This is a bit of hardcoding, but it works
+                            createNode(
+                                {
+                                    id: nodeId,
+                                    position: {
+                                        x:
+                                            containingNode.position.x +
+                                            (containingNode.width ?? 0) +
+                                            75 +
+                                            outputIndex * 20,
+                                        y: containingNode.position.y + outputIndex * 30,
+                                    },
+                                    data: {
+                                        schemaId: VIEW_SCHEMA_ID,
+                                    },
+                                    nodeType: 'regularNode',
+                                },
+                                containingNode.parentNode
+                            );
+                            createConnection({
+                                source: id,
+                                sourceHandle: stringifySourceHandle({ nodeId: id, outputId }),
+                                target: nodeId,
+                                targetHandle: stringifyTargetHandle({
+                                    nodeId,
+                                    inputId: 0 as InputId,
+                                }),
+                            });
+                        }
+                    }}
+                >
+                    <Center
+                        _hover={{
+                            backgroundColor: 'var(--node-image-preview-button-bg-hover)',
+                        }}
+                        bgColor="var(--node-image-preview-button-bg)"
+                        borderRadius="md"
+                        cursor="pointer"
+                        h="1.75rem"
+                        maxH="1.75rem"
+                        maxW="1.75rem"
+                        minH="1.75rem"
+                        minW="1.75rem"
+                        overflow="hidden"
+                        transition="0.15s ease-in-out"
+                        w="1.75rem"
+                    >
+                        <Icon
+                            as={BsEyeFill}
+                            color="var(--node-image-preview-button-fg)"
+                        />
+                    </Center>
+                </Center>
+                <Spacer />
+                {type && (
+                    <Center
+                        h="2rem"
+                        verticalAlign="middle"
+                    >
+                        <TypeTags
+                            isOptional={false}
+                            type={type}
+                        />
+                    </Center>
+                )}
+                <Text
+                    h="full"
+                    lineHeight="2rem"
+                    marginInlineEnd="0.5rem"
+                    ml={1}
+                    textAlign="right"
+                >
+                    {label}
+                </Text>
+            </Flex>
+        );
+    }
+);


### PR DESCRIPTION
When creating a View Image node for each output of Separate RGBA, chainner would place all created node on top of each other. This PR fixes this by adding an offset to the X and Y of the created nodes based on the index of the output creating the node.

![image](https://user-images.githubusercontent.com/20878432/200182462-0440f6bb-c93e-4c9d-9821-e7aeb7a9aac6.png)

Unfortunately, formatting did not place nice with this one. Hide whitespace changes to review this PR.
