### PR TITLE
Fixed DDS's rename not working across drives

### DIFF
--- a/backend/src/nodes/utils/dds.py
+++ b/backend/src/nodes/utils/dds.py
@@ -110,14 +110,29 @@ def save_as_dds(
     See the following page for more information on save options:
     https://github.com/Microsoft/DirectXTex/wiki/Texconv
     """
+    full_name = os.path.basename(path)
+    target_dir = os.path.dirname(path)
+    name, ext = os.path.splitext(full_name)
+
+    assert ext == ".dds", "The file to save must end with '.dds'"
+
     tempDir = mkdtemp(prefix="chaiNNer-")
 
     try:
-        tempName = uuid.uuid4().hex
-        tempPng = os.path.join(tempDir, f"{tempName}.png")
+        tempPng = os.path.join(tempDir, f"{name}.png")
         cv_save_image(tempPng, image, [])
 
-        args = ["-f", dds_format, "-dx10", "-m", str(mipmap_levels), "-o", tempDir]
+        args = [
+            "-y",
+            "-f",
+            dds_format,
+            "-dx10",
+            "-m",
+            str(mipmap_levels),
+            # use texconv to directly produce the target file
+            "-o",
+            target_dir,
+        ]
 
         bc = ""
         bc += "u" if uniform_weighting else ""
@@ -132,15 +147,5 @@ def save_as_dds(
 
         args.append(tempPng)
         __run_texconv(args, "Unable to write DDS")
-
-        tempDds = os.path.join(tempDir, f"{tempName}.dds")
-
-        # delete existing file
-        try:
-            os.remove(path)
-        except:
-            pass
-
-        os.rename(tempDds, path)
     finally:
         shutil.rmtree(tempDir)


### PR DESCRIPTION
Fixes [this issue](https://discord.com/channels/930865462852591648/930865725135011851/1050785149115187300) reported on discord. `save_as_dds` will now use texconv to directly create the final file, instead of creating a temporary DDS file and then renaming it. This worked surprisingly well. I honestly expected texconv to error on Unicode file names, but (unlike certain other encoders) it just worked.