### PR TITLE
Add .avs support

### DIFF
--- a/backend/src/nodes/properties/inputs/file_inputs.py
+++ b/backend/src/nodes/properties/inputs/file_inputs.py
@@ -81,6 +81,7 @@ def VideoFileInput() -> FileInput:
             ".mkv",
             ".flv",
             ".m4v",
+            ".avs",
         ],
         has_handle=False,
     )


### PR DESCRIPTION
It's all still through ffmpeg. This is apparently a video format used to run avisynth scripts for video processing, and it apparently just works and has been tested by musl already