### PR TITLE
Update version of opencv-python to 4.7.0.68

### DIFF
--- a/src/common/dependencies.ts
+++ b/src/common/dependencies.ts
@@ -107,7 +107,7 @@ export const requiredDependencies: Dependency[] = [
     },
     {
         name: 'OpenCV',
-        packages: [{ packageName: 'opencv-python', version: '4.6.0.66', sizeEstimate: 30 * MB }],
+        packages: [{ packageName: 'opencv-python', version: '4.7.0.68', sizeEstimate: 30 * MB }],
     },
     {
         name: 'NumPy',


### PR DESCRIPTION
We can finally support macos under 10.15 lol, assuming everything else works