### PR TITLE
Fixed webpack rules

### DIFF
--- a/webpack.rules.js
+++ b/webpack.rules.js
@@ -20,12 +20,14 @@ module.exports = [
                     ],
                     ...(isDevelopment
                         ? [
-                              'i18next-extract',
-                              {
-                                  outputPath: './src/common/locales/{{locale}}/{{ns}}.json',
-                                  keyAsDefaultValueForDerivedKeys: true,
-                                  discardOldKeys: true,
-                              },
+                              [
+                                  'i18next-extract',
+                                  {
+                                      outputPath: './src/common/locales/{{locale}}/{{ns}}.json',
+                                      keyAsDefaultValueForDerivedKeys: true,
+                                      discardOldKeys: true,
+                                  },
+                              ],
                           ]
                         : []),
                 ],


### PR DESCRIPTION
Fixes this error:

```
App threw an error during load
Error: Module build failed (from ./node_modules/babel-loader/lib/index.js):
Error: [BABEL] C:\Users\micha\Git\chaiNNer\src\main\main.ts: .outputPath is not a valid Plugin property
- Maybe you meant to use
"plugins": [
  ["i18next-extract", {
  "outputPath": "./src/common/locales/{{locale}}/{{ns}}.json",
  "keyAsDefaultValueForDerivedKeys": true,
  "discardOldKeys": true
}]
]
To be a valid plugin, its name and options should be wrapped in a pair of brackets
    at C:\Users\micha\Git\chaiNNer\node_modules\@babel\core\lib\config\validation\plugins.js:55:42
    at Array.forEach (<anonymous>)
    at validatePluginObject (C:\Users\micha\Git\chaiNNer\node_modules\@babel\core\lib\config\validation\plugins.js:45:20)
    at C:\Users\micha\Git\chaiNNer\node_modules\@babel\core\lib\config\full.js:226:55
```