### PR TITLE
Added log-scale sliders

### DIFF
--- a/backend/src/nodes/properties/inputs/numeric_inputs.py
+++ b/backend/src/nodes/properties/inputs/numeric_inputs.py
@@ -1,4 +1,4 @@
-from typing import Union, Tuple, List
+from typing import Union, Tuple, List, Literal
 
 from .base_input import BaseInput, InputKind
 from ...utils.utils import round_half_up
@@ -117,6 +117,7 @@ class SliderInput(NumberInput):
         ends: Tuple[Union[str, None], Union[str, None]] = (None, None),
         hide_trailing_zeros: bool = False,
         gradient: Union[List[str], None] = None,
+        scale: Literal["linear", "log", "log-offset"] = "linear",
     ):
         super().__init__(
             label,
@@ -137,6 +138,7 @@ class SliderInput(NumberInput):
             else (controls_step if controls_step is not None else 10**-precision)
         )
         self.gradient = gradient
+        self.scale = scale
 
     def toDict(self):
         return {
@@ -144,4 +146,5 @@ class SliderInput(NumberInput):
             "ends": self.ends,
             "sliderStep": self.slider_step,
             "gradient": self.gradient,
+            "scale": self.scale,
         }

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -90,6 +90,7 @@ export interface SliderInput extends InputBase {
     readonly ends: readonly [string | null, string | null];
     readonly sliderStep: number;
     readonly gradient?: readonly string[] | null;
+    readonly scale: 'linear' | 'log' | 'log-offset';
 }
 export type InputKind = Input['kind'];
 export type Input =
@@ -158,7 +159,11 @@ export type Group =
     | OptionalListGroup
     | ConditionalEnumGroup;
 
-export type OfKind<T, Kind extends string> = T extends { readonly kind: Kind } ? T : never;
+export type OfKind<T extends { readonly kind: string }, Kind extends T['kind']> = T extends {
+    readonly kind: Kind;
+}
+    ? T
+    : never;
 
 export type NodeType = 'regularNode' | 'iterator' | 'iteratorHelper';
 


### PR DESCRIPTION
As discussed on discord, this PR adds a log scale option for sliders. By default, sliders has a linear scale, but they can also have a log scale or offset log scale. 

- The log scale is actually a log+1 scale. The basic idea is that we offset the minimum of range such it corresponds to 1. This makes the scale increase nicely for number 1..max.
- The offset log scale is slightly different from the log scale. The regular log scale has the problem that the range 0..1 is still quite small for ranges 0..max. This log scale solves this by offsetting the range to a small number (here 0.33) instead of 1. This has the effect that very small values are given more space on the scale.

Here is the same slider with values 0..100.

Linear:
![image](https://user-images.githubusercontent.com/20878432/200926513-9d1043c0-ea73-444a-af61-e54a6c7b9eba.png)

Log:
![image](https://user-images.githubusercontent.com/20878432/200926446-a12f3500-7085-45ed-914b-6bd5678b67f9.png)

Log offset:
![image](https://user-images.githubusercontent.com/20878432/200926365-b685f4ae-29fe-436a-9b3d-02d6e7c9ec6e.png)

---

Other changes:
- I slightly improved the signature of the `OfKind` type to provide better code completion in the IDE.