### PR TITLE
Made text of dropdown options larger

### DIFF
--- a/src/renderer/components/inputs/DropDownInput.tsx
+++ b/src/renderer/components/inputs/DropDownInput.tsx
@@ -44,6 +44,7 @@ export const DropDownInput = memo(({ value, setValue, input, isLocked }: DropDow
             {options.map(({ option }, index) => (
                 <option
                     key={option}
+                    style={{ fontSize: '120%' }}
                     value={index}
                 >
                     {option}


### PR DESCRIPTION
Kim noted that dropdown options use very small text now and I agree. I made them 20% bigger, so they are pretty each to read now.

![image](https://user-images.githubusercontent.com/20878432/206534080-93b83dae-b13d-4897-8f03-0da5f72eea45.png)
