### PR TITLE
Fixed number input ignoring `min-width`

### DIFF
--- a/src/renderer/components/inputs/elements/AdvanceNumberInput.tsx
+++ b/src/renderer/components/inputs/elements/AdvanceNumberInput.tsx
@@ -113,6 +113,7 @@ export const AdvancedNumberInput = memo(
                             borderRightRadius="md"
                             m={0}
                             p={1}
+                            size={1}
                             // dynamic width based on precision
                             w={`${3 + 0.5 * precision}rem`}
                         />
@@ -159,6 +160,7 @@ export const AdvancedNumberInput = memo(
                         borderLeftRadius={unit ? 0 : 'lg'}
                         borderRightRadius="lg"
                         px={unit ? 2 : 4}
+                        size={1}
                     />
                     <NumberInputStepper>
                         <NumberIncrementStepper />


### PR DESCRIPTION
I obtained [arcane knowledge](https://stackoverflow.com/questions/29470676/why-doesnt-the-input-element-respect-min-width).

Text input and so on don't have this problem, so I only applied the fix to number inputs.

![chaiNNer-Untitled-2022-12-30_19-50](https://user-images.githubusercontent.com/20878432/210103329-4477f236-fc08-4354-8cec-41b694fd1d70.png)
