### PR TITLE
Added support for nested groups

### DIFF
--- a/backend/src/nodes/group.py
+++ b/backend/src/nodes/group.py
@@ -29,5 +29,5 @@ class Group(Generic[T]):
             "id": self.info.id,
             "kind": self.info.kind,
             "options": self.info.options,
-            "items": self.items,
+            "items": [i.toDict() if isinstance(i, Group) else i for i in self.items],
         }

--- a/backend/src/nodes/nodes/image/save_image.py
+++ b/backend/src/nodes/nodes/image/save_image.py
@@ -34,7 +34,7 @@ class ImWriteNode(NodeBase):
             DirectoryInput(has_handle=True),
             TextInput("Subdirectory Path").make_optional(),
             TextInput("Image Name"),
-            group("conditional-enum", {"conditions": {5: ["jpg", "webp"]}})(
+            group("conditional-enum", {"conditions": [["jpg", "webp"]]})(
                 ImageExtensionDropdown(),
                 SliderInput(
                     "Quality",
@@ -42,7 +42,7 @@ class ImWriteNode(NodeBase):
                     maximum=100,
                     default=95,
                     slider_step=1,
-                ).with_id(5),
+                ),
             ),
         ]
         self.category = ImageCategory

--- a/backend/src/run.py
+++ b/backend/src/run.py
@@ -10,8 +10,7 @@ from typing import Any, Dict, List, Optional, TypedDict
 import importlib
 import os
 
-# pylint: disable=unused-import
-import cv2
+import cv2  # pylint: disable=unused-import
 from sanic import Sanic
 from sanic.log import logger, access_logger
 from sanic.request import Request
@@ -21,13 +20,13 @@ from sanic_cors import CORS
 from nodes.node_factory import NodeFactory
 from nodes.utils.exec_options import (
     set_execution_options,
-    ExecutionOptions,
     parse_execution_options,
     JsonExecutionOptions,
 )
 from nodes.nodes.builtin_categories import category_order
+from nodes.group import Group
 
-from base_types import NodeId, InputId, OutputId
+from base_types import NodeId, OutputId
 from chain.cache import OutputCache
 from chain.json import parse_json, JsonNode
 from chain.optimize import optimize
@@ -175,7 +174,10 @@ async def nodes(_):
             "category": node_object.category.name,
             "inputs": [x.toDict() for x in node_object.inputs],
             "outputs": [x.toDict() for x in node_object.outputs],
-            "groups": [g.toDict() for g in node_object.groups],
+            "groupLayout": [
+                g.toDict() if isinstance(g, Group) else g
+                for g in node_object.group_layout
+            ],
             "description": node_object.description,
             "icon": node_object.icon,
             "subcategory": node_object.sub,

--- a/src/common/SchemaInputsMap.ts
+++ b/src/common/SchemaInputsMap.ts
@@ -1,52 +1,40 @@
-import { Group, Input, NodeSchema, SchemaId } from './common-types';
-import { groupInputsChecks } from './group-inputs';
+import { Group, InputId, NodeSchema, SchemaId } from './common-types';
+import { GroupInputItem, InputItem, checkGroupInputs } from './group-inputs';
 import { EMPTY_ARRAY } from './util';
 
-export interface SchemaInputItem {
-    readonly kind: 'input';
-    readonly input: Input;
-}
-export interface GroupInputItem {
-    readonly kind: 'group';
-    readonly group: Group;
-    readonly inputs: readonly Input[];
-}
-export type InputItem = SchemaInputItem | GroupInputItem;
-
 const createInputList = (schema: NodeSchema): readonly InputItem[] => {
-    const result: InputItem[] = [];
+    const byId = new Map(schema.inputs.map((input) => [input.id, input]));
 
-    // This code makes the following assumptions:
-    // 1. All groups only references valid input ids.
-    // 2. No two groups reference the same input.
-    // 3. Groups only reference contiguous inputs.
-    // 4. All groups reference at least one input.
+    const groups: GroupInputItem[] = [];
 
-    for (let i = 0; i < schema.inputs.length; i += 1) {
-        const input = schema.inputs[i];
-        const group = schema.groups.find((g) => g.items.includes(input.id));
-        if (group) {
-            const inputs = schema.inputs.slice(i, i + group.items.length);
-
-            const isValidCheck = groupInputsChecks[group.kind] as
-                | undefined
-                | ((inputs: readonly Input[], group: Group) => boolean);
-            const name = `${group.kind} group (id: ${group.id}) in ${schema.name} (id: ${schema.schemaId})`;
-            if (!isValidCheck) {
-                throw new Error(
-                    `The ${name} is invalid. "${group.kind}" is not a valid group kind.`
-                );
-            }
-            if (!isValidCheck(inputs, group as never)) {
-                throw new Error(
-                    `The ${name} is invalid. This is likely a bug in either they python group definition.`
-                );
+    const convertLayout = (items: readonly (Group | InputId)[]): InputItem[] => {
+        return items.map((i) => {
+            if (typeof i === 'object') {
+                const group: GroupInputItem = {
+                    kind: 'group',
+                    group: i,
+                    inputs: convertLayout(i.items),
+                };
+                groups.push(group);
+                return group;
             }
 
-            result.push({ kind: 'group', group, inputs });
-            i += group.items.length - 1;
-        } else {
-            result.push({ kind: 'input', input });
+            const input = byId.get(i);
+            if (input === undefined) {
+                throw new Error(`Invalid or duplicate input id`);
+            }
+            byId.delete(i);
+            return input;
+        });
+    };
+
+    const result = convertLayout(schema.groupLayout);
+
+    for (const { group, inputs } of groups) {
+        const name = `${group.kind} group (id: ${group.id}) in ${schema.name} (id: ${schema.schemaId})`;
+        const validity = checkGroupInputs(inputs, group);
+        if (!validity.isValid) {
+            throw new Error(`The ${name} is invalid. ${validity.reason}`);
         }
     }
 

--- a/src/common/SchemaMap.ts
+++ b/src/common/SchemaMap.ts
@@ -4,7 +4,7 @@ import { InputData, InputId, InputValue, NodeSchema, SchemaId } from './common-t
 const BLANK_SCHEMA: NodeSchema = {
     inputs: [],
     outputs: [],
-    groups: [],
+    groupLayout: [],
     icon: '',
     category: '',
     subcategory: '',

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -130,7 +130,7 @@ interface GroupBase {
     readonly id: GroupId;
     readonly kind: GroupKind;
     readonly options: Readonly<Record<string, unknown>>;
-    readonly items: readonly InputId[];
+    readonly items: readonly (InputId | Group)[];
 }
 interface NcnnFileInputGroup extends GroupBase {
     readonly kind: 'ncnn-file-inputs';
@@ -151,7 +151,7 @@ interface OptionalListGroup extends GroupBase {
 interface ConditionalEnumGroup extends GroupBase {
     readonly kind: 'conditional-enum';
     readonly options: {
-        readonly conditions: Readonly<Partial<Record<InputId, null | readonly InputSchemaValue[]>>>;
+        readonly conditions: readonly (readonly InputSchemaValue[])[];
     };
 }
 export type GroupKind = Group['kind'];
@@ -183,7 +183,7 @@ export interface NodeSchema {
     readonly nodeType: NodeType;
     readonly inputs: readonly Input[];
     readonly outputs: readonly Output[];
-    readonly groups: readonly Group[];
+    readonly groupLayout: readonly (InputId | Group)[];
     readonly defaultNodes?: readonly DefaultNode[];
     readonly schemaId: SchemaId;
     readonly hasSideEffects: boolean;

--- a/src/common/group-inputs.ts
+++ b/src/common/group-inputs.ts
@@ -1,13 +1,29 @@
-import { DropDownInput, FileInput, Group, GroupKind, Input } from './common-types';
+import {
+    DropDownInput,
+    FileInput,
+    Group,
+    GroupKind,
+    Input,
+    InputKind,
+    OfKind,
+} from './common-types';
+import { VALID, Validity, invalid } from './Validity';
+
+export interface GroupInputItem {
+    readonly kind: 'group';
+    readonly group: Group;
+    readonly inputs: readonly InputItem[];
+}
+export type InputItem = Input | GroupInputItem;
 
 // This helper type ensure that all group types are covered
-type InputGuarantees<T extends Record<GroupKind, readonly Input[]>> = T;
+type InputGuarantees<T extends Record<GroupKind, readonly InputItem[]>> = T;
 
 type DeclaredGroupInputs = InputGuarantees<{
-    'conditional-enum': readonly [DropDownInput, ...Input[]];
+    'conditional-enum': readonly [DropDownInput, ...InputItem[]];
     'from-to-dropdowns': readonly [DropDownInput, DropDownInput];
     'ncnn-file-inputs': readonly [FileInput, FileInput];
-    'optional-list': readonly [Input, ...Input[]];
+    'optional-list': readonly [InputItem, ...InputItem[]];
 }>;
 
 // A bit hacky, but this ensures that GroupInputs covers exactly all group types, no more and no less
@@ -15,38 +31,72 @@ type Exact<T extends DeclaredGroupInputs> = T;
 
 export type GroupInputs = Exact<Pick<DeclaredGroupInputs, GroupKind>>;
 
-export const groupInputsChecks: {
-    [Type in GroupKind]: (
-        inputs: readonly Input[],
-        group: Group & { readonly type: Type }
-    ) => boolean;
+const allInputsOfKind = <K extends InputKind>(
+    inputs: readonly InputItem[],
+    kind: K
+): inputs is readonly OfKind<Input, K>[] => {
+    return inputs.every((i) => i.kind === kind);
+};
+const allAreOptional = (inputs: readonly InputItem[]): boolean => {
+    return inputs.every((i) => (i.kind === 'group' ? allAreOptional(i.inputs) : i.optional));
+};
+
+const groupInputsChecks: {
+    [Kind in GroupKind]: (
+        inputs: readonly InputItem[],
+        group: OfKind<Group, Kind>
+    ) => string | undefined;
 } = {
     'conditional-enum': (inputs, { options: { conditions } }) => {
-        if (inputs.length === 0) return false;
+        if (inputs.length === 0) return 'Expected at least 1 item';
 
         const dropdown = inputs[0];
-        if (dropdown.kind !== 'dropdown') return false;
-        if (dropdown.hasHandle) return false;
+        if (dropdown.kind !== 'dropdown') return 'The first item must be a dropdown';
+        if (dropdown.hasHandle) return 'The first dropdown must not have a handle';
         const allowed = new Set(dropdown.options.map((o) => o.value));
-        const idStrings = new Set(inputs.slice(1).map((i) => String(i.id)));
 
-        return Object.entries(conditions).every(([id, cond]) => {
-            if (!cond) return true;
-            return idStrings.has(id) && cond.length > 0 && cond.every((c) => allowed.has(c));
-        });
+        if (conditions.length !== inputs.length - 1)
+            return `The number of conditions (${
+                conditions.length
+            }) must match the number of items excluding the first dropdown (${inputs.length - 1}).`;
+
+        for (const cond of conditions) {
+            if (cond.length === 0) return 'All items must have at least one condition value';
+            const invalidValue = cond.find((c) => !allowed.has(c));
+            if (invalidValue !== undefined)
+                return `Invalid condition value ${JSON.stringify(invalidValue)}`;
+        }
     },
     'from-to-dropdowns': (inputs) => {
-        return (
-            inputs.length === 2 &&
-            inputs.every((i) => {
-                return i.kind === 'dropdown' && !i.hasHandle;
-            })
-        );
+        if (inputs.length !== 2) return 'Expected exactly 2 inputs';
+
+        if (!allInputsOfKind(inputs, 'dropdown') || !inputs.every((input) => !input.hasHandle)) {
+            return `Expected all inputs to dropdowns`;
+        }
     },
     'ncnn-file-inputs': (inputs) => {
-        return inputs.length === 2 && inputs.every((i) => i.kind === 'file');
+        if (inputs.length !== 2) return 'Expected exactly 2 inputs';
+
+        if (!allInputsOfKind(inputs, 'file')) return `Expected all inputs to file inputs`;
     },
     'optional-list': (inputs) => {
-        return inputs.length >= 1 && inputs.every((i) => i.optional);
+        if (inputs.length === 0) return 'Expected at least 1 item';
+
+        if (!allAreOptional(inputs)) return 'Expected all inputs to be optional';
     },
+};
+
+export const checkGroupInputs = (inputs: readonly InputItem[], group: Group): Validity => {
+    const checkFn = groupInputsChecks[group.kind];
+    if (typeof checkFn !== 'function') {
+        return invalid(`"${group.kind}" is not a valid group kind.`);
+    }
+    const reason = checkFn(inputs, group as never);
+    if (reason) return invalid(reason);
+    return VALID;
+};
+
+export const getUniqueKey = (item: InputItem): number => {
+    if (item.kind === 'group') return item.group.id + 2000;
+    return item.id;
 };

--- a/src/renderer/components/groups/ConditionalEnumGroup.tsx
+++ b/src/renderer/components/groups/ConditionalEnumGroup.tsx
@@ -1,9 +1,9 @@
 import { memo } from 'react';
 import { useContext, useContextSelector } from 'use-context-selector';
-import { Input } from '../../../common/common-types';
+import { InputItem, getUniqueKey } from '../../../common/group-inputs';
 import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
-import { SchemaInput } from '../inputs/SchemaInput';
 import { GroupProps } from './props';
+import { someInput } from './util';
 
 export const ConditionalEnumGroup = memo(
     ({
@@ -14,6 +14,7 @@ export const ConditionalEnumGroup = memo(
         nodeId,
         schemaId,
         group,
+        ItemRenderer,
     }: GroupProps<'conditional-enum'>) => {
         const { getNodeInputValue } = useContext(GlobalContext);
 
@@ -25,30 +26,28 @@ export const ConditionalEnumGroup = memo(
             (c) => c.isNodeInputLocked
         );
 
-        const showInput = (input: Input): boolean => {
+        const showInput = (input: InputItem, index: number): boolean => {
             // always show the main dropdown itself
-            if (input === enumInput) return true;
+            if (index === 0) return true;
 
-            const cond = group.options.conditions[input.id];
-            // no condition == always show input
-            if (!cond) return true;
+            const cond = group.options.conditions[index - 1];
 
             // enum has the right value
             if (cond.includes(enumValue)) return true;
 
-            // input is connected to another node
-            return isNodeInputLocked(nodeId, input.id);
+            // input or some input of the group is connected to another node
+            return someInput(input, ({ id }) => isNodeInputLocked(nodeId, id));
         };
 
         return (
             <>
-                {inputs.filter(showInput).map((i) => (
-                    <SchemaInput
-                        input={i}
+                {inputs.filter(showInput).map((item) => (
+                    <ItemRenderer
                         inputData={inputData}
                         inputSize={inputSize}
                         isLocked={isLocked}
-                        key={i.id}
+                        item={item}
+                        key={getUniqueKey(item)}
                         nodeId={nodeId}
                         schemaId={schemaId}
                     />

--- a/src/renderer/components/groups/Group.tsx
+++ b/src/renderer/components/groups/Group.tsx
@@ -1,17 +1,11 @@
 import { memo } from 'react';
-import {
-    Group,
-    GroupKind,
-    Input,
-    InputData,
-    InputSize,
-    SchemaId,
-} from '../../../common/common-types';
+import { Group, GroupKind, InputData, InputSize, SchemaId } from '../../../common/common-types';
+import { InputItem } from '../../../common/group-inputs';
 import { ConditionalEnumGroup } from './ConditionalEnumGroup';
 import { FromToDropdownsGroup } from './FromToDropdownsGroup';
 import { NcnnFileInputsGroup } from './NcnnFileInputsGroup';
 import { OptionalInputsGroup } from './OptionalInputsGroup';
-import { GroupProps } from './props';
+import { GroupProps, InputItemRenderer } from './props';
 
 const GroupComponents: {
     readonly [K in GroupKind]: React.MemoExoticComponent<(props: GroupProps<K>) => JSX.Element>;
@@ -24,19 +18,30 @@ const GroupComponents: {
 
 interface GroupElementProps {
     group: Group;
-    inputs: readonly Input[];
+    inputs: readonly InputItem[];
     schemaId: SchemaId;
     nodeId: string;
     isLocked: boolean;
     inputData: InputData;
     inputSize: InputSize | undefined;
+    ItemRenderer: InputItemRenderer;
 }
 
 export const GroupElement = memo(
-    ({ group, inputs, schemaId, nodeId, isLocked, inputData, inputSize }: GroupElementProps) => {
+    ({
+        group,
+        inputs,
+        schemaId,
+        nodeId,
+        isLocked,
+        inputData,
+        inputSize,
+        ItemRenderer,
+    }: GroupElementProps) => {
         const GroupType = GroupComponents[group.kind];
         return (
             <GroupType
+                ItemRenderer={ItemRenderer}
                 group={group as never}
                 inputData={inputData}
                 inputSize={inputSize}

--- a/src/renderer/components/groups/props.ts
+++ b/src/renderer/components/groups/props.ts
@@ -6,7 +6,16 @@ import {
     OfKind,
     SchemaId,
 } from '../../../common/common-types';
-import { GroupInputs } from '../../../common/group-inputs';
+import { GroupInputs, InputItem } from '../../../common/group-inputs';
+
+export type InputItemRenderer = (props: {
+    item: InputItem;
+    nodeId: string;
+    inputData: InputData;
+    inputSize?: InputSize;
+    isLocked: boolean;
+    schemaId: SchemaId;
+}) => JSX.Element | null;
 
 export interface GroupProps<Kind extends GroupKind> {
     group: OfKind<Group, Kind>;
@@ -16,4 +25,5 @@ export interface GroupProps<Kind extends GroupKind> {
     isLocked: boolean;
     inputData: InputData;
     inputSize: InputSize | undefined;
+    ItemRenderer: InputItemRenderer;
 }

--- a/src/renderer/components/groups/util.ts
+++ b/src/renderer/components/groups/util.ts
@@ -1,0 +1,7 @@
+import { Input } from '../../../common/common-types';
+import { InputItem } from '../../../common/group-inputs';
+
+export const someInput = (item: InputItem, condFn: (input: Input) => boolean): boolean => {
+    if (item.kind !== 'group') return condFn(item);
+    return item.inputs.some((i) => someInput(i, condFn));
+};

--- a/src/renderer/components/node/NodeInputs.tsx
+++ b/src/renderer/components/node/NodeInputs.tsx
@@ -1,9 +1,11 @@
+/* eslint-disable react/prop-types */
 import { memo } from 'react';
 import { useContext } from 'use-context-selector';
 import { InputData, InputSize, NodeSchema } from '../../../common/common-types';
-import { assertNever } from '../../../common/util';
+import { getUniqueKey } from '../../../common/group-inputs';
 import { BackendContext } from '../../contexts/BackendContext';
 import { GroupElement } from '../groups/Group';
+import { InputItemRenderer } from '../groups/props';
 import { SchemaInput } from '../inputs/SchemaInput';
 
 interface NodeInputsProps {
@@ -14,50 +16,58 @@ interface NodeInputsProps {
     isLocked?: boolean;
 }
 
+const ItemRenderer: InputItemRenderer = memo(
+    ({ item, inputData, inputSize, isLocked, nodeId, schemaId }) => {
+        if (item.kind === 'group') {
+            const { group } = item;
+            return (
+                <GroupElement
+                    ItemRenderer={ItemRenderer}
+                    group={group}
+                    inputData={inputData}
+                    inputSize={inputSize}
+                    inputs={item.inputs}
+                    isLocked={isLocked}
+                    nodeId={nodeId}
+                    schemaId={schemaId}
+                />
+            );
+        }
+
+        return (
+            <SchemaInput
+                input={item}
+                inputData={inputData}
+                inputSize={inputSize}
+                isLocked={isLocked}
+                nodeId={nodeId}
+                schemaId={schemaId}
+            />
+        );
+    }
+);
+
 export const NodeInputs = memo(
     ({ schema, id, inputData, inputSize, isLocked = false }: NodeInputsProps) => {
         const { schemaInputs } = useContext(BackendContext);
 
         const { schemaId } = schema;
+
         const inputs = schemaInputs.get(schemaId);
 
         return (
             <>
-                {inputs.map((item) => {
-                    switch (item.kind) {
-                        case 'input': {
-                            const { input } = item;
-                            return (
-                                <SchemaInput
-                                    input={input}
-                                    inputData={inputData}
-                                    inputSize={inputSize}
-                                    isLocked={isLocked}
-                                    key={`i${input.id}`}
-                                    nodeId={id}
-                                    schemaId={schemaId}
-                                />
-                            );
-                        }
-                        case 'group': {
-                            const { group } = item;
-                            return (
-                                <GroupElement
-                                    group={group}
-                                    inputData={inputData}
-                                    inputSize={inputSize}
-                                    inputs={item.inputs}
-                                    isLocked={isLocked}
-                                    key={`g${group.id}`}
-                                    nodeId={id}
-                                    schemaId={schemaId}
-                                />
-                            );
-                        }
-                        default:
-                            return assertNever(item);
-                    }
-                })}
+                {inputs.map((item) => (
+                    <ItemRenderer
+                        inputData={inputData}
+                        inputSize={inputSize}
+                        isLocked={isLocked}
+                        item={item}
+                        key={getUniqueKey(item)}
+                        nodeId={id}
+                        schemaId={schemaId}
+                    />
+                ))}
             </>
         );
     }


### PR DESCRIPTION
Changes:
- Groups are now allowed to contain groups. 
    - Whether the specific group kind allows child groups is a different question though.
    - Right now, only the conditional enum and optional inputs groups support nested groups.
- Schemata now hold a tree presentation of all inputs+groups (called `group_layout`) instead of a list of groups. This makes it way easier to reconstruct this tree in the frontend.
- Changed conditional enum group. The conditions are now represented as an array. The condition of index _i_ will apply to the item _i+1_ (skipping the enum dropdown). Conditions apply to child groups as a whole.
- Changed group checking to return a reason if the group is invalid.
- Added `ItemRenderer` component that renders groups and inputs. Note that this component give itself to groups as a prop. This is because groups need to render their item trees as well.

---

Note that the components for 2 groups *didn't* change. It turned out that nested groups pretty naturally fit within the flat group system. I'm quite happy with that result.