### PR TITLE
Improved performance of previews

### DIFF
--- a/backend/src/nodes/utils/image_utils.py
+++ b/backend/src/nodes/utils/image_utils.py
@@ -373,18 +373,26 @@ def calculate_ssim(img1: np.ndarray, img2: np.ndarray) -> float:
     return float(np.mean(ssim_map))
 
 
-def preview_encode(img: np.ndarray, target_size: int = 512) -> Tuple[str, np.ndarray]:
+def preview_encode(
+    img: np.ndarray,
+    target_size: int = 512,
+    grace: float = 1.2,
+    lossless: bool = False,
+) -> Tuple[str, np.ndarray]:
     """
     resize the image, so the preview loads faster and doesn't lag the UI
-    512 was chosen as the target because a 512x512 RGBA 8bit PNG is at most 1MB in size
+    512 was chosen as the default target because a 512x512 RGBA 8bit PNG is at most 1MB in size
     """
-    h, w, _ = get_h_w_c(img)
+    h, w, c = get_h_w_c(img)
 
-    max_size = target_size * 1.2
+    max_size = target_size * grace
     if w > max_size or h > max_size:
         f = max(w / target_size, h / target_size)
         img = cv2.resize(img, (int(w / f), int(h / f)), interpolation=cv2.INTER_AREA)
 
-    _, encoded_img = cv2.imencode(".webp", (img * 255).astype("uint8"))  # type: ignore
+    image_format = "png" if c > 3 or lossless else "jpg"
+
+    _, encoded_img = cv2.imencode(f".{image_format}", (img * 255).astype("uint8"))  # type: ignore
     base64_img = base64.b64encode(encoded_img).decode("utf8")
-    return f"data:image/webp;base64,{base64_img}", img
+
+    return f"data:image/{image_format};base64,{base64_img}", img


### PR DESCRIPTION
Changes:
- Use PNG or JPEG as the preview encoding format. As discussed on discord, PNG encoding is around 10x faster than WebP and JPEG is around 2x faster than PNG. Right now, PNG will always be used for RGBA images and the largest preview.
- The maximum preview size is now picked optimally. One of the reasons for the performance problem was that the image was encoded as a preview at fully size twice if it was `p_size <= image_size <= p_size * 1.2` where `p_size` is that size of the largest preview. This won't happen anymore.