### PR TITLE
Added amount input for Unsharp Mask

### DIFF
--- a/backend/src/nodes/nodes/image_filter/high_boost_sharpen.py
+++ b/backend/src/nodes/nodes/image_filter/high_boost_sharpen.py
@@ -22,11 +22,11 @@ class HbfSharpenNode(NodeBase):
             SliderInput(
                 "Amount",
                 minimum=0,
-                maximum=20,
+                maximum=100,
                 default=2,
                 precision=1,
                 controls_step=1,
-                slider_step=0.5,
+                scale="log",
             ),
         ]
         self.outputs = [ImageOutput(image_type="Input0")]

--- a/backend/src/nodes/nodes/image_filter/sharpen.py
+++ b/backend/src/nodes/nodes/image_filter/sharpen.py
@@ -6,7 +6,7 @@ import numpy as np
 from . import category as ImageFilterCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
-from ...properties.inputs import ImageInput, NumberInput
+from ...properties.inputs import ImageInput, NumberInput, SliderInput
 from ...properties.outputs import ImageOutput
 
 
@@ -17,7 +17,16 @@ class SharpenNode(NodeBase):
         self.description = "Apply sharpening to an image using an unsharp mask."
         self.inputs = [
             ImageInput(),
-            NumberInput("Amount", precision=1, controls_step=1),
+            NumberInput("Radius", minimum=0, default=3, precision=1, controls_step=1),
+            SliderInput(
+                "Amount",
+                minimum=0,
+                maximum=100,
+                default=1,
+                precision=1,
+                controls_step=1,
+                scale="log",
+            ),
         ]
         self.outputs = [ImageOutput(image_type="Input0")]
         self.category = ImageFilterCategory
@@ -28,12 +37,13 @@ class SharpenNode(NodeBase):
     def run(
         self,
         img: np.ndarray,
+        radius: float,
         amount: float,
     ) -> np.ndarray:
-        if amount == 0:
+        if radius == 0 or amount == 0:
             return img
 
-        blurred = cv2.GaussianBlur(img, (0, 0), amount)
-        img = cv2.addWeighted(img, 2.0, blurred, -1.0, 0)
+        blurred = cv2.GaussianBlur(img, (0, 0), radius)
+        img = cv2.addWeighted(img, amount + 1, blurred, -amount, 0)
 
         return np.clip(img, 0, 1)


### PR DESCRIPTION
This PR adds an amount slider to the Unsharp Mask node. Turns out, the blur radius (which we previously incorrectly called "amount") is only half of unsharp mask. [Gimp docs explain this quite nicely](https://docs.gimp.org/2.10/en/gimp-filter-unsharp-mask.html).

I made amount a log scale, since small amount values are more important. I also adjusted the scale of High Boost for consistency.

![image](https://user-images.githubusercontent.com/20878432/204333062-3194a69d-8888-4e71-a0f5-96162984eb78.png)
