### PR TITLE
Added missing error throw

### DIFF
--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -99,6 +99,10 @@ const processBackendResponse = (rawResponse: BackendNodesResponse): NodesInfo =>
         }
     }
 
+    if (errors.length) {
+        throw new Error(errors.join('\n\n'));
+    }
+
     return {
         rawResponse,
         schemata,


### PR DESCRIPTION
When I added input type declarations, I accidentally moved the `if (errors.length) throw` instead of copying it. So type errors did not cause the frontend to error and display that error anymore, it would just awkwardly move on and produce confusing errors later on.