### PR TITLE
Make nodes 1px thinner

### DIFF
--- a/src/renderer/components/node/Node.tsx
+++ b/src/renderer/components/node/Node.tsx
@@ -158,6 +158,7 @@ const NodeInner = memo(({ data, selected }: NodeProps) => {
             borderRadius="lg"
             borderWidth="0.5px"
             boxShadow="lg"
+            minWidth="240px"
             opacity={disabled.status === DisabledStatus.Enabled ? 1 : 0.75}
             overflow="hidden"
             ref={targetRef}
@@ -172,9 +173,9 @@ const NodeInner = memo(({ data, selected }: NodeProps) => {
             onDrop={onDrop}
         >
             <VStack
-                minWidth="240px"
                 opacity={disabled.status === DisabledStatus.Enabled ? 1 : 0.75}
                 spacing={0}
+                w="full"
             >
                 <VStack
                     spacing={0}


### PR DESCRIPTION
This PR changes the minimum width of nodes to be 1px less. This makes their width divisible by 16, which makes nodes fit perfectly into the default 16x16 (snap to) grid.

I implemented this by moving the min width property into the element with the node's border. The border width is 0.5px, so all nodes are 1px thinner now.

![image](https://user-images.githubusercontent.com/20878432/210182303-4487fca6-b9fc-4d33-a523-64d844501e7c.png)

![image](https://user-images.githubusercontent.com/20878432/210182298-62ca9318-f124-42d5-8a7f-dd28a1575d07.png)
