### PR TITLE
NCNN input image dims getter

### DIFF
--- a/backend/src/nodes/utils/ncnn_model.py
+++ b/backend/src/nodes/utils/ncnn_model.py
@@ -787,3 +787,12 @@ class NcnnModelWrapper:
         in_nc = weight_data_size // nf // kernel_w // kernel_h
 
         return nf, in_nc
+
+    @staticmethod
+    def get_input_dims(model: NcnnModel) -> Tuple[int, int, int]:
+        input_layer = model.layers[0]
+        w = checked_cast(int, input_layer.params[0].value)
+        h = checked_cast(int, input_layer.params[1].value)
+        c = checked_cast(int, input_layer.params[2].value)
+
+        return h, w, c


### PR DESCRIPTION
Per @RunDevelopment's request in discord. Returns height, width, channels for an NCNN model's input. 0 is default for each and means that there is no specific required dimension. Static method of NcnnModelWrapper, called just like get_broadcast_data().