### PR TITLE
Unified `SetState<T>`

### DIFF
--- a/src/renderer/contexts/ExecutionContext.tsx
+++ b/src/renderer/contexts/ExecutionContext.tsx
@@ -25,6 +25,7 @@ import {
 import { getConnectedInputs } from '../helpers/connectedInputs';
 import { getEffectivelyDisabledNodes } from '../helpers/disabled';
 import { getNodesWithSideEffects } from '../helpers/sideEffect';
+import { SetState } from '../helpers/types';
 import { useAsyncEffect } from '../hooks/useAsyncEffect';
 import {
     BackendEventMap,
@@ -56,7 +57,7 @@ interface ExecutionContextValue {
     kill: () => Promise<void>;
     status: ExecutionStatus;
     isBackendKilled: boolean;
-    setIsBackendKilled: React.Dispatch<React.SetStateAction<boolean>>;
+    setIsBackendKilled: SetState<boolean>;
 }
 
 export const ExecutionStatusContext = createContext<Readonly<ExecutionStatusContextValue>>({

--- a/src/renderer/contexts/GlobalNodeState.tsx
+++ b/src/renderer/contexts/GlobalNodeState.tsx
@@ -54,6 +54,7 @@ import {
     expandSelection,
     setSelected,
 } from '../helpers/reactFlowUtil';
+import { GetSetState, SetState } from '../helpers/types';
 import { TypeState } from '../helpers/TypeState';
 import { useAsyncEffect } from '../hooks/useAsyncEffect';
 import {
@@ -84,8 +85,6 @@ function getNodeInputValue<T extends NonNullable<InputValue>>(
     return (inputData[inputId] ?? undefined) as T | undefined;
 }
 
-type SetState<T> = React.Dispatch<React.SetStateAction<T>>;
-
 interface GlobalVolatile {
     nodeChanges: ChangeCounter;
     edgeChanges: ChangeCounter;
@@ -100,10 +99,7 @@ interface GlobalVolatile {
     isAnimated: (nodeId: string) => boolean;
     inputHashes: ReadonlyMap<string, string>;
     outputDataMap: ReadonlyMap<string, OutputDataEntry>;
-    useConnectingFrom: readonly [
-        OnConnectStartParams | null,
-        SetState<OnConnectStartParams | null>
-    ];
+    useConnectingFrom: GetSetState<OnConnectStartParams | null>;
 }
 interface Global {
     reactFlowWrapper: React.RefObject<Element>;

--- a/src/renderer/contexts/SettingsContext.tsx
+++ b/src/renderer/contexts/SettingsContext.tsx
@@ -2,41 +2,36 @@ import { useColorMode } from '@chakra-ui/react';
 import React, { memo, useEffect } from 'react';
 import { createContext } from 'use-context-selector';
 import { SchemaId } from '../../common/common-types';
+import { GetSetState, SetState } from '../helpers/types';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 import { useMemoArray, useMemoObject } from '../hooks/useMemo';
 
 interface Settings {
     // Global settings
-    useIsCpu: readonly [boolean, React.Dispatch<React.SetStateAction<boolean>>];
-    useIsFp16: readonly [boolean, React.Dispatch<React.SetStateAction<boolean>>];
-    usePyTorchGPU: readonly [number, React.Dispatch<React.SetStateAction<number>>];
-    useNcnnGPU: readonly [number, React.Dispatch<React.SetStateAction<number>>];
-    useOnnxGPU: readonly [number, React.Dispatch<React.SetStateAction<number>>];
-    useOnnxExecutionProvider: readonly [string, React.Dispatch<React.SetStateAction<string>>];
-    useIsSystemPython: readonly [boolean, React.Dispatch<React.SetStateAction<boolean>>];
-    useSystemPythonLocation: readonly [
-        string | null,
-        React.Dispatch<React.SetStateAction<string | null>>
-    ];
-    useDisHwAccel: readonly [boolean, React.Dispatch<React.SetStateAction<boolean>>];
-    useCheckUpdOnStrtUp: readonly [boolean, React.Dispatch<React.SetStateAction<boolean>>];
+    useIsCpu: GetSetState<boolean>;
+    useIsFp16: GetSetState<boolean>;
+    usePyTorchGPU: GetSetState<number>;
+    useNcnnGPU: GetSetState<number>;
+    useOnnxGPU: GetSetState<number>;
+    useOnnxExecutionProvider: GetSetState<string>;
+    useIsSystemPython: GetSetState<boolean>;
+    useSystemPythonLocation: GetSetState<string | null>;
+    useDisHwAccel: GetSetState<boolean>;
+    useCheckUpdOnStrtUp: GetSetState<boolean>;
     useSnapToGrid: readonly [
         snapToGrid: boolean,
-        setSnapToGrid: React.Dispatch<React.SetStateAction<boolean>>,
+        setSnapToGrid: SetState<boolean>,
         snapToGridAmount: number,
-        setSnapToGridAmount: React.Dispatch<React.SetStateAction<number>>
+        setSnapToGridAmount: SetState<number>
     ];
-    useStartupTemplate: readonly [string, React.Dispatch<React.SetStateAction<string>>];
-    useIsDarkMode: readonly [boolean, React.Dispatch<React.SetStateAction<boolean>>];
-    useAnimateChain: readonly [boolean, React.Dispatch<React.SetStateAction<boolean>>];
-    useExperimentalFeatures: readonly [boolean, React.Dispatch<React.SetStateAction<boolean>>];
+    useStartupTemplate: GetSetState<string>;
+    useIsDarkMode: GetSetState<boolean>;
+    useAnimateChain: GetSetState<boolean>;
+    useExperimentalFeatures: GetSetState<boolean>;
 
     // Node Settings
-    useNodeFavorites: readonly [
-        readonly SchemaId[],
-        React.Dispatch<React.SetStateAction<readonly SchemaId[]>>
-    ];
-    useNodeSelectorCollapsed: readonly [boolean, React.Dispatch<React.SetStateAction<boolean>>];
+    useNodeFavorites: GetSetState<readonly SchemaId[]>;
+    useNodeSelectorCollapsed: GetSetState<boolean>;
 }
 
 // TODO: create context requires default values

--- a/src/renderer/helpers/copyAndPaste.ts
+++ b/src/renderer/helpers/copyAndPaste.ts
@@ -8,8 +8,7 @@ import { v4 as uuid4 } from 'uuid';
 import { EdgeData, InputId, NodeData, SchemaId } from '../../common/common-types';
 import { createUniqueId, deriveUniqueId } from '../../common/util';
 import { NodeProto, copyEdges, copyNodes, expandSelection, setSelected } from './reactFlowUtil';
-
-type SetState<T> = React.Dispatch<React.SetStateAction<T>>;
+import { SetState } from './types';
 
 interface ClipboardChain {
     nodes: Node<NodeData>[];

--- a/src/renderer/helpers/dataTransfer.ts
+++ b/src/renderer/helpers/dataTransfer.ts
@@ -8,8 +8,7 @@ import { SchemaMap } from '../../common/SchemaMap';
 import { createUniqueId, deriveUniqueId } from '../../common/util';
 import { PresetFile } from '../components/NodeSelectorPanel/presets';
 import { NodeProto, copyEdges, copyNodes, setSelected } from './reactFlowUtil';
-
-type SetState<T> = React.Dispatch<React.SetStateAction<T>>;
+import { SetState } from './types';
 
 export interface ChainnerDragData {
     schemaId: SchemaId;

--- a/src/renderer/helpers/types.ts
+++ b/src/renderer/helpers/types.ts
@@ -1,0 +1,2 @@
+export type SetState<T> = React.Dispatch<React.SetStateAction<T>>;
+export type GetSetState<T> = readonly [T, SetState<T>];

--- a/src/renderer/hooks/useChangeCounter.ts
+++ b/src/renderer/hooks/useChangeCounter.ts
@@ -1,4 +1,5 @@
 import { useCallback, useRef, useState } from 'react';
+import { SetState } from '../helpers/types';
 
 export type ChangeCounter = number & { __changeCounter: true };
 
@@ -20,19 +21,16 @@ export const useChangeCounter = () => {
     return [counter as ChangeCounter, change, counterRef] as const;
 };
 
-export const wrapChanges = <T>(
-    setter: React.Dispatch<React.SetStateAction<T>>,
-    addChange: () => void
-): React.Dispatch<React.SetStateAction<T>> => {
+export const wrapChanges = <T>(setter: SetState<T>, addChange: () => void): SetState<T> => {
     return (value) => {
         setter(value);
         addChange();
     };
 };
 export const wrapRefChanges = <T>(
-    setter: Readonly<React.MutableRefObject<React.Dispatch<React.SetStateAction<T>>>>,
+    setter: Readonly<React.MutableRefObject<SetState<T>>>,
     addChange: () => void
-): React.Dispatch<React.SetStateAction<T>> => {
+): SetState<T> => {
     return (value) => {
         setter.current(value);
         addChange();


### PR DESCRIPTION
We had 3 `SetState<T>` types, so I unified them. I also added a `GetSetState<T>` type to simplify the type of state-value-setter pairs. 