### PR TITLE
Added DDS option to separate alpha

### DIFF
--- a/backend/src/nodes/impl/dds.py
+++ b/backend/src/nodes/impl/dds.py
@@ -106,6 +106,7 @@ def save_as_dds(
     minimal_compression: bool = False,
     maximum_compression: bool = False,
     dx9: bool = False,
+    separate_alpha: bool = False,
 ):
     """
     Saves an image as DDS using texconv.
@@ -144,6 +145,9 @@ def save_as_dds(
 
         if dds_format in __SRGB_DDS_FORMATS:
             args.append("-srgbi")
+
+        if separate_alpha:
+            args.append("-sepalpha")
 
         args.append(tempPng)
         __run_texconv(args, "Unable to write DDS")

--- a/backend/src/nodes/nodes/image/save_image.py
+++ b/backend/src/nodes/nodes/image/save_image.py
@@ -79,7 +79,15 @@ class ImWriteNode(NodeBase):
                 "conditional-enum",
                 {
                     "enum": 4,
-                    "conditions": [["jpg", "webp"], "jpg", "jpg", "dds", "dds", "dds"],
+                    "conditions": [
+                        ["jpg", "webp"],
+                        "jpg",
+                        "jpg",
+                        "dds",
+                        "dds",
+                        "dds",
+                        "dds",
+                    ],
                 },
             )(
                 SliderInput(
@@ -118,6 +126,9 @@ class ImWriteNode(NodeBase):
                     BoolInput("Dithering", default=False).with_id(8),
                 ),
                 DdsMipMapsDropdown().with_id(10),
+                group("conditional-enum", {"enum": 10, "conditions": [0]})(
+                    BoolInput("Separate Alpha for Mip Maps", default=False).with_id(13),
+                ),
             ),
         ]
         self.category = ImageCategory
@@ -143,6 +154,7 @@ class ImWriteNode(NodeBase):
         dds_error_metric: DDSErrorMetric,
         dds_dithering: bool,
         dds_mipmap_levels: int,
+        dds_separate_alpha: bool,
     ) -> None:
         """Write an image to the specified path and return write status"""
 
@@ -180,6 +192,7 @@ class ImWriteNode(NodeBase):
                 minimal_compression=dds_bc7_compression == BC7Compression.BEST_SPEED,
                 maximum_compression=dds_bc7_compression == BC7Compression.BEST_QUALITY,
                 dx9=legacy_dds,
+                separate_alpha=dds_separate_alpha,
             )
             return
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20878432/214897711-725eb4d2-16d3-41fb-af70-f6d7dc0ccbab.png)

This option is necessary to correctly resize mipmaps for images with transparent colors. This is necessary for e.g. normal maps with transparency.