### PR TITLE
Added `convenientUpscale` type function to ensure consistent types between implementations

### DIFF
--- a/backend/src/nodes/nodes/ncnn/upscale_image.py
+++ b/backend/src/nodes/nodes/ncnn/upscale_image.py
@@ -9,7 +9,6 @@ from sanic.log import logger
 
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
-from ...properties import expression
 from ...properties.inputs import ImageInput, NcnnModelInput, TileSizeDropdown
 from ...properties.outputs import ImageOutput
 from ...utils.auto_split import MaxTileSize
@@ -63,7 +62,7 @@ class NcnnUpscaleImageNode(NodeBase):
             TileSizeDropdown(),
         ]
         self.outputs = [
-            ImageOutput(image_type=expression.Image(channels="Input1.channels"))
+            ImageOutput(image_type="""convenientUpscale(Input0, Input1)"""),
         ]
         self.category = NCNNCategory
         self.name = "Upscale Image"

--- a/backend/src/nodes/nodes/onnx/upscale_image.py
+++ b/backend/src/nodes/nodes/onnx/upscale_image.py
@@ -10,7 +10,6 @@ from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import OnnxModelInput, ImageInput, TileSizeDropdown
 from ...properties.outputs import ImageOutput
-from ...properties import expression
 from ...utils.auto_split_tiles import parse_tile_size_input, TileSize
 from ...utils.auto_split import ExactTileSize
 from ...utils.onnx_auto_split import onnx_auto_split
@@ -57,7 +56,7 @@ class OnnxImageUpscaleNode(NodeBase):
         self.outputs = [
             ImageOutput(
                 "Upscaled Image",
-                image_type=expression.Image(channels="Input1.channels"),
+                image_type="""convenientUpscale(Input0, Input1)""",
             )
         ]
 

--- a/backend/src/nodes/nodes/pytorch/upscale_image.py
+++ b/backend/src/nodes/nodes/pytorch/upscale_image.py
@@ -38,13 +38,7 @@ class ImageUpscaleNode(NodeBase):
         self.outputs = [
             ImageOutput(
                 "Upscaled Image",
-                image_type="""
-                Image {
-                    width: Input0.scale * Input1.width,
-                    height: Input0.scale * Input1.height,
-                    channels: Input1.channels
-                }
-                """,
+                image_type="""convenientUpscale(Input0, Input1)""",
             )
         ]
 

--- a/src/common/types/chainner-scope.ts
+++ b/src/common/types/chainner-scope.ts
@@ -63,7 +63,9 @@ struct NcnnNetwork {
 }
 
 struct OnnxFile;
-struct OnnxModel;
+struct OnnxModel {
+    scale: int(1..),
+}
 
 struct IteratorAuto;
 
@@ -120,6 +122,14 @@ def FpMode::toString(mode: FpMode) {
     match mode {
         FpMode::fp32 => "fp32",
         FpMode::fp16 => "fp16",
+    }
+}
+
+def convenientUpscale(model: PyTorchModel | NcnnNetwork | OnnxModel, image: Image) {
+    Image {
+        width: model.scale * image.width,
+        height: model.scale * image.height,
+        channels: image.channels
     }
 }
 `;


### PR DESCRIPTION
I noticed that NCNN's Upscale Image nodes didn't predict the size of the output image, so I fixed that. I added a `convenientUpscale` type function that captures the behavior of `convenient_upscale`. This should also make it easier for zamboni to adjust the types of these nodes after fixing `convenient_upscale`.


![image](https://user-images.githubusercontent.com/20878432/205659136-dc6e6a77-c292-4af8-947d-b96d3e039f3e.png)
