### PR TITLE
Added support for Lab and LCh color spaces

### DIFF
--- a/backend/src/nodes/utils/color/convert_data.py
+++ b/backend/src/nodes/utils/color/convert_data.py
@@ -1,4 +1,5 @@
 from typing import List, Union, Tuple
+import math
 import numpy as np
 import cv2
 
@@ -16,17 +17,25 @@ CMYK = ColorSpace(6, "CMYK", 4)
 YUVA = ColorSpace(7, "YUVA", 4)
 HSVA = ColorSpace(8, "HSVA", 4)
 HSLA = ColorSpace(9, "HSLA", 4)
+LAB = ColorSpace(10, "L*a*b*", 3)
+LABA = ColorSpace(11, "L*a*b*A", 4)
+LCH = ColorSpace(12, "L*C*h°", 3)
+LCHA = ColorSpace(13, "L*C*h°A", 4)
 
 RGB_LIKE = ColorSpaceDetector(1000, "RGB", [GRAY, RGB, RGBA])
 YUV_LIKE = ColorSpaceDetector(1001, "YUV", [YUV, YUVA])
 HSV_LIKE = ColorSpaceDetector(1002, "HSV", [HSV, HSVA])
 HSL_LIKE = ColorSpaceDetector(1003, "HSL", [HSL, HSLA])
+LAB_LIKE = ColorSpaceDetector(1004, "L*a*b*", [LAB, LABA])
+LCH_LIKE = ColorSpaceDetector(1005, "L*C*h°", [LCH, LCHA])
 
 ALPHA_PAIRS: List[Tuple[ColorSpace, ColorSpace]] = [
     (RGB, RGBA),
     (YUV, YUVA),
     (HSV, HSVA),
     (HSL, HSLA),
+    (LAB, LABA),
+    (LCH, LCHA),
 ]
 
 color_spaces: List[ColorSpace] = [
@@ -40,6 +49,10 @@ color_spaces: List[ColorSpace] = [
     HSL,
     HSLA,
     CMYK,
+    LAB,
+    LABA,
+    LCH,
+    LCHA,
 ]
 color_spaces_or_detectors: List[Union[ColorSpace, ColorSpaceDetector]] = [
     RGB_LIKE,
@@ -48,6 +61,8 @@ color_spaces_or_detectors: List[Union[ColorSpace, ColorSpaceDetector]] = [
     HSV_LIKE,
     HSL_LIKE,
     CMYK,
+    LAB_LIKE,
+    LCH_LIKE,
 ]
 
 
@@ -122,6 +137,46 @@ def __cmyk_to_rgb(img: np.ndarray) -> np.ndarray:
     return cv2.merge((b, g, r))
 
 
+def __rgb_to_lab(img: np.ndarray) -> np.ndarray:
+    # 0≤L≤100 , −127≤a≤127, −127≤b≤127
+    img = cv2.cvtColor(img, cv2.COLOR_BGR2LAB)
+    l = img[:, :, 0] / 100
+    a = (img[:, :, 1] + 127) / 254
+    b = (img[:, :, 2] + 127) / 254
+    return cv2.merge((b, a, l))
+
+
+def __lab_to_rgb(img: np.ndarray) -> np.ndarray:
+    # 0≤L≤100 , −127≤a≤127, −127≤b≤127
+    l = img[:, :, 2] * 100
+    a = img[:, :, 1] * 254 - 127
+    b = img[:, :, 0] * 254 - 127
+    return cv2.cvtColor(cv2.merge((l, a, b)), cv2.COLOR_LAB2BGR)
+
+
+def __lab_to_lch(img: np.ndarray) -> np.ndarray:
+    l = img[:, :, 2]
+    # a and b must be centered at 0
+    a = img[:, :, 1] - 0.5
+    b = img[:, :, 0] - 0.5
+
+    # calculate c and h and normalize them to [0,1]
+    c = np.hypot(a, b) / math.sqrt(0.5)
+    h = np.arctan2(b, a) / (math.pi * 2) + 0.5
+    return cv2.merge((h, c, l))
+
+
+def __lch_to_lab(img: np.ndarray) -> np.ndarray:
+    l = img[:, :, 2]
+    # undo the c and h [0,1] normalization
+    c = img[:, :, 1] * math.sqrt(0.5)
+    h = (img[:, :, 0] - 0.5) * (math.pi * 2)
+
+    a = c * np.cos(h) + 0.5
+    b = c * np.sin(h) + 0.5
+    return cv2.merge((b, a, l))
+
+
 # The conversion loses one channel of information (e.g. the alpha channel, or a color channel)
 __CHANNEL_LOST = 1000
 # The conversion loses hue/chroma information in certain edge cases
@@ -193,6 +248,25 @@ conversions: List[Conversion] = [
     Conversion(
         direction=(CMYK, RGB),
         convert=__cmyk_to_rgb,
+        cost=__CHROMA_LOST,
+    ),
+    # LAB
+    Conversion(
+        direction=(RGB, LAB),
+        convert=__rgb_to_lab,
+    ),
+    Conversion(
+        direction=(LAB, RGB),
+        convert=__lab_to_rgb,
+    ),
+    # LCH
+    Conversion(
+        direction=(LAB, LCH),
+        convert=__lab_to_lch,
+    ),
+    Conversion(
+        direction=(LCH, LAB),
+        convert=__lch_to_lab,
         cost=__CHROMA_LOST,
     ),
 ]


### PR DESCRIPTION
This adds L*a*b* and L*C*h° support for Convert Colorspace.

While L*a*b* is supported by OpenCV, I had to implement LCh myself. I used [the formulas from Wikipedia](https://en.wikipedia.org/wiki/CIELAB_color_space#CIEHLC_cylindrical_model) to convert Lab <-> LCh. The conversion to LCh is relatively straightforward except for one thing: C normalization. We need values [0,1], but C is a bit more difficult to normalize because the maximum value of C depends on h. I have a lengthy comment explaining the problem and the solution. The end result is that all possible values of LCh are valid colors, which is a very nice property. This property also makes it possible to implement #1318 since PS seems to use LCh as well.

Lab:
![image](https://user-images.githubusercontent.com/20878432/206858472-3e3f8120-c6a3-4aa8-abdd-664eab9f04ab.png)

LCh
![image](https://user-images.githubusercontent.com/20878432/206859841-67e77594-5511-4472-8e4d-472883b3bd48.png)
