### PR TITLE
Removed unnecessary `as_2d_grayscale` call

### DIFF
--- a/backend/src/nodes/utils/image_utils.py
+++ b/backend/src/nodes/utils/image_utils.py
@@ -218,7 +218,6 @@ def as_target_channels(img: np.ndarray, target_channels: int) -> np.ndarray:
 
     if target_channels == 3:
         if c == 1:
-            img = as_2d_grayscale(img)
             return np.dstack((img, img, img))
 
     if target_channels == 4:


### PR DESCRIPTION
As pointed out by @theflyingzamboni [here](https://github.com/chaiNNer-org/chaiNNer/pull/1366#issuecomment-1346851966).