### PR TITLE
Ignore null in type error messages

### DIFF
--- a/src/common/nodes/checkNodeValidity.ts
+++ b/src/common/nodes/checkNodeValidity.ts
@@ -1,6 +1,7 @@
 import { Input, InputData, InputId, NodeSchema } from '../common-types';
 import { FunctionInstance } from '../types/function';
 import { generateAssignmentErrorTrace, printErrorTrace, simpleError } from '../types/mismatch';
+import { withoutNull } from '../types/util';
 import { VALID, Validity, invalid } from '../Validity';
 
 const formatMissingInputs = (missingInputs: Input[]) => {
@@ -41,7 +42,7 @@ export const checkNodeValidity = ({
         for (const { inputId, assignedType, inputType } of functionInstance.inputErrors) {
             const input = schema.inputs.find((i) => i.id === inputId)!;
 
-            const error = simpleError(assignedType, inputType);
+            const error = simpleError(assignedType, withoutNull(inputType));
             if (error) {
                 return invalid(
                     `Input ${input.label} requires ${error.definition} but was connected with ${error.assigned}.`
@@ -52,7 +53,7 @@ export const checkNodeValidity = ({
         if (functionInstance.inputErrors.length > 0) {
             const { inputId, assignedType, inputType } = functionInstance.inputErrors[0];
             const input = schema.inputs.find((i) => i.id === inputId)!;
-            const traceTree = generateAssignmentErrorTrace(assignedType, inputType);
+            const traceTree = generateAssignmentErrorTrace(assignedType, withoutNull(inputType));
             if (!traceTree) throw new Error('Cannot determine assignment error');
             const trace = printErrorTrace(traceTree);
             return invalid(

--- a/src/common/types/util.ts
+++ b/src/common/types/util.ts
@@ -6,6 +6,7 @@ import {
     StructType,
     Type,
     UnionType,
+    without,
 } from '@chainner/navi';
 
 export type IntNumberType =
@@ -38,3 +39,7 @@ export const isDirectory = (
 export const getField = (struct: StructType, field: string): NonNeverType | undefined => {
     return struct.fields.find((f) => f.name === field)?.type;
 };
+
+const nullType = new StructType('null');
+
+export const withoutNull = (type: Type): Type => without(type, nullType);

--- a/src/renderer/components/TypeTag.tsx
+++ b/src/renderer/components/TypeTag.tsx
@@ -1,15 +1,8 @@
-import {
-    NeverType,
-    StructType,
-    Type,
-    isNumericLiteral,
-    isStringLiteral,
-    without,
-} from '@chainner/navi';
+import { NeverType, Type, isNumericLiteral, isStringLiteral } from '@chainner/navi';
 import { Tag, Tooltip, forwardRef } from '@chakra-ui/react';
 import React, { memo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { getField, isDirectory, isImage } from '../../common/types/util';
+import { getField, isDirectory, isImage, withoutNull } from '../../common/types/util';
 import { assertNever } from '../../common/util';
 
 const getColorMode = (channels: number) => {
@@ -24,8 +17,6 @@ const getColorMode = (channels: number) => {
             return undefined;
     }
 };
-
-const nullType = new StructType('null');
 
 type TagValue =
     | { kind: 'literal'; value: string }
@@ -165,7 +156,7 @@ const TagRenderer = memo(({ tag }: { tag: TagValue }) => {
 
 export const TypeTags = memo(({ type, isOptional }: TypeTagsProps) => {
     const { t } = useTranslation();
-    const tags = getTypeText(without(type, nullType));
+    const tags = getTypeText(withoutNull(type));
 
     return (
         <>

--- a/src/renderer/contexts/GlobalNodeState.tsx
+++ b/src/renderer/contexts/GlobalNodeState.tsx
@@ -36,6 +36,7 @@ import {
     printErrorTrace,
     simpleError,
 } from '../../common/types/mismatch';
+import { withoutNull } from '../../common/types/util';
 import {
     EMPTY_SET,
     createUniqueId,
@@ -868,7 +869,9 @@ export const GlobalProvider = memo(
                 if (outputType !== undefined && !targetFn.canAssign(targetHandleId, outputType)) {
                     const schema = schemata.get(targetNode.data.schemaId);
                     const input = schema.inputs.find((i) => i.id === targetHandleId)!;
-                    const inputType = targetFn.definition.inputDefaults.get(targetHandleId)!;
+                    const inputType = withoutNull(
+                        targetFn.definition.inputDefaults.get(targetHandleId)!
+                    );
 
                     const error = simpleError(outputType, inputType);
                     if (error) {


### PR DESCRIPTION
This slightly improves error messages by ignoring `null` in error involving optional inputs. `null` doesn't have any value in error messages anyway, because no output can output `null` right now.

![image](https://user-images.githubusercontent.com/20878432/212897885-8798e1d2-3ab4-4f6b-a90f-a2673f5f325a.png)
