### PR TITLE
Allow video iterator to use tag duration

### DIFF
--- a/backend/src/nodes/nodes/image/video_frame_iterator.py
+++ b/backend/src/nodes/nodes/image/video_frame_iterator.py
@@ -203,8 +203,6 @@ class SimpleVideoFrameIteratorNode(IteratorNodeBase):
 
         probe = ffmpeg.probe(path, cmd=ffprobe_path)
         video_format = probe["format"]
-        logger.info(probe)
-        exit(0)
         video_stream = next(
             (stream for stream in probe["streams"] if stream["codec_type"] == "video"),
             None,

--- a/backend/src/nodes/nodes/image/video_frame_iterator.py
+++ b/backend/src/nodes/nodes/image/video_frame_iterator.py
@@ -202,7 +202,9 @@ class SimpleVideoFrameIteratorNode(IteratorNodeBase):
         writer = {"out": None}
 
         probe = ffmpeg.probe(path, cmd=ffprobe_path)
-        video_format = probe["format"]
+        video_format = probe.get("format", None)
+        if video_format is None:
+            raise Exception("Failed to get video format. Please report.")
         video_stream = next(
             (stream for stream in probe["streams"] if stream["codec_type"] == "video"),
             None,

--- a/backend/src/nodes/nodes/image/video_frame_iterator.py
+++ b/backend/src/nodes/nodes/image/video_frame_iterator.py
@@ -202,6 +202,9 @@ class SimpleVideoFrameIteratorNode(IteratorNodeBase):
         writer = {"out": None}
 
         probe = ffmpeg.probe(path, cmd=ffprobe_path)
+        video_format = probe["format"]
+        logger.info(probe)
+        exit(0)
         video_stream = next(
             (stream for stream in probe["streams"] if stream["codec_type"] == "video"),
             None,
@@ -225,6 +228,8 @@ class SimpleVideoFrameIteratorNode(IteratorNodeBase):
         frame_count = video_stream.get("nb_frames", None)
         if frame_count is None:
             duration = video_stream.get("duration", None)
+            if duration is None:
+                duration = video_format.get("duration", None)
             if duration is not None:
                 frame_count = float(duration) * fps
             else:


### PR DESCRIPTION
Remember when I said we could worry about this when we found a video without a duration in the wild?

Anyway, I discovered it also exists on the tags, so lets hope falling back to that covers 99% of cases where it doesn't have it on the stream.