### PR TITLE
Further improvements to Node Edge collision PR

### DIFF
--- a/src/renderer/components/node/Node.tsx
+++ b/src/renderer/components/node/Node.tsx
@@ -77,21 +77,23 @@ const NodeInner = memo(({ data, selected }: NodeProps) => {
     const targetRef = useRef<HTMLDivElement>(null);
     const [checkedSize, setCheckedSize] = useState(false);
 
-    const collidingEdge = useContextSelector(GlobalVolatileContext, (c) => c.collidingEdge);
-    const collidingNode = useContextSelector(GlobalVolatileContext, (c) => c.collidingNode);
-    const typeState = useContextSelector(GlobalVolatileContext, (c) => c.typeState);
-    let collidingAccentColor;
-    if (collidingNode && collidingNode === id && collidingEdge) {
-        const collidingEdgeActual = getEdge(collidingEdge);
-        if (collidingEdgeActual && collidingEdgeActual.sourceHandle) {
-            const edgeType = typeState.functions
-                .get(collidingEdgeActual.source)
-                ?.outputs.get(parseSourceHandle(collidingEdgeActual.sourceHandle).outputId);
-            if (edgeType) {
-                [collidingAccentColor] = getTypeAccentColors(edgeType);
+    const collidingAccentColor = useContextSelector(
+        GlobalVolatileContext,
+        ({ collidingEdge, collidingNode, typeState }) => {
+            if (collidingNode && collidingNode === id && collidingEdge) {
+                const collidingEdgeActual = getEdge(collidingEdge);
+                if (collidingEdgeActual && collidingEdgeActual.sourceHandle) {
+                    const edgeType = typeState.functions
+                        .get(collidingEdgeActual.source)
+                        ?.outputs.get(parseSourceHandle(collidingEdgeActual.sourceHandle).outputId);
+                    if (edgeType) {
+                        return getTypeAccentColors(edgeType)[0];
+                    }
+                }
             }
+            return undefined;
         }
-    }
+    );
 
     useLayoutEffect(() => {
         if (targetRef.current && parentNode) {


### PR DESCRIPTION
Changes:
- Combined 3 `useContextSelector` calls into one by moving the color-picking logic into the selector. This is cleaner and should hopefully improve performance a bit.
- Removed `quick` parameter. Functions are cheap to create.
- Removed `status: 'success'` because it contained no information.
- Don't calculate `getFirstPossible{Input,Output}` twice for the intersecting edge.
- Stricter type guard.