### PR TITLE
Changed snap to grid amount default

### DIFF
--- a/src/renderer/contexts/SettingsContext.tsx
+++ b/src/renderer/contexts/SettingsContext.tsx
@@ -73,7 +73,7 @@ export const SettingsProvider = memo(({ children }: React.PropsWithChildren<unkn
 
     // Snap to grid
     const [isSnapToGrid, setIsSnapToGrid] = useLocalStorage('snap-to-grid', false);
-    const [snapToGridAmount, setSnapToGridAmount] = useLocalStorage('snap-to-grid-amount', 15);
+    const [snapToGridAmount, setSnapToGridAmount] = useLocalStorage('snap-to-grid-amount', 16);
     const useSnapToGrid = useMemoArray([
         isSnapToGrid,
         setIsSnapToGrid,


### PR DESCRIPTION
The dots of the React flow box background are spaced 16px. With a snap to grid amount of 16, nodes perfectly snap to the background dots which is really satisfying.