### PR TITLE
Simpler generic input

### DIFF
--- a/src/renderer/components/inputs/GenericInput.tsx
+++ b/src/renderer/components/inputs/GenericInput.tsx
@@ -1,37 +1,26 @@
 import { Box, Center, Text } from '@chakra-ui/react';
 import { memo } from 'react';
 import { TypeTags } from '../TypeTag';
+import { WithoutLabel } from './InputContainer';
 import { InputProps } from './props';
 
 export const GenericInput = memo(({ input, definitionType }: InputProps<'generic'>) => {
     const { label, optional } = input;
 
     return (
-        // These both need to have -1 margins to thin it out... I don't know why
-        <Box
-            display="flex"
-            flexDirection="row"
-            h="full"
-            minH="2rem"
-            verticalAlign="middle"
-            w="full"
-        >
-            <Text
-                h="full"
-                lineHeight="2rem"
-                textAlign="left"
+        <WithoutLabel>
+            <Box
+                display="flex"
+                flexDirection="row"
             >
-                {label}
-            </Text>
-            <Center
-                h="2rem"
-                verticalAlign="middle"
-            >
-                <TypeTags
-                    isOptional={optional}
-                    type={definitionType}
-                />
-            </Center>
-        </Box>
+                <Text>{label}</Text>
+                <Center>
+                    <TypeTags
+                        isOptional={optional}
+                        type={definitionType}
+                    />
+                </Center>
+            </Box>
+        </WithoutLabel>
     );
 });


### PR DESCRIPTION
I simplified the markup of our generic inputs a bit. They look exactly the same as before (pixel for pixel).