### PR TITLE
Make InterpolationMethod an enum

### DIFF
--- a/backend/src/nodes/nodes/image_dimension/resize_factor.py
+++ b/backend/src/nodes/nodes/image_dimension/resize_factor.py
@@ -9,7 +9,7 @@ from ...node_factory import NodeFactory
 from ...properties.inputs import ImageInput, NumberInput, InterpolationInput
 from ...properties.outputs import ImageOutput
 from ...properties import expression
-from ...impl.pil_utils import resize
+from ...impl.pil_utils import resize, InterpolationMethod
 from ...utils.utils import get_h_w_c, round_half_up
 
 
@@ -46,7 +46,9 @@ class ImResizeByFactorNode(NodeBase):
         self.icon = "MdOutlinePhotoSizeSelectLarge"
         self.sub = "Resize"
 
-    def run(self, img: np.ndarray, scale: float, interpolation: int) -> np.ndarray:
+    def run(
+        self, img: np.ndarray, scale: float, interpolation: InterpolationMethod
+    ) -> np.ndarray:
         """Takes an image and resizes it"""
 
         logger.debug(f"Resizing image by {scale} via {interpolation}")

--- a/backend/src/nodes/nodes/image_dimension/resize_resolution.py
+++ b/backend/src/nodes/nodes/image_dimension/resize_resolution.py
@@ -9,7 +9,7 @@ from ...node_factory import NodeFactory
 from ...properties.inputs import ImageInput, NumberInput, InterpolationInput
 from ...properties.outputs import ImageOutput
 from ...properties import expression
-from ...impl.pil_utils import resize
+from ...impl.pil_utils import resize, InterpolationMethod
 
 
 @NodeFactory.register("chainner:image:resize_resolution")
@@ -41,7 +41,11 @@ class ImResizeToResolutionNode(NodeBase):
         self.sub = "Resize"
 
     def run(
-        self, img: np.ndarray, width: int, height: int, interpolation: int
+        self,
+        img: np.ndarray,
+        width: int,
+        height: int,
+        interpolation: InterpolationMethod,
     ) -> np.ndarray:
         """Takes an image and resizes it"""
 

--- a/backend/src/nodes/nodes/image_dimension/resize_to_side.py
+++ b/backend/src/nodes/nodes/image_dimension/resize_to_side.py
@@ -14,7 +14,7 @@ from ...properties.inputs import (
     ResizeCondition,
 )
 from ...properties.outputs import ImageOutput
-from ...impl.pil_utils import resize
+from ...impl.pil_utils import resize, InterpolationMethod
 from ...utils.utils import get_h_w_c, resize_to_side_conditional
 
 
@@ -104,7 +104,7 @@ class ImResizeToSide(NodeBase):
         img: np.ndarray,
         target: int,
         side: str,
-        interpolation: int,
+        interpolation: InterpolationMethod,
         condition: str,
     ) -> np.ndarray:
         """Takes an image and resizes it"""

--- a/backend/src/nodes/nodes/image_utility/rotate.py
+++ b/backend/src/nodes/nodes/image_utility/rotate.py
@@ -13,7 +13,12 @@ from ...properties.inputs import (
     FillColorDropdown,
 )
 from ...properties.outputs import ImageOutput
-from ...impl.pil_utils import rotate, RotateSizeChange, FillColor
+from ...impl.pil_utils import (
+    rotate,
+    RotateSizeChange,
+    FillColor,
+    RotationInterpolationMethod,
+)
 
 
 @NodeFactory.register("chainner:image:rotate")
@@ -108,7 +113,7 @@ class RotateNode(NodeBase):
         self,
         img: np.ndarray,
         angle: float,
-        interpolation: int,
+        interpolation: RotationInterpolationMethod,
         expand: RotateSizeChange,
         fill: FillColor,
     ) -> np.ndarray:

--- a/backend/src/nodes/properties/inputs/image_dropdown_inputs.py
+++ b/backend/src/nodes/properties/inputs/image_dropdown_inputs.py
@@ -2,7 +2,7 @@ import cv2
 
 # pylint: disable=relative-beyond-top-level
 from ...impl.image_utils import BorderType
-from ...impl.pil_utils import InterpolationMethod
+from ...impl.pil_utils import InterpolationMethod, RotationInterpolationMethod
 from ...impl.color.convert_data import (
     color_spaces,
     color_spaces_or_detectors,
@@ -52,35 +52,12 @@ def ColorSpaceInput(label: str = "Color Space") -> DropDownInput:
 
 def InterpolationInput() -> DropDownInput:
     """Resize interpolation dropdown"""
-    return DropDownInput(
-        input_type="InterpolationMode",
-        label="Interpolation Method",
-        options=[
-            {
-                "option": "Auto",
-                "value": InterpolationMethod.AUTO,
-            },
-            {
-                "option": "Nearest Neighbor",
-                "value": InterpolationMethod.NEAREST,
-            },
-            {
-                "option": "Area (Box)",
-                "value": InterpolationMethod.BOX,
-            },
-            {
-                "option": "Linear",
-                "value": InterpolationMethod.LINEAR,
-            },
-            {
-                "option": "Cubic",
-                "value": InterpolationMethod.CUBIC,
-            },
-            {
-                "option": "Lanczos",
-                "value": InterpolationMethod.LANCZOS,
-            },
-        ],
+    return EnumInput(
+        InterpolationMethod,
+        option_labels={
+            InterpolationMethod.NEAREST: "Nearest Neighbor",
+            InterpolationMethod.BOX: "Area (Box)",
+        },
     )
 
 
@@ -140,23 +117,12 @@ def ResizeCondition() -> DropDownInput:
 
 
 def RotateInterpolationInput() -> DropDownInput:
-    return DropDownInput(
-        input_type="RotateInterpolationMode",
+    return EnumInput(
+        RotationInterpolationMethod,
         label="Interpolation Method",
-        options=[
-            {
-                "option": "Cubic",
-                "value": InterpolationMethod.CUBIC,
-            },
-            {
-                "option": "Linear",
-                "value": InterpolationMethod.LINEAR,
-            },
-            {
-                "option": "Nearest Neighbor",
-                "value": InterpolationMethod.NEAREST,
-            },
-        ],
+        option_labels={
+            RotationInterpolationMethod.NEAREST: "Nearest Neighbor",
+        },
     )
 
 

--- a/src/common/types/chainner-scope.ts
+++ b/src/common/types/chainner-scope.ts
@@ -79,7 +79,6 @@ struct ColorSpace { channels: 1 | 3 | 4, supportsAlpha: bool }
 struct DdsFormat;
 struct DdsMipMaps;
 struct ImageExtension;
-struct InterpolationMode;
 struct MathOperation { operation: string }
 struct NormalChannelInvert;
 struct RotateInterpolationMode;


### PR DESCRIPTION
I had to make another enum called `RotationInterpolationMethod` as well to account for the fact that PIL's rotate method only supports a few interpolation methods.