### PR TITLE
Use PIL to save GIF images

### DIFF
--- a/backend/src/nodes/nodes/image/save_image.py
+++ b/backend/src/nodes/nodes/image/save_image.py
@@ -75,7 +75,7 @@ class ImWriteNode(NodeBase):
 
         os.makedirs(base_directory, exist_ok=True)
         # Any image not supported by cv2, will be handled by pillow.
-        if extension not in ["png", "jpg", "gif", "tiff", "webp"]:
+        if extension not in ["png", "jpg", "tiff", "webp"]:
             channels = get_h_w_c(img)[2]
             if channels == 1:
                 # PIL supports grayscale images just fine, so we don't need to do any conversion


### PR DESCRIPTION
Fixes #1199.

I tested grayscale, RGB, and RGBA images, and they all worked. The compressed images are a bit suboptimal because PIL doesn't use dithering, but that might be fine.