### PR TITLE
Specify output format as RGBA when loading DDS

### DIFF
--- a/backend/src/nodes/impl/dds.py
+++ b/backend/src/nodes/impl/dds.py
@@ -71,6 +71,8 @@ def dds_to_png_texconv(path: str) -> str:
 
     __run_texconv(
         [
+            "-f",
+            "rgba",
             "-ft",
             "png",
             "-px",


### PR DESCRIPTION
After search around for a bit why converting BC5 to PNG didn't work, I found this issue: https://github.com/microsoft/DirectXTex/issues/146

Loading BC5 and any other 2-channel format works now.