### PR TITLE
Thinner Change Colorspace node

### DIFF
--- a/backend/src/nodes/utils/color/convert_data.py
+++ b/backend/src/nodes/utils/color/convert_data.py
@@ -17,7 +17,7 @@ YUVA = ColorSpace(7, "YUVA", 4)
 HSVA = ColorSpace(8, "HSVA", 4)
 HSLA = ColorSpace(9, "HSLA", 4)
 
-RGB_LIKE = ColorSpaceDetector(1000, "Gray/RGB", [GRAY, RGB, RGBA])
+RGB_LIKE = ColorSpaceDetector(1000, "RGB", [GRAY, RGB, RGBA])
 YUV_LIKE = ColorSpaceDetector(1001, "YUV", [YUV, YUVA])
 HSV_LIKE = ColorSpaceDetector(1002, "HSV", [HSV, HSVA])
 HSL_LIKE = ColorSpaceDetector(1003, "HSL", [HSL, HSLA])
@@ -43,6 +43,7 @@ color_spaces: List[ColorSpace] = [
 ]
 color_spaces_or_detectors: List[Union[ColorSpace, ColorSpaceDetector]] = [
     RGB_LIKE,
+    GRAY,
     YUV_LIKE,
     HSV_LIKE,
     HSL_LIKE,

--- a/src/renderer/components/groups/FromToDropdownsGroup.tsx
+++ b/src/renderer/components/groups/FromToDropdownsGroup.tsx
@@ -24,7 +24,7 @@ const DropDown = memo(({ nodeId, input, inputData, isLocked }: DropDownProps) =>
     );
 
     return (
-        <Box w="7.5em">
+        <Box w="6em">
             <DropDownInput
                 input={input}
                 isLocked={isLocked}


### PR DESCRIPTION
I change the Change Colorspace node, so it has the same width as a normal node now (e.g. Load Image). I did this by renaming "Gray/RGB" -> "RGB" and adding a "Gray" from direction. Nothing about "RGB" (fromerly "Gray/RGB") changed btw, it still accepts grayscale images. The "Gray" option is just there for users to know that grayscale images are supported as inputs.

Before:
![image](https://user-images.githubusercontent.com/20878432/205377797-46f768fd-3092-4257-9a2b-4c13e8c078f7.png)

After:
![image](https://user-images.githubusercontent.com/20878432/205377811-e9e4381f-5c8f-4d7b-8024-ef38a189585e.png)

The thickness of this boi is now determined by the node name of all things. I initially wanted to go even thinner, but...
![image](https://user-images.githubusercontent.com/20878432/205378740-4444e121-439e-4352-835a-057dfb333d99.png)
