### PR TITLE
Added type tags for strings and directories

### DIFF
--- a/src/common/types/util.ts
+++ b/src/common/types/util.ts
@@ -2,6 +2,7 @@ import {
     IntIntervalType,
     NonNeverType,
     NumericLiteralType,
+    StringPrimitive,
     StructType,
     Type,
     UnionType,
@@ -23,6 +24,15 @@ export const isImage = (
     ];
 } => {
     return type.type === 'struct' && type.name === 'Image' && type.fields.length === 3;
+};
+
+export const isDirectory = (
+    type: Type
+): type is StructType & {
+    readonly name: 'Directory';
+    readonly fields: readonly [{ readonly name: 'path'; readonly type: StringPrimitive }];
+} => {
+    return type.type === 'struct' && type.name === 'Directory' && type.fields.length === 1;
 };
 
 export const getField = (struct: StructType, field: string): NonNeverType | undefined => {

--- a/src/renderer/components/TypeTag.tsx
+++ b/src/renderer/components/TypeTag.tsx
@@ -1,7 +1,15 @@
-import { NeverType, StructType, Type, isNumericLiteral, without } from '@chainner/navi';
-import { Tag } from '@chakra-ui/react';
+import {
+    NeverType,
+    StructType,
+    Type,
+    isNumericLiteral,
+    isStringLiteral,
+    without,
+} from '@chainner/navi';
+import { Tag, Tooltip, forwardRef } from '@chakra-ui/react';
 import React, { memo } from 'react';
-import { getField, isImage } from '../../common/types/util';
+import { getField, isDirectory, isImage } from '../../common/types/util';
+import { assertNever } from '../../common/util';
 
 const getColorMode = (channels: number) => {
     switch (channels) {
@@ -18,28 +26,45 @@ const getColorMode = (channels: number) => {
 
 const nullType = new StructType('null');
 
-const getTypeText = (type: Type): string[] => {
-    if (isNumericLiteral(type)) return [type.toString()];
+type TagValue =
+    | { kind: 'literal'; value: string }
+    | { kind: 'string'; value: string }
+    | { kind: 'path'; value: string };
 
-    const tags: string[] = [];
+const getTypeText = (type: Type): TagValue[] => {
+    if (isNumericLiteral(type)) return [{ kind: 'literal', value: type.toString() }];
+    if (isStringLiteral(type)) return [{ kind: 'string', value: type.value }];
+
+    const tags: TagValue[] = [];
     if (type.type === 'struct') {
         if (isImage(type)) {
             const [width, height, channels] = type.fields;
             if (isNumericLiteral(width.type) && isNumericLiteral(height.type)) {
-                tags.push(`${width.type.toString()}x${height.type.toString()}`);
+                tags.push({
+                    kind: 'literal',
+                    value: `${width.type.toString()}x${height.type.toString()}`,
+                });
             }
             if (isNumericLiteral(channels.type)) {
                 const mode = getColorMode(channels.type.value);
                 if (mode) {
-                    tags.push(mode);
+                    tags.push({ kind: 'literal', value: mode });
                 }
+            }
+        }
+
+        if (isDirectory(type)) {
+            const [path] = type.fields;
+
+            if (isStringLiteral(path.type)) {
+                tags.push({ kind: 'path', value: path.type.value });
             }
         }
 
         if (type.name === 'PyTorchModel' || type.name === 'NcnnNetwork') {
             const scale = getField(type, 'scale') ?? NeverType.instance;
             if (isNumericLiteral(scale)) {
-                tags.push(`${scale.toString()}x`);
+                tags.push({ kind: 'literal', value: `${scale.toString()}x` });
             }
         }
     }
@@ -50,39 +75,100 @@ export interface TypeTagProps {
     isOptional?: boolean;
 }
 
-export const TypeTag = memo(({ children, isOptional }: React.PropsWithChildren<TypeTagProps>) => {
-    return (
-        <Tag
-            bgColor="var(--tag-bg)"
-            color="var(--tag-fg)"
-            fontSize="x-small"
-            fontStyle={isOptional ? 'italic' : undefined}
-            height="15px"
-            lineHeight="auto"
-            minHeight="15px"
-            minWidth={0}
-            ml={1}
-            px={1}
-            size="sm"
-            variant="subtle"
-        >
-            {children}
-        </Tag>
-    );
-});
+export const TypeTag = memo(
+    forwardRef<TypeTagProps, 'span'>((props, ref) => {
+        const { isOptional, ...rest } = props;
+        return (
+            <Tag
+                bgColor="var(--tag-bg)"
+                color="var(--tag-fg)"
+                fontSize="x-small"
+                fontStyle={isOptional ? 'italic' : undefined}
+                height="15px"
+                lineHeight="auto"
+                minHeight="15px"
+                minWidth={0}
+                ml={1}
+                px={1}
+                ref={ref}
+                size="sm"
+                variant="subtle"
+                whiteSpace="pre"
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...rest}
+            />
+        );
+    })
+);
 
 export interface TypeTagsProps {
     type: Type;
     isOptional: boolean;
 }
 
+const Punctuation = memo(({ children }: React.PropsWithChildren<unknown>) => {
+    return <span style={{ opacity: '50%' }}>{children}</span>;
+});
+
+const TagRenderer = memo(({ tag }: { tag: TagValue }) => {
+    const { kind, value } = tag;
+
+    switch (kind) {
+        case 'path': {
+            const maxLength = 16;
+            return (
+                <Tooltip
+                    hasArrow
+                    borderRadius={8}
+                    label={value}
+                    openDelay={500}
+                    px={2}
+                    textAlign="center"
+                >
+                    <TypeTag>
+                        {value.length > maxLength && <Punctuation>…</Punctuation>}
+                        {value.slice(value.length - maxLength)}
+                    </TypeTag>
+                </Tooltip>
+            );
+        }
+        case 'string': {
+            const maxLength = 16;
+            return (
+                <Tooltip
+                    hasArrow
+                    borderRadius={8}
+                    label={value}
+                    openDelay={500}
+                    px={2}
+                    textAlign="center"
+                >
+                    <TypeTag>
+                        <Punctuation>&quot;</Punctuation>
+                        {value.slice(0, maxLength)}
+                        <Punctuation>{value.length > maxLength && '…'}&quot;</Punctuation>
+                    </TypeTag>
+                </Tooltip>
+            );
+        }
+        case 'literal': {
+            return <TypeTag>{value}</TypeTag>;
+        }
+        default:
+            return assertNever(kind);
+    }
+});
+
 export const TypeTags = memo(({ type, isOptional }: TypeTagsProps) => {
     const tags = getTypeText(without(type, nullType));
 
     return (
         <>
-            {tags.map((text) => (
-                <TypeTag key={text}>{text}</TypeTag>
+            {tags.map((tag) => (
+                <TagRenderer
+                    key={`${tag.kind};${tag.value}`}
+                    tag={tag}
+                />
             ))}
             {isOptional && <TypeTag isOptional>optional</TypeTag>}
         </>


### PR DESCRIPTION
All types that evaluate to a string literal or a directory will now have a type tag. Those type tags also have a tooltip each that shows the full string.

The main motivation for this PR is our text nodes. I feel like those nodes are rather abstract to many users (especially new ones), so I hope that the instant feedback of type tags will help them understand those nodes more easily.

![image](https://user-images.githubusercontent.com/20878432/201350223-89a8f7bf-1f35-4219-9288-3a9db63d49e1.png)
![image](https://user-images.githubusercontent.com/20878432/201353028-34d35f08-f28f-4884-bb14-7888f00c02ca.png)
![image](https://user-images.githubusercontent.com/20878432/201350418-5c403c46-9750-43b1-a40c-d0697d15b178.png)
![image](https://user-images.githubusercontent.com/20878432/201350527-bcaefc8b-1689-4ab8-8881-cefaffc55a12.png)

---

## Privacy concerns

The partial file paths displayed in the newly added type tags may reveal personal information, such as parts of the user's real name. This can be a problem because chains (or parts of them) are commonly shared via screenshots. An example of this can be seen in the above screenshots (...rs\\***micha***\Desktop).

However, I think that we can dismiss those concerns because we already display type previews of paths in directory inputs. Example:
![image](https://user-images.githubusercontent.com/20878432/201351682-b6544a6f-b49c-4da7-82e0-70292aa2a4da.png)
