### PR TITLE
Format on save for python files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,8 @@
     "reactflow",
     "sanic",
     "vram"
-  ]
+  ],
+  "[python]": {
+    "editor.formatOnSave": true
+  }
 }


### PR DESCRIPTION
I added a VSCode setting to format all python files on save. No more CI fails because of black. 