### PR TITLE
Refactored snap to grid setting input

### DIFF
--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -195,11 +195,16 @@ const AppearanceSettings = memo(() => {
                 title="Snap to grid amount"
             >
                 <NumberInput
-                    defaultValue={snapToGridAmount || 1}
                     max={45}
                     min={1}
-                    value={Number(snapToGridAmount || 1)}
-                    onChange={(number: string) => setSnapToGridAmount(Number(number || 1))}
+                    value={snapToGridAmount}
+                    onChange={(number: string) => {
+                        const value = Number(number);
+
+                        if (!Number.isNaN(value)) {
+                            setSnapToGridAmount(value);
+                        }
+                    }}
                 >
                     <NumberInputField />
                     <NumberInputStepper>


### PR DESCRIPTION
In response to [this comment](https://github.com/chaiNNer-org/chaiNNer/pull/1243#discussion_r1027126678).

The number input of snap to grid now uses the same general props as the one for viewport export padding.