### PR TITLE
Fix using arrow keys in number inputs moving nodes

### DIFF
--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -224,3 +224,7 @@ export const delay = (ms: number): Promise<void> => {
 
 export const getInputValues = <T>(schema: NodeSchema, getValue: (inputId: InputId) => T): T[] =>
     schema.inputs.map((input) => getValue(input.id));
+
+export const stopPropagation = (event: { readonly stopPropagation: () => void }): void => {
+    event.stopPropagation();
+};

--- a/src/renderer/components/inputs/TextAreaInput.tsx
+++ b/src/renderer/components/inputs/TextAreaInput.tsx
@@ -3,6 +3,7 @@ import { Resizable } from 're-resizable';
 import { ChangeEvent, memo, useEffect, useState } from 'react';
 import { useContextSelector } from 'use-context-selector';
 import { useDebouncedCallback } from 'use-debounce';
+import { stopPropagation } from '../../../common/util';
 import { GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { InputProps } from './props';
 
@@ -70,9 +71,7 @@ export const TextAreaInput = memo(
                         setTempText(event.target.value);
                         handleChange(event);
                     }}
-                    onKeyDown={(event) => {
-                        event.stopPropagation();
-                    }}
+                    onKeyDown={stopPropagation}
                 />
             </Resizable>
         );

--- a/src/renderer/components/inputs/TextInput.tsx
+++ b/src/renderer/components/inputs/TextInput.tsx
@@ -3,6 +3,7 @@ import { Input } from '@chakra-ui/react';
 import { ChangeEvent, memo, useEffect, useState } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
 import { getChainnerScope } from '../../../common/types/chainner-scope';
+import { stopPropagation } from '../../../common/util';
 import { InputProps } from './props';
 
 const typeToString = (type: Type): Type => {
@@ -63,9 +64,7 @@ export const TextInput = memo(
                     setTempText(event.target.value);
                     handleChange(event);
                 }}
-                onKeyDown={(event) => {
-                    event.stopPropagation();
-                }}
+                onKeyDown={stopPropagation}
             />
         );
     }

--- a/src/renderer/components/inputs/elements/AdvanceNumberInput.tsx
+++ b/src/renderer/components/inputs/elements/AdvanceNumberInput.tsx
@@ -8,7 +8,7 @@ import {
     NumberInputStepper,
 } from '@chakra-ui/react';
 import { memo } from 'react';
-import { areApproximatelyEqual } from '../../../../common/util';
+import { areApproximatelyEqual, stopPropagation } from '../../../../common/util';
 
 const clamp = (value: number, min?: number | null, max?: number | null): number => {
     if (min != null && value < min) return min;
@@ -104,6 +104,7 @@ export const AdvancedNumberInput = memo(
                         value={inputString}
                         onBlur={onBlur}
                         onChange={setInputString}
+                        onKeyDown={stopPropagation}
                     >
                         <NumberInputField
                             borderLeftRadius={unit ? 0 : 'xs'}
@@ -142,6 +143,7 @@ export const AdvancedNumberInput = memo(
                     value={inputString}
                     onBlur={onBlur}
                     onChange={setInputString}
+                    onKeyDown={stopPropagation}
                 >
                     <NumberInputField
                         borderLeftRadius={unit ? 0 : 'md'}


### PR DESCRIPTION
Same as #1205, but for number inputs (they had the same problem).

I also extracted the stop propagation caller into a util function. This should make things slightly more efficient for React.