### PR TITLE
Better error message for PyTorch Load Model

### DIFF
--- a/backend/src/nodes/impl/pytorch/model_loading.py
+++ b/backend/src/nodes/impl/pytorch/model_loading.py
@@ -13,6 +13,10 @@ from .architecture.face.codeformer import CodeFormer
 from .types import PyTorchModel
 
 
+class UnsupportedModel(Exception):
+    pass
+
+
 def load_state_dict(state_dict) -> PyTorchModel:
     logger.debug(f"Loading state dict into pytorch model arch")
 
@@ -70,5 +74,5 @@ def load_state_dict(state_dict) -> PyTorchModel:
             model = ESRGAN(state_dict)
         except:
             # pylint: disable=raise-missing-from
-            raise ValueError("Model unsupported by chaiNNer. Please try another.")
+            raise UnsupportedModel
     return model

--- a/backend/src/nodes/nodes/pytorch/load_model.py
+++ b/backend/src/nodes/nodes/pytorch/load_model.py
@@ -67,13 +67,10 @@ class LoadModelNode(NodeBase):
                 model = model.half()
             else:
                 model = model.float()
-        except ValueError as e:
-            raise e
-        except Exception:
-            # pylint: disable=raise-missing-from
+        except Exception as e:
             raise ValueError(
                 f"Model {os.path.basename(path)} is unsupported by chaiNNer. Please try another."
-            )
+            ) from e
 
         dirname, basename, _ = split_file_path(path)
         return model, dirname, basename


### PR DESCRIPTION
Fixes #1432.

This changes `load_state_dict` to no longer be responsible for error message. If the function detects that the model is unsupported, it will throw an `UnsupportedModel` exception and the caller is responsible for generating a good error message.

Error message for the model provided in #1432:
![image](https://user-images.githubusercontent.com/20878432/209448044-5e1855c1-e5e3-4ff2-8152-7a2ca6ab8d6c.png)
