### PR TITLE
Onnx getter for input shape and better error message for models

### DIFF
--- a/backend/src/nodes/nodes/onnx/upscale_image.py
+++ b/backend/src/nodes/nodes/onnx/upscale_image.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Tuple, Literal
 import numpy as np
 import onnxruntime as ort
 from sanic.log import logger
@@ -10,12 +11,34 @@ from ...node_factory import NodeFactory
 from ...properties.inputs import OnnxModelInput, ImageInput, TileSizeDropdown
 from ...properties.outputs import ImageOutput
 from ...properties import expression
-from ...utils.auto_split_tiles import parse_tile_size_input, TileSize
+from ...utils.auto_split_tiles import parse_tile_size_input, TileSize, NO_TILING
 from ...utils.onnx_auto_split import onnx_auto_split
 from ...utils.onnx_model import OnnxModel
 from ...utils.onnx_session import get_onnx_session
 from ...utils.utils import get_h_w_c, convenient_upscale
 from ...utils.exec_options import get_execution_options
+
+
+OnnxInputShape = Literal["BCHW", "BHWC"]
+
+
+def as_int(value) -> int | None:
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def get_input_shape(
+    session: ort.InferenceSession,
+) -> Tuple[OnnxInputShape, int, int | None, int | None]:
+    """
+    Returns the input shape, input channels, input width (optional), and input height (optional).
+    """
+    shape = session.get_inputs()[0].shape
+    if isinstance(shape[1], int) and shape[1] <= 4:
+        return "BCHW", shape[1], as_int(shape[3]), as_int(shape[2])
+    else:
+        return "BHWC", shape[3], as_int(shape[2]), as_int(shape[1])
 
 
 @NodeFactory.register("chainner:onnx:upscale_image")
@@ -48,11 +71,20 @@ class OnnxImageUpscaleNode(NodeBase):
         session: ort.InferenceSession,
         tile_size: TileSize,
         change_shape: bool,
+        exact_size: Tuple[int, int] | None,
     ) -> np.ndarray:
         logger.debug("Upscaling image")
 
         def estimate():
             raise ValueError
+
+        if exact_size is not None:
+            h, w, _ = get_h_w_c(img)
+            same_size = (w, h) == exact_size
+            assert (
+                same_size
+            ), f"The current model only support images with a size of {exact_size[0]}x{exact_size[1]}px"
+            tile_size = NO_TILING
 
         return onnx_auto_split(
             img,
@@ -69,13 +101,15 @@ class OnnxImageUpscaleNode(NodeBase):
     ) -> np.ndarray:
         """Upscales an image with a pretrained model"""
         session = get_onnx_session(model, get_execution_options())
-        shape = session.get_inputs()[0].shape
-        if isinstance(shape[1], int) and shape[1] <= 4:
-            in_nc = shape[1]
-            change_shape = False
-        else:
-            in_nc = shape[3]
-            change_shape = True
+
+        input_shape, in_nc, req_width, req_height = get_input_shape(session)
+        change_shape = input_shape == "BHWC"
+
+        exact_size = None
+        if req_width is not None:
+            exact_size = req_width, req_height or req_width
+        elif req_height is not None:
+            exact_size = req_width or req_height, req_height
 
         h, w, c = get_h_w_c(img)
         logger.debug(f"Image is {h}x{w}x{c}")
@@ -83,5 +117,5 @@ class OnnxImageUpscaleNode(NodeBase):
         return convenient_upscale(
             img,
             in_nc,
-            lambda i: self.upscale(i, session, tile_size, change_shape),
+            lambda i: self.upscale(i, session, tile_size, change_shape, exact_size),
         )

--- a/backend/src/nodes/nodes/pytorch/convert_to_onnx.py
+++ b/backend/src/nodes/nodes/pytorch/convert_to_onnx.py
@@ -48,8 +48,8 @@ class ConvertTorchToONNXNode(NodeBase):
         model = model.to(torch.device(exec_options.full_device))
         # https://github.com/onnx/onnx/issues/654
         dynamic_axes = {
-            "input": {0: "batch_size", 2: "width", 3: "height"},
-            "output": {0: "batch_size", 2: "width", 3: "height"},
+            "input": {0: "batch_size", 2: "height", 3: "width"},
+            "output": {0: "batch_size", 2: "height", 3: "width"},
         }
         dummy_input = torch.rand(1, model.in_nc, 64, 64)  # type: ignore
         dummy_input = dummy_input.to(torch.device(exec_options.full_device))


### PR DESCRIPTION
Changes:
- Added function to determine the input shape of an Onnx model.
- Added error message for models with input size requirements that are not met.

I'll add the tiling and padding stuff for exact-size models some day else. For now, an error will do.