### PR TITLE
Show the current position in the queue of alerts

### DIFF
--- a/src/renderer/contexts/AlertBoxContext.tsx
+++ b/src/renderer/contexts/AlertBoxContext.tsx
@@ -182,6 +182,13 @@ export const AlertBoxProvider = memo(({ children }: React.PropsWithChildren<unkn
     const current = queue[0] as InternalMessage | undefined;
     const isLast = queue.length < 2;
 
+    const [done, setDone] = useState(0);
+    useEffect(() => {
+        if (current === undefined) {
+            setDone(0);
+        }
+    }, [current]);
+
     const push = useCallback(
         (message: InternalMessage) => setQueue((q) => [...q, message]),
         [setQueue]
@@ -222,6 +229,7 @@ export const AlertBoxProvider = memo(({ children }: React.PropsWithChildren<unkn
         (button: number) => {
             current?.resolve(button);
             setQueue((q) => q.slice(1));
+            setDone((prev) => prev + 1);
             if (isLast) {
                 onDisclosureClose();
                 ipcRenderer.send('enable-menu');
@@ -261,6 +269,9 @@ export const AlertBoxProvider = memo(({ children }: React.PropsWithChildren<unkn
         return () => clearTimeout(timerId);
     }, [isOpen, buttons]);
 
+    const progressCurrent = done + 1;
+    const progressTotal = done + queue.length;
+
     return (
         <AlertBoxContext.Provider value={value}>
             <AlertDialog
@@ -273,7 +284,10 @@ export const AlertBoxProvider = memo(({ children }: React.PropsWithChildren<unkn
                 <AlertDialogOverlay />
 
                 <AlertDialogContent>
-                    <AlertDialogHeader>{current?.title}</AlertDialogHeader>
+                    <AlertDialogHeader>
+                        {current?.title}
+                        {progressTotal > 1 ? ` (${progressCurrent}/${progressTotal})` : ''}
+                    </AlertDialogHeader>
                     <AlertDialogCloseButton />
                     <AlertDialogBody whiteSpace="pre-wrap">{current?.message}</AlertDialogBody>
                     <AlertDialogFooter>


### PR DESCRIPTION
This PR solves a problem with alerts: there was no way for users to tell whether another alert was queued up behind the current one. This caused problems in the past already. 

We had an issue with error messages that caused the same error to be alerted twice, however, we initially thought that it was a problem with alerts because we had to click "ok" twice. Since 2 alerts with the same contents were shown with no visual difference, it was not possible for users to see that those were 2 separate alerts.

This PR fixes this problem by showing a progress indication.

![image](https://user-images.githubusercontent.com/20878432/200594784-45629045-4f99-4b30-a337-dffd97f949d1.png)

The number on the left is the number of the current alert (starting with 1) and the number on the right is the total number of alerts. If the user handles this alert (e.g. by clicking "Ok"), then the next progress shown will be 3/5.

Note that progress is only indicated if there have been multiple alerts in the queue. If only one alert is in the queue with no other alerts hidden, progress will not be displayed.