### PR TITLE
Improved `auto_split` for PixTransform

### DIFF
--- a/backend/src/nodes/impl/ncnn/auto_split.py
+++ b/backend/src/nodes/impl/ncnn/auto_split.py
@@ -34,7 +34,7 @@ def ncnn_auto_split(
     staging_vkallocator,
     tiler: Tiler,
 ) -> np.ndarray:
-    def upscale(img: np.ndarray):
+    def upscale(img: np.ndarray, _):
         ex = net.create_extractor()
         ex.set_blob_vkallocator(blob_vkallocator)
         ex.set_workspace_vkallocator(blob_vkallocator)

--- a/backend/src/nodes/impl/onnx/auto_split.py
+++ b/backend/src/nodes/impl/onnx/auto_split.py
@@ -20,7 +20,7 @@ def onnx_auto_split(
 
     is_fp16_model = session.get_inputs()[0].type == "tensor(float16)"
 
-    def upscale(img: np.ndarray):
+    def upscale(img: np.ndarray, _):
         try:
             lr_img = np2nptensor(img, change_range=False)
             lr_img = lr_img.astype(np.float16) if is_fp16_model else lr_img

--- a/backend/src/nodes/impl/pytorch/auto_split.py
+++ b/backend/src/nodes/impl/pytorch/auto_split.py
@@ -22,7 +22,7 @@ def pytorch_auto_split(
     model = model.to(device)
     model = model.half() if use_fp16 else model.float()
 
-    def upscale(img: np.ndarray):
+    def upscale(img: np.ndarray, _):
         img_tensor = np2tensor(img, change_range=True)
 
         d_img = None

--- a/backend/src/nodes/impl/upscale/auto_split.py
+++ b/backend/src/nodes/impl/upscale/auto_split.py
@@ -1,67 +1,97 @@
 from __future__ import annotations
-from abc import ABC, abstractmethod
-from typing import Callable, Optional, Union, Tuple
+from typing import Callable, Optional, Union
 import math
 
 import numpy as np
 from sanic.log import logger
 
-from ...utils.utils import get_h_w_c, Region
+from ...utils.utils import get_h_w_c, Region, Size
 from .exact_split import exact_split
+from .tiler import Tiler
 
 
 class Split:
     pass
 
 
-class Tiler(ABC):
-    def exact_tile_size(self) -> Tuple[int, int] | None:
-        return None
-
-    @abstractmethod
-    def starting_tile_size(self, width: int, height: int, channels: int) -> int:
-        pass
-
-    def split(self, tile_size: int) -> int:
-        assert tile_size >= 16
-        return max(16, tile_size // 2)
-
-
-class NoTiling(Tiler):
-    def starting_tile_size(self, width: int, height: int, _channels: int) -> int:
-        return max(width, height)
-
-    def split(self, _tile_size: int) -> int:
-        raise ValueError(f"Image cannot be upscale with No Tiling mode.")
-
-
-class MaxTileSize(Tiler):
-    def __init__(self, tile_size: int = 2**31) -> None:
-        self.tile_size: int = tile_size
-
-    def starting_tile_size(self, width: int, height: int, _channels: int) -> int:
-        # Tile size a lot larger than the image don't make sense.
-        # So we use the minimum of the image dimensions and the given tile size.
-        max_tile_size = max(width + 10, height + 10)
-        return min(self.tile_size, max_tile_size)
-
-
-class ExactTileSize(Tiler):
-    def __init__(self, exact_size: Tuple[int, int]) -> None:
-        self.exact_size = exact_size
-
-    def exact_tile_size(self) -> Tuple[int, int] | None:
-        return self.exact_size
-
-    def starting_tile_size(self, width: int, height: int, _channels: int) -> int:
-        return max(*self.exact_size)
+SplitImageOp = Callable[[np.ndarray, Region], Union[np.ndarray, Split]]
 
 
 def auto_split(
     img: np.ndarray,
-    upscale: Callable[[np.ndarray], Union[np.ndarray, Split]],
+    upscale: SplitImageOp,
     tiler: Tiler,
     overlap: int = 16,
+) -> np.ndarray:
+    """
+    Splits the image into tiles according to the given tiler.
+
+    This method only changes the size of the given image, the tiles passed into the upscale function will have same number of channels.
+
+    The region passed into the upscale function is the region of the current tile.
+    The size of the region is guaranteed to be the same as the size of the given tile.
+
+    ## Padding
+
+    If the given tiler allows smaller tile sizes, then it is guaranteed that no padding will be added.
+    Otherwise, no padding is only guaranteed if the starting tile size is not larger than the size of the given image.
+    """
+
+    h, w, c = get_h_w_c(img)
+    split = _max_split if tiler.allow_smaller_tile_size() else _exact_split
+
+    return split(
+        img,
+        upscale=upscale,
+        starting_tile_size=tiler.starting_tile_size(w, h, c),
+        split_tile_size=tiler.split,
+        overlap=overlap,
+    )
+
+
+class _SplitEx(Exception):
+    pass
+
+
+def _exact_split(
+    img: np.ndarray,
+    upscale: SplitImageOp,
+    starting_tile_size: Size,
+    split_tile_size: Callable[[Size], Size],
+    overlap: int,
+) -> np.ndarray:
+    h, w, c = get_h_w_c(img)
+    logger.info(
+        f"Exact size split image ({w}x{h}px @ {c}) with exact tile size {starting_tile_size[0]}x{starting_tile_size[1]}px."
+    )
+
+    def no_split_upscale(i: np.ndarray, r: Region) -> np.ndarray:
+        result = upscale(i, r)
+        if isinstance(result, Split):
+            raise _SplitEx
+        return result
+
+    MAX_ITER = 20
+    for _ in range(MAX_ITER):
+        try:
+            return exact_split(
+                img=img,
+                exact_size=starting_tile_size,
+                upscale=no_split_upscale,
+                overlap=overlap,
+            )
+        except _SplitEx:
+            starting_tile_size = split_tile_size(starting_tile_size)
+
+    raise ValueError(f"Aborting after {MAX_ITER} splits. Unable to upscale image.")
+
+
+def _max_split(
+    img: np.ndarray,
+    upscale: SplitImageOp,
+    starting_tile_size: Size,
+    split_tile_size: Callable[[Size], Size],
+    overlap: int,
 ) -> np.ndarray:
     """
     Splits the image into tiles with at most the given tile size.
@@ -71,41 +101,21 @@ def auto_split(
 
     h, w, c = get_h_w_c(img)
 
-    exact_tile_size = tiler.exact_tile_size()
-    if exact_tile_size is not None:
-        logger.info(
-            f"Exact size split image ({w}x{h}px @ {c}) with exact tile size {exact_tile_size[0]}x{exact_tile_size[1]}px."
-        )
+    img_region = Region(0, 0, w, h)
 
-        def no_split_upscale(i: np.ndarray) -> np.ndarray:
-            result = upscale(i)
-            if isinstance(result, Split):
-                raise ValueError(
-                    f"Splits are not supported for exact size ({exact_tile_size[0]}x{exact_tile_size[1]}px) splitting."
-                    f" This typically means that your machine does not have enough VRAM to run the current model."
-                )
-            return result
-
-        return exact_split(
-            img=img,
-            exact_size=exact_tile_size,
-            upscale=no_split_upscale,
-            overlap=overlap,
-        )
-
-    max_tile_size = tiler.starting_tile_size(w, h, c)
+    max_tile_size = starting_tile_size
     logger.info(
         f"Auto split image ({w}x{h}px @ {c}) with initial tile size {max_tile_size}."
     )
 
-    if h <= max_tile_size and w <= max_tile_size:
+    if w <= max_tile_size[0] and h <= max_tile_size[1]:
         # the image might be small enough so that we don't have to split at all
-        upscale_result = upscale(img)
+        upscale_result = upscale(img, img_region)
         if not isinstance(upscale_result, Split):
             return upscale_result
 
         # the image was too large
-        max_tile_size = tiler.split(max_tile_size)
+        max_tile_size = split_tile_size(max_tile_size)
 
         logger.info(
             f"Unable to upscale the whole image at once. Reduced tile size to {max_tile_size}."
@@ -122,8 +132,6 @@ def auto_split(
     result: Optional[np.ndarray] = None
     scale: int = 0
 
-    img_region = Region(0, 0, w, h)
-
     restart = True
     while restart:
         restart = False
@@ -134,8 +142,8 @@ def auto_split(
         # Instead, we use tile_size to calculate how many tiles we get in the x and y direction
         # and then calculate the optimal tile size for the x and y direction using the counts.
         # This yields optimal tile sizes which should prevent unnecessary splitting.
-        tile_count_x = math.ceil(w / max_tile_size)
-        tile_count_y = math.ceil(h / max_tile_size)
+        tile_count_x = math.ceil(w / max_tile_size[0])
+        tile_count_y = math.ceil(h / max_tile_size[1])
         tile_size_x = math.ceil(w / tile_count_x)
         tile_size_y = math.ceil(h / tile_count_y)
 
@@ -159,13 +167,13 @@ def auto_split(
                 pad = img_region.child_padding(tile).min(overlap)
                 padded_tile = tile.add_padding(pad)
 
-                upscale_result = upscale(padded_tile.read_from(img))
+                upscale_result = upscale(padded_tile.read_from(img), padded_tile)
 
                 if isinstance(upscale_result, Split):
-                    max_tile_size = tiler.split(max_tile_size)
+                    max_tile_size = split_tile_size(max_tile_size)
 
-                    new_tile_count_x = math.ceil(w / max_tile_size)
-                    new_tile_count_y = math.ceil(h / max_tile_size)
+                    new_tile_count_x = math.ceil(w / max_tile_size[0])
+                    new_tile_count_y = math.ceil(h / max_tile_size[1])
                     new_tile_size_x = math.ceil(w / new_tile_count_x)
                     new_tile_size_y = math.ceil(h / new_tile_count_y)
                     start_x = (x * tile_size_x) // new_tile_size_x

--- a/backend/src/nodes/impl/upscale/auto_split_tiles.py
+++ b/backend/src/nodes/impl/upscale/auto_split_tiles.py
@@ -3,7 +3,7 @@ import numpy as np
 from sanic.log import logger
 
 from ...utils.utils import get_h_w_c
-from .auto_split import Tiler, MaxTileSize, NoTiling
+from .tiler import Tiler, MaxTileSize, NoTiling
 
 
 def estimate_tile_size(

--- a/backend/src/nodes/impl/upscale/exact_split.py
+++ b/backend/src/nodes/impl/upscale/exact_split.py
@@ -7,11 +7,11 @@ from dataclasses import dataclass
 import numpy as np
 from sanic.log import logger
 
-from ...utils.utils import get_h_w_c, Region, Padding
+from ...utils.utils import get_h_w_c, Region, Padding, Size
 from ..image_utils import create_border, BorderType
 
 
-def pad_image(img: np.ndarray, min_size: Tuple[int, int]):
+def _pad_image(img: np.ndarray, min_size: Size):
     h, w, _ = get_h_w_c(img)
 
     min_w, min_h = min_size
@@ -24,7 +24,7 @@ def pad_image(img: np.ndarray, min_size: Tuple[int, int]):
 
 
 @dataclass
-class Segment:
+class _Segment:
     start: int
     end: int
     startPadding: int
@@ -39,21 +39,21 @@ class Segment:
         return self.end + self.endPadding - (self.start - self.startPadding)
 
 
-def exact_split_into_segments(length: int, exact: int, overlap: int) -> List[Segment]:
+def _exact_split_into_segments(length: int, exact: int, overlap: int) -> List[_Segment]:
     """
     Splits the given length into segments of `exact` (padded) length.
     Segments will overlap into each other with at least the given overlap.
     """
     if length == exact:
         # trivial
-        return [Segment(0, exact, 0, 0)]
+        return [_Segment(0, exact, 0, 0)]
 
     assert length > exact
     assert exact > overlap * 2
 
-    result: List[Segment] = []
+    result: List[_Segment] = []
 
-    def add(s: Segment):
+    def add(s: _Segment):
         assert s.padded_length == exact
         result.append(s)
 
@@ -65,7 +65,7 @@ def exact_split_into_segments(length: int, exact: int, overlap: int) -> List[Seg
     # However, this is complex to implement and the current method also works.
 
     # we know that the first segment looks like this
-    add(Segment(0, exact - overlap, 0, overlap))
+    add(_Segment(0, exact - overlap, 0, overlap))
 
     innerStart = exact - overlap
     while innerStart < length:
@@ -80,14 +80,14 @@ def exact_split_into_segments(length: int, exact: int, overlap: int) -> List[Seg
             end = length
             startPadding = exact - (end - start)
 
-        result.append(Segment(start, end, startPadding, endPadding))
+        result.append(_Segment(start, end, startPadding, endPadding))
 
         start = end
 
     return result
 
 
-def exact_split_into_regions(
+def _exact_split_into_regions(
     w: int,
     h: int,
     exact_w: int,
@@ -101,8 +101,8 @@ def exact_split_into_regions(
     """
 
     # we can split x and y independently from each other and then combine the results
-    x_segments = exact_split_into_segments(w, exact_w, overlap)
-    y_segments = exact_split_into_segments(h, exact_h, overlap)
+    x_segments = _exact_split_into_segments(w, exact_w, overlap)
+    y_segments = _exact_split_into_segments(h, exact_h, overlap)
 
     logger.info(
         f"Image is split into {len(x_segments)}x{len(y_segments)} tiles each exactly {exact_w}x{exact_h}px."
@@ -120,10 +120,10 @@ def exact_split_into_regions(
     return result
 
 
-def exact_split_without_padding(
+def _exact_split_without_padding(
     img: np.ndarray,
-    exact_size: Tuple[int, int],
-    upscale: Callable[[np.ndarray], np.ndarray],
+    exact_size: Size,
+    upscale: Callable[[np.ndarray, Region], np.ndarray],
     overlap: int,
 ) -> np.ndarray:
     h, w, c = get_h_w_c(img)
@@ -131,18 +131,18 @@ def exact_split_without_padding(
     assert w >= exact_w and h >= exact_h
 
     if (w, h) == exact_size:
-        return upscale(img)
+        return upscale(img, Region(0, 0, w, h))
 
     # To allocate the result image, we need to know the upscale factor first,
     # and we only get to know this factor after the first successful upscale.
     result: Optional[np.ndarray] = None
     scale: int = 0
 
-    regions = exact_split_into_regions(w, h, exact_w, exact_h, overlap)
+    regions = _exact_split_into_regions(w, h, exact_w, exact_h, overlap)
     for tile, pad in regions:
         padded_tile = tile.add_padding(pad)
 
-        upscale_result = upscale(padded_tile.read_from(img))
+        upscale_result = upscale(padded_tile.read_from(img), padded_tile)
 
         # figure out by how much the image was upscaled by
         up_h, up_w, _ = get_h_w_c(upscale_result)
@@ -172,8 +172,8 @@ def exact_split_without_padding(
 
 def exact_split(
     img: np.ndarray,
-    exact_size: Tuple[int, int],
-    upscale: Callable[[np.ndarray], np.ndarray],
+    exact_size: Size,
+    upscale: Callable[[np.ndarray, Region], np.ndarray],
     overlap: int = 16,
 ) -> np.ndarray:
     """
@@ -183,10 +183,10 @@ def exact_split(
     """
 
     # ensure that the image is at least as large as the given size
-    img, base_padding = pad_image(img, exact_size)
+    img, base_padding = _pad_image(img, exact_size)
     h, w, _ = get_h_w_c(img)
 
-    result = exact_split_without_padding(img, exact_size, upscale, overlap)
+    result = _exact_split_without_padding(img, exact_size, upscale, overlap)
     scale = get_h_w_c(result)[0] // h
 
     if base_padding.empty:

--- a/backend/src/nodes/impl/upscale/tiler.py
+++ b/backend/src/nodes/impl/upscale/tiler.py
@@ -7,10 +7,10 @@ class Tiler(ABC):
     @abstractmethod
     def allow_smaller_tile_size(self) -> bool:
         """
-        Whether auto split may also use tile sizes than the ones returned by this tiler.
+        Whether the split implementation may use tile sizes smaller than the ones returned by this tiler.
 
-        If False is returned, then auto split guarantees that the all tiles are of exactly the size returned by this tiler.
-        If the image is smaller than the returned tile size, then it will be padded to reach the given size.
+        If False, then the split implementation guarantees that the all tiles are of exactly the size returned by this tiler.
+        If the image is smaller than the returned tile size, then it has to be padded to reach the given size.
         """
 
     @abstractmethod

--- a/backend/src/nodes/impl/upscale/tiler.py
+++ b/backend/src/nodes/impl/upscale/tiler.py
@@ -1,0 +1,72 @@
+from abc import ABC, abstractmethod
+
+from ...utils.utils import Size
+
+
+class Tiler(ABC):
+    @abstractmethod
+    def allow_smaller_tile_size(self) -> bool:
+        """
+        Whether auto split may also use tile sizes than the ones returned by this tiler.
+
+        If False is returned, then auto split guarantees that the all tiles are of exactly the size returned by this tiler.
+        If the image is smaller than the returned tile size, then it will be padded to reach the given size.
+        """
+
+    @abstractmethod
+    def starting_tile_size(self, width: int, height: int, channels: int) -> Size:
+        """
+        The starting tile size is the first tile size that will be used.
+
+        We generally prefer square tile sizes, but any tile size may be used.
+        """
+
+    def split(self, tile_size: Size) -> Size:
+        w, h = tile_size
+        assert w >= 16 and h >= 16
+        return max(16, w // 2), max(16, h // 2)
+
+
+class NoTiling(Tiler):
+    def allow_smaller_tile_size(self) -> bool:
+        return True
+
+    def starting_tile_size(self, width: int, height: int, _channels: int) -> Size:
+        size = max(width, height)
+        # we prefer square tiles
+        return size, size
+
+    def split(self, _: Size) -> Size:
+        raise ValueError(f"Image cannot be upscale with No Tiling mode.")
+
+
+class MaxTileSize(Tiler):
+    def __init__(self, tile_size: int = 2**31) -> None:
+        self.tile_size: int = tile_size
+
+    def allow_smaller_tile_size(self) -> bool:
+        return True
+
+    def starting_tile_size(self, width: int, height: int, _channels: int) -> Size:
+        # Tile size a lot larger than the image don't make sense.
+        # So we use the minimum of the image dimensions and the given tile size.
+        max_tile_size = max(width + 10, height + 10)
+        size = min(self.tile_size, max_tile_size)
+        return size, size
+
+
+class ExactTileSize(Tiler):
+    def __init__(self, exact_size: Size) -> None:
+        self.exact_size = exact_size
+
+    def allow_smaller_tile_size(self) -> bool:
+        return False
+
+    def starting_tile_size(self, _width: int, _height: int, _channels: int) -> Size:
+        return self.exact_size
+
+    def split(self, _tile_size: Size) -> Size:
+        raise ValueError(
+            f"Splits are not supported for exact size ({self.exact_size[0]}x{self.exact_size[1]}px) splitting."
+            f" This typically means that your machine does not have enough VRAM to run the current model."
+        )

--- a/backend/src/nodes/nodes/ncnn/upscale_image.py
+++ b/backend/src/nodes/nodes/ncnn/upscale_image.py
@@ -11,7 +11,7 @@ from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import ImageInput, NcnnModelInput, TileSizeDropdown
 from ...properties.outputs import ImageOutput
-from ...impl.upscale.auto_split import MaxTileSize
+from ...impl.upscale.tiler import MaxTileSize
 from ...impl.upscale.auto_split_tiles import (
     estimate_tile_size,
     parse_tile_size_input,

--- a/backend/src/nodes/nodes/onnx/upscale_image.py
+++ b/backend/src/nodes/nodes/onnx/upscale_image.py
@@ -10,7 +10,7 @@ from ...impl.onnx.auto_split import onnx_auto_split
 from ...impl.onnx.model import OnnxModel
 from ...impl.onnx.session import get_onnx_session
 from ...impl.onnx.utils import get_input_shape, get_output_shape
-from ...impl.upscale.auto_split import ExactTileSize
+from ...impl.upscale.tiler import ExactTileSize
 from ...impl.upscale.auto_split_tiles import TileSize, parse_tile_size_input
 from ...impl.upscale.convenient_upscale import convenient_upscale
 from ...node_base import NodeBase

--- a/backend/src/nodes/nodes/pytorch/upscale_image.py
+++ b/backend/src/nodes/nodes/pytorch/upscale_image.py
@@ -18,7 +18,7 @@ from ...impl.upscale.auto_split_tiles import (
     parse_tile_size_input,
     TileSize,
 )
-from ...impl.upscale.auto_split import MaxTileSize
+from ...impl.upscale.tiler import MaxTileSize
 from ...impl.upscale.convenient_upscale import convenient_upscale
 from ...impl.pytorch.utils import to_pytorch_execution_options
 from ...impl.pytorch.auto_split import pytorch_auto_split

--- a/backend/src/nodes/utils/utils.py
+++ b/backend/src/nodes/utils/utils.py
@@ -9,6 +9,11 @@ import os
 import numpy as np
 from sanic.log import logger
 
+Size = Tuple[int, int]
+"""
+The width and height (in that order) of an image.
+"""
+
 NUMBERS = re.compile(r"(\d+)")
 
 ALPHABET = [*"ABCDEFGHIJKLMNOPQRSTUVWXYZ"]
@@ -173,7 +178,7 @@ class Region:
     height: int
 
     @property
-    def size(self) -> Tuple[int, int]:
+    def size(self) -> Size:
         return self.width, self.height
 
     def scale(self, factor: int) -> Region:


### PR DESCRIPTION
To add tiling to #1506, I need 2 new features in `auto_split`:

1. Support for splitting in exact size mode. PixTransform requires square images, but we can largely choose the size of the square.
2. Region information. Since guided upsampling has a guide image, we need to be able to map the region of the current tile to its region in the guide image.

This PR adds those 2 features and makes a few additional changes:
- Added support for splitting in exact size mode. This is done in a simple loop where we repeatedly start from scratch when the tile size is changed.
- Added region information. `auto_split`'s upscale function parameter now takes a `Region` values. This is the location of the current tile within the given image.
- Added support for non-square tile sizes. By simplifying the `Tiler` interface, this just kinda happened. The underlying split implementations already supported non-square tile sizes internally, so this was easy to implement.
- Renamed a few module-scoped functions and variables to not export them.

I made this its own PR, because `auto_split` is very important, so I'd like us to test this PR in isolation.