### PR TITLE
Multi-select context menu

### DIFF
--- a/src/renderer/components/ReactFlowBox.tsx
+++ b/src/renderer/components/ReactFlowBox.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-shadow */
 import { Box } from '@chakra-ui/react';
 import log from 'electron-log';
-import { DragEvent, memo, useCallback, useMemo } from 'react';
+import { DragEvent, memo, useCallback, useMemo, useState } from 'react';
 import { FaFileExport } from 'react-icons/fa';
 import ReactFlow, {
     Background,
@@ -30,6 +30,7 @@ import { SettingsContext } from '../contexts/SettingsContext';
 import { DataTransferProcessorOptions, dataTransferProcessors } from '../helpers/dataTransfer';
 import { expandSelection, isSnappedToGrid, snapToGrid } from '../helpers/reactFlowUtil';
 import { useMemoArray } from '../hooks/useMemo';
+import { useNodesMenu } from '../hooks/useNodesMenu';
 import { usePaneNodeSearchMenu } from '../hooks/usePaneNodeSearchMenu';
 
 const compareById = (a: Edge | Node, b: Edge | Node) => a.id.localeCompare(b.id);
@@ -384,6 +385,16 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
 
     const { onConnectStart, onConnectStop, onPaneContextMenu } = usePaneNodeSearchMenu(wrapperRef);
 
+    const [selectedNodes, setSelectedNodes] = useState<Node<NodeData>[]>([]);
+    const selectionMenu = useNodesMenu(selectedNodes);
+    const onSelectionContextMenu = useCallback(
+        (event: React.MouseEvent, nodes: Node<NodeData>[]) => {
+            setSelectedNodes(nodes);
+            selectionMenu.onContextMenu(event);
+        },
+        [selectionMenu, setSelectedNodes]
+    );
+
     return (
         <Box
             bg="var(--chain-editor-bg)"
@@ -428,6 +439,7 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
                 onNodesDelete={onNodesDelete}
                 onPaneClick={closeContextMenu}
                 onPaneContextMenu={onPaneContextMenu}
+                onSelectionContextMenu={onSelectionContextMenu}
                 onSelectionDragStop={onSelectionDragStop}
             >
                 <Background

--- a/src/renderer/contexts/GlobalNodeState.tsx
+++ b/src/renderer/contexts/GlobalNodeState.tsx
@@ -124,11 +124,11 @@ interface Global {
         inputId: InputId,
         inputSize: InputSize | undefined
     ) => readonly [Readonly<Size> | undefined, (size: Readonly<Size>) => void];
-    removeNodeById: (id: string) => void;
+    removeNodesById: (ids: string[]) => void;
     removeEdgeById: (id: string) => void;
     duplicateNodes: (nodeIds: string[]) => void;
     toggleNodeLock: (id: string) => void;
-    clearNode: (id: string) => void;
+    clearNodes: (ids: string[]) => void;
     setIteratorSize: (id: string, size: IteratorSize) => void;
     updateIteratorBounds: (
         id: string,
@@ -697,14 +697,16 @@ export const GlobalProvider = memo(
             [firstLoad, sendAlert, setFirstLoad, startupTemplate]
         );
 
-        const removeNodeById = useCallback(
-            (id: string) => {
-                const node = getNode(id);
-                if (!node || node.type === 'iteratorHelper') return;
+        const removeNodesById = useCallback(
+            (ids: string[]) => {
+                const filteredIds = ids.filter((id) => {
+                    const node = getNode(id);
+                    return !(!node || node.type === 'iteratorHelper');
+                });
                 const toRemove = new Set([
-                    id,
+                    ...filteredIds,
                     ...getNodes()
-                        .filter((n) => n.parentNode === id)
+                        .filter((n) => n.parentNode && filteredIds.includes(n.parentNode))
                         .map((n) => n.id),
                 ]);
                 changeNodes((nodes) => nodes.filter((n) => !toRemove.has(n.id)));
@@ -1108,16 +1110,18 @@ export const GlobalProvider = memo(
             [getNodes, changeNodes, changeEdges]
         );
 
-        const clearNode = useCallback(
-            (id: string) => {
-                modifyNode(id, (old) => {
-                    const newNode = copyNode(old);
-                    newNode.data.inputData = schemata.getDefaultInput(old.data.schemaId);
-                    return newNode;
+        const clearNodes = useCallback(
+            (ids: string[]) => {
+                ids.forEach((id) => {
+                    modifyNode(id, (old) => {
+                        const newNode = copyNode(old);
+                        newNode.data.inputData = schemata.getDefaultInput(old.data.schemaId);
+                        return newNode;
+                    });
+                    outputDataActions.delete(id);
+                    addInputDataChanges();
+                    backend.clearNodeCacheIndividual(id).catch((error) => log.error(error));
                 });
-                outputDataActions.delete(id);
-                addInputDataChanges();
-                backend.clearNodeCacheIndividual(id).catch((error) => log.error(error));
             },
             [modifyNode, addInputDataChanges, outputDataActions, backend, schemata]
         );
@@ -1306,8 +1310,8 @@ export const GlobalProvider = memo(
             setNodeInputValue,
             useInputSize,
             toggleNodeLock,
-            clearNode,
-            removeNodeById,
+            clearNodes,
+            removeNodesById,
             removeEdgeById,
             duplicateNodes,
             updateIteratorBounds,

--- a/src/renderer/contexts/GlobalNodeState.tsx
+++ b/src/renderer/contexts/GlobalNodeState.tsx
@@ -124,11 +124,11 @@ interface Global {
         inputId: InputId,
         inputSize: InputSize | undefined
     ) => readonly [Readonly<Size> | undefined, (size: Readonly<Size>) => void];
-    removeNodesById: (ids: string[]) => void;
+    removeNodesById: (ids: readonly string[]) => void;
     removeEdgeById: (id: string) => void;
-    duplicateNodes: (nodeIds: string[]) => void;
+    duplicateNodes: (nodeIds: readonly string[]) => void;
     toggleNodeLock: (id: string) => void;
-    clearNodes: (ids: string[]) => void;
+    clearNodes: (ids: readonly string[]) => void;
     setIteratorSize: (id: string, size: IteratorSize) => void;
     updateIteratorBounds: (
         id: string,
@@ -698,7 +698,7 @@ export const GlobalProvider = memo(
         );
 
         const removeNodesById = useCallback(
-            (ids: string[]) => {
+            (ids: readonly string[]) => {
                 const filteredIds = ids.filter((id) => {
                     const node = getNode(id);
                     return !(!node || node.type === 'iteratorHelper');
@@ -1076,8 +1076,8 @@ export const GlobalProvider = memo(
         );
 
         const duplicateNodes = useCallback(
-            (nodeIds: string[]) => {
-                const nodesToCopy = expandSelection(getNodes(), nodeIds);
+            (ids: readonly string[]) => {
+                const nodesToCopy = expandSelection(getNodes(), ids);
 
                 const duplicationId = createUniqueId();
                 const deriveId = (oldId: string) =>
@@ -1089,7 +1089,7 @@ export const GlobalProvider = memo(
                         deriveId,
                         deriveId
                     );
-                    const derivedIds = nodeIds.map((id) => deriveId(id));
+                    const derivedIds = ids.map((id) => deriveId(id));
                     newNodes.forEach((n) => {
                         // eslint-disable-next-line no-param-reassign
                         n.selected = derivedIds.includes(n.id);
@@ -1111,7 +1111,7 @@ export const GlobalProvider = memo(
         );
 
         const clearNodes = useCallback(
-            (ids: string[]) => {
+            (ids: readonly string[]) => {
                 ids.forEach((id) => {
                     modifyNode(id, (old) => {
                         const newNode = copyNode(old);

--- a/src/renderer/hooks/useNodeMenu.tsx
+++ b/src/renderer/hooks/useNodeMenu.tsx
@@ -27,7 +27,7 @@ export const useNodeMenu = (
 ): UseContextMenu => {
     const { id, isLocked = false, parentNode } = data;
 
-    const { removeNodeById, clearNode, duplicateNodes, toggleNodeLock, releaseNodeFromParent } =
+    const { removeNodesById, clearNodes, duplicateNodes, toggleNodeLock, releaseNodeFromParent } =
         useContext(GlobalContext);
     const { isDirectlyDisabled, canDisable, toggleDirectlyDisabled } = useDisabled;
 
@@ -44,7 +44,7 @@ export const useNodeMenu = (
             <MenuItem
                 icon={<CloseIcon />}
                 onClick={() => {
-                    clearNode(id);
+                    clearNodes([id]);
                 }}
             >
                 Clear
@@ -81,7 +81,7 @@ export const useNodeMenu = (
             <MenuItem
                 icon={<DeleteIcon />}
                 onClick={() => {
-                    removeNodeById(id);
+                    removeNodesById([id]);
                 }}
             >
                 Delete

--- a/src/renderer/hooks/useNodesMenu.tsx
+++ b/src/renderer/hooks/useNodesMenu.tsx
@@ -1,0 +1,42 @@
+import { CloseIcon, CopyIcon, DeleteIcon } from '@chakra-ui/icons';
+import { MenuItem, MenuList } from '@chakra-ui/react';
+import { Node } from 'reactflow';
+import { useContext } from 'use-context-selector';
+import { NodeData } from '../../common/common-types';
+import { GlobalContext } from '../contexts/GlobalNodeState';
+import { UseContextMenu, useContextMenu } from './useContextMenu';
+
+export const useNodesMenu = (nodes: Node<NodeData>[]): UseContextMenu => {
+    const { removeNodesById, clearNodes, duplicateNodes } = useContext(GlobalContext);
+
+    const nodeIds = nodes.map((n) => n.id);
+
+    return useContextMenu(() => (
+        <MenuList className="nodrag">
+            <MenuItem
+                icon={<CopyIcon />}
+                onClick={() => {
+                    duplicateNodes(nodeIds);
+                }}
+            >
+                Duplicate
+            </MenuItem>
+            <MenuItem
+                icon={<CloseIcon />}
+                onClick={() => {
+                    clearNodes(nodeIds);
+                }}
+            >
+                Clear
+            </MenuItem>
+            <MenuItem
+                icon={<DeleteIcon />}
+                onClick={() => {
+                    removeNodesById(nodeIds);
+                }}
+            >
+                Delete
+            </MenuItem>
+        </MenuList>
+    ));
+};


### PR DESCRIPTION
Partially implements #835

You still can't mass enable/disable or lock nodes though. I'm not sure how to accomplish that with the way we currently have the hooks set up (for individual changes). 

Also, this is only for the actual shift+drag multi-select, not the "hold ctrl down" multi-select

![image](https://user-images.githubusercontent.com/34788790/204199926-5f8f23dc-c9b4-43cf-b38c-25737bc5385f.png)
