### PR TITLE
Removed PyTorch scale tag in output

### DIFF
--- a/backend/src/nodes/nodes/pytorch/upscale_face.py
+++ b/backend/src/nodes/nodes/pytorch/upscale_face.py
@@ -31,7 +31,7 @@ class FaceUpscaleNode(NodeBase):
         super().__init__()
         self.description = "Uses face-detection to upscales and restore face(s) in an image using a PyTorch Face Super-Resolution model. Right now supports GFPGAN and RestoreFormer."
         self.inputs = [
-            FaceModelInput("Face SR Model"),
+            FaceModelInput("Model"),
             ImageInput(),
             ImageInput("Upscaled Background").make_optional(),
             NumberInput(

--- a/backend/src/nodes/properties/inputs/pytorch_inputs.py
+++ b/backend/src/nodes/properties/inputs/pytorch_inputs.py
@@ -37,9 +37,7 @@ class SrModelInput(ModelInput):
     ):
         super().__init__(
             label,
-            intersect(
-                input_type, "PyTorchModel { arch: invStrSet(PyTorchModel::FaceArchs) }"
-            ),
+            intersect(input_type, "PyTorchSRModel"),
         )
 
     def enforce(self, value):
@@ -55,7 +53,7 @@ class FaceModelInput(ModelInput):
     ):
         super().__init__(
             label,
-            intersect(input_type, "PyTorchModel { arch: PyTorchModel::FaceArchs }"),
+            intersect(input_type, "PyTorchFaceModel"),
         )
 
     def enforce(self, value):

--- a/backend/src/nodes/properties/inputs/pytorch_inputs.py
+++ b/backend/src/nodes/properties/inputs/pytorch_inputs.py
@@ -49,7 +49,7 @@ class SrModelInput(ModelInput):
 
 class FaceModelInput(ModelInput):
     def __init__(
-        self, label: str = "Face SR Model", input_type: ExpressionJson = "PyTorchModel"
+        self, label: str = "Model", input_type: ExpressionJson = "PyTorchModel"
     ):
         super().__init__(
             label,

--- a/src/common/types/chainner-scope.ts
+++ b/src/common/types/chainner-scope.ts
@@ -43,7 +43,14 @@ struct PyTorchModel {
     size: string,
     subType: string,
 }
-let PyTorchModel::FaceArchs = "GFPGAN" | "RestoreFormer";
+let PyTorchFaceModel = PyTorchModel {
+    arch: "GFPGAN" | "RestoreFormer",
+    subType: "Face SR"
+};
+let PyTorchSRModel = PyTorchModel {
+    arch: invStrSet(PyTorchFaceModel.arch),
+    subType: "SR"
+};
 
 struct NcnnBinFile;
 struct NcnnParamFile;

--- a/src/renderer/components/TypeTag.tsx
+++ b/src/renderer/components/TypeTag.tsx
@@ -67,6 +67,10 @@ const getTypeText = (type: Type): TagValue[] => {
             if (isNumericLiteral(scale)) {
                 tags.push({ kind: 'literal', value: `${scale.toString()}x` });
             }
+            const subType = getField(type, 'subType') ?? NeverType.instance;
+            if (isStringLiteral(subType)) {
+                tags.push({ kind: 'literal', value: subType.value });
+            }
         }
     }
     return tags;

--- a/src/renderer/components/outputs/PyTorchOutput.tsx
+++ b/src/renderer/components/outputs/PyTorchOutput.tsx
@@ -103,14 +103,6 @@ export const PyTorchOutput = memo(
                                     bgColor={tagColor}
                                     textColor={fontColor}
                                 >
-                                    {current.scale}x
-                                </Tag>
-                            </WrapItem>
-                            <WrapItem>
-                                <Tag
-                                    bgColor={tagColor}
-                                    textColor={fontColor}
-                                >
                                     {getColorMode(current.inNc)}→{getColorMode(current.outNc)}
                                 </Tag>
                             </WrapItem>

--- a/src/renderer/components/outputs/PyTorchOutput.tsx
+++ b/src/renderer/components/outputs/PyTorchOutput.tsx
@@ -95,14 +95,6 @@ export const PyTorchOutput = memo(
                                     bgColor={tagColor}
                                     textColor={fontColor}
                                 >
-                                    {current.subType}
-                                </Tag>
-                            </WrapItem>
-                            <WrapItem>
-                                <Tag
-                                    bgColor={tagColor}
-                                    textColor={fontColor}
-                                >
                                     {getColorMode(current.inNc)}→{getColorMode(current.outNc)}
                                 </Tag>
                             </WrapItem>


### PR DESCRIPTION
We already removed this for NCNN, so I removed for PyTorch as well.
![image](https://user-images.githubusercontent.com/20878432/204637688-94a9b236-dd7a-4a0e-8f17-a4b2382d62e8.png)
