### PR TITLE
Improved modified during execution check

### DIFF
--- a/src/renderer/contexts/ExecutionContext.tsx
+++ b/src/renderer/contexts/ExecutionContext.tsx
@@ -301,12 +301,13 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
         }
     }, [eventSourceStatus, unAnimate, isBackendKilled, ownsBackend, sendAlert]);
 
-    const previousStatus = useRef(status);
+    const lastChangesRef = useRef(`${nodeChanges} ${edgeChanges}`);
     useEffect(() => {
-        if (
-            status === ExecutionStatus.RUNNING &&
-            previousStatus.current === ExecutionStatus.RUNNING
-        ) {
+        const currentChanges = `${nodeChanges} ${edgeChanges}`;
+        if (lastChangesRef.current === currentChanges) return;
+        lastChangesRef.current = currentChanges;
+
+        if (status === ExecutionStatus.RUNNING) {
             sendToast({
                 status: 'warning',
                 description:
@@ -315,10 +316,7 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
                 variant: 'subtle',
                 position: 'bottom',
             });
-        } else if (
-            status === ExecutionStatus.PAUSED &&
-            previousStatus.current === ExecutionStatus.PAUSED
-        ) {
+        } else if (status === ExecutionStatus.PAUSED) {
             sendToast({
                 status: 'warning',
                 description:
@@ -328,7 +326,6 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
                 position: 'bottom',
             });
         }
-        previousStatus.current = status;
     }, [status, nodeChanges, edgeChanges, sendToast]);
 
     const runNodes = useCallback(async () => {


### PR DESCRIPTION
It took me quite some time to understand why `previousStatus` is necessary. I finally understood that it was there to prevent the warning from popping up when the status changed, but not the chain itself. Unfortunately, the `previousStatus` trick is not guaranteed to work, even though it works in practice. The deps array is an optimization is React. React is technically allowed to completely ignore the deps array and execute all effects on each render, it just doesn't do so for performance reasons.

So I replaced `previousStatus` with `lastChangesRef`. This ref holds the last changes (node + edges) seen and is used to de-duplicate effects.