### PR TITLE
CLI input overrides

### DIFF
--- a/src/common/input-override.ts
+++ b/src/common/input-override.ts
@@ -1,0 +1,167 @@
+import log from 'electron-log';
+import { readFile } from 'fs/promises';
+import { extname } from 'path';
+import { EdgeData, InputData, InputId, InputValue, Mutable, NodeData } from './common-types';
+import { SchemaMap } from './SchemaMap';
+import { joinEnglish } from './util';
+import type { Edge, Node } from 'reactflow';
+
+export type OverrideInputId = string & { readonly __override_input_id?: never };
+
+export const createOverrideInputId = (nodeId: string, inputId: InputId): OverrideInputId => {
+    if (nodeId.length !== 36)
+        throw new Error('Expected node id to be a 36 character hexadecimal UUID.');
+    return `#${nodeId}:${inputId}`;
+};
+
+const isValidOverrideInputId = (id: OverrideInputId) => /^#[a-f0-9-]{36}:\d+$/.test(id);
+export const parseOverrideInputId = (id: OverrideInputId): { nodeId: string; inputId: InputId } => {
+    if (!isValidOverrideInputId(id)) throw new Error(`"${id}" is not a valid override input id.`);
+
+    const nodeId = id.substring(1, 37);
+    const inputId = Number(id.slice(38)) as InputId;
+
+    return { nodeId, inputId };
+};
+
+export interface OverrideFile {
+    inputs?: Record<OverrideInputId, string | number | null>;
+}
+
+export const readOverrideFile = async (filePath: string): Promise<OverrideFile> => {
+    const content = await readFile(filePath, { encoding: 'utf-8' });
+    const data = JSON.parse(content) as unknown;
+    if (typeof data !== 'object')
+        throw new Error('Expected the override file to contain an object');
+    return data as OverrideFile;
+};
+
+const assignInput = (
+    node: Node<NodeData>,
+    inputId: InputId,
+    value: InputValue,
+    schemata: SchemaMap
+): void => {
+    const schema = schemata.get(node.data.schemaId);
+    const input = schema.inputs.find((i) => i.id === inputId);
+    if (!input) throw new Error(`No input with id ${inputId} for node ${node.id}.`);
+
+    const inputData = node.data.inputData as Mutable<InputData>;
+
+    if (value === undefined) {
+        if (!input.optional)
+            throw new Error(
+                `The input with id ${inputId} on node ${node.id} is not optional but was assigned null/undefined.`
+            );
+
+        inputData[inputId] = undefined;
+        return;
+    }
+
+    const errorStart = `The input with id ${inputId} on node ${node.id} is a ${input.kind} input`;
+
+    switch (input.kind) {
+        case 'directory': {
+            if (typeof value !== 'string')
+                throw new Error(`${errorStart}, which expects a string value.`);
+
+            inputData[inputId] = value;
+            break;
+        }
+        case 'file': {
+            if (typeof value !== 'string')
+                throw new Error(`${errorStart}, which expects a string value.`);
+
+            const ext = extname(value).toLowerCase();
+            if (!input.filetypes.includes(ext)) {
+                throw new Error(
+                    `${errorStart}, which expects ${joinEnglish(
+                        input.filetypes,
+                        'or'
+                    )} files but was given ${value}.`
+                );
+            }
+
+            inputData[inputId] = value;
+            break;
+        }
+        case 'number':
+        case 'slider': {
+            if (typeof value !== 'number')
+                throw new Error(`${errorStart}, which expects a number value.`);
+
+            const { min, max, precision } = input;
+            if (precision === 0 && !Number.isInteger(value))
+                throw new Error(`${errorStart}, which expects an integer found ${value}.`);
+            if (min != null && value < min)
+                throw new Error(
+                    `${errorStart}, which expects a number >= ${min} but found ${value}.`
+                );
+            if (max != null && value > max)
+                throw new Error(
+                    `${errorStart}, which expects a number <= ${max} but found ${value}.`
+                );
+
+            inputData[inputId] = value;
+            break;
+        }
+        case 'text': {
+            inputData[inputId] = String(value);
+            break;
+        }
+        case 'text-line': {
+            const text = String(value);
+
+            const { minLength, maxLength } = input;
+            if (minLength != null && text.length < minLength)
+                throw new Error(`${errorStart}, which expects at least ${minLength} characters.`);
+            if (maxLength != null && text.length > maxLength)
+                throw new Error(`${errorStart}, which expects at most ${maxLength} characters.`);
+
+            inputData[inputId] = text;
+            break;
+        }
+        default:
+            throw new Error(`${errorStart}, which does not support overrides.`);
+    }
+};
+
+export const applyOverrides = (
+    nodes: readonly Node<NodeData>[],
+    edges: readonly Edge<EdgeData>[],
+    schemata: SchemaMap,
+    overrideFile: OverrideFile
+): void => {
+    if (!overrideFile.inputs) {
+        // nothing to do
+        return;
+    }
+
+    const overrides = new Map<string, Map<InputId, string | number | null>>();
+    for (const [id, value] of Object.entries(overrideFile.inputs)) {
+        const { nodeId, inputId } = parseOverrideInputId(id);
+
+        let perNode = overrides.get(nodeId);
+        if (perNode === undefined) {
+            perNode = new Map();
+            overrides.set(nodeId, perNode);
+        }
+
+        perNode.set(inputId, value);
+    }
+
+    for (const node of nodes) {
+        const perNode = overrides.get(node.id);
+        if (perNode) {
+            overrides.delete(node.id);
+            for (const [inputId, value] of perNode) {
+                assignInput(node, inputId, value ?? undefined, schemata);
+            }
+        }
+    }
+
+    const unused = [...overrides.values()].flatMap((o) => o.size).reduce((a, b) => a + b, 0);
+    if (unused > 0) {
+        log.warn(`${unused} unused override(s).`);
+    }
+};

--- a/src/common/locales/en/translation.json
+++ b/src/common/locales/en/translation.json
@@ -10,10 +10,10 @@
   "error": {
     "error": "Error",
     "message": {
-      "criticalBackend": "A critical error occurred while processing the node data returned by the backend"
+      "criticalBackend": "A critical error occurred while processing the node data returned by the backend."
     },
     "title": {
-      "unableToProcessNodes": "Unable to process backend nodes"
+      "unableToProcessNodes": "Unable to process backend nodes."
     }
   },
   "header": {
@@ -26,7 +26,9 @@
     "stopButton": "Stop button"
   },
   "inputs": {
+    "copyOverrideInputId": "Copy Override Input Id",
     "directory": {
+      "copyFullDirectoryPath": "Copy Full Directory Path",
       "openInFileExplorer": "Open in File Explorer",
       "selectDirectory": "Select a directory..."
     },
@@ -35,6 +37,14 @@
       "copyFullFilePath": "Copy Full File Path",
       "openInFileExplorer": "Open in File Explorer",
       "selectFile": "Select a file..."
+    },
+    "number": {
+      "copyText": "Copy Number",
+      "paste": "Paste"
+    },
+    "text": {
+      "copyText": "Copy Text",
+      "paste": "Paste"
     }
   },
   "loading": "Loading...",

--- a/src/main/arguments.ts
+++ b/src/main/arguments.ts
@@ -11,6 +11,7 @@ export interface OpenArguments extends ArgumentOptions {
 export interface RunArguments extends ArgumentOptions {
     command: 'run';
     file: string;
+    overrideFile: string | undefined;
 }
 export type ParsedArguments = OpenArguments | RunArguments;
 
@@ -32,10 +33,22 @@ export const parseArgs = (args: readonly string[]): ParsedArguments => {
             'run <file>',
             'Run the given chain in the command line without opening the GUI',
             (y) => {
-                return y.positional('file', {
-                    type: 'string',
-                    description: 'The chain to run. This should be a .chn file',
-                });
+                return y
+                    .positional('file', {
+                        type: 'string',
+                        description: 'The chain to run. This should be a .chn file',
+                    })
+                    .options({
+                        override: {
+                            type: 'string',
+                            description:
+                                'An optional JSON file with input overrides.' +
+                                ' The file is expected to have the following structure: `{ "inputs": { "<input id>": string | number | null } }`.' +
+                                ' Input ids can be obtained in the GUI by right-clicking on an overridable input.' +
+                                ' Note that not all inputs are overridable.' +
+                                ' Right now, only number, text, file, and directory inputs are supported.',
+                        },
+                    });
             }
         )
         .options({
@@ -67,6 +80,7 @@ export const parseArgs = (args: readonly string[]): ParsedArguments => {
             return {
                 command: 'run',
                 file: parsed.file!,
+                overrideFile: parsed.override,
                 ...options,
             };
         default:

--- a/src/main/cli/run.ts
+++ b/src/main/cli/run.ts
@@ -10,6 +10,7 @@ import {
 import { EdgeData, NodeData, NodeSchema, SchemaId } from '../../common/common-types';
 import { getOnnxTensorRtCacheLocation } from '../../common/env';
 import { formatExecutionErrorMessage } from '../../common/formatExecutionErrorMessage';
+import { applyOverrides, readOverrideFile } from '../../common/input-override';
 import { checkNodeValidity } from '../../common/nodes/checkNodeValidity';
 import { getConnectedInputs } from '../../common/nodes/connectedInputs';
 import { getEffectivelyDisabledNodes } from '../../common/nodes/disabled';
@@ -238,6 +239,12 @@ export const runChainInCli = async (args: RunArguments) => {
         log.warn(
             `The save file has been tampered with. This might lead to errors in the execution of this chain.`
         );
+    }
+
+    if (args.overrideFile) {
+        log.info(`Read override file ${args.overrideFile}`);
+        const overrideFile = await readOverrideFile(args.overrideFile);
+        applyOverrides(saveFile.nodes, saveFile.edges, schemata, overrideFile);
     }
 
     const disabledNodes = new Set(

--- a/src/renderer/components/inputs/DirectoryInput.tsx
+++ b/src/renderer/components/inputs/DirectoryInput.tsx
@@ -9,14 +9,15 @@ import {
     MenuList,
     Tooltip,
 } from '@chakra-ui/react';
-import { shell } from 'electron';
+import { clipboard, shell } from 'electron';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { BsFolderPlus } from 'react-icons/bs';
-import { MdFolder } from 'react-icons/md';
+import { MdContentCopy, MdFolder } from 'react-icons/md';
 import { ipcRenderer } from '../../../common/safeIpc';
 import { useContextMenu } from '../../hooks/useContextMenu';
 import { useLastDirectory } from '../../hooks/useLastDirectory';
+import { CopyOverrideIdSection } from './elements/CopyOverrideIdSection';
 import { InputProps } from './props';
 
 const getDirectoryPath = (type: Type): string | undefined => {
@@ -39,9 +40,11 @@ export const DirectoryInput = memo(
         value,
         setValue,
         isLocked,
+        input,
         inputKey,
         useInputConnected,
         useInputType,
+        nodeId,
     }: InputProps<'directory', string>) => {
         const { t } = useTranslation();
 
@@ -66,8 +69,8 @@ export const DirectoryInput = memo(
         const menu = useContextMenu(() => (
             <MenuList className="nodrag">
                 <MenuItem
-                    disabled={isLocked || isInputConnected}
                     icon={<BsFolderPlus />}
+                    isDisabled={isLocked || isInputConnected}
                     // eslint-disable-next-line @typescript-eslint/no-misused-promises
                     onClick={onButtonClick}
                 >
@@ -85,6 +88,21 @@ export const DirectoryInput = memo(
                 >
                     {t('inputs.directory.openInFileExplorer', 'Open in File Explorer')}
                 </MenuItem>
+                <MenuItem
+                    icon={<MdContentCopy />}
+                    isDisabled={!displayDirectory}
+                    onClick={() => {
+                        if (displayDirectory) {
+                            clipboard.writeText(displayDirectory);
+                        }
+                    }}
+                >
+                    {t('inputs.directory.copyFullDirectoryPath', 'Copy Full Directory Path')}
+                </MenuItem>
+                <CopyOverrideIdSection
+                    inputId={input.id}
+                    nodeId={nodeId}
+                />
             </MenuList>
         ));
 

--- a/src/renderer/components/inputs/FileInput.tsx
+++ b/src/renderer/components/inputs/FileInput.tsx
@@ -21,6 +21,7 @@ import { AlertBoxContext } from '../../contexts/AlertBoxContext';
 import { getSingleFileWithExtension } from '../../helpers/dataTransfer';
 import { useContextMenu } from '../../hooks/useContextMenu';
 import { useLastDirectory } from '../../hooks/useLastDirectory';
+import { CopyOverrideIdSection } from './elements/CopyOverrideIdSection';
 import { InputProps } from './props';
 
 export const FileInput = memo(
@@ -31,6 +32,7 @@ export const FileInput = memo(
         inputKey,
         useInputConnected,
         isLocked,
+        nodeId,
     }: InputProps<'file', string>) => {
         const { t } = useTranslation();
 
@@ -103,8 +105,8 @@ export const FileInput = memo(
         const menu = useContextMenu(() => (
             <MenuList className="nodrag">
                 <MenuItem
-                    disabled={isLocked || isInputConnected}
                     icon={<BsFileEarmarkPlus />}
+                    isDisabled={isLocked || isInputConnected}
                     // eslint-disable-next-line @typescript-eslint/no-misused-promises
                     onClick={onButtonClick}
                 >
@@ -122,7 +124,6 @@ export const FileInput = memo(
                 >
                     {t('inputs.file.openInFileExplorer', 'Open in File Explorer')}
                 </MenuItem>
-                <MenuDivider />
                 <MenuItem
                     icon={<MdContentCopy />}
                     isDisabled={!filePath}
@@ -145,6 +146,10 @@ export const FileInput = memo(
                 >
                     {t('inputs.file.copyFullFilePath', 'Copy Full File Path')}
                 </MenuItem>
+                <CopyOverrideIdSection
+                    inputId={input.id}
+                    nodeId={nodeId}
+                />
             </MenuList>
         ));
 

--- a/src/renderer/components/inputs/NumberInput.tsx
+++ b/src/renderer/components/inputs/NumberInput.tsx
@@ -1,8 +1,13 @@
 import { isNumericLiteral } from '@chainner/navi';
-import { HStack } from '@chakra-ui/react';
+import { HStack, MenuItem, MenuList } from '@chakra-ui/react';
+import { clipboard } from 'electron';
 import { memo, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { MdContentCopy, MdContentPaste } from 'react-icons/md';
 import { areApproximatelyEqual } from '../../../common/util';
+import { useContextMenu } from '../../hooks/useContextMenu';
 import { AdvancedNumberInput } from './elements/AdvanceNumberInput';
+import { CopyOverrideIdSection } from './elements/CopyOverrideIdSection';
 import { InputProps } from './props';
 
 export const NumberInput = memo(
@@ -13,6 +18,7 @@ export const NumberInput = memo(
         isLocked,
         useInputConnected,
         useInputType,
+        nodeId,
     }: InputProps<'number', number>) => {
         const { def, min, max, unit, precision, controlsStep, hideTrailingZeros } = input;
 
@@ -36,6 +42,42 @@ export const NumberInput = memo(
         const isInputConnected = useInputConnected();
         const inputType = useInputType();
         const typeNumberString = isNumericLiteral(inputType) ? inputType.toString() : '';
+        const displayString = isInputConnected ? typeNumberString : inputString;
+
+        const { t } = useTranslation();
+
+        const menu = useContextMenu(() => (
+            <MenuList className="nodrag">
+                <MenuItem
+                    icon={<MdContentCopy />}
+                    isDisabled={!displayString}
+                    onClick={() => {
+                        clipboard.writeText(displayString);
+                    }}
+                >
+                    {t('inputs.number.copyText', 'Copy Number')}
+                </MenuItem>
+                <MenuItem
+                    icon={<MdContentPaste />}
+                    onClick={() => {
+                        const n = Number(clipboard.readText());
+                        if (
+                            !Number.isNaN(n) &&
+                            (min == null || min <= n) &&
+                            (max == null || max >= n)
+                        ) {
+                            setValue(n);
+                        }
+                    }}
+                >
+                    {t('inputs.number.paste', 'Paste')}
+                </MenuItem>
+                <CopyOverrideIdSection
+                    inputId={input.id}
+                    nodeId={nodeId}
+                />
+            </MenuList>
+        ));
 
         return (
             <HStack w="full">
@@ -43,7 +85,7 @@ export const NumberInput = memo(
                     controlsStep={controlsStep}
                     defaultValue={def}
                     hideTrailingZeros={hideTrailingZeros}
-                    inputString={isInputConnected ? typeNumberString : inputString}
+                    inputString={displayString}
                     isDisabled={isLocked || isInputConnected}
                     max={max ?? Infinity}
                     min={min ?? -Infinity}
@@ -51,6 +93,7 @@ export const NumberInput = memo(
                     setInput={setValue}
                     setInputString={setInputString}
                     unit={unit}
+                    onContextMenu={menu.onContextMenu}
                 />
             </HStack>
         );

--- a/src/renderer/components/inputs/SchemaInput.tsx
+++ b/src/renderer/components/inputs/SchemaInput.tsx
@@ -118,6 +118,7 @@ export const SchemaInput = memo(
                 input={input as never}
                 inputKey={`${schemaId}-${inputId}`}
                 isLocked={isLocked}
+                nodeId={nodeId}
                 resetValue={resetValue}
                 setValue={setValue}
                 useInputConnected={useInputConnected}

--- a/src/renderer/components/inputs/elements/AdvanceNumberInput.tsx
+++ b/src/renderer/components/inputs/elements/AdvanceNumberInput.tsx
@@ -7,7 +7,7 @@ import {
     NumberInputField,
     NumberInputStepper,
 } from '@chakra-ui/react';
-import { memo } from 'react';
+import { MouseEventHandler, memo } from 'react';
 import { areApproximatelyEqual, stopPropagation } from '../../../../common/util';
 
 const clamp = (value: number, min?: number | null, max?: number | null): number => {
@@ -41,6 +41,8 @@ interface AdvancedNumberInputProps {
     inputString: string;
     setInputString: (input: string) => void;
     setInput: (value: number) => void;
+
+    onContextMenu?: MouseEventHandler<HTMLElement> | undefined;
 }
 
 export const AdvancedNumberInput = memo(
@@ -59,6 +61,8 @@ export const AdvancedNumberInput = memo(
         inputString,
         setInputString,
         setInput,
+
+        onContextMenu,
     }: AdvancedNumberInputProps) => {
         const onBlur = () => {
             const valAsNumber =
@@ -83,6 +87,7 @@ export const AdvancedNumberInput = memo(
                     mx={0}
                     size="xs"
                     w="fit-content"
+                    onContextMenu={onContextMenu}
                 >
                     {unit && (
                         <InputLeftAddon
@@ -130,6 +135,7 @@ export const AdvancedNumberInput = memo(
             <InputGroup
                 size="sm"
                 w="full"
+                onContextMenu={onContextMenu}
             >
                 {unit && (
                     <InputLeftAddon

--- a/src/renderer/components/inputs/elements/CopyOverrideIdSection.tsx
+++ b/src/renderer/components/inputs/elements/CopyOverrideIdSection.tsx
@@ -1,0 +1,34 @@
+import { MenuDivider, MenuItem } from '@chakra-ui/react';
+import { clipboard } from 'electron';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { MdContentCopy } from 'react-icons/md';
+import { InputId } from '../../../../common/common-types';
+import { createOverrideInputId } from '../../../../common/input-override';
+
+interface CopyOverrideIdSectionProps {
+    nodeId: string | undefined;
+    inputId: InputId | undefined;
+}
+
+export const CopyOverrideIdSection = memo(({ nodeId, inputId }: CopyOverrideIdSectionProps) => {
+    const { t } = useTranslation();
+
+    if (nodeId === undefined || inputId === undefined) {
+        return null;
+    }
+
+    return (
+        <>
+            <MenuDivider />
+            <MenuItem
+                icon={<MdContentCopy />}
+                onClick={() => {
+                    clipboard.writeText(createOverrideInputId(nodeId, inputId));
+                }}
+            >
+                {t('inputs.copyOverrideInputId', 'Copy Override Input Id')}
+            </MenuItem>
+        </>
+    );
+});

--- a/src/renderer/components/inputs/elements/StyledSlider.tsx
+++ b/src/renderer/components/inputs/elements/StyledSlider.tsx
@@ -8,7 +8,7 @@ import {
     Text,
     Tooltip,
 } from '@chakra-ui/react';
-import { memo, useMemo, useState } from 'react';
+import { MouseEventHandler, memo, useMemo, useState } from 'react';
 import { getTypeAccentColors } from '../../../helpers/getTypeAccentColors';
 
 export interface Scale {
@@ -65,6 +65,8 @@ interface StyledSliderProps {
     tooltip: string;
     onChange: (value: number) => void;
     onChangeEnd: (value: number) => void;
+
+    onContextMenu?: MouseEventHandler<HTMLElement> | undefined;
 }
 export const StyledSlider = memo(
     ({
@@ -79,6 +81,7 @@ export const StyledSlider = memo(
         tooltip,
         onChange,
         onChangeEnd,
+        onContextMenu,
     }: StyledSliderProps) => {
         const [showTooltip, setShowTooltip] = useState(false);
 
@@ -96,6 +99,7 @@ export const StyledSlider = memo(
                 value={scale.toScale(value)}
                 onChange={(n) => onChange(scale.fromScale(n))}
                 onChangeEnd={(n) => onChangeEnd(scale.fromScale(n))}
+                onContextMenu={onContextMenu}
                 onDoubleClick={() => onChangeEnd(def)}
                 onMouseEnter={() => setShowTooltip(true)}
                 onMouseLeave={() => setShowTooltip(false)}

--- a/src/renderer/components/inputs/props.ts
+++ b/src/renderer/components/inputs/props.ts
@@ -1,11 +1,13 @@
 import { Type } from '@chainner/navi';
 import { Input, InputKind, OfKind, Size } from '../../../common/common-types';
 
+type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+
 export interface InputProps<Kind extends InputKind, Value extends string | number = never> {
     readonly value: Value | undefined;
     readonly setValue: (input: Value) => void;
     readonly resetValue: () => void;
-    readonly input: Omit<OfKind<Input, Kind>, 'id' | 'type' | 'conversion'>;
+    readonly input: Omit<PartialBy<OfKind<Input, Kind>, 'id'>, 'type' | 'conversion'>;
     readonly definitionType: Type;
     readonly isLocked: boolean;
     readonly inputKey: string;
@@ -15,4 +17,5 @@ export interface InputProps<Kind extends InputKind, Value extends string | numbe
         Readonly<Size> | undefined,
         (size: Readonly<Size>) => void
     ];
+    readonly nodeId?: string;
 }


### PR DESCRIPTION
This adds support for primitive CLI overrides. The overrides are defined in a given JSON files. Inputs are identified using an identifier specifically for overrides. This can be obtained in the UI via the context menu of an input. Not all inputs support overrides right now. Only file, directory, number, slider, and text inputs are supported.

To add the context menu option, I need to add per-input context menus for all support input kinds. File and directory inputs already had context menus, but I had to add them for the rest. Since there isn't much context menus can do for text and number inputs, I just gave them Copy and Paste options.

![image](https://user-images.githubusercontent.com/20878432/213313078-d7c89fba-86c0-4ce6-bb1e-e68ff444c782.png)
![image](https://user-images.githubusercontent.com/20878432/213313101-fdf63abd-aeb1-4076-a87a-eb72ca894195.png)
![image](https://user-images.githubusercontent.com/20878432/213313139-9188c6bb-0460-4900-a0a6-bf0872372032.png)

---

I'm not really happy with this version of input overrides. They aren't easy to use and require users to see node and input ids. They also don't work across chains, i.e. overrides for one chain cannot be reused for another.
This is why I prefixed all override input ids with a `#`. This will allow us to identify "legacy" override ids when we figure out a better system.