### PR TITLE
Fixed being able to select text in file/dir inputs

### DIFF
--- a/src/renderer/components/inputs/DirectoryInput.tsx
+++ b/src/renderer/components/inputs/DirectoryInput.tsx
@@ -110,7 +110,6 @@ export const DirectoryInput = memo(
                     <Input
                         isReadOnly
                         borderRadius="lg"
-                        className="nodrag"
                         cursor="pointer"
                         disabled={isLocked || isInputConnected}
                         draggable={false}

--- a/src/renderer/components/inputs/FileInput.tsx
+++ b/src/renderer/components/inputs/FileInput.tsx
@@ -175,7 +175,6 @@ export const FileInput = memo(
                             isReadOnly
                             alt={filePath}
                             borderRadius="lg"
-                            className="nodrag"
                             cursor="pointer"
                             disabled={isLocked || isInputConnected}
                             draggable={false}


### PR DESCRIPTION
We always had this issue where we would sometimes select the text of file/dir inputs without being able to deselect it again. I fixed this by making those inputs draggable. This apparently makes it so that you can't select the text, and it's nice to have more draggable surface as well.