### PR TITLE
Guarantee that `getTypeAccentColors` returns at least one color

### DIFF
--- a/src/renderer/helpers/getTypeAccentColors.ts
+++ b/src/renderer/helpers/getTypeAccentColors.ts
@@ -24,9 +24,11 @@ const colorList = lazy(() => {
     ];
 });
 
-export const getTypeAccentColors = (inputType: Type): string[] => {
+const defaultColorList = [defaultColor] as const;
+
+export const getTypeAccentColors = (inputType: Type): readonly [string, ...string[]] => {
     if (inputType.type === 'any') {
-        return [defaultColor];
+        return defaultColorList;
     }
 
     const colors: string[] = [];
@@ -35,5 +37,5 @@ export const getTypeAccentColors = (inputType: Type): string[] => {
             colors.push(color);
         }
     }
-    return colors.length > 0 ? colors : [defaultColor];
+    return colors.length > 0 ? (colors as [string, ...string[]]) : defaultColorList;
 };


### PR DESCRIPTION
All uses of `getTypeAccentColors` assumed that it returns at least one color, so I add this guarantee to its type.