### PR TITLE
Make zip builds more portable (python & ffmpeg)

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -1,0 +1,102 @@
+const AdmZip = require('adm-zip');
+
+module.exports = {
+    packagerConfig: {
+        executableName: 'chainner',
+        extraResource: './backend/src/',
+        icon: './src/public/icons/cross_platform/icon',
+    },
+    publishers: [
+        {
+            name: '@electron-forge/publisher-github',
+            config: {
+                repository: {
+                    owner: 'chaiNNer-org',
+                    name: 'chaiNNer',
+                },
+            },
+            draft: true,
+            prerelease: true,
+        },
+    ],
+    makers: [
+        {
+            name: '@electron-forge/maker-squirrel',
+            config: {
+                name: 'chainner',
+                iconUrl:
+                    'https://github.com/chaiNNer-org/chaiNNer/blob/main/src/public/icons/win/icon.ico',
+                setupIcon: './src/public/icons/win/icon.ico',
+                loadingGif: './src/public/icons/win/installing_loop.gif',
+            },
+        },
+        {
+            name: '@electron-forge/maker-zip',
+            platforms: ['darwin', 'linux', 'win32'],
+        },
+        {
+            name: '@electron-forge/maker-dmg',
+            config: {
+                format: 'ULFO',
+                name: 'chaiNNer',
+                icon: './src/public/icons/mac/icon.icns',
+            },
+        },
+        {
+            name: '@electron-forge/maker-deb',
+            config: {
+                name: 'chainner',
+                options: {
+                    icon: './src/public/icons/cross_platform/icon.png',
+                },
+            },
+        },
+        {
+            name: '@electron-forge/maker-rpm',
+            config: {
+                name: 'chainner',
+                options: {
+                    icon: './src/public/icons/cross_platform/icon.png',
+                },
+            },
+        },
+    ],
+    plugins: [
+        {
+            name: '@electron-forge/plugin-webpack',
+            config: {
+                mainConfig: './webpack.main.config.js',
+                renderer: {
+                    config: './webpack.renderer.config.js',
+                    nodeIntegration: true,
+                    contextIsolation: false,
+                    entryPoints: [
+                        {
+                            html: './src/renderer/index.html',
+                            js: './src/renderer/renderer.js',
+                            name: 'main_window',
+                        },
+                        {
+                            html: './src/renderer/splash.html',
+                            js: './src/renderer/splash_renderer.js',
+                            name: 'splash_screen',
+                        },
+                    ],
+                },
+                devContentSecurityPolicy: '',
+            },
+        },
+    ],
+    hooks: {
+        postMake: async (forgeConfig, makeResults) => {
+            const justArtifacts = makeResults.map((m) => m.artifacts).reduce((a, b) => a.concat(b));
+            const zipArtifact = justArtifacts.find((a) => a.endsWith('.zip'));
+            if (zipArtifact) {
+                // Add an empty `portable` file to the zip
+                const zip = new AdmZip(zipArtifact);
+                zip.addFile('portable', Buffer.alloc(0));
+                zip.writeZip(zipArtifact);
+            }
+        },
+    },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@emotion/styled": "^11.8.1",
         "@fontsource/open-sans": "^4.5.10",
         "@react-nano/use-event-source": "^0.12.0",
+        "adm-zip": "^0.5.10",
         "bezier-js": "^6.1.0",
         "cross-fetch": "^3.1.5",
         "decompress": "^4.2.1",
@@ -6418,6 +6419,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
+      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
+      "engines": {
+        "node": ">=6.0"
       }
     },
     "node_modules/agent-base": {
@@ -30109,6 +30118,11 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true
+    },
+    "adm-zip": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
+      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ=="
     },
     "agent-base": {
       "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -33,99 +33,6 @@
     "npm": ">=7.0.0"
   },
   "license": "GPLv3",
-  "config": {
-    "forge": {
-      "packagerConfig": {
-        "executableName": "chainner",
-        "extraResource": "./backend/src/",
-        "icon": "./src/public/icons/cross_platform/icon"
-      },
-      "publishers": [
-        {
-          "name": "@electron-forge/publisher-github",
-          "config": {
-            "repository": {
-              "owner": "joeyballentine",
-              "name": "chaiNNer"
-            }
-          },
-          "draft": true,
-          "prerelease": true
-        }
-      ],
-      "makers": [
-        {
-          "name": "@electron-forge/maker-squirrel",
-          "config": {
-            "name": "chainner",
-            "iconUrl": "https://github.com/chaiNNer-org/chaiNNer/blob/main/src/public/icons/win/icon.ico",
-            "setupIcon": "./src/public/icons/win/icon.ico",
-            "loadingGif": "./src/public/icons/win/installing_loop.gif"
-          }
-        },
-        {
-          "name": "@electron-forge/maker-zip",
-          "platforms": [
-            "darwin",
-            "linux",
-            "win32"
-          ]
-        },
-        {
-          "name": "@electron-forge/maker-dmg",
-          "config": {
-            "format": "ULFO",
-            "name": "chaiNNer",
-            "icon": "./src/public/icons/mac/icon.icns"
-          }
-        },
-        {
-          "name": "@electron-forge/maker-deb",
-          "config": {
-            "name": "chainner",
-            "options": {
-              "icon": "./src/public/icons/cross_platform/icon.png"
-            }
-          }
-        },
-        {
-          "name": "@electron-forge/maker-rpm",
-          "config": {
-            "name": "chainner",
-            "options": {
-              "icon": "./src/public/icons/cross_platform/icon.png"
-            }
-          }
-        }
-      ],
-      "plugins": [
-        {
-          "name": "@electron-forge/plugin-webpack",
-          "config": {
-            "mainConfig": "./webpack.main.config.js",
-            "renderer": {
-              "config": "./webpack.renderer.config.js",
-              "nodeIntegration": true,
-              "contextIsolation": false,
-              "entryPoints": [
-                {
-                  "html": "./src/renderer/index.html",
-                  "js": "./src/renderer/renderer.js",
-                  "name": "main_window"
-                },
-                {
-                  "html": "./src/renderer/splash.html",
-                  "js": "./src/renderer/splash_renderer.js",
-                  "name": "splash_screen"
-                }
-              ]
-            },
-            "devContentSecurityPolicy": ""
-          }
-        }
-      ]
-    }
-  },
   "devDependencies": {
     "@babel/core": "^7.18.2",
     "@babel/preset-react": "^7.17.12",
@@ -200,6 +107,7 @@
     "@emotion/styled": "^11.8.1",
     "@fontsource/open-sans": "^4.5.10",
     "@react-nano/use-event-source": "^0.12.0",
+    "adm-zip": "^0.5.10",
     "bezier-js": "^6.1.0",
     "cross-fetch": "^3.1.5",
     "decompress": "^4.2.1",

--- a/src/main/backend/setup.ts
+++ b/src/main/backend/setup.ts
@@ -1,4 +1,3 @@
-import { app } from 'electron';
 import log from 'electron-log';
 import { t } from 'i18next';
 import path from 'path';
@@ -317,9 +316,6 @@ export const setupBackend = async (
     getRootDir: () => Promise<string>
 ): Promise<BackendProcess> => {
     token.submitProgress({ totalProgress: 0 });
-
-    const currentExecutableDir = path.dirname(app.getPath('exe'));
-    log.info(`currentExecutableDir setupBackend: ${currentExecutableDir}`);
 
     const backend = getArguments().noBackend
         ? await setupBorrowedBackend(token, 8000)

--- a/src/main/backend/setup.ts
+++ b/src/main/backend/setup.ts
@@ -269,9 +269,9 @@ const setupOwnedBackend = async (
     });
     const port = await getValidPort();
 
-    const currentExecuatbleDir = path.dirname(process.execPath);
-    const isPortable = await checkFileExists(path.join(currentExecuatbleDir, 'portable'));
-    const rootDir = isPortable ? currentExecuatbleDir : app.getAppPath();
+    const currentExecutableDir = path.dirname(app.getAppPath());
+    const isPortable = await checkFileExists(path.join(currentExecutableDir, 'portable'));
+    const rootDir = isPortable ? currentExecutableDir : app.getPath('userData');
 
     token.submitProgress({
         status: t('splash.checkingPython', 'Checking system environment for valid Python...'),

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -20,6 +20,7 @@ import { BackendProcess } from './backend/process';
 import { setupBackend } from './backend/setup';
 import { MenuData, setMainMenu } from './menu';
 import { createNvidiaSmiVRamChecker, getNvidiaGpuNames, getNvidiaSmi } from './nvidiaSmi';
+import { getRootDir } from './platform';
 import { addSplashScreen } from './splash';
 import { getGpuInfo } from './systemInfo';
 import { hasUpdate } from './update';
@@ -273,12 +274,19 @@ const checkNvidiaSmi = async () => {
 };
 
 const nvidiaSmiPromise = checkNvidiaSmi();
+const getRootDirPromise = getRootDir();
 
 const createBackend = async (token: ProgressToken) => {
     const useSystemPython = localStorage.getItem('use-system-python') === 'true';
     const systemPythonLocation = localStorage.getItem('system-python-location');
 
-    return setupBackend(token, useSystemPython, systemPythonLocation, () => nvidiaSmiPromise);
+    return setupBackend(
+        token,
+        useSystemPython,
+        systemPythonLocation,
+        () => nvidiaSmiPromise,
+        () => getRootDirPromise
+    );
 };
 
 const createWindow = lazy(async () => {

--- a/src/main/platform.ts
+++ b/src/main/platform.ts
@@ -1,4 +1,7 @@
+import { app } from 'electron';
 import os from 'os';
+import path from 'path';
+import { checkFileExists } from '../common/util';
 
 export type SupportedPlatform = 'linux' | 'darwin' | 'win32';
 
@@ -14,4 +17,17 @@ export const getPlatform = (): SupportedPlatform => {
                 `Unsupported platform: ${platform}. Please report this to us and we may add support.`
             );
     }
+};
+
+export const currentExecutableDir = path.dirname(app.getPath('exe'));
+
+export const getIsPortable = async (): Promise<boolean> => {
+    const isPortable = await checkFileExists(path.join(currentExecutableDir, 'portable'));
+    return isPortable;
+};
+
+export const getRootDir = async (): Promise<string> => {
+    const isPortable = await getIsPortable();
+    const rootDir = isPortable ? currentExecutableDir : app.getPath('userData');
+    return rootDir;
 };


### PR DESCRIPTION
This PR does three things:
- Moves the forge config out of package.json and into its own config file
- Uses a build hook to write a `portable` file to the zip, if the build is a zip
- Checks for the existence of this file when checking for python/ffmpeg, and if the file exists will use the current executable directory rather than appdata.

Note: Settings still save to appdata. I will accomplish that next.