### PR TITLE
Fixed usage of `useContextSelector` in ExecutionProvider

### DIFF
--- a/src/renderer/contexts/ExecutionContext.tsx
+++ b/src/renderer/contexts/ExecutionContext.tsx
@@ -200,10 +200,8 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
     const { useIsCpu, useIsFp16, usePyTorchGPU, useNcnnGPU, useOnnxGPU, useOnnxExecutionProvider } =
         useContext(SettingsContext);
     const { sendAlert, sendToast } = useContext(AlertBoxContext);
-    const { nodeChanges, edgeChanges } = useContextSelector(GlobalVolatileContext, (c) => ({
-        nodeChanges: c.nodeChanges,
-        edgeChanges: c.edgeChanges,
-    }));
+    const nodeChanges = useContextSelector(GlobalVolatileContext, (c) => c.nodeChanges);
+    const edgeChanges = useContextSelector(GlobalVolatileContext, (c) => c.edgeChanges);
 
     const [isCpu] = useIsCpu;
     const [isFp16] = useIsFp16;


### PR DESCRIPTION
`useContextSelector` will cause a re-render if the value returned by its selector function changes. "Changes" means the usual React strict value equal for values and referential equal for objects. Since the changed `useContextSelector` used to always return a new object, it caused a lot of unnecessary re-renders.