### PR TITLE
Better Save Changes popup

### DIFF
--- a/src/common/safeIpc.ts
+++ b/src/common/safeIpc.ts
@@ -83,6 +83,8 @@ export interface SendChannels {
     'show-collected-information': SendChannelInfo<[info: Record<string, unknown>]>;
     'disable-menu': SendChannelInfo;
     'enable-menu': SendChannelInfo;
+    'save-before-exit': SendChannelInfo;
+    'exit-after-save': SendChannelInfo;
 
     // history
     'history-undo': SendChannelInfo;

--- a/src/renderer/contexts/DependencyContext.tsx
+++ b/src/renderer/contexts/DependencyContext.tsx
@@ -457,7 +457,7 @@ export const DependencyProvider = memo(({ children }: React.PropsWithChildren<un
                                                 title: 'Uninstall',
                                                 message: `Are you sure you want to uninstall ${dep.name}?`,
                                                 buttons: ['Cancel', 'Uninstall'],
-                                                defaultButton: 0,
+                                                defaultId: 0,
                                             })
                                                 .then((button) => {
                                                     if (button === 1) {

--- a/src/renderer/contexts/GlobalNodeState.tsx
+++ b/src/renderer/contexts/GlobalNodeState.tsx
@@ -149,14 +149,14 @@ interface Global {
     getInputHash: (nodeId: string) => string;
 }
 
-const unsavedChangesWarning = {
-    type: AlertType.WARN,
-    title: 'Discard unsaved changes?',
-    message:
-        'The current chain has some unsaved changes. Do you really want to discard those changes?',
-    buttons: ['Discard changes', 'No'],
-    defaultButton: 1,
-};
+enum SaveResult {
+    /** The contents were written to disk. */
+    Saved,
+    /** The file was not saved either because the file did not chain unsaved changes or because the user said not to. */
+    NotSaved,
+    /** The user canceled the option. */
+    Canceled,
+}
 
 // TODO: Find default
 export const GlobalVolatileContext = createContext<Readonly<GlobalVolatile>>({} as GlobalVolatile);
@@ -365,14 +365,123 @@ export const GlobalProvider = memo(
             };
         }, [getNodes, getEdges, getViewport]);
 
+        const performSave = useCallback(
+            async (saveAs: boolean): Promise<SaveResult> => {
+                try {
+                    const saveData = dumpState();
+                    if (!saveAs && savePath) {
+                        await ipcRenderer.invoke('file-save-json', saveData, savePath);
+                    } else {
+                        const result = await ipcRenderer.invoke(
+                            'file-save-as-json',
+                            saveData,
+                            savePath || (openRecent[0] && dirname(openRecent[0]))
+                        );
+                        if (result.kind === 'Canceled') {
+                            return SaveResult.Canceled;
+                        }
+                        setSavePath(result.path);
+                    }
+                    setLastSavedChanges([nodeChangesRef.current, edgeChangesRef.current]);
+                    return SaveResult.Saved;
+                } catch (error) {
+                    log.error(error);
+
+                    sendToast({
+                        status: 'error',
+                        duration: 10_000,
+                        description: `Failed to save chain`,
+                    });
+
+                    return SaveResult.Canceled;
+                }
+            },
+            [
+                dumpState,
+                edgeChangesRef,
+                nodeChangesRef,
+                openRecent,
+                savePath,
+                sendToast,
+                setSavePath,
+            ]
+        );
+        const exportTemplate = useCallback(async () => {
+            try {
+                const saveData = dumpState();
+                saveData.nodes = saveData.nodes.map((n) => {
+                    const inputData = { ...n.data.inputData } as Mutable<InputData>;
+                    const nodeSchema = schemata.get(n.data.schemaId);
+                    nodeSchema.inputs.forEach((input) => {
+                        const clearKinds = new Set<InputKind>(['file', 'directory']);
+                        if (clearKinds.has(input.kind)) {
+                            delete inputData[input.id];
+                        }
+                    });
+                    return {
+                        ...n,
+                        data: {
+                            ...n.data,
+                            inputData,
+                        },
+                    };
+                });
+
+                const result = await ipcRenderer.invoke('file-save-as-json', saveData, undefined);
+                if (result.kind === 'Canceled') return;
+            } catch (error) {
+                log.error(error);
+
+                sendToast({
+                    status: 'error',
+                    duration: 10_000,
+                    description: `Failed to export chain`,
+                });
+            }
+        }, [dumpState, schemata, sendToast]);
+        const saveUnsavedChanges = useCallback(async (): Promise<SaveResult> => {
+            if (!hasRelevantUnsavedChanges) {
+                return SaveResult.NotSaved;
+            }
+
+            const resp = await showAlert({
+                type: AlertType.WARN,
+                title: 'Unsaved changes',
+                message: 'The current chain has unsaved changes.',
+                buttons: ['Save', "Don't Save", 'Cancel'],
+                defaultId: 0,
+                cancelId: 2,
+            });
+            if (resp === 1) {
+                // Don't Save
+                return SaveResult.NotSaved;
+            }
+            if (resp === 2) {
+                // cancel
+                return SaveResult.Canceled;
+            }
+
+            return performSave(false);
+        }, [hasRelevantUnsavedChanges, showAlert, performSave]);
+
+        useIpcRendererListener(
+            'save-before-exit',
+            () => {
+                performSave(false)
+                    .then((result) => {
+                        if (result === SaveResult.Saved) {
+                            ipcRenderer.send('exit-after-save');
+                        }
+                    })
+                    .catch((reason) => log.error(reason));
+            },
+            [performSave]
+        );
+
         const setStateFromJSON = useCallback(
             async (savedData: ParsedSaveData, path: string, loadPosition = false) => {
-                if (hasRelevantUnsavedChanges) {
-                    const resp = await showAlert(unsavedChangesWarning);
-                    if (resp === 1) {
-                        // abort
-                        return;
-                    }
+                if ((await saveUnsavedChanges()) === SaveResult.Canceled) {
+                    return;
                 }
 
                 const validNodes = savedData.nodes
@@ -449,7 +558,7 @@ export const GlobalProvider = memo(
                 changeEdges,
                 changeNodes,
                 edgeChangesRef,
-                hasRelevantUnsavedChanges,
+                saveUnsavedChanges,
                 nodeChangesRef,
                 outputDataActions,
                 pushOpenPath,
@@ -457,19 +566,14 @@ export const GlobalProvider = memo(
                 sendAlert,
                 setSavePath,
                 setViewport,
-                showAlert,
             ]
         );
         const setStateFromJSONRef = useRef(setStateFromJSON);
         setStateFromJSONRef.current = setStateFromJSON;
 
         const clearState = useCallback(async () => {
-            if (hasRelevantUnsavedChanges) {
-                const resp = await showAlert(unsavedChangesWarning);
-                if (resp === 1) {
-                    // abort
-                    return;
-                }
+            if ((await saveUnsavedChanges()) === SaveResult.Canceled) {
+                return;
             }
 
             changeNodes([]);
@@ -480,90 +584,11 @@ export const GlobalProvider = memo(
         }, [
             changeEdges,
             changeNodes,
-            hasRelevantUnsavedChanges,
+            saveUnsavedChanges,
             outputDataActions,
             setSavePath,
             setViewport,
-            showAlert,
         ]);
-
-        const performSave = useCallback(
-            (saveAs: boolean) => {
-                (async () => {
-                    try {
-                        const saveData = dumpState();
-                        if (!saveAs && savePath) {
-                            await ipcRenderer.invoke('file-save-json', saveData, savePath);
-                        } else {
-                            const result = await ipcRenderer.invoke(
-                                'file-save-as-json',
-                                saveData,
-                                savePath || (openRecent[0] && dirname(openRecent[0]))
-                            );
-                            if (result.kind === 'Canceled') return;
-                            setSavePath(result.path);
-                        }
-                        setLastSavedChanges([nodeChangesRef.current, edgeChangesRef.current]);
-                    } catch (error) {
-                        log.error(error);
-
-                        sendToast({
-                            status: 'error',
-                            duration: 10_000,
-                            description: `Failed to save chain`,
-                        });
-                    }
-                })();
-            },
-            [
-                dumpState,
-                edgeChangesRef,
-                nodeChangesRef,
-                openRecent,
-                savePath,
-                sendToast,
-                setSavePath,
-            ]
-        );
-        const exportTemplate = useCallback(() => {
-            (async () => {
-                try {
-                    const saveData = dumpState();
-                    saveData.nodes = saveData.nodes.map((n) => {
-                        const inputData = { ...n.data.inputData } as Mutable<InputData>;
-                        const nodeSchema = schemata.get(n.data.schemaId);
-                        nodeSchema.inputs.forEach((input) => {
-                            const clearKinds = new Set<InputKind>(['file', 'directory']);
-                            if (clearKinds.has(input.kind)) {
-                                delete inputData[input.id];
-                            }
-                        });
-                        return {
-                            ...n,
-                            data: {
-                                ...n.data,
-                                inputData,
-                            },
-                        };
-                    });
-
-                    const result = await ipcRenderer.invoke(
-                        'file-save-as-json',
-                        saveData,
-                        undefined
-                    );
-                    if (result.kind === 'Canceled') return;
-                } catch (error) {
-                    log.error(error);
-
-                    sendToast({
-                        status: 'error',
-                        duration: 10_000,
-                        description: `Failed to export chain`,
-                    });
-                }
-            })();
-        }, [dumpState, schemata, sendToast]);
 
         // Register New File event handler
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
@@ -603,8 +628,11 @@ export const GlobalProvider = memo(
         );
 
         // Register Save/Save-As event handlers
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         useIpcRendererListener('file-save-as', () => performSave(true), [performSave]);
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         useIpcRendererListener('file-save', () => performSave(false), [performSave]);
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         useIpcRendererListener('file-export-template', exportTemplate, [exportTemplate]);
 
         const [firstLoad, setFirstLoad] = useSessionStorage('firstLoad', true);


### PR DESCRIPTION
Fixes #1100.

I added a new `saveUnsavedChanges` function will save any unsaved changes. When closing the app with unsaved changes, the main process will now send an IPC message to the renderer to save, after which the renderer closes itself.

I also had to make some changes to alerts to consistently select the "Save" button as the default, while making "Cancel" the least destructive ref.

Alert:
![image](https://user-images.githubusercontent.com/20878432/200579312-c70d77e3-8428-4ae0-b543-ff1eb9bfaaa7.png)


System:
![image](https://user-images.githubusercontent.com/20878432/200579370-f4200a7d-371d-482f-af97-729de14b9804.png)
