### PR TITLE
Fix face upscaling in video iterator

### DIFF
--- a/backend/src/nodes/nodes/pytorch/upscale_face.py
+++ b/backend/src/nodes/nodes/pytorch/upscale_face.py
@@ -132,6 +132,8 @@ class FaceUpscaleNode(NodeBase):
         del face_helper
         torch.cuda.empty_cache()
 
+        restored_img = np.clip(restored_img.astype("float32") / 255.0, 0, 1)
+
         return restored_img
 
     def run(


### PR DESCRIPTION
Without this, using face upscaling in a video iterator makes the output inverted and overflows. I assume the output was a 0-255 range float image, which we wouldn't catch with the enforced normalization. Anyway, this fixes it.