### PR TITLE
Fix spawning chosen python path

### DIFF
--- a/src/main/childProc.ts
+++ b/src/main/childProc.ts
@@ -1,0 +1,25 @@
+import { spawn } from 'child_process';
+
+export const promisifiedSpawn = async (command: string, args: string[]): Promise<string> => {
+    return new Promise((resolve, reject) => {
+        const proc = spawn(command, args);
+        let stdout = '';
+        let stderr = '';
+        proc.stdout.on('data', (data) => {
+            stdout += data;
+        });
+        proc.stderr.on('data', (data) => {
+            stderr += data;
+        });
+        proc.on('error', (err) => {
+            reject(err);
+        });
+        proc.on('close', (code) => {
+            if (code !== 0) {
+                reject(new Error(stderr));
+            } else {
+                resolve(stdout);
+            }
+        });
+    });
+};

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -215,8 +215,16 @@ const checkPythonEnv = async (splashWindow: BrowserWindowWithSafeIpc) => {
     let pythonInfo: PythonInfo;
 
     const useSystemPython = localStorage.getItem('use-system-python') === 'true';
-    const systemPythonLocation = localStorage.getItem('system-python-location');
-    const integratedPythonFolderPath = path.join(app.getPath('userData'), '/python');
+    let systemPythonLocation = localStorage.getItem('system-python-location');
+    let integratedPythonFolderPath = path.join(app.getPath('userData'), '/python');
+
+    if (systemPythonLocation) {
+        systemPythonLocation = path.normalize(systemPythonLocation);
+    }
+
+    if (integratedPythonFolderPath) {
+        integratedPythonFolderPath = path.normalize(integratedPythonFolderPath);
+    }
 
     if (useSystemPython) {
         try {

--- a/src/main/python/version.ts
+++ b/src/main/python/version.ts
@@ -1,13 +1,10 @@
-import { exec as _exec } from 'child_process';
-import util from 'util';
 import { Version } from '../../common/common-types';
 import { parse, versionGte } from '../../common/version';
-
-const exec = util.promisify(_exec);
+import { promisifiedSpawn } from '../childProc';
 
 export const getPythonVersion = async (python: string) => {
-    const { stdout } = await exec(`"${python}" --version`);
-    return parse(stdout);
+    const version = await promisifiedSpawn(python, ['--version']);
+    return parse(version);
 };
 
 export const isSupportedPythonVersion = (version: Version) => versionGte(version, '3.7.0');


### PR DESCRIPTION
Fixes https://github.com/chaiNNer-org/chaiNNer-nightly/issues/2

I was able to recreate this issue on windows, and can confirm this does fix it.

What I did:
- Normalize paths, just in case
- Use spawn instead of exec so it can be properly escaped