### PR TITLE
Fixed Clear not affecting text inputs

### DIFF
--- a/src/renderer/components/inputs/TextAreaInput.tsx
+++ b/src/renderer/components/inputs/TextAreaInput.tsx
@@ -16,6 +16,12 @@ export const TextAreaInput = memo(
         const [tempText, setTempText] = useState(value ?? '');
 
         useEffect(() => {
+            if (value !== undefined) {
+                setTempText(value);
+            }
+        }, [value]);
+
+        useEffect(() => {
             if (!size) {
                 setSize({ width: 320, height: 240 });
             }

--- a/src/renderer/components/inputs/TextInput.tsx
+++ b/src/renderer/components/inputs/TextInput.tsx
@@ -25,6 +25,12 @@ export const TextInput = memo(
         const [tempText, setTempText] = useState(value ?? '');
 
         useEffect(() => {
+            if (value !== undefined) {
+                setTempText(value);
+            }
+        }, [value]);
+
+        useEffect(() => {
             if (value === undefined) {
                 if (def != null) {
                     setValue(def);


### PR DESCRIPTION
Right click > Clear on a node with text inputs would clear the input data value in the background, but the input itself would still display the old value.

I fixed this by updating the text/display text every time the value changes.