### PR TITLE
General alpha conversions for all 3-channel color spaces

### DIFF
--- a/src/common/migrations.js
+++ b/src/common/migrations.js
@@ -830,6 +830,31 @@ const convertNormalGenerator = (data) => {
     return data;
 };
 
+const convertColorSpaceFromDetectors = (data) => {
+    const YUV = 3;
+    const HSV = 4;
+    const HSL = 5;
+    const YUV_LIKE = 1001;
+    const HSV_LIKE = 1002;
+    const HSL_LIKE = 1003;
+
+    /** @type {Partial<Record<number, [number, number]>>} */
+    const mapping = {
+        [YUV]: YUV_LIKE,
+        [HSV]: HSV_LIKE,
+        [HSL]: HSL_LIKE,
+    };
+
+    data.nodes.forEach((node) => {
+        if (node.data.schemaId === 'chainner:image:change_colorspace') {
+            const from = node.data.inputData[1];
+            node.data.inputData[1] = mapping[from] ?? from;
+        }
+    });
+
+    return data;
+};
+
 // ==============
 
 const versionToMigration = (version) => {
@@ -873,6 +898,7 @@ const migrations = [
     convertColorSpaceFromTo,
     convertColorRGBLikeDetector,
     convertNormalGenerator,
+    convertColorSpaceFromDetectors,
 ];
 
 export const currentMigration = migrations.length;


### PR DESCRIPTION
I was experimenting with HSV and swapping the hues of images when I ran into an issue: Combine RGBA outputs and RGBA images, but Change Colorspace only accepts RGB images when converting from HSV.

So I added HSVA, HSLA, and YUVA color spaces along with detectors and a general method for generating alpha conversions from their non-alpha color conversions. The "From" dropdown now uses detectors instead of the raw color spaces for the abovementioned ones.

![image](https://user-images.githubusercontent.com/20878432/205090693-3f7971af-980e-4694-9dfe-8b8fd7a4c5cc.png)

![image](https://user-images.githubusercontent.com/20878432/205091150-299fb2dc-bdb8-4175-9e43-6391b3569051.png)
![image](https://user-images.githubusercontent.com/20878432/205091172-0890307a-eea2-4d30-a9d8-4a41dfb767ab.png)
