### PR TITLE
Fixed stuck progress bar

### DIFF
--- a/src/renderer/contexts/ExecutionContext.tsx
+++ b/src/renderer/contexts/ExecutionContext.tsx
@@ -527,6 +527,9 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
         <ExecutionContext.Provider value={value}>
             <ExecutionStatusContext.Provider value={statusValue}>
                 {children}
+                <div style={{ display: 'none' }}>
+                    {status};{percentComplete}
+                </div>
             </ExecutionStatusContext.Provider>
         </ExecutionContext.Provider>
     );

--- a/src/renderer/contexts/ExecutionContext.tsx
+++ b/src/renderer/contexts/ExecutionContext.tsx
@@ -207,15 +207,16 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
     const [percentComplete, setPercentComplete] = useState<number | undefined>(undefined);
 
     useEffect(() => {
-        ipcRenderer.send('set-progress-bar', percentComplete ?? null);
-    }, [percentComplete]);
+        const displayProgress = status === ExecutionStatus.RUNNING ? percentComplete : undefined;
+        ipcRenderer.send('set-progress-bar', displayProgress ?? null);
+    }, [status, percentComplete]);
 
     useEffect(() => {
         if (status !== ExecutionStatus.READY) {
             ipcRenderer.send('start-sleep-blocker');
         } else {
             ipcRenderer.send('stop-sleep-blocker');
-            ipcRenderer.send('set-progress-bar', null);
+            setPercentComplete(undefined);
         }
     }, [status]);
 


### PR DESCRIPTION
This fix consistent of 3 parts:
1. The `percentComplete` state is now the source of truth and the only thing sending to `'set-progress-bar'`.
2. When the current status is "not running", we will (1) reset progress (like before) and (2) never display progress.
3. I added an invisible element to ensure that changes to `status` and `percentComplete` cause DOM changes, which are a requirement for effects to run.