### PR TITLE
Specify that picking the system python location is optional

### DIFF
--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -451,7 +451,7 @@ const PythonSettings = memo(() => {
                         />
                         <SettingsItem
                             description="If wanted, use a specific python binary rather than the default one invoked by 'python3' or 'python'. This is useful if you have multiple python versions installed and want to pick a specific one."
-                            title="System Python location"
+                            title="System Python location (optional)"
                         >
                             <HStack>
                                 <Tooltip


### PR DESCRIPTION
I've seen a couple people treat this as necessary, so might as well make it obvious that it isn't necessary 