### PR TITLE
increase default codeformer weight to 0.7

### DIFF
--- a/backend/src/nodes/nodes/pytorch/upscale_face.py
+++ b/backend/src/nodes/nodes/pytorch/upscale_face.py
@@ -152,7 +152,7 @@ class FaceUpscaleNode(NodeBase):
             exec_options = to_pytorch_execution_options(get_execution_options())
             device = torch.device(exec_options.full_device)
 
-            weight = 0.5
+            weight = 0.7
 
             with torch.no_grad():
                 appdata_path = user_data_dir(roaming=True)


### PR DESCRIPTION
as discussed on discord, 0.7 is seemingly a better weight to use by default until we can customize this
