### PR TITLE
Shorter directory type tags

### DIFF
--- a/src/renderer/components/TypeTag.tsx
+++ b/src/renderer/components/TypeTag.tsx
@@ -120,7 +120,7 @@ const TagRenderer = memo(({ tag }: { tag: TagValue }) => {
 
     switch (kind) {
         case 'path': {
-            const maxLength = 16;
+            const maxLength = 14;
             return (
                 <Tooltip
                     hasArrow


### PR DESCRIPTION
I noticed that directory type tags are now causing Load Image nodes to become wider because of the more compact design. I tried to fix this by making the tag 2 chars shorter. 

While this does help, we really need a general solution for type tags causing nodes to widen, but I don't have any...