### PR TITLE
Cache SD API verification

### DIFF
--- a/backend/src/nodes/impl/external_stable_diffusion.py
+++ b/backend/src/nodes/impl/external_stable_diffusion.py
@@ -93,7 +93,7 @@ def verify_api_connection():
 
     Call this function at import time if you want to make certain node available only when the API is up.
     """
-    global has_api_connection
+    global has_api_connection  # pylint: disable=global-statement
     if has_api_connection is None:
         has_api_connection = False
         get(STABLE_DIFFUSION_OPTIONS_URL)

--- a/backend/src/nodes/impl/external_stable_diffusion.py
+++ b/backend/src/nodes/impl/external_stable_diffusion.py
@@ -84,10 +84,23 @@ def nearest_valid_size(width, height):
     return (width // 8) * 8, (height // 8) * 8
 
 
-# Call the API at import time
-# If this fails (because the API isn't up) it will raise an exception and the
-# nodes importing this file won't be registered
-STABLE_DIFFUSION_OPTIONS = get(STABLE_DIFFUSION_OPTIONS_URL)
+has_api_connection: Union[bool, None] = None
+
+
+def verify_api_connection():
+    """
+    This function will throw if the stable diffusion API service is unavailable.
+
+    Call this function at import time if you want to make certain node available only when the API is up.
+    """
+    global has_api_connection
+    if has_api_connection is None:
+        has_api_connection = False
+        get(STABLE_DIFFUSION_OPTIONS_URL)
+        has_api_connection = True
+
+    if not has_api_connection:
+        raise ValueError("Cannot connect to stable diffusion API service.")
 
 
 def decode_base64_image(image_bytes: Union[bytes, str]) -> np.ndarray:

--- a/backend/src/nodes/nodes/external_stable_diffusion/img2img.py
+++ b/backend/src/nodes/nodes/external_stable_diffusion/img2img.py
@@ -15,6 +15,7 @@ from ...impl.external_stable_diffusion import (
     nearest_valid_size,
     ResizeMode,
     RESIZE_MODE_LABELS,
+    verify_api_connection,
 )
 from ...node_base import NodeBase, group
 from ...node_factory import NodeFactory
@@ -27,6 +28,8 @@ from ...properties.inputs import (
 )
 from ...properties.outputs import ImageOutput
 from ...utils.utils import get_h_w_c
+
+verify_api_connection()
 
 
 @NodeFactory.register("chainner:external_stable_diffusion:img2img")

--- a/backend/src/nodes/nodes/external_stable_diffusion/interrogate.py
+++ b/backend/src/nodes/nodes/external_stable_diffusion/interrogate.py
@@ -7,11 +7,14 @@ from ...impl.external_stable_diffusion import (
     STABLE_DIFFUSION_INTERROGATE_URL,
     post,
     encode_base64_image,
+    verify_api_connection,
 )
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import ImageInput
 from ...properties.outputs import TextOutput
+
+verify_api_connection()
 
 
 @NodeFactory.register("chainner:external_stable_diffusion:interrograte")

--- a/backend/src/nodes/nodes/external_stable_diffusion/outpainting.py
+++ b/backend/src/nodes/nodes/external_stable_diffusion/outpainting.py
@@ -18,6 +18,7 @@ from ...impl.external_stable_diffusion import (
     ResizeMode,
     RESIZE_MODE_LABELS,
     InpaintingFill,
+    verify_api_connection,
 )
 from ...node_base import NodeBase, group
 from ...node_factory import NodeFactory
@@ -31,6 +32,8 @@ from ...properties.inputs import (
 )
 from ...properties.outputs import ImageOutput
 from ...utils.utils import get_h_w_c
+
+verify_api_connection()
 
 
 class OutpaintingMethod(Enum):

--- a/backend/src/nodes/nodes/external_stable_diffusion/txt2img.py
+++ b/backend/src/nodes/nodes/external_stable_diffusion/txt2img.py
@@ -12,6 +12,7 @@ from ...impl.external_stable_diffusion import (
     STABLE_DIFFUSION_TEXT2IMG_URL,
     post,
     nearest_valid_size,
+    verify_api_connection,
 )
 from ...node_base import NodeBase, group
 from ...node_factory import NodeFactory
@@ -23,6 +24,8 @@ from ...properties.inputs import (
 )
 from ...properties.outputs import ImageOutput
 from ...utils.utils import get_h_w_c
+
+verify_api_connection()
 
 
 @NodeFactory.register("chainner:external_stable_diffusion:txt2img")


### PR DESCRIPTION
Verify that an SD API service is available is now done manually via the `verify_api_connection`. Nodes that wish to only appear when an SD API is up should call this function before registering. This also allows us to define SD nodes that should appear even if no external API is up.

The main motivation for this function are logs, though. The error message for when no API service is available is very detailed. This is good, but the message is also repeated 4 times, which makes it spam the log output.

<details>

```
> Attempting to spawn backend...
> Backend: [6868] [ERROR] A critical error occurred when importing module nodes.nodes.external_stable_diffusion.img2img: 
If you want to use external stable diffusion nodes, run the Automatic1111 web ui with the --api flag, like so:

./webui.sh --api

ChaiNNer is currently configured to look for the API at http://127.0.0.1:7860.  If you
have it running somewhere else, you can change this using the STABLE_DIFFUSION_HOST and STABLE_DIFFUSION_PORT
environment variables.

18:06:40.038 > Backend: [6868] [ERROR] A critical error occurred when importing module nodes.nodes.external_stable_diffusion.interrogate: 
If you want to use external stable diffusion nodes, run the Automatic1111 web ui with the --api flag, like so:

./webui.sh --api

ChaiNNer is currently configured to look for the API at http://127.0.0.1:7860.  If you
have it running somewhere else, you can change this using the STABLE_DIFFUSION_HOST and STABLE_DIFFUSION_PORT
environment variables.

18:06:42.055 > Backend: [6868] [ERROR] A critical error occurred when importing module nodes.nodes.external_stable_diffusion.outpainting: 
If you want to use external stable diffusion nodes, run the Automatic1111 web ui with the --api flag, like so:

./webui.sh --api

ChaiNNer is currently configured to look for the API at http://127.0.0.1:7860.  If you
have it running somewhere else, you can change this using the STABLE_DIFFUSION_HOST and STABLE_DIFFUSION_PORT
environment variables.

18:06:44.127 > Backend: [6868] [ERROR] A critical error occurred when importing module nodes.nodes.external_stable_diffusion.txt2img: 
If you want to use external stable diffusion nodes, run the Automatic1111 web ui with the --api flag, like so:

./webui.sh --api

ChaiNNer is currently configured to look for the API at http://127.0.0.1:7860.  If you
have it running somewhere else, you can change this using the STABLE_DIFFUSION_HOST and STABLE_DIFFUSION_PORT
environment variables.
```

</details>

The new function will only use an error with the detailed error message the first time around.

@adodge Thoughts?