### PR TITLE
Simpler `useOutputData`

### DIFF
--- a/src/renderer/components/outputs/props.ts
+++ b/src/renderer/components/outputs/props.ts
@@ -10,7 +10,7 @@ export interface OutputProps {
     readonly hasHandle: boolean;
     readonly useOutputData: <T>(
         outputId: OutputId
-    ) => readonly [value: T | undefined, inputHash: string];
+    ) => readonly [value: T, inputHash: string] | readonly [value: undefined, inputHash: undefined];
     readonly animated: boolean;
     readonly kind: OutputKind;
 }


### PR DESCRIPTION
I noticed that we never actually used the `getInputHash(id)` value, so why even calculate it in the first place?