### PR TITLE
Use restricted unpickler

### DIFF
--- a/backend/src/nodes/nodes/pytorch/load_model.py
+++ b/backend/src/nodes/nodes/pytorch/load_model.py
@@ -15,6 +15,7 @@ from ...utils.exec_options import get_execution_options
 from ...utils.torch_types import PyTorchModel
 from ...utils.pytorch_model_loading import load_state_dict
 from ...utils.pytorch_utils import to_pytorch_execution_options
+from ...utils.unpickler import RestrictedUnpickle
 
 
 @NodeFactory.register("chainner:pytorch:load_model")
@@ -50,7 +51,9 @@ class LoadModelNode(NodeBase):
         try:
             logger.debug(f"Reading state dict from path: {path}")
             state_dict = torch.load(
-                path, map_location=torch.device(exec_options.full_device)
+                path,
+                map_location=torch.device(exec_options.full_device),
+                pickle_module=RestrictedUnpickle,  # type: ignore
             )
             model = load_state_dict(state_dict)
 

--- a/backend/src/nodes/utils/unpickler.py
+++ b/backend/src/nodes/utils/unpickler.py
@@ -1,0 +1,26 @@
+# Safe unpickler to prevent arbitrary code execution
+import pickle
+from types import SimpleNamespace
+
+safe_list = {
+    ("collections", "OrderedDict"),
+    ("torch._utils", "_rebuild_tensor_v2"),
+    ("torch", "FloatStorage"),
+}
+
+
+class RestrictedUnpickler(pickle.Unpickler):
+    def find_class(self, module, name):
+        # Only allow required classes to load state dict
+        if (module, name) not in safe_list:
+            raise pickle.UnpicklingError(
+                "Global '{}.{}' is forbidden".format(module, name)
+            )
+        return super().find_class(module, name)
+
+
+RestrictedUnpickle = SimpleNamespace(
+    Unpickler=RestrictedUnpickler,
+    __name__="pickle",
+    load=lambda *args, **kwargs: RestrictedUnpickler(*args, **kwargs).load(),
+)


### PR DESCRIPTION
This is something I just copied wholesale from my ESRGAN-Bot code. Basically, all it does is prevent arbitrary code execution from loading pickles (which .pth files are). Pickles are notoriously unsafe and this just restricts it to what torch needs. I completely forgot that I hadn't added this to chaiNNer until now.