### PR TITLE
Automatically restart backend on deps changes

### DIFF
--- a/src/common/safeIpc.ts
+++ b/src/common/safeIpc.ts
@@ -45,7 +45,6 @@ export interface InvokeChannels {
     >;
     'get-cli-open': ChannelInfo<FileOpenResult<ParsedSaveData> | undefined>;
     'owns-backend': ChannelInfo<boolean>;
-    'kill-backend': ChannelInfo<void>;
     'restart-backend': ChannelInfo<void>;
     'relaunch-application': ChannelInfo<void>;
     'quit-application': ChannelInfo<void>;

--- a/src/renderer/components/CustomEdge/CustomEdge.tsx
+++ b/src/renderer/components/CustomEdge/CustomEdge.tsx
@@ -1,3 +1,4 @@
+import { NeverType } from '@chainner/navi';
 import { Center, Icon, IconButton } from '@chakra-ui/react';
 import { memo, useEffect, useMemo, useState } from 'react';
 import { TbUnlink } from 'react-icons/tb';
@@ -65,9 +66,9 @@ export const CustomEdge = memo(
         const [isHovered, setIsHovered] = useState(false);
 
         const { outputId } = useMemo(() => parseSourceHandle(sourceHandleId!), [sourceHandleId]);
-        const definitionType = functionDefinitions
-            .get(parentNode.data.schemaId)!
-            .outputDefaults.get(outputId)!;
+        const definitionType =
+            functionDefinitions.get(parentNode.data.schemaId)?.outputDefaults.get(outputId) ??
+            NeverType.instance;
         const type = useContextSelector(GlobalVolatileContext, (c) =>
             c.typeState.functions.get(source)?.outputs.get(outputId)
         );

--- a/src/renderer/components/node/NodeOutputs.tsx
+++ b/src/renderer/components/node/NodeOutputs.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-props-no-spreading */
 
-import { Type } from '@chainner/navi';
+import { NeverType, Type } from '@chainner/navi';
 import { memo, useCallback } from 'react';
 import { useContext, useContextSelector } from 'use-context-selector';
 import { Output, OutputId, OutputKind, SchemaId } from '../../../common/common-types';
@@ -88,7 +88,7 @@ export const NodeOutputs = memo(({ outputs, id, schemaId, animated = false }: No
         [outputDataEntry, inputHash]
     );
 
-    const functions = functionDefinitions.get(schemaId)!.outputDefaults;
+    const functions = functionDefinitions.get(schemaId)?.outputDefaults;
     return (
         <>
             {outputs.map((output) => {
@@ -99,7 +99,7 @@ export const NodeOutputs = memo(({ outputs, id, schemaId, animated = false }: No
                     useOutputData,
                     kind: output.kind,
                     schemaId,
-                    definitionType: functions.get(output.id)!,
+                    definitionType: functions?.get(output.id) ?? NeverType.instance,
                     hasHandle: output.hasHandle,
                     animated,
                 };

--- a/src/renderer/contexts/AlertBoxContext.tsx
+++ b/src/renderer/contexts/AlertBoxContext.tsx
@@ -252,13 +252,13 @@ export const AlertBoxProvider = memo(({ children }: React.PropsWithChildren<unkn
 
     const onClose = useCallback(
         (button: number) => {
-            current?.resolve(button);
             setQueue((q) => q.slice(1));
             setDone((prev) => prev + 1);
             if (isLast) {
                 onDisclosureClose();
                 setHotkeysEnabled(true);
             }
+            current?.resolve(button);
         },
         [current, isLast, setQueue, onDisclosureClose, setHotkeysEnabled]
     );

--- a/src/renderer/contexts/BackendContext.tsx
+++ b/src/renderer/contexts/BackendContext.tsx
@@ -1,15 +1,18 @@
-import React, { memo, useMemo } from 'react';
+import React, { memo, useCallback, useMemo, useRef, useState } from 'react';
 import { createContext } from 'use-context-selector';
 import { Backend, getBackend } from '../../common/Backend';
 import { Category, PythonInfo, SchemaId } from '../../common/common-types';
+import { ipcRenderer } from '../../common/safeIpc';
 import { SchemaInputsMap } from '../../common/SchemaInputsMap';
 import { SchemaMap } from '../../common/SchemaMap';
 import { FunctionDefinition } from '../../common/types/function';
+import { useAsyncEffect } from '../hooks/useAsyncEffect';
 import { useMemoObject } from '../hooks/useMemo';
 
 interface BackendContextState {
     port: number;
     backend: Backend;
+    ownsBackend: boolean;
     schemata: SchemaMap;
     schemaInputs: SchemaInputsMap;
     pythonInfo: PythonInfo;
@@ -21,6 +24,8 @@ interface BackendContextState {
     categories: Category[];
     categoriesMissingNodes: string[];
     functionDefinitions: Map<SchemaId, FunctionDefinition>;
+    restartingRef: Readonly<React.MutableRefObject<boolean>>;
+    restart: () => Promise<void>;
 }
 
 export const BackendContext = createContext<Readonly<BackendContextState>>(
@@ -34,6 +39,7 @@ interface BackendProviderProps {
     categories: Category[];
     categoriesMissingNodes: string[];
     functionDefinitions: Map<SchemaId, FunctionDefinition>;
+    refreshNodes: () => void;
 }
 
 export const BackendProvider = memo(
@@ -44,21 +50,71 @@ export const BackendProvider = memo(
         categories,
         categoriesMissingNodes,
         functionDefinitions,
+        refreshNodes,
         children,
     }: React.PropsWithChildren<BackendProviderProps>) => {
         const backend = getBackend(port);
 
+        const [ownsBackend, setOwnsBackend] = useState<boolean>(false);
+        useAsyncEffect(
+            () => ({
+                supplier: () => ipcRenderer.invoke('owns-backend'),
+                successEffect: setOwnsBackend,
+            }),
+            []
+        );
+
         const schemaInputs = useMemo(() => new SchemaInputsMap(schemata.schemata), [schemata]);
+
+        const restartingRef = useRef(false);
+        const restartPromiseRef = useRef<Promise<void>>();
+        const needsNewRestartRef = useRef(false);
+        const restart = useCallback((): Promise<void> => {
+            if (restartPromiseRef.current) {
+                // another promise is currently restarting the backend, so we just request another restart
+                needsNewRestartRef.current = true;
+                return restartPromiseRef.current;
+            }
+
+            restartingRef.current = true;
+            restartPromiseRef.current = (async () => {
+                let error;
+                do {
+                    needsNewRestartRef.current = false;
+                    try {
+                        // eslint-disable-next-line no-await-in-loop
+                        await ipcRenderer.invoke('restart-backend');
+                        error = null;
+                    } catch (e) {
+                        error = e;
+                    }
+                    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+                } while (needsNewRestartRef.current);
+
+                // Done. At this point, the backend either restarted or failed trying
+                restartingRef.current = false;
+                restartPromiseRef.current = undefined;
+                refreshNodes();
+
+                if (error !== null) {
+                    throw error;
+                }
+            })();
+            return restartPromiseRef.current;
+        }, [refreshNodes]);
 
         const value = useMemoObject<BackendContextState>({
             port,
             backend,
+            ownsBackend,
             schemata,
             schemaInputs,
             pythonInfo,
             categories,
             categoriesMissingNodes,
             functionDefinitions,
+            restartingRef,
+            restart,
         });
 
         return <BackendContext.Provider value={value}>{children}</BackendContext.Provider>;

--- a/src/renderer/contexts/ExecutionContext.tsx
+++ b/src/renderer/contexts/ExecutionContext.tsx
@@ -1,3 +1,4 @@
+import log from 'electron-log';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { Edge, Node, useReactFlow } from 'reactflow';
 import { createContext, useContext, useContextSelector } from 'use-context-selector';
@@ -24,8 +25,6 @@ import {
 import { getConnectedInputs } from '../helpers/connectedInputs';
 import { getEffectivelyDisabledNodes } from '../helpers/disabled';
 import { getNodesWithSideEffects } from '../helpers/sideEffect';
-import { SetState } from '../helpers/types';
-import { useAsyncEffect } from '../hooks/useAsyncEffect';
 import {
     BackendEventMap,
     BackendEventSourceListener,
@@ -56,8 +55,6 @@ interface ExecutionContextValue {
     pause: () => Promise<void>;
     kill: () => Promise<void>;
     status: ExecutionStatus;
-    isBackendKilled: boolean;
-    setIsBackendKilled: SetState<boolean>;
 }
 
 export const ExecutionStatusContext = createContext<Readonly<ExecutionStatusContextValue>>({
@@ -196,7 +193,7 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
         outputDataActions,
         getInputHash,
     } = useContext(GlobalContext);
-    const { schemata, port, backend } = useContext(BackendContext);
+    const { schemata, port, backend, ownsBackend, restartingRef } = useContext(BackendContext);
     const { sendAlert, sendToast } = useContext(AlertBoxContext);
     const nodeChanges = useContextSelector(GlobalVolatileContext, (c) => c.nodeChanges);
     const edgeChanges = useContextSelector(GlobalVolatileContext, (c) => c.edgeChanges);
@@ -206,8 +203,6 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
     const { getNodes, getEdges } = useReactFlow<NodeData, EdgeData>();
 
     const [status, setStatus] = useState(ExecutionStatus.READY);
-
-    const [isBackendKilled, setIsBackendKilled] = useState(false);
 
     useEffect(() => {
         if (status !== ExecutionStatus.READY) {
@@ -274,25 +269,13 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
     }, 350);
     useBackendEventSourceListener(eventSource, 'iterator-progress-update', updateIteratorProgress);
 
-    const [ownsBackend, setOwnsBackend] = useState(true);
-    useAsyncEffect(
-        () => ({
-            supplier: () => ipcRenderer.invoke('owns-backend'),
-            successEffect: setOwnsBackend,
-        }),
-        [setOwnsBackend]
-    );
-
     useEffect(() => {
-        if (ownsBackend && !isBackendKilled && eventSourceStatus === 'error') {
-            sendAlert({
-                type: AlertType.ERROR,
-                message: 'An unexpected error occurred. You may need to restart chaiNNer.',
-            });
+        if (ownsBackend && !restartingRef.current && eventSourceStatus === 'error') {
+            log.warn('The backend event source errored.');
             unAnimate();
             setStatus(ExecutionStatus.READY);
         }
-    }, [eventSourceStatus, unAnimate, isBackendKilled, ownsBackend, sendAlert]);
+    }, [eventSourceStatus, unAnimate, restartingRef, ownsBackend]);
 
     const lastChangesRef = useRef(`${nodeChanges} ${edgeChanges}`);
     useEffect(() => {
@@ -523,8 +506,6 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
         pause,
         kill,
         status,
-        isBackendKilled,
-        setIsBackendKilled,
     });
 
     return (

--- a/src/renderer/helpers/TypeState.ts
+++ b/src/renderer/helpers/TypeState.ts
@@ -6,6 +6,7 @@ import {
     StructType,
     Type,
 } from '@chainner/navi';
+import log from 'electron-log';
 import { Edge, Node } from 'reactflow';
 import { EdgeData, InputId, NodeData, OutputId, SchemaId } from '../../common/common-types';
 import { FunctionDefinition, FunctionInstance } from '../../common/types/function';
@@ -48,18 +49,19 @@ export class TypeState {
                 if (sourceNode) {
                     // eslint-disable-next-line @typescript-eslint/no-use-before-define
                     const functionInstance = addNode(sourceNode);
-                    return functionInstance.outputs.get(sourceHandle.outputId);
+                    return functionInstance?.outputs.get(sourceHandle.outputId);
                 }
             }
             return undefined;
         };
-        const addNode = (n: Node<NodeData>): FunctionInstance => {
+        const addNode = (n: Node<NodeData>): FunctionInstance | undefined => {
             const cached = functions.get(n.id);
             if (cached) return cached;
 
             const definition = functionDefinitions.get(n.data.schemaId);
             if (!definition) {
-                throw new Error(`No function definition for schema id ${n.data.schemaId}`);
+                log.warn(`Unknown schema id ${n.data.schemaId}`);
+                return undefined;
             }
 
             let instance;


### PR DESCRIPTION
Changes:
- The deps manager will automatically restart the backend after (un)installing dependencies.
- Removed "Restart chaiNNer" button from deps manager.
- Everything related to types is not allowed to assume that the schema id of a node is valid.
- While testing, I found that the backend event source is not a good indicator to find out whether the backend is still alive. When restarting the backend, the event source *sometimes* errors (as in, its current state is "error"), but it actually still works just fine. So I demoted the event source error alert to a log warning.