### PR TITLE
Align all slider number inputs in a node

### DIFF
--- a/src/renderer/components/inputs/SchemaInput.tsx
+++ b/src/renderer/components/inputs/SchemaInput.tsx
@@ -119,6 +119,7 @@ export const SchemaInput = memo(
                 inputKey={`${schemaId}-${inputId}`}
                 isLocked={isLocked}
                 nodeId={nodeId}
+                nodeSchemaId={schemaId}
                 resetValue={resetValue}
                 setValue={setValue}
                 useInputConnected={useInputConnected}

--- a/src/renderer/components/inputs/elements/AdvanceNumberInput.tsx
+++ b/src/renderer/components/inputs/elements/AdvanceNumberInput.tsx
@@ -43,6 +43,7 @@ interface AdvancedNumberInputProps {
     setInput: (value: number) => void;
 
     onContextMenu?: MouseEventHandler<HTMLElement> | undefined;
+    inputWidth?: string;
 }
 
 export const AdvancedNumberInput = memo(
@@ -63,6 +64,7 @@ export const AdvancedNumberInput = memo(
         setInput,
 
         onContextMenu,
+        inputWidth,
     }: AdvancedNumberInputProps) => {
         const onBlur = () => {
             const valAsNumber =
@@ -119,8 +121,7 @@ export const AdvancedNumberInput = memo(
                             m={0}
                             p={1}
                             size={1}
-                            // dynamic width based on precision
-                            w={`${3 + 0.5 * precision}rem`}
+                            w={inputWidth}
                         />
                         <NumberInputStepper w={4}>
                             <NumberIncrementStepper />
@@ -167,6 +168,7 @@ export const AdvancedNumberInput = memo(
                         borderRightRadius="lg"
                         px={unit ? 2 : 4}
                         size={1}
+                        w={inputWidth}
                     />
                     <NumberInputStepper>
                         <NumberIncrementStepper />

--- a/src/renderer/components/inputs/props.ts
+++ b/src/renderer/components/inputs/props.ts
@@ -1,5 +1,5 @@
 import { Type } from '@chainner/navi';
-import { Input, InputKind, OfKind, Size } from '../../../common/common-types';
+import { Input, InputKind, OfKind, SchemaId, Size } from '../../../common/common-types';
 
 type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 
@@ -18,4 +18,5 @@ export interface InputProps<Kind extends InputKind, Value extends string | numbe
         (size: Readonly<Size>) => void
     ];
     readonly nodeId?: string;
+    readonly nodeSchemaId?: SchemaId;
 }


### PR DESCRIPTION
Changes:
- All slider number inputs in a node now have the same width.
- Changed formula to determine the number input width. It will now account for the number of digits of all possible values in the slider range and possible minus signs. It will generally try to make the space allocated per number input consistent across many different parameters. This results in slider number inputs being smaller now and some being larger.

Before:
![image](https://user-images.githubusercontent.com/20878432/214558860-a470202b-0aeb-41a5-9810-709754aaf1db.png)

After:
![image](https://user-images.githubusercontent.com/20878432/214558882-a31b614a-d798-4ded-921f-77cdc0f834cd.png)
