### PR TITLE
Added menu entry for manually reloading starting nodes

### DIFF
--- a/src/renderer/components/node/Node.tsx
+++ b/src/renderer/components/node/Node.tsx
@@ -123,10 +123,11 @@ const NodeInner = memo(({ data, selected }: NodeProps) => {
         }
     };
 
-    const disabled = useDisabled(data);
-    const menu = useNodeMenu(data, disabled);
+    const startingNode = isStartingNode(schema);
+    const reload = useRunNode(data, validity.isValid && startingNode);
 
-    useRunNode(data, validity.isValid && isStartingNode(schema));
+    const disabled = useDisabled(data);
+    const menu = useNodeMenu(data, disabled, { reload: startingNode ? reload : undefined });
 
     return (
         <Center

--- a/src/renderer/hooks/useNodeMenu.tsx
+++ b/src/renderer/hooks/useNodeMenu.tsx
@@ -1,4 +1,11 @@
-import { CloseIcon, CopyIcon, DeleteIcon, LockIcon, UnlockIcon } from '@chakra-ui/icons';
+import {
+    CloseIcon,
+    CopyIcon,
+    DeleteIcon,
+    LockIcon,
+    RepeatIcon,
+    UnlockIcon,
+} from '@chakra-ui/icons';
 import { MenuItem, MenuList } from '@chakra-ui/react';
 import { BsLayerForward } from 'react-icons/bs';
 import { MdPlayArrow, MdPlayDisabled } from 'react-icons/md';
@@ -10,12 +17,13 @@ import { UseDisabled } from './useDisabled';
 
 export interface UseNodeMenuOptions {
     canLock?: boolean;
+    reload?: () => void;
 }
 
 export const useNodeMenu = (
     data: NodeData,
     useDisabled: UseDisabled,
-    { canLock = true }: UseNodeMenuOptions = {}
+    { canLock = true, reload }: UseNodeMenuOptions = {}
 ): UseContextMenu => {
     const { id, isLocked = false, parentNode } = data;
 
@@ -60,6 +68,16 @@ export const useNodeMenu = (
                     {isLocked ? 'Unlock' : 'Lock'}
                 </MenuItem>
             )}
+
+            {reload && (
+                <MenuItem
+                    icon={<RepeatIcon />}
+                    onClick={reload}
+                >
+                    Refresh Preview
+                </MenuItem>
+            )}
+
             <MenuItem
                 icon={<DeleteIcon />}
                 onClick={() => {


### PR DESCRIPTION
Partially addresses #732.

![image](https://user-images.githubusercontent.com/20878432/200607500-fbf1231c-98b1-405a-ac6d-5b15889c5e1b.png)

This was actually quite easy to do. The basic idea is that we initiate a reload by changing the input hash. Since the inputs haven't actually changed, I added a little counter that gets added to the input hash. To reload a node, you just have to call the reload function, which increments the counter internally. The counter itself is just an implementation detail.