### PR TITLE
Fixed `setManualOutputType` crashing the app for invalid type expressions

### DIFF
--- a/src/renderer/contexts/GlobalNodeState.tsx
+++ b/src/renderer/contexts/GlobalNodeState.tsx
@@ -203,16 +203,30 @@ export const GlobalProvider = memo(
             map: new Map<string, Map<OutputId, Type>>(),
         }));
         const setManualOutputType = useCallback(
-            (nodeId: string, outputId: OutputId, type: Expression | undefined): void => {
+            (nodeId: string, outputId: OutputId, expression: Expression | undefined): void => {
+                const getType = () => {
+                    if (expression === undefined) {
+                        return undefined;
+                    }
+
+                    try {
+                        return evaluate(expression, getChainnerScope());
+                    } catch (error) {
+                        log.error(error);
+                        return undefined;
+                    }
+                };
+
                 setManualOutputTypes(({ map }) => {
                     let inner = map.get(nodeId);
+                    const type = getType();
                     if (type) {
                         if (!inner) {
                             inner = new Map();
                             map.set(nodeId, inner);
                         }
 
-                        inner.set(outputId, evaluate(type, getChainnerScope()));
+                        inner.set(outputId, type);
                     } else {
                         inner?.delete(outputId);
                     }


### PR DESCRIPTION
Fixes what zamboni reported on discord.

The problem was that `setManualOutputType` trusted the given type expression to be correct. This was quite the assumption since type expression can easily be invalid. With this fixed, `setManualOutputType` will now reset the manual output type if an invalid type expression is given.