### PR TITLE
Removed trailing new line from backend log

### DIFF
--- a/src/main/backend/process.ts
+++ b/src/main/backend/process.ts
@@ -68,14 +68,15 @@ export class OwnedBackendProcess implements BaseBackendProcess {
             },
         });
 
+        const removedTrailingNewLine = (s: string) => s.replace(/\r?\n$/, '');
         backend.stdout.on('data', (data) => {
             const dataString = String(data);
             // Remove unneeded timestamp
             const fixedData = dataString.split('] ').slice(1).join('] ');
-            log.info(`Backend: ${fixedData}`);
+            log.info(`Backend: ${removedTrailingNewLine(fixedData)}`);
         });
         backend.stderr.on('data', (data) => {
-            log.error(`Backend: ${String(data)}`);
+            log.error(`Backend: ${removedTrailingNewLine(String(data))}`);
         });
 
         return backend;


### PR DESCRIPTION
Text from stdout and stderr is read line by line and contains a trailing new line. This resulted in an additional empty line because `log.{info,warn,error}` also adds a trailing new line. So I removed the trailing new line.

Everything logged to console is nicely dense now:
```
23:58:26.049 > Attempting to check for a port...
23:58:26.068 > Port found: 8000
23:58:26.070 > Attempting to check Python env...
23:58:26.113 > Final Python binary: C:\Users\micha\AppData\Roaming\chaiNNer\python\python\python.exe
23:58:26.114 > {
  python: 'C:\\Users\\micha\\AppData\\Roaming\\chaiNNer\\python\\python\\python.exe',
  version: '3.9.7'
}
23:58:26.117 > Attempting to check Ffmpeg env...
23:58:26.119 > Final ffmpeg binary: C:\Users\micha\AppData\Roaming\chaiNNer\ffmpeg\ffmpeg.exe
23:58:26.119 > Final ffprobe binary: C:\Users\micha\AppData\Roaming\chaiNNer\ffmpeg\ffprobe.exe
23:58:26.276 > Attempting to check Python deps...
23:58:26.277 > Python executable: C:\Users\micha\AppData\Roaming\chaiNNer\python\python\python.exe
23:58:26.278 > Running pip command: pip list --format=json --disable-pip-version-check
23:58:27.046 > Attempting to spawn backend...
23:58:28.550 > Backend: [15128] [INFO] Goin' Fast @ http://127.0.0.1:8000
23:58:28.579 > Backend: [15128] [INFO] Starting worker [15128]
23:58:43.254 > Backend: - (sanic.access)[INFO][127.0.0.1:55826]: GET http://localhost:8000/nodes  200 180710
23:58:43.775 > Python executable: C:\Users\micha\AppData\Roaming\chaiNNer\python\python\python.exe
23:58:43.777 > Running pip command: pip list --format=json --disable-pip-version-check
23:58:58.284 > Backend: [15128] [INFO] PyTorch execution options: fp16: False, device: gpu | NCNN execution options: gpu_index: 0 | ONNX execution options: gpu_index: 0, execution_provider: CUDAExecutionProvider, should_tensorrt_cache: False, tensorrt_cache_path: C:\Users\micha\AppData\Roaming\chaiNNer\onnx-tensorrt-cache
23:58:58.547 > Backend: - (sanic.access)[INFO][127.0.0.1:55835]: POST http://localhost:8000/run/individual  200 28
00:04:35.246 > Attempting to kill backend...
00:04:35.247 > Successfully killed backend.
00:04:35.248 > Cleaning up temp folders...
```