### PR TITLE
Removed Window menu

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -112,9 +112,7 @@ export const setMainMenu = ({ mainWindow, menuData, enabled = false }: MainMenuA
                     enabled,
                 },
                 { type: 'separator' },
-                isMac
-                    ? { role: 'close', enabled, accelerator: 'CmdOrCtrl+Q' }
-                    : { role: 'quit', enabled, accelerator: 'CmdOrCtrl+Q' },
+                isMac ? { role: 'close', enabled } : { role: 'quit', enabled },
             ],
         },
         {

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -112,7 +112,9 @@ export const setMainMenu = ({ mainWindow, menuData, enabled = false }: MainMenuA
                     enabled,
                 },
                 { type: 'separator' },
-                isMac ? { role: 'close', enabled } : { role: 'quit', enabled },
+                isMac
+                    ? { role: 'close', enabled, accelerator: 'CmdOrCtrl+Q' }
+                    : { role: 'quit', enabled, accelerator: 'CmdOrCtrl+Q' },
             ],
         },
         {
@@ -177,21 +179,6 @@ export const setMainMenu = ({ mainWindow, menuData, enabled = false }: MainMenuA
                 { role: 'zoomOut', enabled },
                 { type: 'separator' },
                 { role: 'togglefullscreen' },
-            ],
-        },
-        {
-            label: 'Window',
-            submenu: [
-                { role: 'minimize' },
-                { role: 'zoom', enabled },
-                ...(isMac
-                    ? [
-                          { type: 'separator' },
-                          { role: 'front', enabled },
-                          { type: 'separator' },
-                          { role: 'window', enabled },
-                      ]
-                    : [{ role: 'close', enabled }]),
                 ...(!app.isPackaged ? [{ type: 'separator' }, { role: 'toggleDevTools' }] : []),
             ],
         },


### PR DESCRIPTION
Kim mentioned before that the *Zoom* entry under *Window* just does nothing. Since nothing, aside from *Toggle Dev Tools*, in Window seemed useful, I just removed it and moved the dev tools entry into *View*.

I also gave *Exit* a shortcut.

![image](https://user-images.githubusercontent.com/20878432/207106515-7723dde6-af34-44da-a5c5-37bc8ac9fe03.png)
![image](https://user-images.githubusercontent.com/20878432/207106630-ab9429ba-5df8-414d-8077-a02c02729e29.png)
