### PR TITLE
Make BlendMode an enum

### DIFF
--- a/backend/src/nodes/impl/blend.py
+++ b/backend/src/nodes/impl/blend.py
@@ -1,3 +1,4 @@
+from enum import Enum
 import cv2
 import numpy as np
 
@@ -5,62 +6,60 @@ from ..utils.utils import get_h_w_c
 from .image_utils import as_target_channels
 
 
-class BlendModes:
-    """Blending mode constants"""
-
+class BlendMode(Enum):
     NORMAL = 0
-    MULTIPLY = 1
     DARKEN = 2
-    LIGHTEN = 3
-    ADD = 4
+    MULTIPLY = 1
     COLOR_BURN = 5
-    COLOR_DODGE = 6
-    REFLECT = 7
-    GLOW = 8
-    OVERLAY = 9
-    DIFFERENCE = 10
-    NEGATION = 11
+    LINEAR_BURN = 22
+    LIGHTEN = 3
     SCREEN = 12
-    XOR = 13
-    SUBTRACT = 14
-    DIVIDE = 15
-    EXCLUSION = 16
+    COLOR_DODGE = 6
+    ADD = 4
+    OVERLAY = 9
     SOFT_LIGHT = 17
     HARD_LIGHT = 18
     VIVID_LIGHT = 19
     LINEAR_LIGHT = 20
     PIN_LIGHT = 21
-    LINEAR_BURN = 22
+    REFLECT = 7
+    GLOW = 8
+    DIFFERENCE = 10
+    EXCLUSION = 16
+    NEGATION = 11
+    SUBTRACT = 14
+    DIVIDE = 15
+    XOR = 13
 
 
 __normalized = {
-    BlendModes.NORMAL: True,
-    BlendModes.MULTIPLY: True,
-    BlendModes.DARKEN: True,
-    BlendModes.LIGHTEN: True,
-    BlendModes.ADD: False,
-    BlendModes.COLOR_BURN: False,
-    BlendModes.COLOR_DODGE: False,
-    BlendModes.REFLECT: False,
-    BlendModes.GLOW: False,
-    BlendModes.OVERLAY: True,
-    BlendModes.DIFFERENCE: True,
-    BlendModes.NEGATION: True,
-    BlendModes.SCREEN: True,
-    BlendModes.XOR: True,
-    BlendModes.SUBTRACT: False,
-    BlendModes.DIVIDE: False,
-    BlendModes.EXCLUSION: True,
-    BlendModes.SOFT_LIGHT: True,
-    BlendModes.HARD_LIGHT: True,
-    BlendModes.VIVID_LIGHT: False,
-    BlendModes.LINEAR_LIGHT: False,
-    BlendModes.PIN_LIGHT: True,
-    BlendModes.LINEAR_BURN: False,
+    BlendMode.NORMAL: True,
+    BlendMode.MULTIPLY: True,
+    BlendMode.DARKEN: True,
+    BlendMode.LIGHTEN: True,
+    BlendMode.ADD: False,
+    BlendMode.COLOR_BURN: False,
+    BlendMode.COLOR_DODGE: False,
+    BlendMode.REFLECT: False,
+    BlendMode.GLOW: False,
+    BlendMode.OVERLAY: True,
+    BlendMode.DIFFERENCE: True,
+    BlendMode.NEGATION: True,
+    BlendMode.SCREEN: True,
+    BlendMode.XOR: True,
+    BlendMode.SUBTRACT: False,
+    BlendMode.DIVIDE: False,
+    BlendMode.EXCLUSION: True,
+    BlendMode.SOFT_LIGHT: True,
+    BlendMode.HARD_LIGHT: True,
+    BlendMode.VIVID_LIGHT: False,
+    BlendMode.LINEAR_LIGHT: False,
+    BlendMode.PIN_LIGHT: True,
+    BlendMode.LINEAR_BURN: False,
 }
 
 
-def blend_mode_normalized(blend_mode: int) -> bool:
+def blend_mode_normalized(blend_mode: BlendMode) -> bool:
     """
     Returns whether the given blend mode is guaranteed to produce normalized results (value between 0 and 1).
     """
@@ -72,32 +71,34 @@ class ImageBlender:
 
     def __init__(self):
         self.modes = {
-            BlendModes.NORMAL: self.__normal,
-            BlendModes.MULTIPLY: self.__multiply,
-            BlendModes.DARKEN: self.__darken,
-            BlendModes.LIGHTEN: self.__lighten,
-            BlendModes.ADD: self.__add,
-            BlendModes.COLOR_BURN: self.__color_burn,
-            BlendModes.COLOR_DODGE: self.__color_dodge,
-            BlendModes.REFLECT: self.__reflect,
-            BlendModes.GLOW: self.__glow,
-            BlendModes.OVERLAY: self.__overlay,
-            BlendModes.DIFFERENCE: self.__difference,
-            BlendModes.NEGATION: self.__negation,
-            BlendModes.SCREEN: self.__screen,
-            BlendModes.XOR: self.__xor,
-            BlendModes.SUBTRACT: self.__subtract,
-            BlendModes.DIVIDE: self.__divide,
-            BlendModes.EXCLUSION: self.__exclusion,
-            BlendModes.SOFT_LIGHT: self.__soft_light,
-            BlendModes.HARD_LIGHT: self.__hard_light,
-            BlendModes.VIVID_LIGHT: self.__vivid_light,
-            BlendModes.LINEAR_LIGHT: self.__linear_light,
-            BlendModes.PIN_LIGHT: self.__pin_light,
-            BlendModes.LINEAR_BURN: self.__linear_burn,
+            BlendMode.NORMAL: self.__normal,
+            BlendMode.MULTIPLY: self.__multiply,
+            BlendMode.DARKEN: self.__darken,
+            BlendMode.LIGHTEN: self.__lighten,
+            BlendMode.ADD: self.__add,
+            BlendMode.COLOR_BURN: self.__color_burn,
+            BlendMode.COLOR_DODGE: self.__color_dodge,
+            BlendMode.REFLECT: self.__reflect,
+            BlendMode.GLOW: self.__glow,
+            BlendMode.OVERLAY: self.__overlay,
+            BlendMode.DIFFERENCE: self.__difference,
+            BlendMode.NEGATION: self.__negation,
+            BlendMode.SCREEN: self.__screen,
+            BlendMode.XOR: self.__xor,
+            BlendMode.SUBTRACT: self.__subtract,
+            BlendMode.DIVIDE: self.__divide,
+            BlendMode.EXCLUSION: self.__exclusion,
+            BlendMode.SOFT_LIGHT: self.__soft_light,
+            BlendMode.HARD_LIGHT: self.__hard_light,
+            BlendMode.VIVID_LIGHT: self.__vivid_light,
+            BlendMode.LINEAR_LIGHT: self.__linear_light,
+            BlendMode.PIN_LIGHT: self.__pin_light,
+            BlendMode.LINEAR_BURN: self.__linear_burn,
         }
 
-    def apply_blend(self, a: np.ndarray, b: np.ndarray, blend_mode: int) -> np.ndarray:
+    def apply_blend(
+        self, a: np.ndarray, b: np.ndarray, blend_mode: BlendMode
+    ) -> np.ndarray:
         return self.modes[blend_mode](a, b)
 
     def __normal(self, a: np.ndarray, _: np.ndarray) -> np.ndarray:
@@ -181,7 +182,7 @@ class ImageBlender:
         return a + b - 1
 
 
-def blend_images(overlay: np.ndarray, base: np.ndarray, blend_mode: int):
+def blend_images(overlay: np.ndarray, base: np.ndarray, blend_mode: BlendMode):
     """
     Changes the given image to the background overlayed with the image.
 

--- a/backend/src/nodes/impl/fill_alpha.py
+++ b/backend/src/nodes/impl/fill_alpha.py
@@ -4,7 +4,7 @@ import math
 import cv2
 import numpy as np
 
-from .blend import BlendModes, blend_images
+from .blend import BlendMode, blend_images
 from ..utils.utils import get_h_w_c
 
 
@@ -87,7 +87,7 @@ def fill_alpha_fragment_blur(img: np.ndarray) -> np.ndarray:
         blurred = fragment_blur(img, 5, i, 1 << i)
         # Blurred tends to be a bit too transparent
         with_self_as_background(blurred)
-        result = blend_images(result, blurred, BlendModes.NORMAL)
+        result = blend_images(result, blurred, BlendMode.NORMAL)
 
     return result
 
@@ -130,5 +130,5 @@ def fill_alpha_edge_extend(img: np.ndarray, distance: int) -> np.ndarray:
         r[:, :, 2] *= f
         r[:, :, 3] = np.minimum(r[:, :, 3], 1)
 
-        img = blend_images(img, r, BlendModes.NORMAL)
+        img = blend_images(img, r, BlendMode.NORMAL)
     return img

--- a/backend/src/nodes/nodes/image_utility/blend.py
+++ b/backend/src/nodes/nodes/image_utility/blend.py
@@ -9,7 +9,7 @@ from ...node_factory import NodeFactory
 from ...properties.inputs import ImageInput, BlendModeDropdown
 from ...properties.outputs import ImageOutput
 from ...properties import expression
-from ...impl.blend import blend_images
+from ...impl.blend import blend_images, BlendMode
 from ...impl.image_utils import as_2d_grayscale
 from ...impl.pil_utils import convert_to_BGRA
 from ...utils.utils import get_h_w_c
@@ -44,7 +44,7 @@ class ImBlend(NodeBase):
         self,
         base: np.ndarray,
         ov: np.ndarray,
-        blend_mode: int,
+        blend_mode: BlendMode,
     ) -> np.ndarray:
         """Blend images together"""
 

--- a/backend/src/nodes/properties/inputs/generic_inputs.py
+++ b/backend/src/nodes/properties/inputs/generic_inputs.py
@@ -7,7 +7,7 @@ from sanic.log import logger
 from .. import expression
 
 from .base_input import BaseInput
-from ...impl.blend import BlendModes as bm
+from ...impl.blend import BlendMode
 from ...impl.image_utils import FillColor, normalize
 from ...utils.utils import (
     split_snake_case,
@@ -379,34 +379,11 @@ def VideoPresetDropdown() -> DropDownInput:
 
 def BlendModeDropdown() -> DropDownInput:
     """Blending Mode option dropdown"""
-    return DropDownInput(
-        input_type="BlendMode",
-        label="Blend Mode",
-        options=[
-            {"option": "Normal", "value": bm.NORMAL},
-            {"option": "Darken", "value": bm.DARKEN},
-            {"option": "Multiply", "value": bm.MULTIPLY},
-            {"option": "Color Burn", "value": bm.COLOR_BURN},
-            {"option": "Linear Burn", "value": bm.LINEAR_BURN},
-            {"option": "Lighten", "value": bm.LIGHTEN},
-            {"option": "Screen", "value": bm.SCREEN},
-            {"option": "Color Dodge", "value": bm.COLOR_DODGE},
-            {"option": "Linear Dodge (Add)", "value": bm.ADD},
-            {"option": "Overlay", "value": bm.OVERLAY},
-            {"option": "Soft Light", "value": bm.SOFT_LIGHT},
-            {"option": "Hard Light", "value": bm.HARD_LIGHT},
-            {"option": "Vivid Light", "value": bm.VIVID_LIGHT},
-            {"option": "Linear Light", "value": bm.LINEAR_LIGHT},
-            {"option": "Pin Light", "value": bm.PIN_LIGHT},
-            {"option": "Reflect", "value": bm.REFLECT},
-            {"option": "Glow", "value": bm.GLOW},
-            {"option": "Difference", "value": bm.DIFFERENCE},
-            {"option": "Exclusion", "value": bm.EXCLUSION},
-            {"option": "Negation", "value": bm.NEGATION},
-            {"option": "Subtract", "value": bm.SUBTRACT},
-            {"option": "Divide", "value": bm.DIVIDE},
-            {"option": "Xor", "value": bm.XOR},
-        ],
+    return EnumInput(
+        BlendMode,
+        option_labels={
+            BlendMode.ADD: "Linear Dodge (Add)",
+        },
     )
 
 

--- a/src/common/types/chainner-scope.ts
+++ b/src/common/types/chainner-scope.ts
@@ -74,7 +74,6 @@ struct IteratorAuto;
 // various inputs
 struct AdaptiveMethod;
 struct AdaptiveThresholdType;
-struct BlendMode;
 struct ColorSpace { channels: 1 | 3 | 4, supportsAlpha: bool }
 struct DdsFormat;
 struct DdsMipMaps;


### PR DESCRIPTION
I had to reorder our blend modes because the order of enum variants is displayed as in the generated dropdown.

This is the last enum PR for now.