### PR TITLE
Allow users to select alert text

### DIFF
--- a/src/renderer/contexts/AlertBoxContext.tsx
+++ b/src/renderer/contexts/AlertBoxContext.tsx
@@ -318,7 +318,12 @@ export const AlertBoxProvider = memo(({ children }: React.PropsWithChildren<unkn
                     </AlertDialogHeader>
 
                     <AlertDialogCloseButton />
-                    <AlertDialogBody whiteSpace="pre-wrap">{current?.message}</AlertDialogBody>
+                    <AlertDialogBody
+                        userSelect="text"
+                        whiteSpace="pre-wrap"
+                    >
+                        {current?.message}
+                    </AlertDialogBody>
                     <AlertDialogFooter>
                         <HStack width="full">
                             <IconButton


### PR DESCRIPTION
Useful for when you only want to copy a part of an error message.