### PR TITLE
Added support for exact-size splitting

### DIFF
--- a/backend/src/nodes/nodes/image_utility/create_border.py
+++ b/backend/src/nodes/nodes/image_utility/create_border.py
@@ -9,6 +9,7 @@ from ...properties.inputs import ImageInput, BorderInput, NumberInput
 from ...properties.outputs import ImageOutput
 from ...properties import expression
 from ...utils.image_utils import create_border
+from ...utils.utils import Padding
 
 
 @NodeFactory.register("chainner:image:create_border")
@@ -36,4 +37,4 @@ class CreateBorderNode(NodeBase):
         self.sub = "Miscellaneous"
 
     def run(self, img: np.ndarray, border_type: int, amount: int) -> np.ndarray:
-        return create_border(img, border_type, amount, amount, amount, amount)
+        return create_border(img, border_type, Padding.all(amount))

--- a/backend/src/nodes/nodes/image_utility/create_edges.py
+++ b/backend/src/nodes/nodes/image_utility/create_edges.py
@@ -9,6 +9,7 @@ from ...properties.inputs import ImageInput, BorderInput, NumberInput
 from ...properties.outputs import ImageOutput
 from ...properties import expression
 from ...utils.image_utils import create_border
+from ...utils.utils import Padding
 
 
 @NodeFactory.register("chainner:image:create_edges")
@@ -47,4 +48,4 @@ class CreateEdgesNode(NodeBase):
         right: int,
         bottom: int,
     ) -> np.ndarray:
-        return create_border(img, border_type, top, right, bottom, left)
+        return create_border(img, border_type, Padding(top, right, bottom, left))

--- a/backend/src/nodes/utils/exact_split.py
+++ b/backend/src/nodes/utils/exact_split.py
@@ -40,6 +40,10 @@ class Segment:
 
 
 def exact_split_into_segments(length: int, exact: int, overlap: int) -> List[Segment]:
+    """
+    Splits the given length into segments of `exact` (padded) length.
+    Segments will overlap into each other with at least the given overlap.
+    """
     if length == exact:
         # trivial
         return [Segment(0, exact, 0, 0)]
@@ -53,6 +57,13 @@ def exact_split_into_segments(length: int, exact: int, overlap: int) -> List[Seg
         assert s.padded_length == exact
         result.append(s)
 
+    # The current strategy is to go from left to right and to align segments
+    # such that we use the least overlap possible. The last segment will then
+    # be the smallest with potentially a lot of overlap.
+    # While this is easy to implement, it's actually not ideal. Ideally, we
+    # would want for the overlap to be distributed evenly between segments.
+    # However, this is complex to implement and the current method also works.
+
     # we know that the first segment looks like this
     add(Segment(0, exact - overlap, 0, overlap))
 
@@ -64,6 +75,7 @@ def exact_split_into_segments(length: int, exact: int, overlap: int) -> List[Seg
         endPadding = overlap
 
         if end + endPadding >= length:
+            # last segment
             endPadding = 0
             end = length
             startPadding = exact - (end - start)
@@ -87,6 +99,8 @@ def exact_split_into_regions(
     Each region plus its padding is guaranteed to have the given exact size.
     The padding (if not zero) is guaranteed to be at least the given overlap value.
     """
+
+    # we can split x and y independently from each other and then combine the results
     x_segments = exact_split_into_segments(w, exact_w, overlap)
     y_segments = exact_split_into_segments(h, exact_h, overlap)
 
@@ -163,9 +177,9 @@ def exact_split(
     overlap: int = 16,
 ) -> np.ndarray:
     """
-    Splits the image into tiles with at most the given tile size.
+    Splits the image into tiles with exactly the given tile size.
 
-    If the upscale method requests a split, then the tile size will be lowered.
+    If the image is smaller than the given size, then it will be padded.
     """
 
     # ensure that the image is at least as large as the given size

--- a/backend/src/nodes/utils/exact_split.py
+++ b/backend/src/nodes/utils/exact_split.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from typing import Callable, Optional, Tuple, List
+import math
+from dataclasses import dataclass
+
+import numpy as np
+from sanic.log import logger
+
+from .utils import get_h_w_c, Region, Padding
+from .image_utils import create_border, BorderType
+
+
+def pad_image(img: np.ndarray, min_size: Tuple[int, int]):
+    h, w, _ = get_h_w_c(img)
+
+    min_w, min_h = min_size
+    x = max(0, min_w - w) / 2
+    y = max(0, min_h - h) / 2
+
+    padding = Padding(math.floor(y), math.floor(x), math.ceil(y), math.ceil(x))
+
+    return create_border(img, BorderType.REFLECT_MIRROR, padding), padding
+
+
+@dataclass
+class Segment:
+    start: int
+    end: int
+    startPadding: int
+    endPadding: int
+
+    @property
+    def length(self) -> int:
+        return self.end - self.start
+
+    @property
+    def padded_length(self) -> int:
+        return self.end + self.endPadding - (self.start - self.startPadding)
+
+
+def exact_split_into_segments(length: int, exact: int, overlap: int) -> List[Segment]:
+    if length == exact:
+        # trivial
+        return [Segment(0, exact, 0, 0)]
+
+    assert length > exact
+    assert exact > overlap * 2
+
+    result: List[Segment] = []
+
+    def add(s: Segment):
+        assert s.padded_length == exact
+        result.append(s)
+
+    # we know that the first segment looks like this
+    add(Segment(0, exact - overlap, 0, overlap))
+
+    innerStart = exact - overlap
+    while innerStart < length:
+        startPadding = overlap
+        start = innerStart
+        end = start + exact - overlap * 2
+        endPadding = overlap
+
+        if end + endPadding >= length:
+            endPadding = 0
+            end = length
+            startPadding = exact - (end - start)
+
+        result.append(Segment(start, end, startPadding, endPadding))
+
+        start = end
+
+    return result
+
+
+def exact_split_into_regions(
+    w: int,
+    h: int,
+    exact_w: int,
+    exact_h: int,
+    overlap: int,
+) -> List[Tuple[Region, Padding]]:
+    """
+    Returns a list of disjoint regions along with padding.
+    Each region plus its padding is guaranteed to have the given exact size.
+    The padding (if not zero) is guaranteed to be at least the given overlap value.
+    """
+    x_segments = exact_split_into_segments(w, exact_w, overlap)
+    y_segments = exact_split_into_segments(h, exact_h, overlap)
+
+    logger.info(
+        f"Image is split into {len(x_segments)}x{len(y_segments)} tiles each exactly {exact_w}x{exact_h}px."
+    )
+
+    result: List[Tuple[Region, Padding]] = []
+    for y in y_segments:
+        for x in x_segments:
+            result.append(
+                (
+                    Region(x.start, y.start, x.length, y.length),
+                    Padding(y.startPadding, x.endPadding, y.endPadding, y.startPadding),
+                )
+            )
+    return result
+
+
+def exact_split_without_padding(
+    img: np.ndarray,
+    exact_size: Tuple[int, int],
+    upscale: Callable[[np.ndarray], np.ndarray],
+    overlap: int,
+) -> np.ndarray:
+    h, w, c = get_h_w_c(img)
+    exact_w, exact_h = exact_size
+    assert w >= exact_w and h >= exact_h
+
+    if (w, h) == exact_size:
+        return upscale(img)
+
+    # To allocate the result image, we need to know the upscale factor first,
+    # and we only get to know this factor after the first successful upscale.
+    result: Optional[np.ndarray] = None
+    scale: int = 0
+
+    regions = exact_split_into_regions(w, h, exact_w, exact_h, overlap)
+    for tile, pad in regions:
+        padded_tile = tile.add_padding(pad)
+
+        upscale_result = upscale(padded_tile.read_from(img))
+
+        # figure out by how much the image was upscaled by
+        up_h, up_w, _ = get_h_w_c(upscale_result)
+        current_scale = up_h // padded_tile.height
+        assert current_scale > 0
+        assert padded_tile.height * current_scale == up_h
+        assert padded_tile.width * current_scale == up_w
+
+        if result is None:
+            # allocate the result image
+            scale = current_scale
+            result = np.zeros((h * scale, w * scale, c), dtype=np.float32)
+
+        assert current_scale == scale
+
+        # remove overlap padding
+        upscale_result = pad.scale(scale).remove_from(upscale_result)
+
+        # copy into result image
+        tile.scale(scale).write_into(result, upscale_result)
+
+    assert result is not None
+
+    # remove initially added padding
+    return result
+
+
+def exact_split(
+    img: np.ndarray,
+    exact_size: Tuple[int, int],
+    upscale: Callable[[np.ndarray], np.ndarray],
+    overlap: int = 16,
+) -> np.ndarray:
+    """
+    Splits the image into tiles with at most the given tile size.
+
+    If the upscale method requests a split, then the tile size will be lowered.
+    """
+
+    # ensure that the image is at least as large as the given size
+    img, base_padding = pad_image(img, exact_size)
+    h, w, _ = get_h_w_c(img)
+
+    result = exact_split_without_padding(img, exact_size, upscale, overlap)
+    scale = get_h_w_c(result)[0] // h
+
+    if base_padding.empty:
+        return result
+
+    # remove initially added padding
+    return (
+        Region(0, 0, w, h).remove_padding(base_padding).scale(scale).read_from(result)
+    )

--- a/backend/src/nodes/utils/image_utils.py
+++ b/backend/src/nodes/utils/image_utils.py
@@ -6,7 +6,7 @@ import numpy as np
 from sanic.log import logger
 
 from .blend_modes import ImageBlender, blend_mode_normalized
-from .utils import get_h_w_c
+from .utils import get_h_w_c, Padding
 
 
 class FillColor:
@@ -228,16 +228,16 @@ def as_target_channels(img: np.ndarray, target_channels: int) -> np.ndarray:
 def create_border(
     img: np.ndarray,
     border_type: int,
-    top: int,
-    right: int,
-    bottom: int,
-    left: int,
+    border: Padding,
 ) -> np.ndarray:
     """
     Returns a new image with a specified border.
 
     The border type value is expected to come from the `BorderType` class.
     """
+
+    if border.empty:
+        return img
 
     _, _, c = get_h_w_c(img)
     if c == 4 and border_type == BorderType.BLACK:
@@ -252,10 +252,10 @@ def create_border(
 
     return cv2.copyMakeBorder(
         img,
-        top=top,
-        left=left,
-        right=right,
-        bottom=bottom,
+        top=border.top,
+        left=border.left,
+        right=border.right,
+        bottom=border.bottom,
         borderType=border_type,
         value=value,
     )


### PR DESCRIPTION
This PR extends `auto_split`'s tilers to have a method for returning an option exact size. If the tiler does have an exact size, `auto_split` will defer all work to `exact_split`. `exact_split` itself is basically just a simpler version of `auto_split` but with some additional padding logic. The meat of the new splitting algorithm is actually in how the tiles are determined. Ensuring an exact size turned out to be non-trivial and the current approach is a simple one that isn't ideal. 

Other changes:
Since a lot of logic in `auto_split` and `exact_split` revolves around regions of images and padding, I added classes for this. This made both functions quite a bit easier, and the `create_border` also benefitted from the new `Padding` class.