### PR TITLE
General file drag'n'drop

### DIFF
--- a/backend/src/nodes/nodes/image/load_image.py
+++ b/backend/src/nodes/nodes/image/load_image.py
@@ -22,7 +22,7 @@ class ImReadNode(NodeBase):
     def __init__(self):
         super().__init__()
         self.description = "Load image from specified file."
-        self.inputs = [ImageFileInput()]
+        self.inputs = [ImageFileInput(primary_input=True)]
         self.outputs = [
             LargeImageOutput(),
             DirectoryOutput("Image Directory"),
@@ -50,7 +50,7 @@ class ImReadNode(NodeBase):
                 ) from e
 
         if img is None:
-            raise RuntimeError(  # pylint: disable=raise-missing-from
+            raise RuntimeError(
                 f'Error reading image image from path "{path}". Image may be corrupt.'
             )
 

--- a/backend/src/nodes/nodes/ncnn/load_model.py
+++ b/backend/src/nodes/nodes/ncnn/load_model.py
@@ -18,8 +18,8 @@ class NcnnLoadModelNode(NodeBase):
         self.description = "Load NCNN model (.bin and .param files)."
         self.inputs = [
             group("ncnn-file-inputs")(
-                ParamFileInput(),
-                BinFileInput(),
+                ParamFileInput(primary_input=True),
+                BinFileInput(primary_input=True),
             )
         ]
         self.outputs = [

--- a/backend/src/nodes/nodes/onnx/load_model.py
+++ b/backend/src/nodes/nodes/onnx/load_model.py
@@ -21,7 +21,7 @@ class OnnxLoadModelNode(NodeBase):
         self.description = (
             """Load ONNX model file (.onnx). Theoretically supports any ONNX model."""
         )
-        self.inputs = [OnnxFileInput()]
+        self.inputs = [OnnxFileInput(primary_input=True)]
         self.outputs = [
             OnnxModelOutput(),
             DirectoryOutput("Model Directory").with_id(2),

--- a/backend/src/nodes/nodes/pytorch/load_model.py
+++ b/backend/src/nodes/nodes/pytorch/load_model.py
@@ -25,7 +25,7 @@ class LoadModelNode(NodeBase):
             Supports most variations of the RRDB architecture
             (ESRGAN, Real-ESRGAN, RealSR, BSRGAN, SPSR),
             Real-ESRGAN's SRVGG architecture, Swift-SRGAN, SwinIR, Swin2SR, and HAT."""
-        self.inputs = [PthFileInput()]
+        self.inputs = [PthFileInput(primary_input=True)]
         self.outputs = [
             ModelOutput(kind="pytorch", should_broadcast=True),
             DirectoryOutput("Model Directory").with_id(2),

--- a/backend/src/nodes/properties/inputs/file_inputs.py
+++ b/backend/src/nodes/properties/inputs/file_inputs.py
@@ -30,16 +30,19 @@ class FileInput(BaseInput):
         file_kind: FileInputKind,
         filetypes: list[str],
         has_handle: bool = False,
+        primary_input: bool = False,
     ):
         super().__init__(input_type, label, kind="file", has_handle=has_handle)
         self.filetypes = filetypes
         self.file_kind = file_kind
+        self.primary_input = primary_input
 
     def toDict(self):
         return {
             **super().toDict(),
             "filetypes": self.filetypes,
             "fileKind": self.file_kind,
+            "primaryInput": self.primary_input,
         }
 
     def enforce(self, value) -> str:
@@ -49,7 +52,7 @@ class FileInput(BaseInput):
         return value
 
 
-def ImageFileInput() -> FileInput:
+def ImageFileInput(primary_input: bool = False) -> FileInput:
     """Input for submitting a local image file"""
     return FileInput(
         input_type="ImageFile",
@@ -57,6 +60,7 @@ def ImageFileInput() -> FileInput:
         file_kind="image",
         filetypes=get_available_image_formats(),
         has_handle=False,
+        primary_input=primary_input,
     )
 
 
@@ -81,23 +85,14 @@ def VideoFileInput() -> FileInput:
     )
 
 
-def PthFileInput() -> FileInput:
+def PthFileInput(primary_input: bool = False) -> FileInput:
     """Input for submitting a local .pth file"""
     return FileInput(
         input_type="PthFile",
         label="Pretrained Model",
         file_kind="pth",
         filetypes=[".pth"],
-    )
-
-
-def TorchFileInput() -> FileInput:
-    """Input for submitting a local .pth or .pt file"""
-    return FileInput(
-        input_type="PtFile",
-        label="Pretrained Model",
-        file_kind="pt",
-        filetypes=[".pt"],
+        primary_input=primary_input,
     )
 
 
@@ -150,31 +145,34 @@ def ImageExtensionDropdown() -> DropDownInput:
     )
 
 
-def BinFileInput() -> FileInput:
+def BinFileInput(primary_input: bool = False) -> FileInput:
     """Input for submitting a local .bin file"""
     return FileInput(
         input_type="NcnnBinFile",
         label="NCNN Bin File",
         file_kind="bin",
         filetypes=[".bin"],
+        primary_input=primary_input,
     )
 
 
-def ParamFileInput() -> FileInput:
+def ParamFileInput(primary_input: bool = False) -> FileInput:
     """Input for submitting a local .param file"""
     return FileInput(
         input_type="NcnnParamFile",
         label="NCNN Param File",
         file_kind="param",
         filetypes=[".param"],
+        primary_input=primary_input,
     )
 
 
-def OnnxFileInput() -> FileInput:
+def OnnxFileInput(primary_input: bool = False) -> FileInput:
     """Input for submitting a local .onnx file"""
     return FileInput(
         input_type="OnnxFile",
         label="ONNX Model File",
         file_kind="onnx",
         filetypes=[".onnx"],
+        primary_input=primary_input,
     )

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -51,6 +51,7 @@ export interface FileInput extends InputBase {
     readonly kind: 'file';
     readonly fileKind: FileInputKind;
     readonly filetypes: readonly string[];
+    readonly primaryInput: boolean;
 }
 export interface DirectoryInput extends InputBase {
     readonly kind: 'directory';

--- a/src/renderer/helpers/dataTransfer.ts
+++ b/src/renderer/helpers/dataTransfer.ts
@@ -1,7 +1,7 @@
 import log from 'electron-log';
 import { extname } from 'path';
 import { Edge, Node, XYPosition } from 'reactflow';
-import { EdgeData, Input, InputId, NodeData, SchemaId } from '../../common/common-types';
+import { EdgeData, NodeData, SchemaId } from '../../common/common-types';
 import { ipcRenderer } from '../../common/safeIpc';
 import { openSaveFile } from '../../common/SaveFile';
 import { SchemaMap } from '../../common/SchemaMap';
@@ -132,32 +132,31 @@ const openChainnerFileProcessor: DataTransferProcessor = (dataTransfer) => {
     return false;
 };
 
-const openImageFileProcessor: DataTransferProcessor = (
+const openFileProcessor: DataTransferProcessor = (
     dataTransfer,
     { schemata, getNodePosition, createNode }
 ) => {
-    const LOAD_IMAGE_ID = 'chainner:image:load' as SchemaId;
-    if (!schemata.has(LOAD_IMAGE_ID)) return false;
-    const schema = schemata.get(LOAD_IMAGE_ID);
-    const input = schema.inputs[0] as Input | undefined;
-    const fileTypes = input && input.kind === 'file' && input.filetypes;
-    if (!fileTypes) return false;
+    for (const schema of schemata.schemata) {
+        for (const input of schema.inputs) {
+            if (input.kind === 'file' && input.primaryInput) {
+                const path = getSingleFileWithExtension(dataTransfer, input.filetypes);
+                if (path) {
+                    // found a supported file type
 
-    const path = getSingleFileWithExtension(dataTransfer, fileTypes);
-    if (path) {
-        // found a supported image file
+                    createNode({
+                        // hard-coded offset because it looks nicer
+                        position: getNodePosition(100, 100),
+                        data: {
+                            schemaId: schema.schemaId,
+                            inputData: { [input.id]: path },
+                        },
+                        nodeType: schema.nodeType,
+                    });
 
-        createNode({
-            // hard-coded offset because it looks nicer
-            position: getNodePosition(100, 100),
-            data: {
-                schemaId: LOAD_IMAGE_ID,
-                inputData: { [0 as InputId]: path },
-            },
-            nodeType: schema.nodeType,
-        });
-
-        return true;
+                    return true;
+                }
+            }
+        }
     }
     return false;
 };
@@ -166,5 +165,5 @@ export const dataTransferProcessors: readonly DataTransferProcessor[] = [
     chainnerSchemaProcessor,
     chainnerPresetProcessor,
     openChainnerFileProcessor,
-    openImageFileProcessor,
+    openFileProcessor,
 ];


### PR DESCRIPTION
Resolves #1196.

This was actually really easy to implement. Basically, every file input can now declare itself as the primary input for its file types. When a file is dragged into chainner, we go through all primary file inputs and create the node of the first matching one.

The NCNN group changed because only one input is set when the user drops a file. So I changed the group to fix that.

I also removed the `TorchFileInput`. It wasn't used.
