### PR TITLE
Added conditional enum inputs

### DIFF
--- a/backend/src/nodes/nodes/image/save_image.py
+++ b/backend/src/nodes/nodes/image/save_image.py
@@ -11,7 +11,7 @@ from PIL import Image
 from sanic.log import logger
 
 from . import category as ImageCategory
-from ...node_base import NodeBase
+from ...node_base import NodeBase, group
 from ...node_factory import NodeFactory
 from ...properties.inputs import (
     ImageInput,
@@ -34,9 +34,15 @@ class ImWriteNode(NodeBase):
             DirectoryInput(has_handle=True),
             TextInput("Subdirectory Path").make_optional(),
             TextInput("Image Name"),
-            ImageExtensionDropdown(),
-            SliderInput(
-                "Quality (JPEG/WEBP)", minimum=0, maximum=100, default=95, slider_step=1
+            group("conditional-enum", {"conditions": {5: ["jpg", "webp"]}})(
+                ImageExtensionDropdown(),
+                SliderInput(
+                    "Quality",
+                    minimum=0,
+                    maximum=100,
+                    default=95,
+                    slider_step=1,
+                ).with_id(5),
             ),
         ]
         self.category = ImageCategory

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -141,8 +141,22 @@ interface OptionalListGroup extends GroupBase {
     readonly kind: 'optional-list';
     readonly options: Readonly<Record<string, never>>;
 }
+interface OptionalListGroup extends GroupBase {
+    readonly kind: 'optional-list';
+    readonly options: Readonly<Record<string, never>>;
+}
+interface ConditionalEnumGroup extends GroupBase {
+    readonly kind: 'conditional-enum';
+    readonly options: {
+        readonly conditions: Readonly<Partial<Record<InputId, null | readonly InputSchemaValue[]>>>;
+    };
+}
 export type GroupKind = Group['kind'];
-export type Group = NcnnFileInputGroup | FromToDropdownsGroup | OptionalListGroup;
+export type Group =
+    | NcnnFileInputGroup
+    | FromToDropdownsGroup
+    | OptionalListGroup
+    | ConditionalEnumGroup;
 
 export type OfKind<T, Kind extends string> = T extends { readonly kind: Kind } ? T : never;
 

--- a/src/common/group-inputs.ts
+++ b/src/common/group-inputs.ts
@@ -4,6 +4,7 @@ import { DropDownInput, FileInput, Group, GroupKind, Input } from './common-type
 type InputGuarantees<T extends Record<GroupKind, readonly Input[]>> = T;
 
 type DeclaredGroupInputs = InputGuarantees<{
+    'conditional-enum': readonly [DropDownInput, ...Input[]];
     'from-to-dropdowns': readonly [DropDownInput, DropDownInput];
     'ncnn-file-inputs': readonly [FileInput, FileInput];
     'optional-list': readonly [Input, ...Input[]];
@@ -20,6 +21,20 @@ export const groupInputsChecks: {
         group: Group & { readonly type: Type }
     ) => boolean;
 } = {
+    'conditional-enum': (inputs, { options: { conditions } }) => {
+        if (inputs.length === 0) return false;
+
+        const dropdown = inputs[0];
+        if (dropdown.kind !== 'dropdown') return false;
+        if (dropdown.hasHandle) return false;
+        const allowed = new Set(dropdown.options.map((o) => o.value));
+        const idStrings = new Set(inputs.slice(1).map((i) => String(i.id)));
+
+        return Object.entries(conditions).every(([id, cond]) => {
+            if (!cond) return true;
+            return idStrings.has(id) && cond.length > 0 && cond.every((c) => allowed.has(c));
+        });
+    },
     'from-to-dropdowns': (inputs) => {
         return (
             inputs.length === 2 &&

--- a/src/renderer/components/groups/ConditionalEnumGroup.tsx
+++ b/src/renderer/components/groups/ConditionalEnumGroup.tsx
@@ -1,0 +1,59 @@
+import { memo } from 'react';
+import { useContext, useContextSelector } from 'use-context-selector';
+import { Input } from '../../../common/common-types';
+import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
+import { SchemaInput } from '../inputs/SchemaInput';
+import { GroupProps } from './props';
+
+export const ConditionalEnumGroup = memo(
+    ({
+        inputs,
+        inputData,
+        inputSize,
+        isLocked,
+        nodeId,
+        schemaId,
+        group,
+    }: GroupProps<'conditional-enum'>) => {
+        const { getNodeInputValue } = useContext(GlobalContext);
+
+        const enumInput = inputs[0];
+        const enumValue = getNodeInputValue(enumInput.id, inputData) ?? enumInput.options[0].value;
+
+        const isNodeInputLocked = useContextSelector(
+            GlobalVolatileContext,
+            (c) => c.isNodeInputLocked
+        );
+
+        const showInput = (input: Input): boolean => {
+            // always show the main dropdown itself
+            if (input === enumInput) return true;
+
+            const cond = group.options.conditions[input.id];
+            // no condition == always show input
+            if (!cond) return true;
+
+            // enum has the right value
+            if (cond.includes(enumValue)) return true;
+
+            // input is connected to another node
+            return isNodeInputLocked(nodeId, input.id);
+        };
+
+        return (
+            <>
+                {inputs.filter(showInput).map((i) => (
+                    <SchemaInput
+                        input={i}
+                        inputData={inputData}
+                        inputSize={inputSize}
+                        isLocked={isLocked}
+                        key={i.id}
+                        nodeId={nodeId}
+                        schemaId={schemaId}
+                    />
+                ))}
+            </>
+        );
+    }
+);

--- a/src/renderer/components/groups/Group.tsx
+++ b/src/renderer/components/groups/Group.tsx
@@ -7,6 +7,7 @@ import {
     InputSize,
     SchemaId,
 } from '../../../common/common-types';
+import { ConditionalEnumGroup } from './ConditionalEnumGroup';
 import { FromToDropdownsGroup } from './FromToDropdownsGroup';
 import { NcnnFileInputsGroup } from './NcnnFileInputsGroup';
 import { OptionalInputsGroup } from './OptionalInputsGroup';
@@ -15,6 +16,7 @@ import { GroupProps } from './props';
 const GroupComponents: {
     readonly [K in GroupKind]: React.MemoExoticComponent<(props: GroupProps<K>) => JSX.Element>;
 } = {
+    'conditional-enum': ConditionalEnumGroup,
     'from-to-dropdowns': FromToDropdownsGroup,
     'ncnn-file-inputs': NcnnFileInputsGroup,
     'optional-list': OptionalInputsGroup,


### PR DESCRIPTION
This adds a new group that hides inputs based on the value of a certain dropdown. This makes it possible to have conditional inputs. While I don't think that it's the best solution for conditional inputs, it's functional for now.

Usage: The options of the `conditional-enum` groups define a dictionary of conditions. The keys of the dict are input ids and the values are the enum values for which the input will be shown.

| PNG | JPG |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/20878432/200659997-8d2065c9-29a5-4907-a4be-7b6a2b87e4ed.png) | ![image](https://user-images.githubusercontent.com/20878432/200660142-53044b77-d338-4233-a9ba-a8d36d0ae3ff.png) |



---

So while I initially wanted to make a specialized group for the Same Image node, it ended up being easier to implement it in this general manner.