### PR TITLE
Make settings portable for zips

### DIFF
--- a/src/main/backend/setup.ts
+++ b/src/main/backend/setup.ts
@@ -260,15 +260,13 @@ const setupOwnedBackend = async (
     useSystemPython: boolean,
     systemPythonLocation: string | undefined | null,
     hasNvidia: () => Promise<boolean>,
-    getRootDir: () => Promise<string>
+    rootDir: string
 ): Promise<OwnedBackendProcess> => {
     token.submitProgress({
         status: t('splash.checkingPort', 'Checking for available port...'),
         totalProgress: 0.1,
     });
     const port = await getValidPort();
-
-    const rootDir = await getRootDir();
 
     token.submitProgress({
         status: t('splash.checkingPython', 'Checking system environment for valid Python...'),
@@ -313,19 +311,13 @@ export const setupBackend = async (
     useSystemPython: boolean,
     systemPythonLocation: string | undefined | null,
     hasNvidia: () => Promise<boolean>,
-    getRootDir: () => Promise<string>
+    rootDir: string
 ): Promise<BackendProcess> => {
     token.submitProgress({ totalProgress: 0 });
 
     const backend = getArguments().noBackend
         ? await setupBorrowedBackend(token, 8000)
-        : await setupOwnedBackend(
-              token,
-              useSystemPython,
-              systemPythonLocation,
-              hasNvidia,
-              getRootDir
-          );
+        : await setupOwnedBackend(token, useSystemPython, systemPythonLocation, hasNvidia, rootDir);
 
     token.submitProgress({ totalProgress: 1 });
     return backend;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -20,7 +20,7 @@ import { BackendProcess } from './backend/process';
 import { setupBackend } from './backend/setup';
 import { MenuData, setMainMenu } from './menu';
 import { createNvidiaSmiVRamChecker, getNvidiaGpuNames, getNvidiaSmi } from './nvidiaSmi';
-import { getRootDir, getRootDirSync } from './platform';
+import { getRootDirSync } from './platform';
 import { addSplashScreen } from './splash';
 import { getGpuInfo } from './systemInfo';
 import { hasUpdate } from './update';
@@ -39,7 +39,9 @@ if (!hasInstanceLock) {
     app.quit();
 }
 
-const localStorageLocation = path.join(getRootDirSync(), 'settings');
+const applicationDataRootDir = getRootDirSync();
+
+const localStorageLocation = path.join(applicationDataRootDir, 'settings');
 ipcMain.handle('get-localstorage-location', () => localStorageLocation);
 const localStorage = new LocalStorage(localStorageLocation);
 
@@ -274,7 +276,6 @@ const checkNvidiaSmi = async () => {
 };
 
 const nvidiaSmiPromise = checkNvidiaSmi();
-const getRootDirPromise = getRootDir();
 
 const createBackend = async (token: ProgressToken) => {
     const useSystemPython = localStorage.getItem('use-system-python') === 'true';
@@ -285,7 +286,7 @@ const createBackend = async (token: ProgressToken) => {
         useSystemPython,
         systemPythonLocation,
         () => nvidiaSmiPromise,
-        () => getRootDirPromise
+        applicationDataRootDir
     );
 };
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -20,7 +20,7 @@ import { BackendProcess } from './backend/process';
 import { setupBackend } from './backend/setup';
 import { MenuData, setMainMenu } from './menu';
 import { createNvidiaSmiVRamChecker, getNvidiaGpuNames, getNvidiaSmi } from './nvidiaSmi';
-import { getRootDir } from './platform';
+import { getRootDir, getRootDirSync } from './platform';
 import { addSplashScreen } from './splash';
 import { getGpuInfo } from './systemInfo';
 import { hasUpdate } from './update';
@@ -39,7 +39,7 @@ if (!hasInstanceLock) {
     app.quit();
 }
 
-const localStorageLocation = path.join(app.getPath('userData'), 'settings');
+const localStorageLocation = path.join(getRootDirSync(), 'settings');
 ipcMain.handle('get-localstorage-location', () => localStorageLocation);
 const localStorage = new LocalStorage(localStorageLocation);
 

--- a/src/main/platform.ts
+++ b/src/main/platform.ts
@@ -2,7 +2,7 @@ import { app } from 'electron';
 import { existsSync } from 'fs';
 import os from 'os';
 import path from 'path';
-import { checkFileExists, lazy } from '../common/util';
+import { lazy } from '../common/util';
 
 export type SupportedPlatform = 'linux' | 'darwin' | 'win32';
 
@@ -21,17 +21,6 @@ export const getPlatform = (): SupportedPlatform => {
 };
 
 export const currentExecutableDir = path.dirname(app.getPath('exe'));
-
-export const getIsPortable = async (): Promise<boolean> => {
-    const isPortable = await checkFileExists(path.join(currentExecutableDir, 'portable'));
-    return isPortable;
-};
-
-export const getRootDir = async (): Promise<string> => {
-    const isPortable = await getIsPortable();
-    const rootDir = isPortable ? currentExecutableDir : app.getPath('userData');
-    return rootDir;
-};
 
 export const getIsPortableSync = lazy((): boolean => {
     const isPortable = existsSync(path.join(currentExecutableDir, 'portable'));

--- a/src/main/platform.ts
+++ b/src/main/platform.ts
@@ -2,7 +2,7 @@ import { app } from 'electron';
 import { existsSync } from 'fs';
 import os from 'os';
 import path from 'path';
-import { checkFileExists } from '../common/util';
+import { checkFileExists, lazy } from '../common/util';
 
 export type SupportedPlatform = 'linux' | 'darwin' | 'win32';
 
@@ -33,13 +33,13 @@ export const getRootDir = async (): Promise<string> => {
     return rootDir;
 };
 
-export const getIsPortableSync = (): boolean => {
+export const getIsPortableSync = lazy((): boolean => {
     const isPortable = existsSync(path.join(currentExecutableDir, 'portable'));
     return isPortable;
-};
+});
 
-export const getRootDirSync = (): string => {
+export const getRootDirSync = lazy((): string => {
     const isPortable = getIsPortableSync();
     const rootDir = isPortable ? currentExecutableDir : app.getPath('userData');
     return rootDir;
-};
+});

--- a/src/main/platform.ts
+++ b/src/main/platform.ts
@@ -1,4 +1,5 @@
 import { app } from 'electron';
+import { existsSync } from 'fs';
 import os from 'os';
 import path from 'path';
 import { checkFileExists } from '../common/util';
@@ -28,6 +29,17 @@ export const getIsPortable = async (): Promise<boolean> => {
 
 export const getRootDir = async (): Promise<string> => {
     const isPortable = await getIsPortable();
+    const rootDir = isPortable ? currentExecutableDir : app.getPath('userData');
+    return rootDir;
+};
+
+export const getIsPortableSync = (): boolean => {
+    const isPortable = existsSync(path.join(currentExecutableDir, 'portable'));
+    return isPortable;
+};
+
+export const getRootDirSync = (): string => {
+    const isPortable = getIsPortableSync();
     const rootDir = isPortable ? currentExecutableDir : app.getPath('userData');
     return rootDir;
 };


### PR DESCRIPTION
Unfortunately, I needed to make a synchronous version of the check. This makes me wonder if I should use that sync check for everything since I could get it once at the top of main.ts and pass it through to the other stuff from the previous PR.

Alternatively, we could switch to Node 18 and use top-level-await (though we'd need to wait for electron to update first)
