### PR TITLE
Refactored `hoveredNode`

### DIFF
--- a/src/renderer/components/NodeSelectorPanel/RepresentativeNodeWrapper.tsx
+++ b/src/renderer/components/NodeSelectorPanel/RepresentativeNodeWrapper.tsx
@@ -3,9 +3,9 @@ import { Box, Center, MenuItem, MenuList, Tooltip, useDisclosure } from '@chakra
 import { DragEvent, memo, useCallback, useEffect, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { useReactFlow } from 'reactflow';
-import { useContext, useContextSelector } from 'use-context-selector';
+import { useContext } from 'use-context-selector';
 import { NodeSchema } from '../../../common/common-types';
-import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
+import { GlobalContext } from '../../contexts/GlobalNodeState';
 import { ChainnerDragData, TransferTypes } from '../../helpers/dataTransfer';
 import { useContextMenu } from '../../hooks/useContextMenu';
 import { useNodeFavorites } from '../../hooks/useNodeFavorites';
@@ -30,8 +30,7 @@ interface RepresentativeNodeWrapperProps {
 
 export const RepresentativeNodeWrapper = memo(
     ({ node, collapsed = false }: RepresentativeNodeWrapperProps) => {
-        const createNode = useContextSelector(GlobalVolatileContext, (c) => c.createNode);
-        const { reactFlowWrapper, setHoveredNode } = useContext(GlobalContext);
+        const { reactFlowWrapper, setHoveredNode, createNode } = useContext(GlobalContext);
         const reactFlowInstance = useReactFlow();
 
         const { favorites, addFavorites, removeFavorite } = useNodeFavorites();
@@ -129,12 +128,12 @@ export const RepresentativeNodeWrapper = memo(
                                     createNodeFromSelector();
                                 }}
                                 onDragEnd={() => {
-                                    setHoveredNode(null);
+                                    setHoveredNode(undefined);
                                 }}
                                 onDragStart={(event) => {
                                     setDidSingleClick(false);
                                     onDragStart(event, node);
-                                    setHoveredNode(null);
+                                    setHoveredNode(undefined);
                                 }}
                             >
                                 <RepresentativeNode

--- a/src/renderer/components/ReactFlowBox.tsx
+++ b/src/renderer/components/ReactFlowBox.tsx
@@ -25,7 +25,7 @@ import { EdgeData, NodeData } from '../../common/common-types';
 import { AlertBoxContext, AlertType } from '../contexts/AlertBoxContext';
 import { BackendContext } from '../contexts/BackendContext';
 import { ContextMenuContext } from '../contexts/ContextMenuContext';
-import { GlobalContext, GlobalVolatileContext } from '../contexts/GlobalNodeState';
+import { GlobalContext } from '../contexts/GlobalNodeState';
 import { SettingsContext } from '../contexts/SettingsContext';
 import { DataTransferProcessorOptions, dataTransferProcessors } from '../helpers/dataTransfer';
 import { expandSelection, isSnappedToGrid, snapToGrid } from '../helpers/reactFlowUtil';
@@ -157,7 +157,6 @@ interface ReactFlowBoxProps {
 export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlowBoxProps) => {
     const { sendAlert } = useContext(AlertBoxContext);
     const { closeContextMenu } = useContext(ContextMenuContext);
-    const { createNode, createConnection } = useContext(GlobalVolatileContext);
     const {
         setZoom,
         setHoveredNode,
@@ -165,6 +164,8 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
         addEdgeChanges,
         changeNodes,
         changeEdges,
+        createNode,
+        createConnection,
         setNodesRef,
         setEdgesRef,
         exportViewportScreenshot,
@@ -326,7 +327,7 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
     }, []);
 
     const onDragStart = useCallback(() => {
-        setHoveredNode(null);
+        setHoveredNode(undefined);
     }, [setHoveredNode]);
 
     const wrapper = wrapperRef.current;

--- a/src/renderer/components/node/IteratorNodeBody.tsx
+++ b/src/renderer/components/node/IteratorNodeBody.tsx
@@ -151,7 +151,7 @@ export const IteratorNodeBody = memo(
                         setHoveredNode(id);
                     }}
                     onDragLeave={() => {
-                        setHoveredNode(null);
+                        setHoveredNode(undefined);
                     }}
                 >
                     <Box

--- a/src/renderer/components/outputs/DefaultImageOutput.tsx
+++ b/src/renderer/components/outputs/DefaultImageOutput.tsx
@@ -30,13 +30,8 @@ export const DefaultImageOutput = memo(
             c.typeState.functions.get(id)?.outputs.get(outputId)
         );
 
-        const createNode = useContextSelector(GlobalVolatileContext, (c) => c.createNode);
-        const createConnection = useContextSelector(
-            GlobalVolatileContext,
-            (c) => c.createConnection
-        );
-
-        const { selectNode, setManualOutputType } = useContext(GlobalContext);
+        const { selectNode, setManualOutputType, createNode, createConnection } =
+            useContext(GlobalContext);
 
         const outputIndex = useContextSelector(BackendContext, (c) =>
             c.schemata.get(schemaId).outputs.findIndex((o) => o.id === outputId)

--- a/src/renderer/hooks/usePaneNodeSearchMenu.tsx
+++ b/src/renderer/hooks/usePaneNodeSearchMenu.tsx
@@ -14,7 +14,7 @@ import {
 } from '@chakra-ui/react';
 import { memo, useCallback, useMemo, useState } from 'react';
 import { Node, OnConnectStartParams, useReactFlow } from 'reactflow';
-import { useContext } from 'use-context-selector';
+import { useContext, useContextSelector } from 'use-context-selector';
 import {
     Category,
     InputId,
@@ -35,7 +35,7 @@ import {
 import { IconFactory } from '../components/CustomIcons';
 import { BackendContext } from '../contexts/BackendContext';
 import { ContextMenuContext } from '../contexts/ContextMenuContext';
-import { GlobalVolatileContext } from '../contexts/GlobalNodeState';
+import { GlobalContext, GlobalVolatileContext } from '../contexts/GlobalNodeState';
 import { interpolateColor } from '../helpers/colorTools';
 import { getNodeAccentColor } from '../helpers/getNodeAccentColor';
 import { getMatchingNodes, getNodesByCategory, sortSchemata } from '../helpers/nodeSearchFuncs';
@@ -331,8 +331,9 @@ interface Position {
 export const usePaneNodeSearchMenu = (
     wrapperRef: React.RefObject<HTMLDivElement>
 ): UsePaneNodeSearchMenuValue => {
-    const { createNode, createConnection, typeState, useConnectingFrom } =
-        useContext(GlobalVolatileContext);
+    const typeState = useContextSelector(GlobalVolatileContext, (c) => c.typeState);
+    const useConnectingFrom = useContextSelector(GlobalVolatileContext, (c) => c.useConnectingFrom);
+    const { createNode, createConnection } = useContext(GlobalContext);
     const { closeContextMenu } = useContext(ContextMenuContext);
     const { schemata, functionDefinitions, categories } = useContext(BackendContext);
 


### PR DESCRIPTION
Changes:
- `hoveredNode` cannot be null.
- Added a `hoveredNodeRef` for use in `createNode`.
- `createNode` and `createConnection` are now part of the nonvolatile context. This should improve performance.