### PR TITLE
Add support for DDS DXT{1,3,5} formats

### DIFF
--- a/backend/src/nodes/impl/dds.py
+++ b/backend/src/nodes/impl/dds.py
@@ -105,6 +105,7 @@ def save_as_dds(
     dithering: bool = False,
     minimal_compression: bool = False,
     maximum_compression: bool = False,
+    dx9: bool = False,
 ):
     """
     Saves an image as DDS using texconv.
@@ -125,7 +126,7 @@ def save_as_dds(
             "-y",
             "-f",
             dds_format,
-            "-dx10",
+            "-dx9" if dx9 else "-dx10",
             "-m",
             str(mipmap_levels),
             # use texconv to directly produce the target file

--- a/backend/src/nodes/nodes/image/save_image.py
+++ b/backend/src/nodes/nodes/image/save_image.py
@@ -28,7 +28,7 @@ from ...impl.image_utils import cv_save_image
 from ...impl.dds import save_as_dds
 
 BC7_FORMATS = "BC7_UNORM_SRGB", "BC7_UNORM"
-BC1_BC3_FORMATS = (
+BC123_FORMATS = (
     "BC1_UNORM_SRGB",
     "BC1_UNORM",
     "BC3_UNORM_SRGB",
@@ -87,7 +87,7 @@ class ImWriteNode(NodeBase):
                     "conditional-enum",
                     {
                         "enum": 6,
-                        "conditions": [BC7_FORMATS, BC1_BC3_FORMATS, BC1_BC3_FORMATS],
+                        "conditions": [BC7_FORMATS, BC123_FORMATS, BC123_FORMATS],
                     },
                 )(
                     EnumInput(

--- a/backend/src/nodes/nodes/image/save_image.py
+++ b/backend/src/nodes/nodes/image/save_image.py
@@ -18,7 +18,7 @@ from ...properties.inputs import (
     TextInput,
     ImageExtensionDropdown,
     SliderInput,
-    DropDownInput,
+    DdsFormatDropdown,
     BoolInput,
     EnumInput,
     DdsMipMapsDropdown,
@@ -48,55 +48,6 @@ class BC7Compression(Enum):
     BEST_SPEED = 1
     DEFAULT = 0
     BEST_QUALITY = 2
-
-
-def DdsFormatDropdown() -> DropDownInput:
-    return DropDownInput(
-        input_type="DdsFormat",
-        label="DDS Format",
-        options=[
-            {
-                "option": "BC1 (sRGB, DX 10+)",
-                "value": "BC1_UNORM_SRGB",
-            },
-            {
-                "option": "BC1 (Linear, DX 10+)",
-                "value": "BC1_UNORM",
-            },
-            {
-                "option": "BC3 (sRGB, DX 10+)",
-                "value": "BC3_UNORM_SRGB",
-            },
-            {
-                "option": "BC3 (Linear, DX 10+)",
-                "value": "BC3_UNORM",
-            },
-            {
-                "option": "BC4 (Linear, Unsigned, DX 10+)",
-                "value": "BC4_UNORM",
-            },
-            {
-                "option": "BC7 (sRGB, DX 11+)",
-                "value": "BC7_UNORM_SRGB",
-            },
-            {
-                "option": "BC7 (Linear, DX 11+)",
-                "value": "BC7_UNORM",
-            },
-            {
-                "option": "DXT1 (Legacy)",
-                "value": "DXT1",
-            },
-            {
-                "option": "DXT3 (Legacy)",
-                "value": "DXT3",
-            },
-            {
-                "option": "DXT5 (Legacy)",
-                "value": "DXT5",
-            },
-        ],
-    )
 
 
 _LEGACY_DDS_FORMATS = {

--- a/backend/src/nodes/properties/inputs/generic_inputs.py
+++ b/backend/src/nodes/properties/inputs/generic_inputs.py
@@ -357,43 +357,6 @@ def TileSizeDropdown(label="Tile Size", estimate=True) -> DropDownInput:
     )
 
 
-def DdsFormatDropdown() -> DropDownInput:
-    return DropDownInput(
-        input_type="DdsFormat",
-        label="DDS Format",
-        options=[
-            {
-                "option": "BC1 (sRGB)",
-                "value": "BC1_UNORM_SRGB",
-            },
-            {
-                "option": "BC1 (Linear)",
-                "value": "BC1_UNORM",
-            },
-            {
-                "option": "BC3 (sRGB)",
-                "value": "BC3_UNORM_SRGB",
-            },
-            {
-                "option": "BC3 (Linear)",
-                "value": "BC3_UNORM",
-            },
-            {
-                "option": "BC4 (Linear, Unsigned)",
-                "value": "BC4_UNORM",
-            },
-            {
-                "option": "BC7 (sRGB)",
-                "value": "BC7_UNORM_SRGB",
-            },
-            {
-                "option": "BC7 (Linear)",
-                "value": "BC7_UNORM",
-            },
-        ],
-    )
-
-
 def DdsMipMapsDropdown() -> DropDownInput:
     return DropDownInput(
         input_type="DdsMipMaps",

--- a/backend/src/nodes/properties/inputs/generic_inputs.py
+++ b/backend/src/nodes/properties/inputs/generic_inputs.py
@@ -357,6 +357,55 @@ def TileSizeDropdown(label="Tile Size", estimate=True) -> DropDownInput:
     )
 
 
+def DdsFormatDropdown() -> DropDownInput:
+    return DropDownInput(
+        input_type="DdsFormat",
+        label="DDS Format",
+        options=[
+            {
+                "option": "BC1 (sRGB, DX 10+)",
+                "value": "BC1_UNORM_SRGB",
+            },
+            {
+                "option": "BC1 (Linear, DX 10+)",
+                "value": "BC1_UNORM",
+            },
+            {
+                "option": "BC3 (sRGB, DX 10+)",
+                "value": "BC3_UNORM_SRGB",
+            },
+            {
+                "option": "BC3 (Linear, DX 10+)",
+                "value": "BC3_UNORM",
+            },
+            {
+                "option": "BC4 (Linear, Unsigned, DX 10+)",
+                "value": "BC4_UNORM",
+            },
+            {
+                "option": "BC7 (sRGB, DX 11+)",
+                "value": "BC7_UNORM_SRGB",
+            },
+            {
+                "option": "BC7 (Linear, DX 11+)",
+                "value": "BC7_UNORM",
+            },
+            {
+                "option": "DXT1 (Legacy)",
+                "value": "DXT1",
+            },
+            {
+                "option": "DXT3 (Legacy)",
+                "value": "DXT3",
+            },
+            {
+                "option": "DXT5 (Legacy)",
+                "value": "DXT5",
+            },
+        ],
+    )
+
+
 def DdsMipMapsDropdown() -> DropDownInput:
     return DropDownInput(
         input_type="DdsMipMaps",


### PR DESCRIPTION
When upscaling textures for older games, legacy DX9 DDS formats are needed. This PR adds support for DXT{1,3,5}, which are the most commonly used legacy formats. 

I also added DirectX version requirements to each format in the dropdown.