### PR TITLE
Added seed input and group

### DIFF
--- a/backend/src/nodes/nodes/image_filter/add_noise.py
+++ b/backend/src/nodes/nodes/image_filter/add_noise.py
@@ -4,9 +4,9 @@ from enum import Enum
 import numpy as np
 
 from . import category as ImageFilterCategory
-from ...node_base import NodeBase
+from ...node_base import NodeBase, group
 from ...node_factory import NodeFactory
-from ...properties.inputs import ImageInput, SliderInput, EnumInput
+from ...properties.inputs import ImageInput, SliderInput, EnumInput, NumberInput
 from ...properties.outputs import ImageOutput
 from ...impl.noise import (
     gaussian_noise,
@@ -44,6 +44,9 @@ class AddNoiseNode(NodeBase):
                 },
             ),
             SliderInput("Amount", minimum=0, maximum=100, default=50),
+            group("seed")(
+                NumberInput("Seed", minimum=None, maximum=None, default=0),
+            ),
         ]
         self.outputs = [
             ImageOutput(
@@ -69,16 +72,17 @@ class AddNoiseNode(NodeBase):
         noise_type: NoiseType,
         noise_color: NoiseColor,
         amount: int,
+        seed: int,
     ) -> np.ndarray:
         if noise_type == NoiseType.GAUSSIAN:
-            return gaussian_noise(img, amount / 100, noise_color)
+            return gaussian_noise(img, amount / 100, noise_color, seed)
         elif noise_type == NoiseType.UNIFORM:
-            return uniform_noise(img, amount / 100, noise_color)
+            return uniform_noise(img, amount / 100, noise_color, seed)
         elif noise_type == NoiseType.SALT_AND_PEPPER:
-            return salt_and_pepper_noise(img, amount / 100, noise_color)
+            return salt_and_pepper_noise(img, amount / 100, noise_color, seed)
         elif noise_type == NoiseType.POISSON:
-            return poisson_noise(img, amount / 100, noise_color)
+            return poisson_noise(img, amount / 100, noise_color, seed)
         elif noise_type == NoiseType.SPECKLE:
-            return speckle_noise(img, amount / 100, noise_color)
+            return speckle_noise(img, amount / 100, noise_color, seed)
         else:
             raise ValueError(f"Unknown noise type: {noise_type}")

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -173,12 +173,17 @@ interface ConditionalEnumGroup extends GroupBase {
         readonly conditions: readonly (readonly InputSchemaValue[] | InputSchemaValue)[];
     };
 }
+interface SeedGroup extends GroupBase {
+    readonly kind: 'seed';
+    readonly options: Readonly<Record<string, never>>;
+}
 export type GroupKind = Group['kind'];
 export type Group =
     | NcnnFileInputGroup
     | FromToDropdownsGroup
     | OptionalListGroup
-    | ConditionalEnumGroup;
+    | ConditionalEnumGroup
+    | SeedGroup;
 
 export type OfKind<T extends { readonly kind: string }, Kind extends T['kind']> = T extends {
     readonly kind: Kind;

--- a/src/common/group-inputs.ts
+++ b/src/common/group-inputs.ts
@@ -6,6 +6,7 @@ import {
     Input,
     InputKind,
     NodeSchema,
+    NumberInput,
     OfKind,
 } from './common-types';
 import { VALID, Validity, invalid } from './Validity';
@@ -25,6 +26,7 @@ type DeclaredGroupInputs = InputGuarantees<{
     'from-to-dropdowns': readonly [DropDownInput, DropDownInput];
     'ncnn-file-inputs': readonly [FileInput, FileInput];
     'optional-list': readonly [InputItem, ...InputItem[]];
+    seed: readonly [NumberInput];
 }>;
 
 // A bit hacky, but this ensures that GroupInputs covers exactly all group types, no more and no less
@@ -85,6 +87,12 @@ const groupInputsChecks: {
         if (inputs.length === 0) return 'Expected at least 1 item';
 
         if (!allAreOptional(inputs)) return 'Expected all inputs to be optional';
+    },
+    seed: (inputs) => {
+        if (inputs.length !== 1) return 'Expected exactly 1 number input';
+        const [input] = inputs;
+
+        if (input.kind !== 'number') return 'Expected the input to be a number input';
     },
 };
 

--- a/src/renderer/components/groups/Group.tsx
+++ b/src/renderer/components/groups/Group.tsx
@@ -6,6 +6,7 @@ import { FromToDropdownsGroup } from './FromToDropdownsGroup';
 import { NcnnFileInputsGroup } from './NcnnFileInputsGroup';
 import { OptionalInputsGroup } from './OptionalInputsGroup';
 import { GroupProps, InputItemRenderer } from './props';
+import { SeedGroup } from './SeedGroup';
 
 const GroupComponents: {
     readonly [K in GroupKind]: React.MemoExoticComponent<(props: GroupProps<K>) => JSX.Element>;
@@ -14,6 +15,7 @@ const GroupComponents: {
     'from-to-dropdowns': FromToDropdownsGroup,
     'ncnn-file-inputs': NcnnFileInputsGroup,
     'optional-list': OptionalInputsGroup,
+    seed: SeedGroup,
 };
 
 interface GroupElementProps {

--- a/src/renderer/components/groups/SeedGroup.tsx
+++ b/src/renderer/components/groups/SeedGroup.tsx
@@ -1,0 +1,65 @@
+import { IconButton, Tooltip } from '@chakra-ui/react';
+import { memo, useCallback } from 'react';
+import { BsDice5 } from 'react-icons/bs';
+import { useContext, useContextSelector } from 'use-context-selector';
+import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
+import { SchemaInput } from '../inputs/SchemaInput';
+import { GroupProps } from './props';
+
+export const SeedGroup = memo(
+    ({ inputs, inputData, inputSize, isLocked, nodeId, schemaId }: GroupProps<'seed'>) => {
+        const [input] = inputs;
+
+        const { setNodeInputValue } = useContext(GlobalContext);
+
+        const isInputLocked = useContextSelector(GlobalVolatileContext, (c) => c.isNodeInputLocked)(
+            nodeId,
+            input.id
+        );
+
+        const setValue = useCallback(
+            (data: number) => {
+                setNodeInputValue(nodeId, input.id, data);
+            },
+            [nodeId, input.id, setNodeInputValue]
+        );
+
+        const setRandom = useCallback(() => {
+            const RANDOM_MAX = 1e6;
+            setValue(Math.floor(Math.random() * RANDOM_MAX));
+        }, [setValue]);
+
+        return (
+            <SchemaInput
+                afterInput={
+                    <Tooltip
+                        closeOnClick
+                        closeOnPointerDown
+                        hasArrow
+                        borderRadius={8}
+                        label="Random seed"
+                        openDelay={500}
+                    >
+                        <IconButton
+                            aria-label="Random Seed"
+                            h="2rem"
+                            icon={<BsDice5 />}
+                            isDisabled={isLocked || isInputLocked}
+                            minWidth={0}
+                            size="md"
+                            variant="outline"
+                            w="2.4rem"
+                            onClick={setRandom}
+                        />
+                    </Tooltip>
+                }
+                input={input}
+                inputData={inputData}
+                inputSize={inputSize}
+                isLocked={isLocked}
+                nodeId={nodeId}
+                schemaId={schemaId}
+            />
+        );
+    }
+);

--- a/src/renderer/components/groups/SeedGroup.tsx
+++ b/src/renderer/components/groups/SeedGroup.tsx
@@ -1,6 +1,6 @@
 import { IconButton, Tooltip } from '@chakra-ui/react';
 import { memo, useCallback } from 'react';
-import { BsDice5 } from 'react-icons/bs';
+import { HiOutlineRefresh } from 'react-icons/hi';
 import { useContext, useContextSelector } from 'use-context-selector';
 import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { SchemaInput } from '../inputs/SchemaInput';
@@ -43,7 +43,7 @@ export const SeedGroup = memo(
                         <IconButton
                             aria-label="Random Seed"
                             h="2rem"
-                            icon={<BsDice5 />}
+                            icon={<HiOutlineRefresh />}
                             isDisabled={isLocked || isInputLocked}
                             minWidth={0}
                             size="md"

--- a/src/renderer/components/inputs/SchemaInput.tsx
+++ b/src/renderer/components/inputs/SchemaInput.tsx
@@ -1,4 +1,5 @@
 import { NeverType, Type } from '@chainner/navi';
+import { HStack } from '@chakra-ui/react';
 import { memo, useCallback } from 'react';
 import { useContext, useContextSelector } from 'use-context-selector';
 import {
@@ -46,12 +47,22 @@ export interface SingleInputProps {
     inputData: InputData;
     inputSize: InputSize | undefined;
     onSetValue?: (value: InputValue) => void;
+    afterInput?: JSX.Element;
 }
 /**
  * Represents a single input from a schema's input list.
  */
 export const SchemaInput = memo(
-    ({ input, schemaId, nodeId, isLocked, inputData, inputSize, onSetValue }: SingleInputProps) => {
+    ({
+        input,
+        schemaId,
+        nodeId,
+        isLocked,
+        inputData,
+        inputSize,
+        onSetValue,
+        afterInput,
+    }: SingleInputProps) => {
         const { id: inputId, kind, hasHandle } = input;
 
         const {
@@ -115,6 +126,15 @@ export const SchemaInput = memo(
                 value={value}
             />
         );
+
+        if (afterInput) {
+            inputElement = (
+                <HStack w="full">
+                    {inputElement}
+                    {afterInput}
+                </HStack>
+            );
+        }
 
         if (kind !== 'generic' && kind !== 'slider' && kind !== 'dropdown') {
             inputElement = <WithLabel input={input}>{inputElement}</WithLabel>;


### PR DESCRIPTION
I finally got around to adding a "Seed" input for Add Noise. I did this via a new group that just adds a little "Random seed" button to a number input. Adding the button was pretty tricky though. In the end, I did it via an optional prop in `SchemaInput`. Not an elegant solution, but it works.

![image](https://user-images.githubusercontent.com/20878432/210109266-1d971359-abac-4939-af1d-f67dc71b420b.png)
