### PR TITLE
Added option to duplicate node with input connections

### DIFF
--- a/src/common/safeIpc.ts
+++ b/src/common/safeIpc.ts
@@ -82,6 +82,8 @@ export interface SendChannels {
     cut: SendChannelInfo;
     copy: SendChannelInfo;
     paste: SendChannelInfo;
+    duplicate: SendChannelInfo;
+    'duplicate-with-input-edges': SendChannelInfo;
 }
 export type ChannelArgs<C extends keyof (InvokeChannels & SendChannels)> = (InvokeChannels &
     SendChannels)[C]['args'];

--- a/src/main/gui/menu.ts
+++ b/src/main/gui/menu.ts
@@ -165,6 +165,25 @@ export const setMainMenu = ({ mainWindow, menuData, enabled = false }: MainMenuA
                     },
                     enabled,
                 },
+                { type: 'separator' },
+                {
+                    label: 'Duplicate',
+                    accelerator: 'CmdOrCtrl+D',
+                    registerAccelerator: false,
+                    click: () => {
+                        mainWindow.webContents.send('duplicate');
+                    },
+                    enabled,
+                },
+                {
+                    label: 'Duplicate with Connections',
+                    accelerator: 'CmdOrCtrl+Shift+D',
+                    registerAccelerator: false,
+                    click: () => {
+                        mainWindow.webContents.send('duplicate-with-input-edges');
+                    },
+                    enabled,
+                },
             ],
         },
         {


### PR DESCRIPTION
As requested by Rayan(Dahoom), when you now use Ctrl+Shift+D, the selected node(s) will be duplicate with their input connects being duplicated as well.

I also added menu items for "Duplicate" and "Duplicate with connections."