### PR TITLE
Made it so that `npm run dev` restarts only on python changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": ".webpack/main",
   "scripts": {
     "start": "electron-forge start",
-    "dev": "concurrently \"nodemon ./backend/src/run.py 8000\" \"electron-forge start -- --no-backend\"",
+    "dev": "concurrently \"cd backend && nodemon ./src/run.py 8000\" \"electron-forge start -- --no-backend\"",
     "package": "cross-env NODE_ENV=production electron-forge package",
     "make": "cross-env NODE_ENV=production electron-forge make",
     "make-linux-zip": "cross-env NODE_ENV=production electron-forge make --targets @electron-forge/maker-zip --platform linux",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": ".webpack/main",
   "scripts": {
     "start": "electron-forge start",
-    "dev": "concurrently \"cd backend && nodemon ./src/run.py 8000\" \"electron-forge start -- --no-backend\"",
+    "dev": "concurrently \"cd backend/src && nodemon ./run.py 8000\" \"electron-forge start -- --no-backend\"",
     "package": "cross-env NODE_ENV=production electron-forge package",
     "make": "cross-env NODE_ENV=production electron-forge make",
     "make-linux-zip": "cross-env NODE_ENV=production electron-forge make --targets @electron-forge/maker-zip --platform linux",


### PR DESCRIPTION
I noticed that the backend would restart multiple times when running `npm run dev`. This was because `nodemon` was looking for *any* changes in the whole project, which included our 18next babel plugin updating the English translation file.

I start `nodemon` in `backend/src` now, so it'll only look for changes in there.