### PR TITLE
Properly center handle

### DIFF
--- a/src/renderer/components/inputs/InputContainer.tsx
+++ b/src/renderer/components/inputs/InputContainer.tsx
@@ -148,6 +148,7 @@ export const HandleWrapper = memo(
         return (
             <HStack h="full">
                 <Center
+                    className="chainner-handle"
                     left="-6px"
                     position="absolute"
                 >
@@ -192,7 +193,7 @@ export const HandleWrapper = memo(
                         onContextMenu={noContextMenu}
                     />
                 </Center>
-                <Box w="full">{children}</Box>
+                {children}
             </HStack>
         );
     }
@@ -227,7 +228,10 @@ interface WithLabelProps {
 export const WithLabel = memo(
     ({ input: { label, optional }, children }: React.PropsWithChildren<WithLabelProps>) => {
         return (
-            <>
+            <Box
+                className="with-label"
+                w="full"
+            >
                 <Center
                     h="1.25rem"
                     px={1}
@@ -251,7 +255,21 @@ export const WithLabel = memo(
                     )}
                 </Center>
                 <Box pb={1}>{children}</Box>
-            </>
+            </Box>
+        );
+    }
+);
+
+export const WithoutLabel = memo(
+    ({ children }: React.PropsWithChildren<Record<string, unknown>>) => {
+        return (
+            <Box
+                className="without-label"
+                py={1}
+                w="full"
+            >
+                {children}
+            </Box>
         );
     }
 );

--- a/src/renderer/components/inputs/SliderInput.tsx
+++ b/src/renderer/components/inputs/SliderInput.tsx
@@ -1,11 +1,11 @@
 import { isNumericLiteral } from '@chainner/navi';
-import { Box, HStack, Text, VStack } from '@chakra-ui/react';
+import { HStack, Text, VStack } from '@chakra-ui/react';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { Input, OfKind } from '../../../common/common-types';
 import { assertNever } from '../../../common/util';
 import { AdvancedNumberInput } from './elements/AdvanceNumberInput';
 import { LINEAR_SCALE, LogScale, Scale, SliderStyle, StyledSlider } from './elements/StyledSlider';
-import { WithLabel } from './InputContainer';
+import { WithLabel, WithoutLabel } from './InputContainer';
 import { InputProps } from './props';
 
 const parseScale = (
@@ -150,7 +150,7 @@ export const SliderInput = memo(
         );
 
         if (sliderStyle.type === 'label') {
-            return <Box py={1}>{slider}</Box>;
+            return <WithoutLabel>{slider}</WithoutLabel>;
         }
 
         return <WithLabel input={input}>{slider}</WithLabel>;

--- a/src/renderer/global.scss
+++ b/src/renderer/global.scss
@@ -144,3 +144,7 @@ body {
         z-index: 100000;
     }
 }
+
+.chainner-handle:has(+ .with-label) {
+    margin-top: 1rem;
+}


### PR DESCRIPTION
The basic idea is that inputs are now required to be wrapped in either `WithLabel` or `WithoutLabel`. We then have some style that detect which one is used and offsets the handle accordingly. The offset margin was determined experimentally. It centers the handle pixel perfectly.

![image](https://user-images.githubusercontent.com/20878432/206816061-1053cacf-18e8-4fd3-992d-089196f65366.png)
