### PR TITLE
Added backend debugging via debugpy

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Attach Debugger",
+			"type": "python",
+			"request": "attach",
+			"connect": {
+				"host": "localhost",
+				"port": 5678
+			},
+			"justMyCode": true
+		}
+	]
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   "scripts": {
     "start": "electron-forge start",
     "dev": "concurrently \"cd backend/src && nodemon ./run.py 8000\" \"electron-forge start -- --no-backend\"",
+    "debug": "concurrently \"npm run debug:py\" \"electron-forge start -- --no-backend\"",
+    "debug:py": "cd backend/src && nodemon --exec \"python -m debugpy --listen 5678\" ./run.py 8000",
     "package": "cross-env NODE_ENV=production electron-forge package",
     "make": "cross-env NODE_ENV=production electron-forge make",
     "make-linux-zip": "cross-env NODE_ENV=production electron-forge make --targets @electron-forge/maker-zip --platform linux",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 appdirs
 black
+debugpy
 einops
 facexlib
 ffmpeg-python


### PR DESCRIPTION
While working on #1336, I had a hard-to-find logic bug, so it was time to add a python debugger.

If you run the new `npm run debug` command, you can then attach a debugger in VSCode and start debugging. Note that VSCode and `npm run debug` are completely independent. `npm run debug` uses debugpy to open a port that any debugger can attach to. So you can start and stop debugging without it affecting the backend.

Open questions: `npm run debug` is exactly the same as `npm run dev` except for the use of debugpy (and all debugpy does is to create a port for VSCode to listen to). So maybe we should move the debugging logic into `npm run dev` and get rid of `npm run debug`? The only reason I added a new command is that debugpy is a new dependency that needs to be installed before you can run `npm run debug`.