### PR TITLE
More compact node design

### DIFF
--- a/src/renderer/components/node/IteratorHelperNode.tsx
+++ b/src/renderer/components/node/IteratorHelperNode.tsx
@@ -87,7 +87,10 @@ export const IteratorHelperNode = memo(({ data, selected }: IteratorHelperNodePr
                 opacity={disabledStatus === DisabledStatus.Enabled ? 1 : 0.75}
                 spacing={0}
             >
-                <VStack w="full">
+                <VStack
+                    spacing={1}
+                    w="full"
+                >
                     <NodeHeader
                         accentColor={accentColor}
                         disabledStatus={disabledStatus}

--- a/src/renderer/components/node/IteratorNode.tsx
+++ b/src/renderer/components/node/IteratorNode.tsx
@@ -1,4 +1,4 @@
-import { Center, Text, VStack } from '@chakra-ui/react';
+import { Box, Center, Text, VStack } from '@chakra-ui/react';
 import { memo, useMemo, useRef } from 'react';
 import { useContext, useContextSelector } from 'use-context-selector';
 import { NodeData } from '../../../common/common-types';
@@ -79,7 +79,10 @@ const IteratorNodeInner = memo(({ data, selected }: IteratorNodeProps) => {
                 opacity={disabled.status === DisabledStatus.Enabled ? 1 : 0.75}
                 spacing={0}
             >
-                <VStack w="full">
+                <VStack
+                    spacing={1}
+                    w="full"
+                >
                     <IteratorNodeHeader
                         accentColor={accentColor}
                         disabledStatus={disabled.status}
@@ -88,19 +91,7 @@ const IteratorNodeInner = memo(({ data, selected }: IteratorNodeProps) => {
                         percentComplete={percentComplete}
                         selected={selected}
                     />
-                    {inputs.length && (
-                        <Center>
-                            <Text
-                                fontSize="xs"
-                                m={0}
-                                mb={-1}
-                                mt={-1}
-                                p={0}
-                            >
-                                INPUTS
-                            </Text>
-                        </Center>
-                    )}
+                    {inputs.length && <Box />}
                     <NodeInputs
                         id={id}
                         inputData={inputData}
@@ -113,7 +104,7 @@ const IteratorNodeInner = memo(({ data, selected }: IteratorNodeProps) => {
                             m={0}
                             mb={-1}
                             mt={-1}
-                            p={0}
+                            p={1}
                         >
                             ITERATION
                         </Text>
@@ -131,19 +122,7 @@ const IteratorNodeInner = memo(({ data, selected }: IteratorNodeProps) => {
                             minWidth={minWidth}
                         />
                     </Center>
-                    {outputs.length > 0 && (
-                        <Center>
-                            <Text
-                                fontSize="xs"
-                                m={0}
-                                mb={-1}
-                                mt={-1}
-                                p={0}
-                            >
-                                OUTPUTS
-                            </Text>
-                        </Center>
-                    )}
+                    {outputs.length > 0 && <Box />}
                     <NodeOutputs
                         id={id}
                         outputs={outputs}

--- a/src/renderer/components/node/IteratorNode.tsx
+++ b/src/renderer/components/node/IteratorNode.tsx
@@ -47,7 +47,7 @@ const IteratorNodeInner = memo(({ data, selected }: IteratorNodeProps) => {
     // We get inputs and outputs this way in case something changes with them in the future
     // This way, we have to do less in the migration file
     const schema = schemata.get(schemaId);
-    const { inputs, outputs, icon, category, name } = schema;
+    const { outputs, icon, category, name } = schema;
 
     const regularBorderColor = 'var(--node-border-color)';
     const accentColor = getNodeAccentColor(category);
@@ -91,7 +91,6 @@ const IteratorNodeInner = memo(({ data, selected }: IteratorNodeProps) => {
                         percentComplete={percentComplete}
                         selected={selected}
                     />
-                    {inputs.length && <Box />}
                     <NodeInputs
                         id={id}
                         inputData={inputData}

--- a/src/renderer/components/node/Node.tsx
+++ b/src/renderer/components/node/Node.tsx
@@ -154,7 +154,10 @@ const NodeInner = memo(({ data, selected }: NodeProps) => {
                 opacity={disabled.status === DisabledStatus.Enabled ? 1 : 0.75}
                 spacing={0}
             >
-                <VStack w="full">
+                <VStack
+                    spacing={1}
+                    w="full"
+                >
                     <NodeHeader
                         accentColor={accentColor}
                         disabledStatus={disabled.status}

--- a/src/renderer/components/node/NodeBody.tsx
+++ b/src/renderer/components/node/NodeBody.tsx
@@ -1,8 +1,11 @@
-import { Center, Text } from '@chakra-ui/react';
+import { Box } from '@chakra-ui/react';
 import { memo } from 'react';
-import { InputData, InputSize, NodeSchema } from '../../../common/common-types';
+import { Input, InputData, InputSize, NodeSchema } from '../../../common/common-types';
 import { NodeInputs } from './NodeInputs';
 import { NodeOutputs } from './NodeOutputs';
+
+const isAutoInput = (input: Input): boolean =>
+    input.kind === 'generic' && input.optional && !input.hasHandle;
 
 interface NodeBodyProps {
     id: string;
@@ -17,42 +20,21 @@ export const NodeBody = memo(
     ({ schema, id, inputData, inputSize, isLocked, animated = false }: NodeBodyProps) => {
         const { inputs, outputs, schemaId } = schema;
 
+        const autoInput = inputs.length === 1 && isAutoInput(inputs[0]);
+
         return (
             <>
-                {inputs.length > 0 && (
-                    <Center>
-                        <Text
-                            fontSize="xs"
-                            m={0}
-                            mb={-1}
-                            mt={-1}
-                            p={0}
-                        >
-                            INPUTS
-                        </Text>
-                    </Center>
+                {!autoInput && (
+                    <NodeInputs
+                        id={id}
+                        inputData={inputData}
+                        inputSize={inputSize}
+                        isLocked={isLocked}
+                        schema={schema}
+                    />
                 )}
-                <NodeInputs
-                    id={id}
-                    inputData={inputData}
-                    inputSize={inputSize}
-                    isLocked={isLocked}
-                    schema={schema}
-                />
 
-                {outputs.length > 0 && (
-                    <Center>
-                        <Text
-                            fontSize="xs"
-                            m={0}
-                            mb={-1}
-                            mt={-1}
-                            p={0}
-                        >
-                            OUTPUTS
-                        </Text>
-                    </Center>
-                )}
+                {outputs.length > 0 && <Box />}
                 <NodeOutputs
                     animated={animated}
                     id={id}

--- a/src/renderer/components/node/NodeBody.tsx
+++ b/src/renderer/components/node/NodeBody.tsx
@@ -34,7 +34,7 @@ export const NodeBody = memo(
                     />
                 )}
 
-                {outputs.length > 0 && <Box />}
+                {!autoInput && outputs.length > 0 && <Box />}
                 <NodeOutputs
                     animated={animated}
                     id={id}


### PR DESCRIPTION
I changed the design of nodes to be more vertically compact.

Changes:
- Reduced padding between input and outputs.
- Removed "INPUTS" and "OUTPUTS" labels. I just made the padding between the last input and the first output larger. It's pretty obvious what is input and what is output IMO.
- Don't show "Iterator (Auto)" inputs.

Comparison:

| Old design | Compact design |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/20878432/204590518-bdf70e80-cb12-4f4c-aa7d-8d2dc8de4d7b.png) | ![image](https://user-images.githubusercontent.com/20878432/204590545-0b0c2340-1a0d-4307-8173-f10d434ca9fa.png) |
| ![image](https://user-images.githubusercontent.com/20878432/204590615-f64ec286-7880-4783-a656-bfac2ff7d5a7.png) | ![image](https://user-images.githubusercontent.com/20878432/204590640-b9bb7cf2-dfad-4b8a-ae41-0efee852a5c9.png) |
| ![image](https://user-images.githubusercontent.com/20878432/204590691-eedfa6cd-9ffe-4056-9411-e2370aaa4090.png) | ![image](https://user-images.githubusercontent.com/20878432/204590725-e42651a0-05ec-4d2a-8223-8b50ed00d007.png) |