### PR TITLE
Immediate output types for directories and file names

### DIFF
--- a/backend/src/nodes/nodes/image/load_image.py
+++ b/backend/src/nodes/nodes/image/load_image.py
@@ -13,7 +13,7 @@ from . import category as ImageCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import ImageFileInput
-from ...properties.outputs import LargeImageOutput, DirectoryOutput, TextOutput
+from ...properties.outputs import LargeImageOutput, DirectoryOutput, FileNameOutput
 from ...impl.dds import dds_to_png_texconv
 from ...impl.image_formats import get_opencv_formats, get_pil_formats
 from ...impl.image_utils import normalize
@@ -28,8 +28,8 @@ class ImReadNode(NodeBase):
         self.inputs = [ImageFileInput(primary_input=True)]
         self.outputs = [
             LargeImageOutput(),
-            DirectoryOutput("Image Directory"),
-            TextOutput("Image Name"),
+            DirectoryOutput("Image Directory", of_input=0),
+            FileNameOutput("Image Name", of_input=0),
         ]
 
         self.category = ImageCategory

--- a/backend/src/nodes/nodes/ncnn/load_model.py
+++ b/backend/src/nodes/nodes/ncnn/load_model.py
@@ -6,7 +6,7 @@ from typing import Tuple
 from ...node_base import NodeBase, group
 from ...node_factory import NodeFactory
 from ...properties.inputs import BinFileInput, ParamFileInput
-from ...properties.outputs import NcnnModelOutput, TextOutput
+from ...properties.outputs import NcnnModelOutput, FileNameOutput
 from ...impl.ncnn.model import NcnnModel, NcnnModelWrapper
 from ...impl.ncnn.optimizer import NcnnOptimizer
 from . import category as NCNNCategory
@@ -25,7 +25,7 @@ class NcnnLoadModelNode(NodeBase):
         ]
         self.outputs = [
             NcnnModelOutput(kind="ncnn", should_broadcast=True),
-            TextOutput("Model Name"),
+            FileNameOutput("Model Name", of_input=0),
         ]
 
         self.category = NCNNCategory

--- a/backend/src/nodes/nodes/onnx/load_model.py
+++ b/backend/src/nodes/nodes/onnx/load_model.py
@@ -10,7 +10,7 @@ from . import category as ONNXCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import OnnxFileInput
-from ...properties.outputs import OnnxModelOutput, DirectoryOutput, TextOutput
+from ...properties.outputs import OnnxModelOutput, DirectoryOutput, FileNameOutput
 from ...impl.onnx.model import OnnxModel
 
 
@@ -24,8 +24,8 @@ class OnnxLoadModelNode(NodeBase):
         self.inputs = [OnnxFileInput(primary_input=True)]
         self.outputs = [
             OnnxModelOutput(),
-            DirectoryOutput("Model Directory").with_id(2),
-            TextOutput("Model Name").with_id(1),
+            DirectoryOutput("Model Directory", of_input=0).with_id(2),
+            FileNameOutput("Model Name", of_input=0).with_id(1),
         ]
 
         self.category = ONNXCategory

--- a/backend/src/nodes/nodes/pytorch/load_model.py
+++ b/backend/src/nodes/nodes/pytorch/load_model.py
@@ -10,7 +10,7 @@ from . import category as PyTorchCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import PthFileInput
-from ...properties.outputs import ModelOutput, DirectoryOutput, TextOutput
+from ...properties.outputs import ModelOutput, DirectoryOutput, FileNameOutput
 from ...utils.exec_options import get_execution_options
 from ...impl.pytorch.types import PyTorchModel
 from ...impl.pytorch.model_loading import load_state_dict
@@ -29,8 +29,8 @@ class LoadModelNode(NodeBase):
         self.inputs = [PthFileInput(primary_input=True)]
         self.outputs = [
             ModelOutput(kind="pytorch", should_broadcast=True),
-            DirectoryOutput("Model Directory").with_id(2),
-            TextOutput("Model Name").with_id(1),
+            DirectoryOutput("Model Directory", of_input=0).with_id(2),
+            FileNameOutput("Model Name", of_input=0).with_id(1),
         ]
 
         self.category = PyTorchCategory

--- a/backend/src/nodes/properties/inputs/base_input.py
+++ b/backend/src/nodes/properties/inputs/base_input.py
@@ -25,6 +25,7 @@ class BaseInput:
     ):
         self.input_type: expression.ExpressionJson = input_type
         self.input_conversion: expression.ExpressionJson | None = None
+        self.input_adapt: expression.ExpressionJson | None = None
         self.type_definitions: str | None = None
         self.kind: InputKind = kind
         self.label: str = label
@@ -53,6 +54,7 @@ class BaseInput:
             "id": self.id,
             "type": actual_type,
             "conversion": self.input_conversion,
+            "adapt": self.input_adapt,
             "typeDefinitions": self.type_definitions,
             "kind": self.kind,
             "label": self.label,

--- a/backend/src/nodes/properties/inputs/file_inputs.py
+++ b/backend/src/nodes/properties/inputs/file_inputs.py
@@ -5,7 +5,6 @@ import os
 
 # pylint: disable=relative-beyond-top-level
 from ...impl.image_formats import get_available_image_formats
-from .. import expression
 from .base_input import BaseInput
 from .generic_inputs import DropDownInput
 
@@ -25,17 +24,24 @@ class FileInput(BaseInput):
 
     def __init__(
         self,
-        input_type: expression.ExpressionJson,
+        input_type_name: str,
         label: str,
         file_kind: FileInputKind,
         filetypes: list[str],
         has_handle: bool = False,
         primary_input: bool = False,
     ):
-        super().__init__(input_type, label, kind="file", has_handle=has_handle)
+        super().__init__(input_type_name, label, kind="file", has_handle=has_handle)
         self.filetypes = filetypes
         self.file_kind = file_kind
         self.primary_input = primary_input
+
+        self.input_adapt = f"""
+            match Input {{
+                string as path => {input_type_name} {{ path: path }},
+                _ => never
+            }}
+        """
 
     def toDict(self):
         return {
@@ -55,7 +61,7 @@ class FileInput(BaseInput):
 def ImageFileInput(primary_input: bool = False) -> FileInput:
     """Input for submitting a local image file"""
     return FileInput(
-        input_type="ImageFile",
+        input_type_name="ImageFile",
         label="Image File",
         file_kind="image",
         filetypes=get_available_image_formats(),
@@ -67,7 +73,7 @@ def ImageFileInput(primary_input: bool = False) -> FileInput:
 def VideoFileInput() -> FileInput:
     """Input for submitting a local video file"""
     return FileInput(
-        input_type="VideoFile",
+        input_type_name="VideoFile",
         label="Video File",
         file_kind="video",
         filetypes=[
@@ -90,7 +96,7 @@ def VideoFileInput() -> FileInput:
 def PthFileInput(primary_input: bool = False) -> FileInput:
     """Input for submitting a local .pth file"""
     return FileInput(
-        input_type="PthFile",
+        input_type_name="PthFile",
         label="Pretrained Model",
         file_kind="pth",
         filetypes=[".pth"],
@@ -103,6 +109,13 @@ class DirectoryInput(BaseInput):
 
     def __init__(self, label: str = "Base Directory", has_handle: bool = False):
         super().__init__("Directory", label, kind="directory", has_handle=has_handle)
+
+        self.input_adapt = """
+            match Input {
+                string as path => Directory { path: path },
+                _ => never
+            }
+        """
 
     def enforce(self, value):
         assert os.path.exists(value), f"Directory {value} does not exist"
@@ -154,7 +167,7 @@ def ImageExtensionDropdown() -> DropDownInput:
 def BinFileInput(primary_input: bool = False) -> FileInput:
     """Input for submitting a local .bin file"""
     return FileInput(
-        input_type="NcnnBinFile",
+        input_type_name="NcnnBinFile",
         label="NCNN Bin File",
         file_kind="bin",
         filetypes=[".bin"],
@@ -165,7 +178,7 @@ def BinFileInput(primary_input: bool = False) -> FileInput:
 def ParamFileInput(primary_input: bool = False) -> FileInput:
     """Input for submitting a local .param file"""
     return FileInput(
-        input_type="NcnnParamFile",
+        input_type_name="NcnnParamFile",
         label="NCNN Param File",
         file_kind="param",
         filetypes=[".param"],
@@ -176,7 +189,7 @@ def ParamFileInput(primary_input: bool = False) -> FileInput:
 def OnnxFileInput(primary_input: bool = False) -> FileInput:
     """Input for submitting a local .onnx file"""
     return FileInput(
-        input_type="OnnxFile",
+        input_type_name="OnnxFile",
         label="ONNX Model File",
         file_kind="onnx",
         filetypes=[".onnx"],

--- a/backend/src/nodes/properties/outputs/file_outputs.py
+++ b/backend/src/nodes/properties/outputs/file_outputs.py
@@ -26,11 +26,21 @@ def ImageFileOutput() -> FileOutput:
     return FileOutput("ImageFile", "Image File")
 
 
-def DirectoryOutput(label: str = "Directory") -> FileOutput:
-    """Output for saving to a directory"""
-    return FileOutput("Directory", label, kind="directory")
-
-
 def OnnxFileOutput() -> FileOutput:
     """Output for saving a .onnx file"""
     return FileOutput("OnnxFile", "ONNX Model File")
+
+
+def DirectoryOutput(
+    label: str = "Directory", of_input: int | None = None
+) -> FileOutput:
+    """Output for saving to a directory"""
+    directory_type = (
+        "Directory" if of_input is None else f"splitFilePath(Input{of_input}.path).dir"
+    )
+
+    return FileOutput(
+        file_type=directory_type,
+        label=label,
+        kind="directory",
+    )

--- a/backend/src/nodes/properties/outputs/generic_outputs.py
+++ b/backend/src/nodes/properties/outputs/generic_outputs.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .base_output import BaseOutput, OutputKind
 from .. import expression
 
@@ -28,3 +29,13 @@ class TextOutput(BaseOutput):
 
     def validate(self, value) -> None:
         assert isinstance(value, str)
+
+
+def FileNameOutput(label: str = "Name", of_input: int | None = None):
+    output_type = (
+        "string"
+        if of_input is None
+        else f"splitFilePath(Input{of_input}.path).basename"
+    )
+
+    return TextOutput(label=label, output_type=output_type)

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -27,7 +27,22 @@ export type InputSchemaValue = string | number;
 interface InputBase {
     readonly id: InputId;
     readonly type: ExpressionJson;
+    /**
+     * Optional type conversion that occurs before the type system checks
+     * whether 2 types are compatible.
+     *
+     * This can be used to implement e.g. number rounding or type wrapping for
+     * edges.
+     */
     readonly conversion?: ExpressionJson | null;
+    /**
+     * Optional type conversion for adapting input data.
+     *
+     * The frontend stores input data as numbers and strings, but inputs may
+     * use different types. This optional conversion allows inputs to convert
+     * input data to compatible types. E.g. the directory input wraps its path.
+     */
+    readonly adapt?: ExpressionJson | null;
     readonly typeDefinitions?: string | null;
     readonly kind: InputKind;
     readonly label: string;

--- a/src/common/types/chainner-builtin.ts
+++ b/src/common/types/chainner-builtin.ts
@@ -5,11 +5,13 @@ import {
     StringPrimitive,
     StringType,
     StructType,
+    StructTypeField,
     ValueType,
     builtin,
     intersect,
     literal,
 } from '@chainner/navi';
+import path from 'path';
 
 type ReplacementToken =
     | { type: 'literal'; value: string }
@@ -218,3 +220,31 @@ export const padCenter = builtin.wrapTernary<
         return NeverType.instance;
     }
 });
+
+export const splitFilePath = builtin.wrapUnary<StringPrimitive, StructType>(
+    (filePath: StringPrimitive) => {
+        if (filePath.type === 'literal') {
+            const base = path.basename(filePath.value);
+            const ext = path.extname(base);
+            const basename = ext ? base.slice(0, -ext.length) : base;
+            return new StructType('SplitFilePath', [
+                new StructTypeField(
+                    'dir',
+                    new StructType('Directory', [
+                        new StructTypeField('path', literal(path.dirname(filePath.value))),
+                    ])
+                ),
+                new StructTypeField('basename', literal(basename)),
+                new StructTypeField('ext', literal(ext)),
+            ]);
+        }
+        return new StructType('SplitFilePath', [
+            new StructTypeField(
+                'dir',
+                new StructType('Directory', [new StructTypeField('path', StringType.instance)])
+            ),
+            new StructTypeField('basename', StringType.instance),
+            new StructTypeField('ext', StringType.instance),
+        ]);
+    }
+);

--- a/src/common/types/chainner-scope.ts
+++ b/src/common/types/chainner-scope.ts
@@ -12,7 +12,7 @@ import {
     union,
 } from '@chainner/navi';
 import { lazy } from '../util';
-import { formatTextPattern, padCenter, padEnd, padStart } from './chainner-builtin';
+import { formatTextPattern, padCenter, padEnd, padStart, splitFilePath } from './chainner-builtin';
 
 const code = `
 struct null;
@@ -22,18 +22,18 @@ struct Directory { path: string }
 struct AudioFile;
 struct Audio;
 
-struct ImageFile;
+struct ImageFile { path: string }
 struct Image {
     width: uint,
     height: uint,
     channels: int(1..),
 }
 
-struct VideoFile;
+struct VideoFile { path: string }
 struct Video;
 
-struct PthFile;
-struct PtFile;
+struct PthFile { path: string }
+struct PtFile { path: string }
 struct PyTorchScript;
 struct PyTorchModel {
     scale: int(1..),
@@ -52,8 +52,8 @@ let PyTorchSRModel = PyTorchModel {
     subType: "SR"
 };
 
-struct NcnnBinFile;
-struct NcnnParamFile;
+struct NcnnBinFile { path: string }
+struct NcnnParamFile { path: string }
 struct NcnnNetwork {
     scale: int(1..),
     inputChannels: int(1..),
@@ -62,7 +62,7 @@ struct NcnnNetwork {
     fp: string,
 }
 
-struct OnnxFile;
+struct OnnxFile { path: string }
 struct OnnxModel {
     scale: int(1..),
     inputChannels: int(1..),
@@ -138,6 +138,12 @@ def convenientUpscale(model: PyTorchModel | NcnnNetwork | OnnxModel, image: Imag
         }
     }
 }
+
+struct SplitFilePath {
+    dir: Directory,
+    basename: string,
+    ext: string,
+}
 `;
 
 export const getChainnerScope = lazy((): Scope => {
@@ -177,6 +183,9 @@ export const getChainnerScope = lazy((): Scope => {
             intInterval(0, Infinity),
             StringType.instance,
         ])
+    );
+    builder.add(
+        BuiltinFunctionDefinition.unary('splitFilePath', splitFilePath, StringType.instance)
     );
 
     return builder.createScope();

--- a/src/common/types/function.ts
+++ b/src/common/types/function.ts
@@ -1,14 +1,19 @@
 import {
+    AnyType,
     Expression,
     NonNeverType,
+    NumberType,
     ParameterDefinition,
     Scope,
     ScopeBuilder,
+    StringType,
     Type,
     evaluate,
     getReferences,
     intersect,
     isDisjointWith,
+    literal,
+    union,
 } from '@chainner/navi';
 import { Input, InputId, InputSchemaValue, NodeSchema, Output, OutputId } from '../common-types';
 import { EMPTY_MAP, lazyKeyed, topologicalSort } from '../util';
@@ -189,39 +194,81 @@ const evaluateOutputs = (
     return { ordered, defaults };
 };
 
-const evaluateInputOptions = (
+const getInputDataAdapters = (
     schema: NodeSchema,
     scope: Scope
-): Map<InputId, Map<InputSchemaValue, NonNeverType>> => {
-    const result = new Map<InputId, Map<InputSchemaValue, NonNeverType>>();
-    for (const input of schema.inputs) {
-        if (input.kind === 'dropdown') {
-            const options = new Map<InputSchemaValue, NonNeverType>();
-            result.set(input.id, options);
-            for (const o of input.options) {
-                if (o.type !== undefined) {
-                    const name =
-                        `${o.option}=${JSON.stringify(o.value)} ` +
-                        `in (id: ${schema.schemaId}) > ${input.label} (id: ${input.id})`;
+): ReadonlyMap<InputId, (value: InputSchemaValue) => NonNeverType | undefined> => {
+    const adapters = new Map<InputId, (value: InputSchemaValue) => NonNeverType | undefined>();
 
-                    let type;
+    for (const input of schema.inputs) {
+        const inputName = `${schema.name} (id: ${schema.schemaId}) > ${input.label} (id: ${input.id})`;
+
+        switch (input.kind) {
+            case 'number':
+            case 'slider':
+            case 'text':
+            case 'text-line': {
+                adapters.set(input.id, (value) => literal(value as never));
+                break;
+            }
+
+            case 'dropdown': {
+                const options = new Map<InputSchemaValue, NonNeverType>();
+                for (const o of input.options) {
+                    if (o.type !== undefined) {
+                        const name = `${o.option}=${JSON.stringify(o.value)} in ${inputName}`;
+
+                        let type;
+                        try {
+                            type = evaluate(fromJson(o.type), scope);
+                        } catch (error) {
+                            throw new Error(
+                                `Unable to evaluate type of option ${name}: ${String(error)}`
+                            );
+                        }
+                        if (type.type === 'never') {
+                            throw new Error(`Type of ${name} cannot be 'never'.`);
+                        }
+
+                        options.set(o.value, type);
+                    }
+                }
+                adapters.set(input.id, (value) => options.get(value));
+                break;
+            }
+
+            default: {
+                if (input.adapt != null) {
+                    const adoptExpression = fromJson(input.adapt);
+                    const conversionScope = getConversionScope(scope);
+
+                    // verify that it's a valid conversion
                     try {
-                        type = evaluate(fromJson(o.type), scope);
+                        conversionScope.assignParameter(
+                            'Input',
+                            union(NumberType.instance, StringType.instance)
+                        );
+                        evaluate(adoptExpression, conversionScope);
                     } catch (error) {
+                        const name = `${schema.name} (id: ${schema.schemaId}) > ${input.label} (id: ${input.id})`;
                         throw new Error(
-                            `Unable to evaluate type of option ${name}: ${String(error)}`
+                            `The conversion of input ${name} is invalid: ${String(error)}`
                         );
                     }
-                    if (type.type === 'never') {
-                        throw new Error(`Type of ${name} cannot be 'never'.`);
-                    }
 
-                    options.set(o.value, type);
+                    adapters.set(input.id, (value) => {
+                        conversionScope.assignParameter('Input', literal(value as never));
+                        const result = evaluate(adoptExpression, conversionScope);
+                        if (result.type === 'never') return undefined;
+                        return result;
+                    });
                 }
+                break;
             }
         }
     }
-    return result;
+
+    return adapters;
 };
 
 const getConversions = (schema: NodeSchema, scope: Scope): Map<InputId, Expression> => {
@@ -234,7 +281,9 @@ const getConversions = (schema: NodeSchema, scope: Scope): Map<InputId, Expressi
 
         // verify that it's a valid conversion
         try {
-            evaluate(e, getConversionScope(scope));
+            const conversionScope = getConversionScope(scope);
+            conversionScope.assignParameter('Input', AnyType.instance);
+            evaluate(e, conversionScope);
         } catch (error) {
             const name = `${schema.name} (id: ${schema.schemaId}) > ${input.label} (id: ${input.id})`;
             throw new Error(`The conversion of input ${name} is invalid: ${String(error)}`);
@@ -272,11 +321,16 @@ export class FunctionDefinition {
         return this.inputGenerics.size > 0 || this.outputGenerics.size > 0;
     }
 
-    readonly inputDataLiterals: Set<InputId>;
+    /**
+     * Optional per-input functions that take the current input data for their
+     * input and convert it into a type that is compatible with the input.
+     */
+    readonly inputDataAdapters: ReadonlyMap<
+        InputId,
+        (value: InputSchemaValue) => NonNeverType | undefined
+    >;
 
     readonly inputNullable: Set<InputId>;
-
-    readonly inputOptions: ReadonlyMap<InputId, ReadonlyMap<string | number, NonNeverType>>;
 
     readonly defaultInstance: FunctionInstance;
 
@@ -310,20 +364,8 @@ export class FunctionDefinition {
         this.outputEvaluationOrder = outputs.ordered.map(({ output }) => output.id);
 
         // input literal values
-        this.inputDataLiterals = new Set(
-            schema.inputs
-                .filter((i) => {
-                    return (
-                        i.kind === 'number' ||
-                        i.kind === 'slider' ||
-                        i.kind === 'text' ||
-                        i.kind === 'text-line'
-                    );
-                })
-                .map((i) => i.id)
-        );
+        this.inputDataAdapters = getInputDataAdapters(schema, scope);
         this.inputNullable = new Set(schema.inputs.filter((i) => i.optional).map((i) => i.id));
-        this.inputOptions = evaluateInputOptions(schema, scope);
 
         // eslint-disable-next-line @typescript-eslint/no-use-before-define
         this.defaultInstance = FunctionInstance.fromDefinition(this);

--- a/src/renderer/helpers/TypeState.ts
+++ b/src/renderer/helpers/TypeState.ts
@@ -1,11 +1,4 @@
-import {
-    EvaluationError,
-    NonNeverType,
-    NumericLiteralType,
-    StringLiteralType,
-    StructType,
-    Type,
-} from '@chainner/navi';
+import { EvaluationError, NonNeverType, StructType, Type } from '@chainner/navi';
 import log from 'electron-log';
 import { Edge, Node } from 'reactflow';
 import { EdgeData, InputId, NodeData, OutputId, SchemaId } from '../../common/common-types';
@@ -77,19 +70,9 @@ export class TypeState {
                         const inputValue = n.data.inputData[id];
 
                         if (inputValue !== undefined) {
-                            if (definition.inputDataLiterals.has(id)) {
-                                if (typeof inputValue === 'number') {
-                                    return new NumericLiteralType(inputValue);
-                                }
-                                return new StringLiteralType(inputValue);
-                            }
-
-                            const optionTypes = definition.inputOptions.get(id);
-                            if (optionTypes) {
-                                const currentOption = optionTypes.get(inputValue);
-                                if (currentOption) {
-                                    return currentOption;
-                                }
+                            const foo = definition.inputDataAdapters.get(id)?.(inputValue);
+                            if (foo !== undefined) {
+                                return foo;
                             }
                         }
 


### PR DESCRIPTION
When loading models or large files, Chainner needs a second to fully load the file. During this time, no output file name/directory is displayed because we got those via the broadcast.

This PR makes it so that file names and directories and derived from the file input. This makes the frontend slightly more responsive, as deriving types is usually faster than loading files.

To make this feature happen, I had to change 3 things:
1. Input can now define how the current input value (the string/number we store in `inputData`) is converted to a type. This was necessary to let our file input generate the correct types. All file and directory input now store the currently selected path.
2. Added a `splitFilePath` built-in function that mimics the behavior of #1406.
3. Use `splitFilePath` in the backend. I did this by adding an `of_input` parameter to `DirectoryOutput` and `FileNameOutput`s that is used to derive the correct type from a file input. (`FileNameOutput` is new, but it's just a specialized `TextOutput`.)