### PR TITLE
Removed unnecessary default values

### DIFF
--- a/src/renderer/components/outputs/LargeImageOutput.tsx
+++ b/src/renderer/components/outputs/LargeImageOutput.tsx
@@ -17,7 +17,7 @@ interface LargeImageBroadcastData {
 }
 
 export const LargeImageOutput = memo(
-    ({ id, outputId, useOutputData, animated = false, schemaId }: OutputProps) => {
+    ({ id, outputId, useOutputData, animated, schemaId }: OutputProps) => {
         const { setManualOutputType } = useContext(GlobalContext);
         const { schemata } = useContext(BackendContext);
         const schema = schemata.get(schemaId);

--- a/src/renderer/components/outputs/NcnnModelOutput.tsx
+++ b/src/renderer/components/outputs/NcnnModelOutput.tsx
@@ -31,7 +31,7 @@ const getColorMode = (channels: number) => {
 };
 
 export const NcnnModelOutput = memo(
-    ({ id, outputId, useOutputData, animated = false, schemaId }: OutputProps) => {
+    ({ id, outputId, useOutputData, animated, schemaId }: OutputProps) => {
         const [value] = useOutputData<NcnnModelData>(outputId);
 
         const { setManualOutputType } = useContext(GlobalContext);

--- a/src/renderer/components/outputs/PyTorchOutput.tsx
+++ b/src/renderer/components/outputs/PyTorchOutput.tsx
@@ -32,7 +32,7 @@ const getColorMode = (channels: number) => {
 };
 
 export const PyTorchOutput = memo(
-    ({ id, outputId, useOutputData, animated = false, schemaId }: OutputProps) => {
+    ({ id, outputId, useOutputData, animated, schemaId }: OutputProps) => {
         const [value] = useOutputData<PyTorchModelData>(outputId);
 
         const { setManualOutputType } = useContext(GlobalContext);


### PR DESCRIPTION
The `= false`s are useless because `animated` is always a bool and never undefined.

This feels like something a linter should catch, but there seems to be no TS ESLint rule for this.