### PR TITLE
Improved errors for invalid connection tooltip

### DIFF
--- a/src/common/checkNodeValidity.ts
+++ b/src/common/checkNodeValidity.ts
@@ -1,18 +1,6 @@
-import {
-    IntIntervalType,
-    IntersectionExpression,
-    NamedExpression,
-    NumericLiteralType,
-    StructType,
-    Type,
-    evaluate,
-    isDisjointWith,
-} from '@chainner/navi';
 import { Input, InputData, InputId, NodeSchema } from './common-types';
-import { getChainnerScope } from './types/chainner-scope';
 import { FunctionInstance } from './types/function';
-import { IntNumberType, isImage } from './types/util';
-import { assertNever } from './util';
+import { generateAssignmentErrorTrace, printErrorTrace, simpleError } from './types/mismatch';
 
 export type Validity =
     | { readonly isValid: true }
@@ -20,193 +8,8 @@ export type Validity =
 
 export const VALID: Validity = { isValid: true };
 
-const getAcceptedNumbers = (number: IntNumberType): Set<number> | undefined => {
-    const numbers = new Set<number>();
-    let infinite = false;
-
-    const add = (n: NumericLiteralType | IntIntervalType): void => {
-        if (n.type === 'literal') {
-            numbers.add(n.value);
-        } else if (n.max - n.min < 10) {
-            for (let i = n.min; i <= n.max; i += 1) {
-                numbers.add(i);
-            }
-        } else {
-            infinite = true;
-        }
-    };
-
-    if (number.type === 'union') {
-        number.items.forEach(add);
-    } else {
-        add(number);
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    return infinite ? undefined : numbers;
-};
-const formatChannelNumber = (n: IntNumberType): string | undefined => {
-    const numbers = getAcceptedNumbers(n);
-    if (!numbers) return undefined;
-
-    const known: string[] = [];
-    if (numbers.has(1)) known.push('grayscale');
-    if (numbers.has(3)) known.push('RGB');
-    if (numbers.has(4)) known.push('RGBA');
-
-    if (known.length === numbers.size) {
-        const article = known[0] === 'grayscale' ? 'a' : 'an';
-        if (known.length === 1) return `${article} ${known[0]} image`;
-        if (known.length === 2) return `${article} ${known[0]} or ${known[1]} image`;
-        if (known.length === 3) return `${article} ${known[0]}, ${known[1]} or ${known[2]} image`;
-    }
-
-    return undefined;
-};
-
-const explainNumber = (n: Type): string | undefined => {
-    if (n.underlying === 'number') {
-        if (n.type === 'number') return 'a number';
-        if (n.type === 'literal') return `the number ${n.value}`;
-
-        const kind = n.type === 'int-interval' ? 'an integer' : 'a number';
-        if (n.min === -Infinity && n.max === Infinity) return kind;
-        if (n.min === -Infinity) return `${kind} that is at most ${n.max}`;
-        if (n.max === Infinity) return `${kind} that is at least ${n.min}`;
-        return `${kind} between ${n.min} and ${n.max}`;
-    }
-    return undefined;
-};
-
 const formatMissingInputs = (missingInputs: Input[]) => {
     return `Missing required input data: ${missingInputs.map((input) => input.label).join(', ')}`;
-};
-
-type AssignmentErrorTrace = FieldAssignmentError | GeneralAssignmentError;
-interface GeneralAssignmentError {
-    type: 'General';
-    assigned: Type;
-    definition: Type;
-}
-interface FieldAssignmentError {
-    type: 'Field';
-    assigned: StructType;
-    definition: StructType;
-    field: string;
-    inner: AssignmentErrorTrace;
-}
-
-const generateAssignmentErrorTrace = (assigned: Type, definition: Type): AssignmentErrorTrace => {
-    if (
-        assigned.type === 'struct' &&
-        definition.type === 'struct' &&
-        assigned.name === definition.name
-    ) {
-        // find the field that causes the mismatch
-        const mismatchIndex = assigned.fields.findIndex((a, i) => {
-            return isDisjointWith(a.type, definition.fields[i].type);
-        });
-
-        if (mismatchIndex !== -1) {
-            const a = assigned.fields[mismatchIndex];
-            const d = definition.fields[mismatchIndex];
-
-            return {
-                type: 'Field',
-                assigned,
-                definition,
-                field: a.name,
-
-                inner: generateAssignmentErrorTrace(a.type, d.type),
-            };
-        }
-    }
-
-    return { type: 'General', assigned, definition };
-};
-
-const prettyPrintType = (type: Type): string => {
-    switch (type.type) {
-        case 'any':
-        case 'never':
-        case 'literal':
-        case 'number':
-        case 'string':
-        case 'interval':
-            return type.toString();
-
-        case 'inverted-set':
-            return `not(${[...type.excluded].map((s) => JSON.stringify(s)).join(' | ')})`;
-
-        case 'int-interval':
-            if (type.min === -Infinity && type.max === Infinity) {
-                return 'int';
-            }
-            if (type.min === 0 && type.max === Infinity) {
-                return 'uint';
-            }
-            return type.toString();
-
-        case 'union':
-            return type.items.map(prettyPrintType).join(' | ');
-
-        case 'struct':
-            if (type.fields.length === 0) return type.name;
-            return `${type.name} { ${type.fields
-                .map((f) => `${f.name}: ${prettyPrintType(f.type)}`)
-                .join(', ')} }`;
-
-        default:
-            return assertNever(type);
-    }
-};
-
-const shortTypeComparison = (
-    a: Type,
-    b: Type,
-    toString: (t: Type) => string
-): [a: string, b: string] => {
-    if (a.type === 'struct') {
-        if (b.type === 'struct' && b.name !== a.name) {
-            return [a.name, b.name];
-        }
-        if (b.type === 'union' && b.items.every((i) => i.type !== 'struct' || i.name !== a.name)) {
-            return [a.name, toString(b)];
-        }
-    }
-    if (b.type === 'struct') {
-        if (a.type === 'union' && a.items.every((i) => i.type !== 'struct' || i.name !== b.name)) {
-            return [toString(a), b.name];
-        }
-    }
-    return [toString(a), toString(b)];
-};
-
-const printErrorTrace = (trace: AssignmentErrorTrace): string[] => {
-    const { assigned, definition } = trace;
-
-    if (trace.type === 'General') {
-        const [a, d] = shortTypeComparison(assigned, definition, prettyPrintType);
-        return [`The type **${a}** is not connectable with type **${d}**.`];
-    }
-
-    if (trace.inner.type === 'General') {
-        const [a, d] = shortTypeComparison(
-            trace.inner.assigned,
-            trace.inner.definition,
-            prettyPrintType
-        );
-        return [
-            `The **${trace.assigned.name}** types are incompatible because **${trace.field}: ${a}** is not connectable with **${trace.field}: ${d}**.`,
-        ];
-    }
-
-    return [
-        `The type **${prettyPrintType(assigned)}** is not connectable with **${prettyPrintType(
-            definition
-        )}** because the **${trace.field}** fields are incompatible.`,
-        ...printErrorTrace(trace.inner),
-    ];
 };
 
 export interface CheckNodeValidityOptions {
@@ -246,36 +49,11 @@ export const checkNodeValidity = ({
         for (const { inputId, assignedType, inputType } of functionInstance.inputErrors) {
             const input = schema.inputs.find((i) => i.id === inputId)!;
 
-            // image channel mismatch
-            if (isImage(assignedType)) {
-                const iType = evaluate(
-                    new IntersectionExpression([inputType, new NamedExpression('Image')]),
-                    getChainnerScope()
-                );
-                if (isImage(iType)) {
-                    const assignedChannels = assignedType.fields[2].type;
-                    const inputChannels = iType.fields[2].type;
-
-                    if (isDisjointWith(assignedChannels, inputChannels)) {
-                        const expected = formatChannelNumber(inputChannels);
-                        const assigned = formatChannelNumber(assignedChannels);
-                        if (expected && assigned) {
-                            return {
-                                isValid: false,
-                                reason: `Input ${input.label} requires ${expected} but was connected with ${assigned}.`,
-                            };
-                        }
-                    }
-                }
-            }
-
-            // number mismatch
-            const assignedNumber = explainNumber(assignedType);
-            const inputNumber = explainNumber(inputType);
-            if (assignedNumber && inputNumber) {
+            const error = simpleError(assignedType, inputType);
+            if (error) {
                 return {
                     isValid: false,
-                    reason: `Input ${input.label} requires ${inputNumber} but was connected with ${assignedNumber}.`,
+                    reason: `Input ${input.label} requires ${error.definition} but was connected with ${error.assigned}.`,
                 };
             }
         }
@@ -283,7 +61,9 @@ export const checkNodeValidity = ({
         if (functionInstance.inputErrors.length > 0) {
             const { inputId, assignedType, inputType } = functionInstance.inputErrors[0];
             const input = schema.inputs.find((i) => i.id === inputId)!;
-            const trace = printErrorTrace(generateAssignmentErrorTrace(assignedType, inputType));
+            const traceTree = generateAssignmentErrorTrace(assignedType, inputType);
+            if (!traceTree) throw new Error('Cannot determine assignment error');
+            const trace = printErrorTrace(traceTree);
             return {
                 isValid: false,
                 reason: `Input ${

--- a/src/common/types/mismatch.ts
+++ b/src/common/types/mismatch.ts
@@ -1,0 +1,208 @@
+import {
+    IntIntervalType,
+    IntersectionExpression,
+    NamedExpression,
+    NumericLiteralType,
+    StructType,
+    Type,
+    evaluate,
+    isDisjointWith,
+} from '@chainner/navi';
+import { getChainnerScope } from './chainner-scope';
+import { prettyPrintType } from './pretty';
+import { IntNumberType, isImage } from './util';
+
+export type AssignmentErrorTrace = FieldAssignmentError | GeneralAssignmentError;
+export interface GeneralAssignmentError {
+    type: 'General';
+    assigned: Type;
+    definition: Type;
+}
+export interface FieldAssignmentError {
+    type: 'Field';
+    assigned: StructType;
+    definition: StructType;
+    field: string;
+    inner: AssignmentErrorTrace;
+}
+
+export const generateAssignmentErrorTrace = (
+    assigned: Type,
+    definition: Type
+): AssignmentErrorTrace | undefined => {
+    if (!isDisjointWith(assigned, definition)) {
+        // types compatible
+        return undefined;
+    }
+
+    if (
+        assigned.type === 'struct' &&
+        definition.type === 'struct' &&
+        assigned.name === definition.name
+    ) {
+        // find the first field that causes the mismatch
+        for (let i = 0; i < assigned.fields.length; i += 1) {
+            const a = assigned.fields[i];
+            const d = definition.fields[i];
+
+            const inner = generateAssignmentErrorTrace(a.type, d.type);
+            if (inner) {
+                return {
+                    type: 'Field',
+                    assigned,
+                    definition,
+                    field: a.name,
+                    inner,
+                };
+            }
+        }
+    }
+
+    return { type: 'General', assigned, definition };
+};
+
+const shortTypeComparison = (
+    a: Type,
+    b: Type,
+    toString: (t: Type) => string
+): [a: string, b: string] => {
+    if (a.type === 'struct') {
+        if (b.type === 'struct' && b.name !== a.name) {
+            return [a.name, b.name];
+        }
+        if (b.type === 'union' && b.items.every((i) => i.type !== 'struct' || i.name !== a.name)) {
+            return [a.name, toString(b)];
+        }
+    }
+    if (b.type === 'struct') {
+        if (a.type === 'union' && a.items.every((i) => i.type !== 'struct' || i.name !== b.name)) {
+            return [toString(a), b.name];
+        }
+    }
+    return [toString(a), toString(b)];
+};
+
+export const printErrorTrace = (trace: AssignmentErrorTrace): string[] => {
+    const { assigned, definition } = trace;
+
+    if (trace.type === 'General') {
+        const [a, d] = shortTypeComparison(assigned, definition, prettyPrintType);
+        return [`The type **${a}** is not connectable with type **${d}**.`];
+    }
+
+    if (trace.inner.type === 'General') {
+        const [a, d] = shortTypeComparison(
+            trace.inner.assigned,
+            trace.inner.definition,
+            prettyPrintType
+        );
+        return [
+            `The **${trace.assigned.name}** types are incompatible because **${trace.field}: ${a}** is not connectable with **${trace.field}: ${d}**.`,
+        ];
+    }
+
+    return [
+        `The type **${prettyPrintType(assigned)}** is not connectable with **${prettyPrintType(
+            definition
+        )}** because the **${trace.field}** fields are incompatible.`,
+        ...printErrorTrace(trace.inner),
+    ];
+};
+
+const getAcceptedNumbers = (number: IntNumberType): Set<number> | undefined => {
+    const numbers = new Set<number>();
+    let infinite = false;
+
+    const add = (n: NumericLiteralType | IntIntervalType): void => {
+        if (n.type === 'literal') {
+            numbers.add(n.value);
+        } else if (n.max - n.min < 10) {
+            for (let i = n.min; i <= n.max; i += 1) {
+                numbers.add(i);
+            }
+        } else {
+            infinite = true;
+        }
+    };
+
+    if (number.type === 'union') {
+        number.items.forEach(add);
+    } else {
+        add(number);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    return infinite ? undefined : numbers;
+};
+const formatChannelNumber = (n: IntNumberType): string | undefined => {
+    const numbers = getAcceptedNumbers(n);
+    if (!numbers) return undefined;
+
+    const known: string[] = [];
+    if (numbers.has(1)) known.push('grayscale');
+    if (numbers.has(3)) known.push('RGB');
+    if (numbers.has(4)) known.push('RGBA');
+
+    if (known.length === numbers.size) {
+        const article = known[0] === 'grayscale' ? 'a' : 'an';
+        if (known.length === 1) return `${article} ${known[0]} image`;
+        if (known.length === 2) return `${article} ${known[0]} or ${known[1]} image`;
+        if (known.length === 3) return `${article} ${known[0]}, ${known[1]} or ${known[2]} image`;
+    }
+
+    return undefined;
+};
+const explainNumber = (n: Type): string | undefined => {
+    if (n.underlying === 'number') {
+        if (n.type === 'number') return 'a number';
+        if (n.type === 'literal') return `the number ${n.value}`;
+
+        const kind = n.type === 'int-interval' ? 'an integer' : 'a number';
+        if (n.min === -Infinity && n.max === Infinity) return kind;
+        if (n.min === -Infinity) return `${kind} that is at most ${n.max}`;
+        if (n.max === Infinity) return `${kind} that is at least ${n.min}`;
+        return `${kind} between ${n.min} and ${n.max}`;
+    }
+    return undefined;
+};
+
+export const simpleError = (
+    assigned: Type,
+    definition: Type
+): { assigned: string; definition: string } | undefined => {
+    // image channel mismatch
+    if (isImage(assigned)) {
+        const d = evaluate(
+            new IntersectionExpression([definition, new NamedExpression('Image')]),
+            getChainnerScope()
+        );
+
+        if (isImage(d)) {
+            const aChannels = assigned.fields[2].type;
+            const dChannels = d.fields[2].type;
+
+            if (isDisjointWith(aChannels, dChannels)) {
+                const aString = formatChannelNumber(aChannels);
+                const dString = formatChannelNumber(dChannels);
+                if (aString && dString) {
+                    return {
+                        assigned: aString,
+                        definition: dString,
+                    };
+                }
+            }
+        }
+    }
+
+    // number mismatch
+    const assignedNumber = explainNumber(assigned);
+    const definitionNumber = explainNumber(definition);
+    if (assignedNumber && definitionNumber) {
+        return {
+            assigned: assignedNumber,
+            definition: definitionNumber,
+        };
+    }
+
+    return undefined;
+};

--- a/src/common/types/pretty.ts
+++ b/src/common/types/pretty.ts
@@ -1,0 +1,38 @@
+import { Type } from '@chainner/navi';
+import { assertNever } from '../util';
+
+export const prettyPrintType = (type: Type): string => {
+    switch (type.type) {
+        case 'any':
+        case 'never':
+        case 'literal':
+        case 'number':
+        case 'string':
+        case 'interval':
+            return type.toString();
+
+        case 'inverted-set':
+            return `not(${[...type.excluded].map((s) => JSON.stringify(s)).join(' | ')})`;
+
+        case 'int-interval':
+            if (type.min === -Infinity && type.max === Infinity) {
+                return 'int';
+            }
+            if (type.min === 0 && type.max === Infinity) {
+                return 'uint';
+            }
+            return type.toString();
+
+        case 'union':
+            return type.items.map(prettyPrintType).join(' | ');
+
+        case 'struct':
+            if (type.fields.length === 0) return type.name;
+            return `${type.name} { ${type.fields
+                .map((f) => `${f.name}: ${prettyPrintType(f.type)}`)
+                .join(', ')} }`;
+
+        default:
+            return assertNever(type);
+    }
+};

--- a/src/renderer/components/inputs/InputContainer.tsx
+++ b/src/renderer/components/inputs/InputContainer.tsx
@@ -1,6 +1,7 @@
 import { Type } from '@chainner/navi';
 import { Box, Center, HStack, Text, Tooltip, chakra } from '@chakra-ui/react';
 import React, { memo, useCallback, useMemo } from 'react';
+import ReactMarkdown from 'react-markdown';
 import { Connection, Handle, Node, Position, useReactFlow } from 'reactflow';
 import { useContext } from 'use-context-selector';
 import { InputId, NodeData } from '../../../common/common-types';
@@ -30,7 +31,7 @@ const LeftHandle = memo(
             hasArrow
             borderRadius={8}
             display={showHandle ? 'none' : 'block'}
-            label={`Unable to connect: ${showHandleReason}`}
+            label={<ReactMarkdown>{`Unable to connect: ${showHandleReason}`}</ReactMarkdown>}
             mt={1}
             opacity={showHandle ? 0 : 1}
             openDelay={500}

--- a/src/renderer/components/outputs/OutputContainer.tsx
+++ b/src/renderer/components/outputs/OutputContainer.tsx
@@ -1,6 +1,7 @@
 import { Type } from '@chainner/navi';
 import { Box, Center, HStack, Text, Tooltip, chakra } from '@chakra-ui/react';
 import React, { memo, useCallback, useMemo } from 'react';
+import ReactMarkdown from 'react-markdown';
 import { Connection, Handle, Position, useReactFlow } from 'reactflow';
 import { useContext, useContextSelector } from 'use-context-selector';
 import { OutputId } from '../../../common/common-types';
@@ -38,7 +39,7 @@ const RightHandle = memo(
             hasArrow
             borderRadius={8}
             display={showHandle ? 'none' : 'block'}
-            label={`Unable to connect: ${showHandleReason}`}
+            label={<ReactMarkdown>{`Unable to connect: ${showHandleReason}`}</ReactMarkdown>}
             mt={1}
             opacity={showHandle ? 0 : 1}
             openDelay={500}


### PR DESCRIPTION

I just extracted out the whole type mismatch logic from `checkNodeValidity` and reused in `isValidConnect`.

![image](https://user-images.githubusercontent.com/20878432/204571994-66d90a46-51e1-4fd1-b555-9bdd8132fd1b.png)

![image](https://user-images.githubusercontent.com/20878432/204572704-c8cb7bf4-a5e6-4d55-ba39-51434a4479bf.png)

![image](https://user-images.githubusercontent.com/20878432/204572859-28cd44c7-5d4c-4a5f-a5e9-04f65c787c33.png)
