### PR TITLE
Fixed blurry checkers in image preview

### DIFF
--- a/src/renderer/components/outputs/LargeImageOutput.tsx
+++ b/src/renderer/components/outputs/LargeImageOutput.tsx
@@ -135,9 +135,10 @@ export const LargeImageOutput = memo(
                             >
                                 <Image
                                     alt="Image preview failed to load, probably unsupported file type."
-                                    backgroundImage={
+                                    background={
                                         last.channels === 4
-                                            ? 'data:image/webp;base64,UklGRigAAABXRUJQVlA4IBwAAAAwAQCdASoQABAACMCWJaQAA3AA/u11j//aQAAA'
+                                            ? // https://stackoverflow.com/a/65129916/7595472
+                                              'repeating-conic-gradient(#CDCDCD 0% 25%, #FFFFFF 0% 50%) 50% / 20px 20px'
                                             : ''
                                     }
                                     draggable={false}


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/20878432/205060671-48dd7cb4-4e07-4a95-9b05-96b233a84b02.png)

After
![image](https://user-images.githubusercontent.com/20878432/205060569-0e8cc6b2-30d0-455a-9199-138030210dfb.png)
