### PR TITLE
Exhaustive deps for custom hooks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -95,6 +95,7 @@ module.exports = {
                 project: './tsconfig.json',
             },
             rules: {
+                'consistent-return': 'off',
                 'max-classes-per-file': 'off',
                 'no-restricted-syntax': 'off',
                 'react/require-default-props': 'off',
@@ -132,7 +133,7 @@ module.exports = {
                 'react/hook-use-state': 'warn',
                 'react-memo/require-memo': ['error', { strict: true }],
                 'react-hooks/rules-of-hooks': 'error',
-                'react-hooks/exhaustive-deps': 'warn',
+                'react-hooks/exhaustive-deps': ['warn', { additionalHooks: '(useAsyncEffect)' }],
                 'unused-imports/no-unused-imports': 'error',
             },
         },

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -28,15 +28,18 @@ export const App = memo(() => {
     const [port, setPort] = useState<number | null>(null);
     const [storageInitialized, setStorageInitialized] = useState(false);
 
-    useAsyncEffect({ supplier: () => ipcRenderer.invoke('get-port'), successEffect: setPort }, []);
     useAsyncEffect(
-        {
+        () => ({ supplier: () => ipcRenderer.invoke('get-port'), successEffect: setPort }),
+        []
+    );
+    useAsyncEffect(
+        () => ({
             supplier: () => ipcRenderer.invoke('get-localstorage-location'),
             successEffect: (location) => {
                 (global as Record<string, unknown>).customLocalStorage = new LocalStorage(location);
                 setStorageInitialized(true);
             },
-        },
+        }),
         []
     );
 

--- a/src/renderer/components/Header.tsx
+++ b/src/renderer/components/Header.tsx
@@ -25,10 +25,10 @@ export const Header = memo(() => {
 
     const [appVersion, setAppVersion] = useState('#.#.#');
     useAsyncEffect(
-        {
+        () => ({
             supplier: () => ipcRenderer.invoke('get-app-version'),
             successEffect: setAppVersion,
-        },
+        }),
         []
     );
 

--- a/src/renderer/components/HistoryProvider.tsx
+++ b/src/renderer/components/HistoryProvider.tsx
@@ -111,21 +111,19 @@ export const HistoryProvider = memo(
         // Handler for undo menuitem
         useIpcRendererListener(
             'history-undo',
-            () => {
+            useCallback(() => {
                 historyRef.current = historyRef.current.undo();
                 apply(historyRef.current.current);
-            },
-            [apply]
+            }, [apply])
         );
 
         // Handler for redo menuitem
         useIpcRendererListener(
             'history-redo',
-            () => {
+            useCallback(() => {
                 historyRef.current = historyRef.current.redo();
                 apply(historyRef.current.current);
-            },
-            [apply]
+            }, [apply])
         );
 
         // Handler for undo hotkeys

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -313,30 +313,24 @@ const PythonSettings = memo(() => {
     const [onnxExecutionProvider, setOnnxExecutionProvider] = useOnnxExecutionProvider;
     const [nvidiaGpuList, setNvidiaGpuList] = useState<string[]>([]);
     useAsyncEffect(
-        {
+        () => ({
             supplier: async () => {
                 const nvidiaGpus = await ipcRenderer.invoke('get-nvidia-gpus');
-                if (nvidiaGpus) {
-                    return nvidiaGpus;
-                }
-                return [];
+                return nvidiaGpus ?? [];
             },
             successEffect: setNvidiaGpuList,
-        },
+        }),
         []
     );
 
     const [ncnnGPU, setNcnnGPU] = useNcnnGPU;
     const [ncnnGpuList, setNcnnGpuList] = useState<string[]>([]);
     useAsyncEffect(
-        {
-            supplier: async () => {
-                const ncnnGpuInfo = await backend.listNcnnGpus();
-                return ncnnGpuInfo;
-            },
+        () => ({
+            supplier: () => backend.listNcnnGpus(),
             successEffect: setNcnnGpuList,
-        },
-        []
+        }),
+        [backend]
     );
 
     useEffect(() => {

--- a/src/renderer/contexts/ContextMenuContext.tsx
+++ b/src/renderer/contexts/ContextMenuContext.tsx
@@ -114,7 +114,7 @@ export const ContextMenuProvider = memo(({ children }: React.PropsWithChildren<u
         };
     }, [closeContextMenu]);
 
-    useIpcRendererListener('window-blur', closeContextMenu, [closeContextMenu]);
+    useIpcRendererListener('window-blur', closeContextMenu);
 
     const value = useMemoObject<ContentMenu>({
         registerContextMenu,

--- a/src/renderer/helpers/batchedCallback.ts
+++ b/src/renderer/helpers/batchedCallback.ts
@@ -1,5 +1,3 @@
-import { useMemo } from 'react';
-
 /**
  * Returns a batched callback.
  *
@@ -8,7 +6,7 @@ import { useMemo } from 'react';
  * this first invocation that happen before `wait` milliseconds past will be added to a queue. The
  * queued invocations will be executed `wait` milliseconds after the first invocation.
  */
-const getBatchedCallback = <T extends unknown[]>(
+export const batchedCallback = <T extends unknown[]>(
     fn: (...args: T) => void,
     wait: number
 ): ((...arg: T) => void) => {
@@ -42,10 +40,3 @@ const getBatchedCallback = <T extends unknown[]>(
         }
     };
 };
-
-export const useBatchedCallback = <T extends unknown[]>(
-    fn: (...args: T) => void,
-    wait: number,
-    deps: readonly unknown[]
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-): ((...args: T) => void) => useMemo(() => getBatchedCallback(fn, wait), deps);

--- a/src/renderer/hooks/useAsyncEffect.ts
+++ b/src/renderer/hooks/useAsyncEffect.ts
@@ -78,6 +78,8 @@ interface ObjectUseAsyncEffectOptions<T> {
     finallyEffect?: () => void;
 }
 
+const noopPromise = async (): Promise<void> => {};
+
 /**
  * This is an async replacement for `useEffect`.
  *
@@ -92,9 +94,10 @@ interface ObjectUseAsyncEffectOptions<T> {
  * ```
  */
 export const useAsyncEffect = <T>(
-    options: UseAsyncEffectOptions<T>,
+    optionsFn: () => UseAsyncEffectOptions<T> | void | undefined,
     dependencies: readonly unknown[]
 ) => {
+    const options = optionsFn() ?? (noopPromise as () => Promise<T & void>);
     const objOptions: ObjectUseAsyncEffectOptions<T> =
         typeof options === 'function' ? { supplier: options, successEffect: noop } : options;
     const { supplier, successEffect, catchEffect, finallyEffect } = objOptions;

--- a/src/renderer/hooks/useBackendEventSource.ts
+++ b/src/renderer/hooks/useBackendEventSource.ts
@@ -40,8 +40,7 @@ export type BackendEventSourceListener<T extends keyof BackendEventMap> = (
 export const useBackendEventSourceListener = <T extends keyof BackendEventMap>(
     source: BackendEventSource | null,
     type: T,
-    listener: BackendEventSourceListener<T>,
-    dependencies?: unknown[]
+    listener: BackendEventSourceListener<T>
 ): void => {
     useEventSourceListener(
         source,
@@ -65,6 +64,6 @@ export const useBackendEventSourceListener = <T extends keyof BackendEventMap>(
                 );
             }
         },
-        [source, ...(dependencies ?? [])]
+        [source, type, listener]
     );
 };

--- a/src/renderer/hooks/useBatchedCallback.ts
+++ b/src/renderer/hooks/useBatchedCallback.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 /**
  * Returns a batched callback.
  *
@@ -39,4 +41,11 @@ export const batchedCallback = <T extends unknown[]>(
             queue.push(args);
         }
     };
+};
+
+export const useBatchedCallback = <T extends unknown[]>(
+    fn: (...args: T) => void,
+    wait: number
+): ((...arg: T) => void) => {
+    return useMemo(() => batchedCallback(fn, wait), [fn, wait]);
 };

--- a/src/renderer/hooks/useInterval.ts
+++ b/src/renderer/hooks/useInterval.ts
@@ -1,31 +1,13 @@
-import { useEffect, useState } from 'react';
-import { UseAsyncEffectOptions, useAsyncEffect } from './useAsyncEffect';
+import { useEffect } from 'react';
 
-export const useInterval = (
-    callback: () => void,
-    delay: number,
-    dependencies: readonly unknown[] = []
-) => {
+/**
+ * Executes the given effect indefinitely every `delay` ms.
+ *
+ * The interval gets reset every time the callback changes.
+ */
+export const useInterval = (callback: () => void, delay: number) => {
     useEffect(() => {
         const id = setInterval(callback, delay);
         return () => clearInterval(id);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [delay, ...dependencies]);
-};
-
-/**
- * Executes the given async effect indefinitely every `delay` ms.
- *
- * If the async effect takes longer than `delay` ms to execute, it will be canceled.
- */
-export const useAsyncInterval = <T>(
-    options: UseAsyncEffectOptions<T>,
-    delay: number,
-    dependencies: readonly unknown[] = []
-) => {
-    const [counter, setCounter] = useState(0);
-
-    useInterval(() => setCounter((prev) => (prev + 1) % 1000), delay, dependencies);
-
-    useAsyncEffect(options, [counter]);
+    }, [delay, callback]);
 };

--- a/src/renderer/hooks/useIpcRendererListener.ts
+++ b/src/renderer/hooks/useIpcRendererListener.ts
@@ -4,14 +4,12 @@ import { ChannelArgs, SendChannels, ipcRenderer } from '../../common/safeIpc';
 
 export const useIpcRendererListener = <C extends keyof SendChannels>(
     channel: C,
-    listener: (event: IpcRendererEvent, ...args: ChannelArgs<C>) => void,
-    deps: unknown[]
+    listener: (event: IpcRendererEvent, ...args: ChannelArgs<C>) => void
 ) => {
     useEffect(() => {
         ipcRenderer.on(channel, listener);
         return () => {
             ipcRenderer.removeListener(channel, listener);
         };
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, deps);
+    }, [channel, listener]);
 };

--- a/src/renderer/hooks/useLastWindowSize.ts
+++ b/src/renderer/hooks/useLastWindowSize.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { WindowSize } from '../../common/common-types';
 import { debounce } from '../../common/util';
 import { useIpcRendererListener } from './useIpcRendererListener';
@@ -31,9 +31,11 @@ export const useLastWindowSize = () => {
 
     useIpcRendererListener(
         'window-maximized-change',
-        (_, maximized) => {
-            setSize((prev) => ({ ...prev, maximized }));
-        },
-        [setSize]
+        useCallback(
+            (_, maximized) => {
+                setSize((prev) => ({ ...prev, maximized }));
+            },
+            [setSize]
+        )
     );
 };

--- a/src/renderer/hooks/useOpenRecent.ts
+++ b/src/renderer/hooks/useOpenRecent.ts
@@ -45,7 +45,10 @@ export const useOpenRecent = () => {
         [setRecentlyOpen]
     );
 
-    useIpcRendererListener('clear-open-recent', () => setRecentlyOpen([]), [setRecentlyOpen]);
+    useIpcRendererListener(
+        'clear-open-recent',
+        useCallback(() => setRecentlyOpen([]), [setRecentlyOpen])
+    );
 
     return [recentlyOpen, push, remove] as const;
 };

--- a/src/renderer/hooks/useRunNode.ts
+++ b/src/renderer/hooks/useRunNode.ts
@@ -34,7 +34,7 @@ export const useRunNode = ({ inputData, id, schemaId }: NodeData, shouldRun: boo
     const inputHash = useMemo(() => JSON.stringify(inputs), [inputs]);
     const lastInputHash = useRef<string>();
     useAsyncEffect(
-        async (token) => {
+        () => async (token) => {
             if (inputHash === lastInputHash.current) {
                 return;
             }
@@ -72,6 +72,7 @@ export const useRunNode = ({ inputData, id, schemaId }: NodeData, shouldRun: boo
                 }
             }
         },
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [shouldRun, inputHash]
     );
 

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -1,6 +1,6 @@
 import { Box, Center, HStack, Text, VStack } from '@chakra-ui/react';
 import log from 'electron-log';
-import { memo, useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { EdgeTypes, NodeTypes, ReactFlowProvider } from 'reactflow';
 import { useContext } from 'use-context-selector';
 import useFetch, { CachePolicies } from 'use-http';
@@ -128,31 +128,33 @@ export const Main = memo(({ port }: MainProps) => {
 
     useIpcRendererListener(
         'show-collected-information',
-        (_, info) => {
-            const localStorage = getLocalStorage();
-            const fullInfo = {
-                ...info,
-                settings: Object.fromEntries(
-                    getStorageKeys(localStorage).map((k) => [k, localStorage.getItem(k)])
-                ),
-            };
+        useCallback(
+            (_, info) => {
+                const localStorage = getLocalStorage();
+                const fullInfo = {
+                    ...info,
+                    settings: Object.fromEntries(
+                        getStorageKeys(localStorage).map((k) => [k, localStorage.getItem(k)])
+                    ),
+                };
 
-            sendAlert({
-                type: AlertType.INFO,
-                title: 'System information',
-                message: JSON.stringify(fullInfo, undefined, 2),
-                copyToClipboard: true,
-            });
-        },
-        [sendAlert]
+                sendAlert({
+                    type: AlertType.INFO,
+                    title: 'System information',
+                    message: JSON.stringify(fullInfo, undefined, 2),
+                    copyToClipboard: true,
+                });
+            },
+            [sendAlert]
+        )
     );
 
     const [pythonInfo, setPythonInfo] = useState<PythonInfo>();
     useAsyncEffect(
-        {
+        () => ({
             supplier: () => ipcRenderer.invoke('get-python'),
             successEffect: setPythonInfo,
-        },
+        }),
         []
     );
 

--- a/tests/common/chainner-scope.test.ts
+++ b/tests/common/chainner-scope.test.ts
@@ -2,7 +2,6 @@ import { FunctionCallExpression, NamedExpression, evaluate } from '@chainner/nav
 import { getChainnerScope } from '../../src/common/types/chainner-scope';
 import { assertNever } from '../../src/common/util';
 
-// eslint-disable-next-line consistent-return
 test(`Chainner scope is correct`, () => {
     const scope = getChainnerScope();
 


### PR DESCRIPTION
We have a few custom hooks that also take deps arrays. Unfortunately, those deps arrays cannot be verified by ESLint. To solve this, I changed all custom hooks to either assume memoized callbacks or be of a form that ESLint can verify.

Changes:
- `useAsyncEffect` now takes a function that creates options as its first argument. This makes it so that ESLint can verify the deps array.
- `useIpcRendererListener` now assumes memoized callbacks.
- `useBackendEventSourceListener` now assumes memoized callbacks.
- `useBatchedCallback` now assumes memoized callbacks.
- Removed `useAsyncInterval`. The function wasn't easily convertible so that ESLint could understand it.
- Turned off ESLint's `consistent-return` rule. TS makes the kinds of errors this rule is supposed to prevent impossible.

With this PR, we can be reasonably certain that all deps arrays in our code base are correct.