### PR TITLE
Add "Use Pip Directly" option in dependency manager

### DIFF
--- a/src/renderer/contexts/DependencyContext.tsx
+++ b/src/renderer/contexts/DependencyContext.tsx
@@ -468,6 +468,7 @@ export const DependencyProvider = memo(({ children }: React.PropsWithChildren<un
                                     <HStack>
                                         <Switch
                                             isChecked={usePipDirectly}
+                                            isDisabled={isRunningShell}
                                             onChange={() => {
                                                 setUsePipDirectly(!usePipDirectly);
                                             }}

--- a/src/renderer/contexts/DependencyContext.tsx
+++ b/src/renderer/contexts/DependencyContext.tsx
@@ -284,7 +284,7 @@ export const DependencyProvider = memo(({ children }: React.PropsWithChildren<un
     const refreshInstalledPackages = useCallback(() => setPipList(undefined), [setPipList]);
 
     const [isConsoleOpen, setIsConsoleOpen] = useState(false);
-    const [useProgressBars, setUseProgressBars] = useState(false);
+    const [usePipDirectly, setUsePipDirectly] = useState(false);
 
     useAsyncEffect(() => {
         if (pipList) return;
@@ -355,14 +355,14 @@ export const DependencyProvider = memo(({ children }: React.PropsWithChildren<un
     const installPackage = (dep: Dependency) => {
         setInstallingPackage(dep);
         changePackages(() =>
-            runPipInstall(pythonInfo, [dep], useProgressBars ? setProgress : undefined, onStdio)
+            runPipInstall(pythonInfo, [dep], usePipDirectly ? undefined : setProgress, onStdio)
         );
     };
 
     const uninstallPackage = (dep: Dependency) => {
         setUninstallingPackage(dep);
         changePackages(() =>
-            runPipUninstall(pythonInfo, [dep], useProgressBars ? setProgress : undefined, onStdio)
+            runPipUninstall(pythonInfo, [dep], usePipDirectly ? undefined : setProgress, onStdio)
         );
     };
 
@@ -467,18 +467,16 @@ export const DependencyProvider = memo(({ children }: React.PropsWithChildren<un
                                 <HStack>
                                     <HStack>
                                         <Switch
-                                            isChecked={useProgressBars}
+                                            isChecked={usePipDirectly}
                                             onChange={() => {
-                                                setUseProgressBars(!useProgressBars);
+                                                setUsePipDirectly(!usePipDirectly);
                                             }}
                                         />
-                                        <Text>Use Progress Bars</Text>
+                                        <Text>Use Pip Directly</Text>
                                         <Tooltip
                                             hasArrow
                                             borderRadius={8}
-                                            label={
-                                                "Show actual progress bars for accurate download progress reporting. This uses a different download method, and as such may cause issues when downloading, so it's disabled by default."
-                                            }
+                                            label="Disable progress bars and use pip to directly download and install the packages. Use this setting if you are having issues installing normally."
                                             maxW="auto"
                                             openDelay={500}
                                             px={2}
@@ -490,12 +488,12 @@ export const DependencyProvider = memo(({ children }: React.PropsWithChildren<un
                                         </Tooltip>
                                     </HStack>
                                     <Button
-                                        aria-label="View Console"
+                                        aria-label={isConsoleOpen ? 'Hide Console' : 'View Console'}
                                         leftIcon={<BsTerminalFill />}
                                         size="sm"
                                         onClick={() => setIsConsoleOpen(!isConsoleOpen)}
                                     >
-                                        View Console
+                                        {isConsoleOpen ? 'Hide Console' : 'View Console'}
                                     </Button>
                                 </HStack>
                             </Flex>
@@ -545,7 +543,7 @@ export const DependencyProvider = memo(({ children }: React.PropsWithChildren<un
                                                 key={dep.name}
                                                 pipList={pipList}
                                                 progress={
-                                                    useProgressBars &&
+                                                    !usePipDirectly &&
                                                     isRunningShell &&
                                                     (installingPackage || uninstallingPackage)
                                                         ?.name === dep.name

--- a/src/renderer/contexts/DependencyContext.tsx
+++ b/src/renderer/contexts/DependencyContext.tsx
@@ -11,7 +11,7 @@ import {
     Divider,
     Flex,
     HStack,
-    IconButton,
+    Icon,
     Modal,
     ModalBody,
     ModalCloseButton,
@@ -22,6 +22,7 @@ import {
     Progress,
     Spacer,
     Spinner,
+    Switch,
     Tag,
     Text,
     Textarea,
@@ -31,7 +32,7 @@ import {
 } from '@chakra-ui/react';
 import log from 'electron-log';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { BsTerminalFill } from 'react-icons/bs';
+import { BsQuestionCircle, BsTerminalFill } from 'react-icons/bs';
 import { createContext, useContext } from 'use-context-selector';
 import { Version } from '../../common/common-types';
 import { Dependency, PyPiPackage, getOptionalDependencies } from '../../common/dependencies';
@@ -283,6 +284,7 @@ export const DependencyProvider = memo(({ children }: React.PropsWithChildren<un
     const refreshInstalledPackages = useCallback(() => setPipList(undefined), [setPipList]);
 
     const [isConsoleOpen, setIsConsoleOpen] = useState(false);
+    const [useProgressBars, setUseProgressBars] = useState(false);
 
     useAsyncEffect(() => {
         if (pipList) return;
@@ -352,12 +354,16 @@ export const DependencyProvider = memo(({ children }: React.PropsWithChildren<un
 
     const installPackage = (dep: Dependency) => {
         setInstallingPackage(dep);
-        changePackages(() => runPipInstall(pythonInfo, [dep], setProgress, onStdio));
+        changePackages(() =>
+            runPipInstall(pythonInfo, [dep], useProgressBars ? setProgress : undefined, onStdio)
+        );
     };
 
     const uninstallPackage = (dep: Dependency) => {
         setUninstallingPackage(dep);
-        changePackages(() => runPipUninstall(pythonInfo, [dep], setProgress, onStdio));
+        changePackages(() =>
+            runPipUninstall(pythonInfo, [dep], useProgressBars ? setProgress : undefined, onStdio)
+        );
     };
 
     useEffect(() => {
@@ -458,12 +464,40 @@ export const DependencyProvider = memo(({ children }: React.PropsWithChildren<un
                                     Python ({pythonInfo.version}) [
                                     {isSystemPython ? 'System' : 'Integrated'}]
                                 </Text>
-                                <IconButton
-                                    aria-label="Open Console View"
-                                    icon={<BsTerminalFill />}
-                                    size="sm"
-                                    onClick={() => setIsConsoleOpen(!isConsoleOpen)}
-                                />
+                                <HStack>
+                                    <HStack>
+                                        <Switch
+                                            isChecked={useProgressBars}
+                                            onChange={() => {
+                                                setUseProgressBars(!useProgressBars);
+                                            }}
+                                        />
+                                        <Text>Use Progress Bars</Text>
+                                        <Tooltip
+                                            hasArrow
+                                            borderRadius={8}
+                                            label={
+                                                "Show actual progress bars for accurate download progress reporting. This uses a different download method, and as such may cause issues when downloading, so it's disabled by default."
+                                            }
+                                            maxW="auto"
+                                            openDelay={500}
+                                            px={2}
+                                            py={0}
+                                        >
+                                            <Center>
+                                                <Icon as={BsQuestionCircle} />
+                                            </Center>
+                                        </Tooltip>
+                                    </HStack>
+                                    <Button
+                                        aria-label="View Console"
+                                        leftIcon={<BsTerminalFill />}
+                                        size="sm"
+                                        onClick={() => setIsConsoleOpen(!isConsoleOpen)}
+                                    >
+                                        View Console
+                                    </Button>
+                                </HStack>
                             </Flex>
                             {!pipList ? (
                                 <Spinner />
@@ -511,6 +545,7 @@ export const DependencyProvider = memo(({ children }: React.PropsWithChildren<un
                                                 key={dep.name}
                                                 pipList={pipList}
                                                 progress={
+                                                    useProgressBars &&
                                                     isRunningShell &&
                                                     (installingPackage || uninstallingPackage)
                                                         ?.name === dep.name


### PR DESCRIPTION
Also I made the view console button have text so its more obvious what it does.

This should hopefully prevent issues with people's VPNs and whatnot, as it will now default to just using pip directly. Progress bars (and thus our jank workaround for them) is now optional.

![image](https://user-images.githubusercontent.com/34788790/218896262-8c09ba81-9e4b-4f54-9d06-ef466c1d8b0e.png)

![image](https://user-images.githubusercontent.com/34788790/218896343-648ff8a6-e6ce-45c5-8f78-622c56df5e2b.png)


