### PR TITLE
Signed Distance Field Node

### DIFF
--- a/backend/src/nodes/nodes/image_filter/distance_transform.py
+++ b/backend/src/nodes/nodes/image_filter/distance_transform.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import cv2
+import numpy as np
+
+from . import category as ImageFilterCategory
+from ...impl.dithering.common import dtype_to_uint8
+from ...impl.image_utils import as_3d
+from ...node_base import NodeBase
+from ...node_factory import NodeFactory
+from ...properties.inputs import ImageInput, NumberInput
+from ...properties.outputs import ImageOutput
+
+
+@NodeFactory.register("chainner:image:distance_transform")
+class DistanceTransformNode(NodeBase):
+    def __init__(self):
+        super().__init__()
+        self.description = "Perform a distance transform on a monochrome bitmap image, producing a signed distance field."
+        self.inputs = [
+            ImageInput(channels=1),
+            NumberInput("Spread", minimum=1, default=4),
+        ]
+        self.outputs = [ImageOutput(image_type="Input0")]
+        self.category = ImageFilterCategory
+        self.name = "Distance Transform"
+        self.icon = "MdBlurOff"
+        self.sub = "Misc"
+
+    def run(self, img: np.ndarray, spread: int) -> np.ndarray:
+        img = as_3d(dtype_to_uint8(img))
+        img[img < 128] = 0
+        img[img >= 128] = 255
+
+        black_dist = np.empty(shape=img.shape, dtype=np.float32)
+        white_dist = np.empty(shape=img.shape, dtype=np.float32)
+
+        cv2.distanceTransform(
+            src=img,
+            distanceType=cv2.DIST_L2,
+            maskSize=5,
+            dst=black_dist,
+            dstType=cv2.CV_32F,
+        )
+        cv2.distanceTransform(
+            src=255 - img,
+            distanceType=cv2.DIST_L2,
+            maskSize=5,
+            dst=white_dist,
+            dstType=cv2.CV_32F,
+        )
+
+        img1 = img.ravel()
+        signed_distance = np.empty(shape=img.shape, dtype=np.float32).ravel()
+
+        signed_distance[img1 == 255] = (
+            black_dist.ravel()[img1 == 255] / spread / 2 + 0.5
+        )
+        signed_distance[img1 == 0] = 0.5 - white_dist.ravel()[img1 == 0] / spread / 2
+
+        signed_distance = np.clip(signed_distance, 0, 1)
+
+        return signed_distance.reshape(img.shape)


### PR DESCRIPTION
A node that takes a monochrome image and returns a signed distance field, where the color of a pixel is related to the distance from that pixel to the nearest pixel of the other color, such that a threshold at 50% will restore the original image.

Can be used to create low-resolution textures that can be scaled up rendered at a higher resolution with fewer artifacts.  ([paper](https://steamcdn-a.akamaihd.net/apps/valve/2007/SIGGRAPH2007_AlphaTestedMagnification.pdf))

![image](https://user-images.githubusercontent.com/551173/218332572-c753b132-0f4f-4014-b00b-04a5e11a8b29.png)

left: Original full size
middle: scaled down, scaled up, thresholded
right: distance transformed, scaled down, scaled up, thresholded

![image](https://user-images.githubusercontent.com/551173/218332711-6e3e269e-f78e-41e0-9667-20386865aa70.png)

Can also be used to expand or contract a mask:

![image](https://user-images.githubusercontent.com/551173/218332586-83ec88bd-c09c-478d-8680-3fd39fef3720.png)
