### PR TITLE
Use root dir for renderer log

### DIFF
--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -1,5 +1,19 @@
+import log from 'electron-log';
+import path from 'path';
 import { createRoot } from 'react-dom/client';
+import { ipcRenderer } from '../common/safeIpc';
 import { App } from './app';
+
+ipcRenderer
+    .invoke('get-appdata')
+    .then((rootDir) => {
+        log.transports.file.resolvePath = (variables) =>
+            path.join(rootDir, 'logs', variables.fileName!);
+        log.transports.file.level = 'info';
+    })
+    .catch((err) => {
+        log.error(err);
+    });
 
 const container = document.getElementById('root');
 const root = createRoot(container!);


### PR DESCRIPTION
Apparently, you need to do this in both places. Their docs never specify this. 🙃 

This is the last bit necessary for actual true portability