### PR TITLE
theoretically fix for non-cuda device mapping

### DIFF
--- a/backend/src/nodes/utils/exec_options.py
+++ b/backend/src/nodes/utils/exec_options.py
@@ -38,7 +38,7 @@ class ExecutionOptions:
 
     @property
     def full_device(self) -> str:
-        if self.__device != "cpu" and self.__pytorch_gpu_index is not None:
+        if self.__device == "cuda" and self.__pytorch_gpu_index is not None:
             return f"{self.__device}:{self.__pytorch_gpu_index}"
         return self.__device
 


### PR DESCRIPTION
This might fix the error mentioned in the log at the bottom of #1280. I think the error originates from us giving it "dml:0" even though dml probably cannot be mapped to a specific device. Therefore, I changed this check to only add the :{number} in the case of cuda.