### PR TITLE
Fix FaceSR and Transformer-model interpolation

### DIFF
--- a/backend/src/nodes/utils/architecture/GFPGAN/gfpgan_bilinear_arch.py
+++ b/backend/src/nodes/utils/architecture/GFPGAN/gfpgan_bilinear_arch.py
@@ -187,6 +187,7 @@ class GFPGANBilinear(nn.Module):
         self.input_is_latent = input_is_latent
         self.different_w = different_w
         self.num_style_feat = num_style_feat
+        self.min_size_restriction = 512
 
         unet_narrow = narrow * 0.5  # by default, use a half of input channels
         channels = {

--- a/backend/src/nodes/utils/architecture/GFPGAN/gfpganv1_clean_arch.py
+++ b/backend/src/nodes/utils/architecture/GFPGAN/gfpganv1_clean_arch.py
@@ -215,6 +215,7 @@ class GFPGANv1Clean(nn.Module):
 
         self.supports_fp16 = False
         self.supports_bf16 = True
+        self.min_size_restriction = 512
 
         self.input_is_latent = input_is_latent
         self.different_w = different_w

--- a/backend/src/nodes/utils/architecture/GFPGAN/restoreformer_arch.py
+++ b/backend/src/nodes/utils/architecture/GFPGAN/restoreformer_arch.py
@@ -705,6 +705,7 @@ class RestoreFormer(nn.Module):
 
         self.supports_fp16 = False
         self.supports_bf16 = True
+        self.min_size_restriction = 16
 
         self.encoder = MultiHeadEncoder(
             ch=ch,

--- a/backend/src/nodes/utils/architecture/HAT.py
+++ b/backend/src/nodes/utils/architecture/HAT.py
@@ -914,6 +914,7 @@ class HAT(nn.Module):
         self.sub_type = "SR"
         self.supports_fp16 = False
         self.support_bf16 = True
+        self.min_size_restriction = 16
 
         state_keys = list(state_dict.keys())
 

--- a/backend/src/nodes/utils/architecture/RRDB.py
+++ b/backend/src/nodes/utils/architecture/RRDB.py
@@ -81,6 +81,7 @@ class RRDBNet(nn.Module):
 
         self.supports_fp16 = True
         self.supports_bfp16 = True
+        self.min_size_restriction = None
 
         # Detect if pixelunshuffle was used (Real-ESRGAN)
         if self.in_nc in (self.out_nc * 4, self.out_nc * 16) and self.out_nc in (

--- a/backend/src/nodes/utils/architecture/SPSR.py
+++ b/backend/src/nodes/utils/architecture/SPSR.py
@@ -65,6 +65,7 @@ class SPSRNet(nn.Module):
 
         self.supports_fp16 = True
         self.supports_bfp16 = True
+        self.min_size_restriction = None
 
         n_upscale = int(math.log(self.scale, 2))
         if self.scale == 3:

--- a/backend/src/nodes/utils/architecture/SRVGG.py
+++ b/backend/src/nodes/utils/architecture/SRVGG.py
@@ -47,6 +47,7 @@ class SRVGGNetCompact(nn.Module):
 
         self.supports_fp16 = True
         self.supports_bfp16 = True
+        self.min_size_restriction = None
 
         self.body = nn.ModuleList()
         # the first conv

--- a/backend/src/nodes/utils/architecture/SwiftSRGAN.py
+++ b/backend/src/nodes/utils/architecture/SwiftSRGAN.py
@@ -125,6 +125,7 @@ class Generator(nn.Module):
 
         self.supports_fp16 = True
         self.supports_bfp16 = True
+        self.min_size_restriction = None
 
         self.initial = ConvBlock(
             in_channels, num_channels, kernel_size=9, stride=1, padding=4, use_bn=False

--- a/backend/src/nodes/utils/architecture/Swin2SR.py
+++ b/backend/src/nodes/utils/architecture/Swin2SR.py
@@ -1043,6 +1043,7 @@ class Swin2SR(nn.Module):
 
         self.supports_fp16 = False  # Too much weirdness to support this at the moment
         self.supports_bfp16 = True
+        self.min_size_restriction = 16
 
         ## END AUTO DETECTION
 

--- a/backend/src/nodes/utils/architecture/SwinIR.py
+++ b/backend/src/nodes/utils/architecture/SwinIR.py
@@ -977,6 +977,7 @@ class SwinIR(nn.Module):
 
         self.supports_fp16 = False  # Too much weirdness to support this at the moment
         self.supports_bfp16 = True
+        self.min_size_restriction = 16
 
         self.img_range = img_range
         if in_chans == 3:


### PR DESCRIPTION
Fixes #1273

Set a minimum size per-model so that FaceSR (typically restricted to 512x512) and swin/hat (16x16) would properly run the interpolation check