### PR TITLE
Refactor input labels & Add disabled redesign for filled non-gradient sliders

### DIFF
--- a/src/renderer/components/groups/FromToDropdownsGroup.tsx
+++ b/src/renderer/components/groups/FromToDropdownsGroup.tsx
@@ -40,10 +40,7 @@ export const FromToDropdownsGroup = memo(
         const [from, to] = inputs;
 
         return (
-            <InputContainer
-                generic
-                optional={false}
-            >
+            <InputContainer>
                 <HStack
                     mb={2}
                     mt={2}

--- a/src/renderer/components/inputs/InputContainer.tsx
+++ b/src/renderer/components/inputs/InputContainer.tsx
@@ -192,58 +192,66 @@ export const HandleWrapper = memo(
                         onContextMenu={noContextMenu}
                     />
                 </Center>
-                {children}
+                <Box w="full">{children}</Box>
             </HStack>
         );
     }
 );
 
-export interface InputContainerProps {
-    label?: string;
-    optional: boolean;
-    generic: boolean;
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface InputContainerProps {}
+
+export const InputContainer = memo(({ children }: React.PropsWithChildren<InputContainerProps>) => {
+    return (
+        <Box
+            bg="var(--bg-700)"
+            h="auto"
+            ml={0}
+            mr="auto"
+            px={2}
+            verticalAlign="middle"
+            w="full"
+        >
+            {children}
+        </Box>
+    );
+});
+
+interface WithLabelProps {
+    input: {
+        readonly label: string;
+        readonly optional: boolean;
+    };
 }
 
-export const InputContainer = memo(
-    ({ children, label, optional, generic }: React.PropsWithChildren<InputContainerProps>) => {
+export const WithLabel = memo(
+    ({ input: { label, optional }, children }: React.PropsWithChildren<WithLabelProps>) => {
         return (
-            <Box
-                bg="var(--bg-700)"
-                h="auto"
-                minH="2rem"
-                ml={0}
-                mr="auto"
-                px={2}
-                verticalAlign="middle"
-                w="full"
-            >
-                {!generic && (
-                    <Center
-                        h="1.25rem"
-                        px={1}
-                        py={0.5}
-                        verticalAlign="middle"
+            <>
+                <Center
+                    h="1.25rem"
+                    px={1}
+                    py={0.5}
+                    verticalAlign="middle"
+                >
+                    <Text
+                        fontSize="xs"
+                        lineHeight="0.9rem"
+                        textAlign="center"
                     >
-                        <Text
-                            display={label ? 'block' : 'none'}
-                            fontSize="xs"
-                            lineHeight="0.9rem"
-                            textAlign="center"
+                        {label}
+                    </Text>
+                    {optional && (
+                        <Center
+                            h="1rem"
+                            verticalAlign="middle"
                         >
-                            {label}
-                        </Text>
-                        {label && optional && (
-                            <Center
-                                h="1rem"
-                                verticalAlign="middle"
-                            >
-                                <TypeTag isOptional>optional</TypeTag>
-                            </Center>
-                        )}
-                    </Center>
-                )}
-                <Box pb={generic ? 0 : 1}>{children}</Box>
-            </Box>
+                            <TypeTag isOptional>optional</TypeTag>
+                        </Center>
+                    )}
+                </Center>
+                <Box pb={1}>{children}</Box>
+            </>
         );
     }
 );

--- a/src/renderer/components/inputs/SchemaInput.tsx
+++ b/src/renderer/components/inputs/SchemaInput.tsx
@@ -15,7 +15,7 @@ import { DirectoryInput } from './DirectoryInput';
 import { DropDownInput } from './DropDownInput';
 import { FileInput } from './FileInput';
 import { GenericInput } from './GenericInput';
-import { HandleWrapper, InputContainer } from './InputContainer';
+import { HandleWrapper, InputContainer, WithLabel } from './InputContainer';
 import { NumberInput } from './NumberInput';
 import { InputProps } from './props';
 import { SliderInput } from './SliderInput';
@@ -52,15 +52,18 @@ export interface SingleInputProps {
  */
 export const SchemaInput = memo(
     ({ input, schemaId, nodeId, isLocked, inputData, inputSize, onSetValue }: SingleInputProps) => {
-        const { id: inputId, kind, hasHandle, optional, label } = input;
+        const { id: inputId, kind, hasHandle } = input;
 
         const {
             getNodeInputValue,
             setNodeInputValue,
             useInputSize: useInputSizeContext,
         } = useContext(GlobalContext);
-        const definitionType = useContextSelector(BackendContext, (c) =>
-            c.functionDefinitions.get(schemaId)?.inputDefaults.get(inputId)
+        const definitionType = useContextSelector(
+            BackendContext,
+            (c) =>
+                c.functionDefinitions.get(schemaId)?.inputDefaults.get(inputId) ??
+                NeverType.instance
         );
 
         const value = getNodeInputValue(inputId, inputData);
@@ -98,9 +101,9 @@ export const SchemaInput = memo(
         );
 
         const InputType = InputComponents[kind];
-        const inputElement = (
+        let inputElement = (
             <InputType
-                definitionType={definitionType!}
+                definitionType={definitionType}
                 input={input as never}
                 inputKey={`${schemaId}-${inputId}`}
                 isLocked={isLocked}
@@ -113,15 +116,15 @@ export const SchemaInput = memo(
             />
         );
 
+        if (kind !== 'generic' && kind !== 'slider') {
+            inputElement = <WithLabel input={input}>{inputElement}</WithLabel>;
+        }
+
         return (
-            <InputContainer
-                generic={kind === 'generic'}
-                label={label}
-                optional={optional}
-            >
+            <InputContainer>
                 {hasHandle ? (
                     <HandleWrapper
-                        definitionType={definitionType!}
+                        definitionType={definitionType}
                         id={nodeId}
                         inputId={inputId}
                     >

--- a/src/renderer/components/inputs/SliderInput.tsx
+++ b/src/renderer/components/inputs/SliderInput.tsx
@@ -4,7 +4,7 @@ import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { Input, OfKind } from '../../../common/common-types';
 import { assertNever } from '../../../common/util';
 import { AdvancedNumberInput } from './elements/AdvanceNumberInput';
-import { CustomSlider, LINEAR_SCALE, LogScale, Scale, SliderStyle } from './elements/StyledSlider';
+import { LINEAR_SCALE, LogScale, Scale, SliderStyle, StyledSlider } from './elements/StyledSlider';
 import { WithLabel } from './InputContainer';
 import { InputProps } from './props';
 
@@ -108,14 +108,15 @@ export const SliderInput = memo(
             if (!filled) {
                 return { type: 'no-fill' };
             }
-            return { type: 'label', label };
+            // TODO: Use the new label design
+            return { type: 'old-label', label };
         }, [label, gradient, filled]);
 
         const slider = (
             <VStack w="full">
                 <HStack w="full">
                     {ends[0] && <Text fontSize="xs">{ends[0]}</Text>}
-                    <CustomSlider
+                    <StyledSlider
                         def={def}
                         isDisabled={isLocked || isInputConnected}
                         max={max}

--- a/src/renderer/components/inputs/elements/StyledSlider.tsx
+++ b/src/renderer/components/inputs/elements/StyledSlider.tsx
@@ -36,6 +36,10 @@ export class LogScale implements Scale {
     }
 }
 
+interface OldLabelStyle {
+    readonly type: 'old-label';
+    readonly label: string;
+}
 interface LabelStyle {
     readonly type: 'label';
     readonly label: string;
@@ -47,9 +51,9 @@ interface GradientStyle {
 interface NoFillStyle {
     readonly type: 'no-fill';
 }
-export type SliderStyle = LabelStyle | GradientStyle | NoFillStyle;
+export type SliderStyle = OldLabelStyle | LabelStyle | GradientStyle | NoFillStyle;
 
-interface CustomSliderProps {
+interface StyledSliderProps {
     style: SliderStyle;
     scale: Scale;
     isDisabled?: boolean;
@@ -62,7 +66,7 @@ interface CustomSliderProps {
     onChange: (value: number) => void;
     onChangeEnd: (value: number) => void;
 }
-export const CustomSlider = memo(
+export const StyledSlider = memo(
     ({
         style,
         scale,
@@ -75,7 +79,7 @@ export const CustomSlider = memo(
         tooltip,
         onChange,
         onChangeEnd,
-    }: CustomSliderProps) => {
+    }: StyledSliderProps) => {
         const [showTooltip, setShowTooltip] = useState(false);
 
         const [typeAccentColor] = useMemo(() => getTypeAccentColors(NumberType.instance), []);
@@ -135,6 +139,13 @@ export const CustomSlider = memo(
                                 cursor="pointer"
                             />
                         </>
+                    )}
+                    {style.type === 'old-label' && (
+                        <SliderFilledTrack
+                            bg={typeAccentColor}
+                            borderLeftRadius="md"
+                            cursor="pointer"
+                        />
                     )}
                 </SliderTrack>
                 <Tooltip

--- a/src/renderer/components/inputs/elements/StyledSlider.tsx
+++ b/src/renderer/components/inputs/elements/StyledSlider.tsx
@@ -1,0 +1,162 @@
+import { NumberType } from '@chainner/navi';
+import {
+    Box,
+    Slider,
+    SliderFilledTrack,
+    SliderThumb,
+    SliderTrack,
+    Text,
+    Tooltip,
+} from '@chakra-ui/react';
+import { memo, useMemo, useState } from 'react';
+import { getTypeAccentColors } from '../../../helpers/getTypeAccentColors';
+
+export interface Scale {
+    toScale(value: number): number;
+    fromScale(scaledValue: number): number;
+}
+export const LINEAR_SCALE: Scale = { toScale: (n) => n, fromScale: (n) => n };
+export class LogScale implements Scale {
+    public readonly min: number;
+
+    public readonly precision: number;
+
+    constructor(min: number, precision: number) {
+        this.min = min;
+        this.precision = precision;
+    }
+
+    toScale(value: number): number {
+        return Math.log1p(value - this.min);
+    }
+
+    fromScale(scaledValue: number): number {
+        const value = Math.expm1(scaledValue) + this.min;
+        return Number(value.toFixed(this.precision));
+    }
+}
+
+interface LabelStyle {
+    readonly type: 'label';
+    readonly label: string;
+}
+interface GradientStyle {
+    readonly type: 'gradient';
+    readonly gradient: readonly string[];
+}
+interface NoFillStyle {
+    readonly type: 'no-fill';
+}
+export type SliderStyle = LabelStyle | GradientStyle | NoFillStyle;
+
+interface CustomSliderProps {
+    style: SliderStyle;
+    scale: Scale;
+    isDisabled?: boolean;
+    min: number;
+    max: number;
+    def: number;
+    value: number;
+    step: number;
+    tooltip: string;
+    onChange: (value: number) => void;
+    onChangeEnd: (value: number) => void;
+}
+export const CustomSlider = memo(
+    ({
+        style,
+        scale,
+        isDisabled,
+        min,
+        max,
+        def,
+        value,
+        step,
+        tooltip,
+        onChange,
+        onChangeEnd,
+    }: CustomSliderProps) => {
+        const [showTooltip, setShowTooltip] = useState(false);
+
+        const [typeAccentColor] = useMemo(() => getTypeAccentColors(NumberType.instance), []);
+
+        return (
+            <Slider
+                defaultValue={scale.toScale(def)}
+                focusThumbOnChange={false}
+                height={style.type === 'label' ? '1.4em' : '1em'}
+                isDisabled={isDisabled}
+                max={scale.toScale(max)}
+                min={scale.toScale(min)}
+                step={scale === LINEAR_SCALE ? step : 1e-10}
+                value={scale.toScale(value)}
+                onChange={(n) => onChange(scale.fromScale(n))}
+                onChangeEnd={(n) => onChangeEnd(scale.fromScale(n))}
+                onDoubleClick={() => onChangeEnd(def)}
+                onMouseEnter={() => setShowTooltip(true)}
+                onMouseLeave={() => setShowTooltip(false)}
+            >
+                <SliderTrack
+                    bgGradient={
+                        style.type === 'gradient'
+                            ? `linear(to-r, ${style.gradient.join(', ')})`
+                            : 'none'
+                    }
+                    borderRadius="md"
+                    cursor="pointer"
+                    h="100%"
+                >
+                    {style.type === 'label' && (
+                        <>
+                            <Box
+                                color="white"
+                                cursor="pointer"
+                                left={0}
+                                position="absolute"
+                                textAlign="center"
+                                top={0}
+                                userSelect="none"
+                                width="100%"
+                                zIndex={1}
+                            >
+                                <Text
+                                    cursor="pointer"
+                                    fontSize="14px"
+                                    lineHeight="1.4em"
+                                    textAlign="center"
+                                    userSelect="none"
+                                >
+                                    {style.label}
+                                </Text>
+                            </Box>
+                            <SliderFilledTrack
+                                bg={typeAccentColor}
+                                borderLeftRadius="md"
+                                cursor="pointer"
+                            />
+                        </>
+                    )}
+                </SliderTrack>
+                <Tooltip
+                    hasArrow
+                    bg={typeAccentColor}
+                    borderRadius={8}
+                    color="white"
+                    isOpen={showTooltip}
+                    label={tooltip}
+                    placement="top"
+                    px={2}
+                    py={1}
+                >
+                    <SliderThumb
+                        borderRadius="sm"
+                        height="100%"
+                        opacity={style.type === 'label' ? 0 : 1}
+                        width="8px"
+                        zIndex={3}
+                    />
+                </Tooltip>
+            </Slider>
+        );
+    }
+);


### PR DESCRIPTION
As discussed on discord.

I also needed to refactor how labels get added to input. It's a bit hacky, but it works for now. Basically, there is a new `WithLabel` wrapper component that adds the label. Generic inputs don't get a label, slider inputs decides itself whether it wants a label, and all other inputs get a label.

---

![image](https://user-images.githubusercontent.com/20878432/206222945-0aed2519-2b24-41b0-ab62-de5eecdcab61.png)
