### PR TITLE
Fix gap between edges and handles

### DIFF
--- a/src/renderer/components/CustomEdge/CustomEdge.tsx
+++ b/src/renderer/components/CustomEdge/CustomEdge.tsx
@@ -31,8 +31,8 @@ export const CustomEdge = memo(
         data = {},
         style,
     }: EdgeProps<EdgeData>) => {
-        const sourceX = _sourceX; // - 8 <- To align it with the node
-        const targetX = _targetX; // + 8
+        const sourceX = _sourceX - 1; // - 8 <- To align it with the node
+        const targetX = _targetX + 1; // + 8
 
         const effectivelyDisabledNodes = useContextSelector(
             GlobalVolatileContext,


### PR DESCRIPTION
this isn't a "true" fix (from better sorting + more offset), but rather just offsetting the edge slightly to avoid the gap.

This does exacerbate the edge overlap issue present on edge-to-iterator-child connections, but it isn't as much as fully aligning the edge to the center of the handle would do (so I think it's okay). Besides you still can't see that issue without hovering over the handle.

![image](https://user-images.githubusercontent.com/34788790/205513069-35e23a99-7b71-47f4-b431-560ef0963933.png)

![image](https://user-images.githubusercontent.com/34788790/205513128-b8843f9d-ff44-4c90-9473-8d5c73647adb.png)

