### PR TITLE
Removed quotes from string literal type tags

### DIFF
--- a/src/renderer/components/TypeTag.tsx
+++ b/src/renderer/components/TypeTag.tsx
@@ -144,9 +144,8 @@ const TagRenderer = memo(({ tag }: { tag: TagValue }) => {
                     textAlign="center"
                 >
                     <TypeTag>
-                        <Punctuation>&quot;</Punctuation>
                         {value.slice(0, maxLength)}
-                        <Punctuation>{value.length > maxLength && '…'}&quot;</Punctuation>
+                        {value.length > maxLength && <Punctuation>…</Punctuation>}
                     </TypeTag>
                 </Tooltip>
             );


### PR DESCRIPTION
As pointed out by @theflyingzamboni, string literal type tags don't need those quotes because the type color of the output already visually differentiates them from the type tags of other outputs.