### PR TITLE
Remove `promptToCreate`

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -116,7 +116,7 @@ const registerEventHandlers = (mainWindow: BrowserWindowWithSafeIpc) => {
     ipcMain.handle('dir-select', (event, dirPath) =>
         dialog.showOpenDialog(mainWindow, {
             defaultPath: dirPath,
-            properties: ['openDirectory', 'createDirectory', 'promptToCreate'],
+            properties: ['openDirectory', 'createDirectory'],
         })
     );
 


### PR DESCRIPTION
resolves #1086


though, the issue specifies file selection, which does not have this property enabled. Maybe we should keep this on?