### PR TITLE
Added option to turn off broadcast data

### DIFF
--- a/backend/src/run.py
+++ b/backend/src/run.py
@@ -201,6 +201,7 @@ async def nodes(_):
 class RunRequest(TypedDict):
     data: List[JsonNode]
     options: JsonExecutionOptions
+    sendBroadcastData: bool
 
 
 @app.route("/run", methods=["POST"])
@@ -229,6 +230,7 @@ async def run(request: Request):
         executor = Executor(
             chain,
             inputs,
+            full_data["sendBroadcastData"],
             app.loop,
             ctx.queue,
             ctx.pool,

--- a/src/common/Backend.ts
+++ b/src/common/Backend.ts
@@ -51,6 +51,7 @@ export interface BackendExecutionOptions {
 export interface BackendRunRequest {
     data: JsonNode[];
     options: BackendExecutionOptions;
+    sendBroadcastData: boolean;
 }
 export interface BackendRunIndividualRequest {
     id: string;

--- a/src/renderer/contexts/ExecutionContext.tsx
+++ b/src/renderer/contexts/ExecutionContext.tsx
@@ -378,6 +378,7 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
             const response = await backend.run({
                 data,
                 options,
+                sendBroadcastData: true,
             });
             if (response.type === 'error') {
                 // no need to alert here, because the error has already been handled by the queue


### PR DESCRIPTION
Broadcast data (e.g. image previews) are entirely unnecessary for CLI mode, so I added an option to turn them off. Note that this option only controls broadcast *data*, broadcasts will still be sent.