### PR TITLE
Fixed custom system python path selection (For real this time)

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -221,7 +221,7 @@ const checkPythonEnv = async (splashWindow: BrowserWindowWithSafeIpc) => {
     let integratedPythonFolderPath = path.join(app.getPath('userData'), '/python');
 
     if (systemPythonLocation) {
-        systemPythonLocation = path.normalize(systemPythonLocation);
+        systemPythonLocation = path.normalize(String(JSON.parse(systemPythonLocation)));
     }
 
     if (integratedPythonFolderPath) {

--- a/src/main/python/checkPythonPaths.ts
+++ b/src/main/python/checkPythonPaths.ts
@@ -1,10 +1,13 @@
+import log from 'electron-log';
 import { PythonInfo } from '../../common/common-types';
 import { getPythonVersion, isSupportedPythonVersion } from './version';
 
 export const checkPythonPaths = async (pythonsToCheck: string[]): Promise<PythonInfo> => {
     for (const py of pythonsToCheck) {
         // eslint-disable-next-line no-await-in-loop
-        const version = await getPythonVersion(py).catch(() => null);
+        const version = await getPythonVersion(py).catch((err) => {
+            log.error(err);
+        });
         if (version && isSupportedPythonVersion(version)) {
             return { python: py, version };
         }


### PR DESCRIPTION
This was the dumbest thing. The entire time logging out the path I didn't realize it was surrounded by quotes. It was JSON stringified. All the settings are JSON stringified. All the checks we do for settings in main.ts aren't wrapped in a JSON.parse, they just check `=== 'true'` so I didn't even think about it.