### PR TITLE
Fixed slider value resetting visually but not actually

### DIFF
--- a/src/renderer/components/inputs/SliderInput.tsx
+++ b/src/renderer/components/inputs/SliderInput.tsx
@@ -104,7 +104,7 @@ export const SliderInput = memo(
                         value={displaySliderValue}
                         onChange={onSliderChange}
                         onChangeEnd={setValue}
-                        onDoubleClick={() => onSliderChange(def)}
+                        onDoubleClick={() => setValue(def)}
                         onMouseEnter={() => setShowTooltip(true)}
                         onMouseLeave={() => setShowTooltip(false)}
                     >


### PR DESCRIPTION
I used the wrong set function when implementing this feature. So it would reset the slider visually, but the actual value of the input would remain the last value before the reset.