### PR TITLE
Disable shortcuts when alert is open

### DIFF
--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -4,6 +4,7 @@ import { memo, useState } from 'react';
 import { ipcRenderer } from '../common/safeIpc';
 import { AlertBoxProvider } from './contexts/AlertBoxContext';
 import { ContextMenuProvider } from './contexts/ContextMenuContext';
+import { HotkeysProvider } from './contexts/HotKeyContext';
 import { useAsyncEffect } from './hooks/useAsyncEffect';
 import { Main } from './main';
 import { theme } from './theme';
@@ -46,15 +47,17 @@ export const App = memo(() => {
     return (
         <ChakraProvider theme={theme}>
             <ColorModeScript initialColorMode={theme.config.initialColorMode} />
-            <ContextMenuProvider>
-                <AlertBoxProvider>
-                    {!port || !storageInitialized ? (
-                        <LoadingComponent />
-                    ) : (
-                        <MainComponent port={port} />
-                    )}
-                </AlertBoxProvider>
-            </ContextMenuProvider>
+            <HotkeysProvider>
+                <ContextMenuProvider>
+                    <AlertBoxProvider>
+                        {!port || !storageInitialized ? (
+                            <LoadingComponent />
+                        ) : (
+                            <MainComponent port={port} />
+                        )}
+                    </AlertBoxProvider>
+                </ContextMenuProvider>
+            </HotkeysProvider>
         </ChakraProvider>
     );
 });

--- a/src/renderer/contexts/GlobalNodeState.tsx
+++ b/src/renderer/contexts/GlobalNodeState.tsx
@@ -2,7 +2,6 @@ import { Expression, Type, evaluate } from '@chainner/navi';
 import log from 'electron-log';
 import { dirname } from 'path';
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useHotkeys } from 'react-hotkeys-hook';
 import {
     Connection,
     Edge,
@@ -62,6 +61,7 @@ import {
     useChangeCounter,
     wrapRefChanges,
 } from '../hooks/useChangeCounter';
+import { useHotkeys } from '../hooks/useHotkeys';
 import { useInputHashes } from '../hooks/useInputHashes';
 import { useIpcRendererListener } from '../hooks/useIpcRendererListener';
 import { useMemoArray, useMemoObject } from '../hooks/useMemo';
@@ -1128,13 +1128,13 @@ export const GlobalProvider = memo(
             changeEdges((edges) => edges.map((e) => ({ ...e, selected: true })));
         }, [changeNodes, changeEdges]);
 
-        useHotkeys('ctrl+x, cmd+x', cutFn, [cutFn]);
+        useHotkeys('ctrl+x, cmd+x', cutFn);
         useIpcRendererListener('cut', cutFn);
-        useHotkeys('ctrl+c, cmd+c', copyFn, [copyFn]);
+        useHotkeys('ctrl+c, cmd+c', copyFn);
         useIpcRendererListener('copy', copyFn);
-        useHotkeys('ctrl+v, cmd+v', pasteFn, [pasteFn]);
+        useHotkeys('ctrl+v, cmd+v', pasteFn);
         useIpcRendererListener('paste', pasteFn);
-        useHotkeys('ctrl+a, cmd+a', selectAllFn, [selectAllFn]);
+        useHotkeys('ctrl+a, cmd+a', selectAllFn);
 
         const [zoom, setZoom] = useState(1);
 

--- a/src/renderer/contexts/HotKeyContext.tsx
+++ b/src/renderer/contexts/HotKeyContext.tsx
@@ -1,0 +1,34 @@
+import React, { memo, useCallback, useState } from 'react';
+import { createContext } from 'use-context-selector';
+import { ipcRenderer } from '../../common/safeIpc';
+import { noop } from '../../common/util';
+import { useMemoObject } from '../hooks/useMemo';
+
+interface HotkeysContextState {
+    hotkeysEnabled: boolean;
+    setHotkeysEnabled: (value: boolean) => void;
+}
+
+export const HotkeysContext = createContext<Readonly<HotkeysContextState>>({
+    hotkeysEnabled: true,
+    setHotkeysEnabled: noop,
+});
+
+export const HotkeysProvider = memo(({ children }: React.PropsWithChildren<unknown>) => {
+    const [enabled, setEnabled] = useState(true);
+
+    const setHotkeysEnabled = useCallback(
+        (value: boolean) => {
+            setEnabled(value);
+            ipcRenderer.send(value ? 'enable-menu' : 'disable-menu');
+        },
+        [setEnabled]
+    );
+
+    const value = useMemoObject<HotkeysContextState>({
+        hotkeysEnabled: enabled,
+        setHotkeysEnabled,
+    });
+
+    return <HotkeysContext.Provider value={value}>{children}</HotkeysContext.Provider>;
+});

--- a/src/renderer/hooks/useHotkeys.ts
+++ b/src/renderer/hooks/useHotkeys.ts
@@ -1,0 +1,12 @@
+import { useHotkeys as useHotkeysImpl } from 'react-hotkeys-hook';
+import { useContext } from 'use-context-selector';
+import { noop } from '../../common/util';
+import { HotkeysContext } from '../contexts/HotKeyContext';
+
+export const useHotkeys = (keys: string, callback: () => void): void => {
+    const { hotkeysEnabled } = useContext(HotkeysContext);
+
+    const fn = hotkeysEnabled ? callback : noop;
+
+    useHotkeysImpl(keys, fn, [fn]);
+};


### PR DESCRIPTION
Fixes #1202.

Since I had to add a wrapper around `useHotkeys` anyway, I made it so that ESLint can check deps arrays again. ESLint found that the callbacks of the executor context weren't memoized at all, so I fixed that. This was actually surprisingly easy since ESLint basically told me exactly what to do.