### PR TITLE
Add TensorRT caching

### DIFF
--- a/backend/src/nodes/utils/exec_options.py
+++ b/backend/src/nodes/utils/exec_options.py
@@ -1,3 +1,4 @@
+import os
 from sanic.log import logger
 
 
@@ -10,6 +11,8 @@ class ExecutionOptions:
         ncnn_gpu_index: int,
         onnx_gpu_index: int,
         onnx_execution_provider: str,
+        onnx_should_tensorrt_cache: bool,
+        onnx_tensorrt_cache_path: str,
     ) -> None:
         self.__device = device
         self.__fp16 = fp16
@@ -17,6 +20,20 @@ class ExecutionOptions:
         self.__ncnn_gpu_index = ncnn_gpu_index
         self.__onnx_gpu_index = onnx_gpu_index
         self.__onnx_execution_provider = onnx_execution_provider
+        self.__onnx_should_tensorrt_cache = onnx_should_tensorrt_cache
+        self.__onnx_tensorrt_cache_path = onnx_tensorrt_cache_path
+
+        print(onnx_tensorrt_cache_path)
+
+        if (
+            not os.path.exists(onnx_tensorrt_cache_path)
+            and onnx_tensorrt_cache_path != ""
+        ):
+            os.makedirs(onnx_tensorrt_cache_path)
+
+        logger.info(
+            f"PyTorch execution options: fp16: {fp16}, device: {self.full_device} | NCNN execution options: gpu_index: {ncnn_gpu_index} | ONNX execution options: gpu_index: {onnx_gpu_index}, execution_provider: {onnx_execution_provider}, should_tensorrt_cache: {onnx_should_tensorrt_cache}, tensorrt_cache_path: {onnx_tensorrt_cache_path}"
+        )
 
     @property
     def full_device(self) -> str:
@@ -44,14 +61,21 @@ class ExecutionOptions:
     def onnx_execution_provider(self):
         return self.__onnx_execution_provider
 
+    @property
+    def onnx_should_tensorrt_cache(self):
+        return self.__onnx_should_tensorrt_cache
 
-__global_exec_options = ExecutionOptions("cpu", False, 0, 0, 0, "CPUExecutionProvider")
+    @property
+    def onnx_tensorrt_cache_path(self):
+        return self.__onnx_tensorrt_cache_path
+
+
+__global_exec_options = ExecutionOptions(
+    "cpu", False, 0, 0, 0, "CPUExecutionProvider", False, ""
+)
 
 
 def get_execution_options() -> ExecutionOptions:
-    logger.info(
-        f"PyTorch execution options: fp16: {__global_exec_options.fp16}, device: {__global_exec_options.full_device} | NCNN execution options: gpu_index: {__global_exec_options.ncnn_gpu_index} | ONNX execution options: gpu_index: {__global_exec_options.onnx_gpu_index}, execution_provider: {__global_exec_options.onnx_execution_provider}"
-    )
     return __global_exec_options
 
 

--- a/backend/src/nodes/utils/onnx_session.py
+++ b/backend/src/nodes/utils/onnx_session.py
@@ -15,6 +15,8 @@ def create_inference_session(
                 "TensorrtExecutionProvider",
                 {
                     "device_id": exec_options.onnx_gpu_index,
+                    "trt_engine_cache_enable": exec_options.onnx_should_tensorrt_cache,
+                    "trt_engine_cache_path": exec_options.onnx_tensorrt_cache_path,
                 },
             ),
             (

--- a/backend/src/nodes/utils/pytorch_utils.py
+++ b/backend/src/nodes/utils/pytorch_utils.py
@@ -29,6 +29,8 @@ def to_pytorch_execution_options(options: ExecutionOptions):
         ncnn_gpu_index=options.ncnn_gpu_index,
         onnx_gpu_index=options.onnx_gpu_index,
         onnx_execution_provider=options.onnx_execution_provider,
+        onnx_should_tensorrt_cache=options.onnx_should_tensorrt_cache,
+        onnx_tensorrt_cache_path=options.onnx_tensorrt_cache_path,
     )
 
 

--- a/backend/src/run.py
+++ b/backend/src/run.py
@@ -198,6 +198,8 @@ class RunRequest(TypedDict):
     ncnnGPU: int
     onnxGPU: int
     onnxExecutionProvider: str
+    onnxShouldTensorRtCache: bool
+    onnxTensorRtCachePath: str
 
 
 @app.route("/run", methods=["POST"])
@@ -227,6 +229,8 @@ async def run(request: Request):
             ncnn_gpu_index=full_data["ncnnGPU"],
             onnx_gpu_index=full_data["onnxGPU"],
             onnx_execution_provider=full_data["onnxExecutionProvider"],
+            onnx_should_tensorrt_cache=full_data["onnxShouldTensorRtCache"],
+            onnx_tensorrt_cache_path=full_data["onnxTensorRtCachePath"],
         )
         set_execution_options(exec_opts)
         logger.debug(f"Using device: {exec_opts.full_device}")
@@ -280,6 +284,8 @@ class RunIndividualRequest(TypedDict):
     ncnnGPU: int
     onnxGPU: int
     onnxExecutionProvider: str
+    onnxShouldTensorRtCache: bool
+    onnxTensorRtCachePath: str
     schemaId: str
 
 
@@ -299,6 +305,8 @@ async def run_individual(request: Request):
             ncnn_gpu_index=full_data["ncnnGPU"],
             onnx_gpu_index=full_data["onnxGPU"],
             onnx_execution_provider=full_data["onnxExecutionProvider"],
+            onnx_should_tensorrt_cache=full_data["onnxShouldTensorRtCache"],
+            onnx_tensorrt_cache_path=full_data["onnxTensorRtCachePath"],
         )
         set_execution_options(exec_opts)
         logger.debug(f"Using device: {exec_opts.full_device}")

--- a/src/common/Backend.ts
+++ b/src/common/Backend.ts
@@ -46,6 +46,8 @@ export interface BackendRunRequest {
     ncnnGPU: number;
     onnxGPU: number;
     onnxExecutionProvider: string;
+    onnxShouldTensorRtCache: boolean;
+    onnxTensorRtCachePath: string;
 }
 export interface BackendRunIndividualRequest {
     id: string;
@@ -56,6 +58,8 @@ export interface BackendRunIndividualRequest {
     ncnnGPU: number;
     onnxGPU: number;
     onnxExecutionProvider: string;
+    onnxShouldTensorRtCache: boolean;
+    onnxTensorRtCachePath: string;
     schemaId: SchemaId;
 }
 

--- a/src/common/env.ts
+++ b/src/common/env.ts
@@ -1,4 +1,5 @@
 import os from 'os';
+import path from 'path';
 
 export const isWindows = process.platform === 'win32';
 export const isMac = process.platform === 'darwin';
@@ -24,3 +25,7 @@ export const hasTensorRt = !isMac && (hasTensorRtWindows || hasTensorRtLinux);
 const env = { ...process.env };
 delete env.PYTHONHOME;
 export const sanitizedEnv = env;
+
+export const getOnnxTensorRtCacheLocation = (userDataPath: string) => {
+    return path.join(userDataPath, 'onnx-tensorrt-cache');
+};

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -33,6 +33,8 @@ import {
     VStack,
     useDisclosure,
 } from '@chakra-ui/react';
+import log from 'electron-log';
+import { readdir,unlink } from 'fs/promises';
 import path from 'path';
 import {
     PropsWithChildren,
@@ -46,7 +48,7 @@ import {
 import { BsFillPencilFill, BsPaletteFill } from 'react-icons/bs';
 import { FaPython, FaTools } from 'react-icons/fa';
 import { useContext } from 'use-context-selector';
-import { hasTensorRt } from '../../common/env';
+import { getOnnxTensorRtCacheLocation, hasTensorRt } from '../../common/env';
 import { ipcRenderer } from '../../common/safeIpc';
 import { BackendContext } from '../contexts/BackendContext';
 import { SettingsContext } from '../contexts/SettingsContext';
@@ -329,6 +331,7 @@ const PythonSettings = memo(() => {
         useNcnnGPU,
         useOnnxGPU,
         useOnnxExecutionProvider,
+        useOnnxShouldTensorRtCache,
     } = useContext(SettingsContext);
     const { backend } = useContext(BackendContext);
 
@@ -342,6 +345,9 @@ const PythonSettings = memo(() => {
     const [pytorchGPU, setPytorchGPU] = usePyTorchGPU;
     const [onnxGPU, setOnnxGPU] = useOnnxGPU;
     const [onnxExecutionProvider, setOnnxExecutionProvider] = useOnnxExecutionProvider;
+    const [onnxShouldTensorRtCache, setOnnxShouldTensorRtCache] = useOnnxShouldTensorRtCache;
+    const isUsingTensorRt = onnxExecutionProvider === 'TensorrtExecutionProvider';
+
     const [nvidiaGpuList, setNvidiaGpuList] = useState<string[]>([]);
     useAsyncEffect(
         () => ({
@@ -580,6 +586,49 @@ const PythonSettings = memo(() => {
                                 setOnnxExecutionProvider(String(e.target.value));
                             }}
                         />
+                        {isUsingTensorRt && (
+                            <HStack>
+                                <Toggle
+                                    description="Whether or not to cache the converted TensorRT engines to disk. This can speed up inference times immensely once you have converted once."
+                                    title="Cache TensorRT engines"
+                                    value={onnxShouldTensorRtCache}
+                                    onToggle={() => {
+                                        setOnnxShouldTensorRtCache((prev) => !prev);
+                                    }}
+                                />
+                                <Button
+                                    onClick={() => {
+                                        ipcRenderer
+                                            .invoke('get-appdata')
+                                            .then((appDataPath: string) => {
+                                                const onnxTensorRtCacheLocation =
+                                                    getOnnxTensorRtCacheLocation(appDataPath);
+                                                readdir(onnxTensorRtCacheLocation)
+                                                    .then((files) => {
+                                                        for (const file of files) {
+                                                            unlink(
+                                                                path.join(
+                                                                    onnxTensorRtCacheLocation,
+                                                                    file
+                                                                )
+                                                            ).catch((error) => {
+                                                                log.error(error);
+                                                            });
+                                                        }
+                                                    })
+                                                    .catch((err) => {
+                                                        log.error(err);
+                                                    });
+                                            })
+                                            .catch((err) => {
+                                                log.error(err);
+                                            });
+                                    }}
+                                >
+                                    Clear Cache
+                                </Button>
+                            </HStack>
+                        )}
                     </VStack>
                 </TabPanel>
             </TabPanels>

--- a/src/renderer/contexts/SettingsContext.tsx
+++ b/src/renderer/contexts/SettingsContext.tsx
@@ -14,6 +14,7 @@ interface Settings {
     useNcnnGPU: GetSetState<number>;
     useOnnxGPU: GetSetState<number>;
     useOnnxExecutionProvider: GetSetState<string>;
+    useOnnxShouldTensorRtCache: GetSetState<boolean>;
     useIsSystemPython: GetSetState<boolean>;
     useSystemPythonLocation: GetSetState<string | null>;
     useDisHwAccel: GetSetState<boolean>;
@@ -47,6 +48,9 @@ export const SettingsProvider = memo(({ children }: React.PropsWithChildren<unkn
     const useOnnxGPU = useMemoArray(useLocalStorage('onnx-gpu', 0));
     const useOnnxExecutionProvider = useMemoArray(
         useLocalStorage('onnx-execution-provider', 'CUDAExecutionProvider')
+    );
+    const useOnnxShouldTensorRtCache = useMemoArray(
+        useLocalStorage('onnx-should-tensorrt-cache', false)
     );
 
     const useIsSystemPython = useMemoArray(useLocalStorage('use-system-python', false));
@@ -97,6 +101,7 @@ export const SettingsProvider = memo(({ children }: React.PropsWithChildren<unkn
         useNcnnGPU,
         useOnnxGPU,
         useOnnxExecutionProvider,
+        useOnnxShouldTensorRtCache,
 
         // Globals
         useIsSystemPython,

--- a/src/renderer/hooks/useRunNode.ts
+++ b/src/renderer/hooks/useRunNode.ts
@@ -2,6 +2,8 @@ import log from 'electron-log';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useContext } from 'use-context-selector';
 import { NodeData } from '../../common/common-types';
+import { getOnnxTensorRtCacheLocation } from '../../common/env';
+import { ipcRenderer } from '../../common/safeIpc';
 import { delay, getInputValues } from '../../common/util';
 import { AlertBoxContext } from '../contexts/AlertBoxContext';
 import { BackendContext } from '../contexts/BackendContext';
@@ -21,8 +23,15 @@ export const useRunNode = (
     const { sendToast } = useContext(AlertBoxContext);
     const { animate, unAnimate } = useContext(GlobalContext);
     const { schemata, backend } = useContext(BackendContext);
-    const { useIsCpu, useIsFp16, usePyTorchGPU, useNcnnGPU, useOnnxGPU, useOnnxExecutionProvider } =
-        useContext(SettingsContext);
+    const {
+        useIsCpu,
+        useIsFp16,
+        usePyTorchGPU,
+        useNcnnGPU,
+        useOnnxGPU,
+        useOnnxExecutionProvider,
+        useOnnxShouldTensorRtCache,
+    } = useContext(SettingsContext);
 
     const [isCpu] = useIsCpu;
     const [isFp16] = useIsFp16;
@@ -30,6 +39,7 @@ export const useRunNode = (
     const [ncnnGPU] = useNcnnGPU;
     const [onnxGPU] = useOnnxGPU;
     const [onnxExecutionProvider] = useOnnxExecutionProvider;
+    const [onnxShouldTensorRtCache] = useOnnxShouldTensorRtCache;
 
     const [reloadCounter, setReloadCounter] = useState(0);
     const reload = useCallback(() => setReloadCounter((c) => c + 1), []);
@@ -72,6 +82,10 @@ export const useRunNode = (
                     ncnnGPU,
                     onnxGPU,
                     onnxExecutionProvider,
+                    onnxShouldTensorRtCache,
+                    onnxTensorRtCachePath: getOnnxTensorRtCacheLocation(
+                        await ipcRenderer.invoke('get-appdata')
+                    ),
                 });
 
                 if (!result.success) {


### PR DESCRIPTION
Add an option to cache TensorRT conversions done by onnx (it's a built in tensorrt execution provider setting) which is good since they take so long to convert. No clue how they determine a hash or anything like that and I can't get tensorrt to work for me anymore so I have no clue if this even works, but I don't see why it wouldn't (it at least gets through all the parts I changed fine)

Closes #959