### PR TITLE
Added isort

### DIFF
--- a/.github/workflows/lint-backend.yml
+++ b/.github/workflows/lint-backend.yml
@@ -37,6 +37,8 @@ jobs:
                   pip install -r requirements.txt
             - name: Black
               run: black --check backend/
+            - name: isort
+              run: isort backend/ --check --profile=black --src=backend/src
     backend-lint:
         runs-on: ubuntu-latest
         steps:

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,8 @@
 		"ms-python.vscode-pylance",
 		"streetsidesoftware.code-spell-checker",
 		"dbaeumer.vscode-eslint",
-		"ms-python.pylint"
+		"ms-python.pylint",
+		"ms-python.black-formatter",
+		"ms-python.isort"
 	]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -104,6 +104,11 @@
     "YUV"
   ],
   "[python]": {
-    "editor.formatOnSave": true
-  }
+    "editor.defaultFormatter": "ms-python.black-formatter",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+        "source.organizeImports": true
+    }
+  },
+  "isort.args":["--profile", "black", "--src", "${workspaceFolder}/backend/src"]
 }

--- a/backend/src/chain/cache.py
+++ b/backend/src/chain/cache.py
@@ -1,8 +1,9 @@
-from typing import Dict, Generic, Iterable, Optional, Set, TypeVar
 import gc
+from typing import Dict, Generic, Iterable, Optional, Set, TypeVar
+
 from sanic.log import logger
 
-from .chain import NodeId, Chain
+from .chain import Chain, NodeId
 
 
 class CacheStrategy:

--- a/backend/src/chain/chain.py
+++ b/backend/src/chain/chain.py
@@ -1,9 +1,8 @@
 from typing import Callable, Dict, List, TypeVar, Union
 
-from base_types import NodeId, OutputId, InputId
-from nodes.node_base import NodeBase, IteratorNodeBase
+from base_types import InputId, NodeId, OutputId
+from nodes.node_base import IteratorNodeBase, NodeBase
 from nodes.node_factory import NodeFactory
-
 
 K = TypeVar("K")
 V = TypeVar("V")

--- a/backend/src/chain/json.py
+++ b/backend/src/chain/json.py
@@ -2,8 +2,8 @@ from typing import Any, List, Literal, Optional, Tuple, TypedDict, Union
 
 from base_types import NodeId
 
-from .chain import Chain, IteratorNode, FunctionNode, Edge, EdgeSource, EdgeTarget
-from .input import InputMap, EdgeInput, ValueInput, Input
+from .chain import Chain, Edge, EdgeSource, EdgeTarget, FunctionNode, IteratorNode
+from .input import EdgeInput, Input, InputMap, ValueInput
 
 
 class JsonEdgeInput(TypedDict):

--- a/backend/src/chain/optimize.py
+++ b/backend/src/chain/optimize.py
@@ -1,5 +1,6 @@
 from sanic.log import logger
-from .chain import Chain, IteratorNode, Node, EdgeSource
+
+from .chain import Chain, EdgeSource, IteratorNode, Node
 
 
 def __has_side_effects(node: Node) -> bool:

--- a/backend/src/events.py
+++ b/backend/src/events.py
@@ -1,15 +1,7 @@
 import asyncio
-from typing import (
-    Any,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    TypedDict,
-    Union,
-)
+from typing import Any, Dict, List, Literal, Optional, TypedDict, Union
 
-from base_types import NodeId, InputId, OutputId
+from base_types import InputId, NodeId, OutputId
 
 
 class FinishData(TypedDict):

--- a/backend/src/nodes/group.py
+++ b/backend/src/nodes/group.py
@@ -1,6 +1,5 @@
 from typing import Any, Dict, Generic, List, NewType, Optional, TypeVar
 
-
 T = TypeVar("T")
 
 

--- a/backend/src/nodes/groups.py
+++ b/backend/src/nodes/groups.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
+
 from typing import List, Tuple, Union
 
-from .properties.inputs.base_input import BaseInput
-from .node_base import NestedGroup
 from .group import Group, GroupId, GroupInfo
+from .node_base import NestedGroup
+from .properties.inputs.base_input import BaseInput
 
 InputValue = Union[int, str]
 

--- a/backend/src/nodes/impl/blend.py
+++ b/backend/src/nodes/impl/blend.py
@@ -1,4 +1,5 @@
 from enum import Enum
+
 import cv2
 import numpy as np
 

--- a/backend/src/nodes/impl/caption.py
+++ b/backend/src/nodes/impl/caption.py
@@ -1,6 +1,6 @@
-from enum import Enum
 import os
 import sys
+from enum import Enum
 
 import cv2
 import numpy as np

--- a/backend/src/nodes/impl/clipboard/__init__.py
+++ b/backend/src/nodes/impl/clipboard/__init__.py
@@ -1,5 +1,6 @@
-import sys
 import os
+import sys
+
 import numpy as np
 from sanic.log import logger
 

--- a/backend/src/nodes/impl/clipboard/clipboard_base.py
+++ b/backend/src/nodes/impl/clipboard/clipboard_base.py
@@ -1,8 +1,8 @@
-from typing import Tuple
 from abc import ABC, abstractmethod
+from typing import Tuple
 
-import numpy as np
 import cv2
+import numpy as np
 
 
 class ClipboardBase(ABC):

--- a/backend/src/nodes/impl/clipboard/clipboard_darwin.py
+++ b/backend/src/nodes/impl/clipboard/clipboard_darwin.py
@@ -1,4 +1,5 @@
 import sys
+
 import numpy as np
 
 from .clipboard_base import ClipboardBase

--- a/backend/src/nodes/impl/clipboard/clipboard_linux.py
+++ b/backend/src/nodes/impl/clipboard/clipboard_linux.py
@@ -1,5 +1,6 @@
 import shutil
 import subprocess
+
 import numpy as np
 
 from .clipboard_base import ClipboardBase

--- a/backend/src/nodes/impl/clipboard/clipboard_wayland.py
+++ b/backend/src/nodes/impl/clipboard/clipboard_wayland.py
@@ -1,5 +1,6 @@
 import shutil
 import subprocess
+
 import numpy as np
 
 from .clipboard_base import ClipboardBase

--- a/backend/src/nodes/impl/clipboard/clipboard_win32.py
+++ b/backend/src/nodes/impl/clipboard/clipboard_win32.py
@@ -1,6 +1,7 @@
-from ctypes import wintypes
 import ctypes
 import sys
+from ctypes import wintypes
+
 import cv2
 import numpy as np
 

--- a/backend/src/nodes/impl/color/convert.py
+++ b/backend/src/nodes/impl/color/convert.py
@@ -1,9 +1,10 @@
 from dataclasses import dataclass, field
 from typing import Callable, Dict, Generic, Iterable, List, Set, Tuple, TypeVar, Union
+
 import numpy as np
 from sanic.log import logger
 
-from .convert_data import conversions, color_spaces, color_spaces_or_detectors
+from .convert_data import color_spaces, color_spaces_or_detectors, conversions
 from .convert_model import (
     ColorSpace,
     ColorSpaceDetector,

--- a/backend/src/nodes/impl/color/convert_data.py
+++ b/backend/src/nodes/impl/color/convert_data.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
-from typing import Dict, List
+
 import math
-import numpy as np
+from typing import Dict, List
+
 import cv2
+import numpy as np
 
-from .convert_model import ColorSpace, ColorSpaceDetector, Conversion
 from ...utils.utils import get_h_w_c
-
+from .convert_model import ColorSpace, ColorSpaceDetector, Conversion
 
 GRAY = ColorSpace(0, "Gray", 1)
 RGB = ColorSpace(1, "RGB", 3)

--- a/backend/src/nodes/impl/color/convert_model.py
+++ b/backend/src/nodes/impl/color/convert_model.py
@@ -1,4 +1,5 @@
 from typing import Callable, Dict, Iterable, Tuple
+
 import numpy as np
 
 from ...utils.format import format_image_with_channels

--- a/backend/src/nodes/impl/color_transfer.py
+++ b/backend/src/nodes/impl/color_transfer.py
@@ -1,6 +1,7 @@
 """Fast color transfer method using mean and std"""
 
 from __future__ import annotations
+
 from enum import Enum
 
 import cv2

--- a/backend/src/nodes/impl/dds/format.py
+++ b/backend/src/nodes/impl/dds/format.py
@@ -1,6 +1,5 @@
 from typing import Dict, Literal, Set, Union, cast
 
-
 DxgiFormat = Literal[
     "UNKNOWN",
     "R32G32B32A32_TYPELESS",

--- a/backend/src/nodes/impl/dds/texconv.py
+++ b/backend/src/nodes/impl/dds/texconv.py
@@ -1,19 +1,18 @@
 import os
-import sys
+import platform
+import shutil
 import subprocess
+import sys
 import uuid
 from tempfile import mkdtemp
 from typing import List
-import shutil
-import platform
 
 import numpy as np
-
 from sanic.log import logger
 
-from .format import SRGB_FORMATS, DxgiFormat
-from ..image_utils import cv_save_image
 from ...utils.utils import split_file_path
+from ..image_utils import cv_save_image
+from .format import SRGB_FORMATS, DxgiFormat
 
 __TEXCONV_DIR = os.path.join(
     os.path.dirname(sys.modules["__main__"].__file__), "texconv"  # type: ignore

--- a/backend/src/nodes/impl/dithering/color_distance.py
+++ b/backend/src/nodes/impl/dithering/color_distance.py
@@ -3,8 +3,8 @@ from typing import List, Optional
 import cv2
 import numpy as np
 
-from .common import dtype_to_float, float_to_dtype
 from ..image_utils import as_3d
+from .common import dtype_to_float, float_to_dtype
 
 
 def nearest_uniform_color(value: np.ndarray, num_colors: int) -> np.ndarray:

--- a/backend/src/nodes/impl/dithering/constants.py
+++ b/backend/src/nodes/impl/dithering/constants.py
@@ -4,7 +4,6 @@ from typing import Dict, Tuple
 import numpy as np
 from sanic.log import logger
 
-
 # https://tannerhelland.com/2012/12/28/dithering-eleven-algorithms-source-code.html
 
 

--- a/backend/src/nodes/impl/dithering/diffusion.py
+++ b/backend/src/nodes/impl/dithering/diffusion.py
@@ -1,12 +1,9 @@
 import numpy as np
 
-from .color_distance import (
-    nearest_palette_color,
-    nearest_uniform_color,
-)
-from .common import dtype_to_float, float_to_dtype
-from .constants import ErrorDiffusionMap, ERROR_DIFFUSION_MAPS
 from ..image_utils import as_3d
+from .color_distance import nearest_palette_color, nearest_uniform_color
+from .common import dtype_to_float, float_to_dtype
+from .constants import ERROR_DIFFUSION_MAPS, ErrorDiffusionMap
 
 
 def error_diffusion_dither(

--- a/backend/src/nodes/impl/dithering/ordered.py
+++ b/backend/src/nodes/impl/dithering/ordered.py
@@ -2,8 +2,8 @@ from typing import Tuple
 
 import numpy as np
 
-from .common import dtype_to_float, float_to_dtype, apply_to_all_channels
-from .constants import ThresholdMap, THRESHOLD_MAPS
+from .common import apply_to_all_channels, dtype_to_float, float_to_dtype
+from .constants import THRESHOLD_MAPS, ThresholdMap
 
 
 def get_threshold_map(

--- a/backend/src/nodes/impl/dithering/palette.py
+++ b/backend/src/nodes/impl/dithering/palette.py
@@ -1,8 +1,8 @@
 import cv2
 import numpy as np
 
-from .common import dtype_to_float
 from ..image_utils import as_3d
+from .common import dtype_to_float
 
 
 def distinct_colors_palette(image: np.ndarray) -> np.ndarray:

--- a/backend/src/nodes/impl/dithering/riemersma.py
+++ b/backend/src/nodes/impl/dithering/riemersma.py
@@ -3,13 +3,10 @@ from collections import deque
 
 import numpy as np
 
-from .color_distance import (
-    nearest_palette_color,
-    nearest_uniform_color,
-)
+from ..image_utils import as_3d
+from .color_distance import nearest_palette_color, nearest_uniform_color
 from .common import dtype_to_float, float_to_dtype
 from .hilbert import HilbertCurve
-from ..image_utils import as_3d
 
 
 def _next_power_of_two(x: int) -> int:

--- a/backend/src/nodes/impl/external_stable_diffusion.py
+++ b/backend/src/nodes/impl/external_stable_diffusion.py
@@ -11,8 +11,8 @@ import numpy as np
 import requests
 from PIL import Image
 
-from .image_utils import normalize
 from ..utils.utils import get_h_w_c
+from .image_utils import normalize
 
 STABLE_DIFFUSION_HOST = os.environ.get("STABLE_DIFFUSION_HOST", "127.0.0.1")
 STABLE_DIFFUSION_PORT = os.environ.get("STABLE_DIFFUSION_PORT", "7860")

--- a/backend/src/nodes/impl/fill_alpha.py
+++ b/backend/src/nodes/impl/fill_alpha.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import math
+
 import cv2
 import numpy as np
 
-from .blend import BlendMode, blend_images
 from ..utils.utils import get_h_w_c
+from .blend import BlendMode, blend_images
 
 
 class ImageAverage:

--- a/backend/src/nodes/impl/gradients.py
+++ b/backend/src/nodes/impl/gradients.py
@@ -1,4 +1,5 @@
 import math
+
 import numpy as np
 
 

--- a/backend/src/nodes/impl/image_utils.py
+++ b/backend/src/nodes/impl/image_utils.py
@@ -1,13 +1,14 @@
-import cv2
-import numpy as np
 import os
 import random
 import string
 from enum import Enum
-from sanic.log import logger
 from typing import List
 
-from ..utils.utils import get_h_w_c, Padding, split_file_path
+import cv2
+import numpy as np
+from sanic.log import logger
+
+from ..utils.utils import Padding, get_h_w_c, split_file_path
 
 MAX_VALUES_BY_DTYPE = {
     np.dtype("int8"): 127,

--- a/backend/src/nodes/impl/ncnn/auto_split.py
+++ b/backend/src/nodes/impl/ncnn/auto_split.py
@@ -6,8 +6,8 @@ import numpy as np
 from ncnn_vulkan import ncnn
 from sanic.log import logger
 
-from ..upscale.auto_split import auto_split, Split, Tiler
 from ...utils.utils import get_h_w_c
+from ..upscale.auto_split import Split, Tiler, auto_split
 
 
 def fix_dtype_range(img):

--- a/backend/src/nodes/impl/ncnn/model.py
+++ b/backend/src/nodes/impl/ncnn/model.py
@@ -9,7 +9,6 @@ from sanic.log import logger
 
 from ...utils.checked_cast import checked_cast
 
-
 param_schema_file = os.path.join(
     os.path.dirname(os.path.realpath(__file__)), "param_schema.json"
 )

--- a/backend/src/nodes/impl/ncnn/optimizer.py
+++ b/backend/src/nodes/impl/ncnn/optimizer.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from ...utils.checked_cast import checked_cast
 from .model import BinaryOpTypes as BOT
 from .model import EltwiseOpTypes as EOT

--- a/backend/src/nodes/impl/noise.py
+++ b/backend/src/nodes/impl/noise.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from typing import Callable, List
+
 import numpy as np
 
 from ..utils.utils import get_h_w_c

--- a/backend/src/nodes/impl/normals/addition.py
+++ b/backend/src/nodes/impl/normals/addition.py
@@ -1,5 +1,5 @@
-from enum import Enum
 import math
+from enum import Enum
 
 import numpy as np
 

--- a/backend/src/nodes/impl/normals/edge_filter.py
+++ b/backend/src/nodes/impl/normals/edge_filter.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from typing import Dict, Tuple
+
 import numpy as np
 
 

--- a/backend/src/nodes/impl/normals/height.py
+++ b/backend/src/nodes/impl/normals/height.py
@@ -1,5 +1,7 @@
 from enum import Enum
+
 import numpy as np
+
 from ...utils.utils import get_h_w_c
 
 

--- a/backend/src/nodes/impl/normals/util.py
+++ b/backend/src/nodes/impl/normals/util.py
@@ -1,4 +1,5 @@
 from typing import Tuple
+
 import numpy as np
 
 XYZ = Tuple[np.ndarray, np.ndarray, np.ndarray]

--- a/backend/src/nodes/impl/onnx/auto_split.py
+++ b/backend/src/nodes/impl/onnx/auto_split.py
@@ -5,7 +5,7 @@ import gc
 import numpy as np
 import onnxruntime as ort
 
-from ..upscale.auto_split import auto_split, Tiler
+from ..upscale.auto_split import Tiler, auto_split
 from .np_tensor_utils import np2nptensor, nptensor2np
 
 

--- a/backend/src/nodes/impl/onnx/np_tensor_utils.py
+++ b/backend/src/nodes/impl/onnx/np_tensor_utils.py
@@ -2,7 +2,7 @@ from typing import Tuple, Type
 
 import numpy as np
 
-from ..image_utils import as_3d, MAX_VALUES_BY_DTYPE
+from ..image_utils import MAX_VALUES_BY_DTYPE, as_3d
 
 
 def np_denorm(x: np.ndarray, min_max: Tuple[float, float] = (-1.0, 1.0)) -> np.ndarray:

--- a/backend/src/nodes/impl/onnx/session.py
+++ b/backend/src/nodes/impl/onnx/session.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
-import onnxruntime as ort
+
 from weakref import WeakKeyDictionary
+
+import onnxruntime as ort
 
 from ...utils.exec_options import ExecutionOptions
 from .model import OnnxModel

--- a/backend/src/nodes/impl/pil_utils.py
+++ b/backend/src/nodes/impl/pil_utils.py
@@ -4,8 +4,8 @@ from typing import Tuple
 import numpy as np
 from PIL import Image
 
-from .image_utils import FillColor, convert_to_BGRA
 from ..utils.utils import get_h_w_c
+from .image_utils import FillColor, convert_to_BGRA
 
 
 class InterpolationMethod(Enum):

--- a/backend/src/nodes/impl/pytorch/architecture/HAT.py
+++ b/backend/src/nodes/impl/pytorch/architecture/HAT.py
@@ -1,15 +1,15 @@
 # pylint: skip-file
 # HAT from https://github.com/XPixelGroup/HAT/blob/main/hat/archs/hat_arch.py
 import math
+import re
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-import re
+from einops import rearrange
 
 from .timm.helpers import to_2tuple
 from .timm.weight_init import trunc_normal_
-
-from einops import rearrange
 
 
 def drop_path(x, drop_prob: float = 0.0, training: bool = False):

--- a/backend/src/nodes/impl/pytorch/architecture/Swin2SR.py
+++ b/backend/src/nodes/impl/pytorch/architecture/Swin2SR.py
@@ -6,12 +6,13 @@
 # -----------------------------------------------------------------------------------
 
 import math
+import re
+
 import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.utils.checkpoint as checkpoint
-import re
 
 # Originally from the timm package
 from .timm.drop import DropPath

--- a/backend/src/nodes/impl/pytorch/architecture/SwinIR.py
+++ b/backend/src/nodes/impl/pytorch/architecture/SwinIR.py
@@ -5,12 +5,12 @@
 # -----------------------------------------------------------------------------------
 
 import math
+import re
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.utils.checkpoint as checkpoint
-import re
-import math
 
 # Originally from the timm package
 from .timm.drop import DropPath

--- a/backend/src/nodes/impl/pytorch/architecture/block.py
+++ b/backend/src/nodes/impl/pytorch/architecture/block.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import annotations
+
 from collections import OrderedDict
 from typing import Literal
 

--- a/backend/src/nodes/impl/pytorch/architecture/face/codeformer.py
+++ b/backend/src/nodes/impl/pytorch/architecture/face/codeformer.py
@@ -4,14 +4,14 @@ VQGAN code, adapted from the original created by the Unleashing Transformers aut
 https://github.com/samb-t/unleashing-transformers/blob/master/models/vqgan.py
 This verison of the arch specifically was gathered from an old version of GFPGAN. If this is a problem, please contact me.
 """
-from typing import Optional
 import math
+from typing import Optional
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch import Tensor
-
 from sanic.log import logger
+from torch import Tensor
 
 
 class VectorQuantizer(nn.Module):

--- a/backend/src/nodes/impl/pytorch/architecture/face/gfpgan_bilinear_arch.py
+++ b/backend/src/nodes/impl/pytorch/architecture/face/gfpgan_bilinear_arch.py
@@ -2,6 +2,7 @@
 # type: ignore
 import math
 import random
+
 import torch
 from torch import nn
 

--- a/backend/src/nodes/impl/pytorch/architecture/face/gfpganv1_arch.py
+++ b/backend/src/nodes/impl/pytorch/architecture/face/gfpganv1_arch.py
@@ -2,7 +2,12 @@
 # type: ignore
 import math
 import random
+
 import torch
+from torch import nn
+from torch.nn import functional as F
+
+from .fused_act import FusedLeakyReLU
 from .stylegan2_arch import (
     ConvLayer,
     EqualConv2d,
@@ -11,9 +16,6 @@ from .stylegan2_arch import (
     ScaledLeakyReLU,
     StyleGAN2Generator,
 )
-from .fused_act import FusedLeakyReLU
-from torch import nn
-from torch.nn import functional as F
 
 
 class StyleGAN2GeneratorSFT(StyleGAN2Generator):

--- a/backend/src/nodes/impl/pytorch/architecture/face/gfpganv1_clean_arch.py
+++ b/backend/src/nodes/impl/pytorch/architecture/face/gfpganv1_clean_arch.py
@@ -2,6 +2,7 @@
 # type: ignore
 import math
 import random
+
 import torch
 from torch import nn
 from torch.nn import functional as F

--- a/backend/src/nodes/impl/pytorch/architecture/face/stylegan2_arch.py
+++ b/backend/src/nodes/impl/pytorch/architecture/face/stylegan2_arch.py
@@ -2,6 +2,7 @@
 # type: ignore
 import math
 import random
+
 import torch
 from torch import nn
 from torch.nn import functional as F

--- a/backend/src/nodes/impl/pytorch/architecture/face/stylegan2_bilinear_arch.py
+++ b/backend/src/nodes/impl/pytorch/architecture/face/stylegan2_bilinear_arch.py
@@ -2,10 +2,12 @@
 # type: ignore
 import math
 import random
+
 import torch
-from .fused_act import FusedLeakyReLU, fused_leaky_relu
 from torch import nn
 from torch.nn import functional as F
+
+from .fused_act import FusedLeakyReLU, fused_leaky_relu
 
 
 class NormStyleCode(nn.Module):

--- a/backend/src/nodes/impl/pytorch/architecture/face/stylegan2_clean_arch.py
+++ b/backend/src/nodes/impl/pytorch/architecture/face/stylegan2_clean_arch.py
@@ -1,6 +1,7 @@
 # pylint: skip-file
 # type: ignore
 import math
+
 import torch
 from torch import nn
 from torch.nn import functional as F

--- a/backend/src/nodes/impl/pytorch/architecture/face/upfirdn2d.py
+++ b/backend/src/nodes/impl/pytorch/architecture/face/upfirdn2d.py
@@ -3,6 +3,7 @@
 # modify from https://github.com/rosinality/stylegan2-pytorch/blob/master/op/upfirdn2d.py  # noqa:E501
 
 import os
+
 import torch
 from torch.autograd import Function
 from torch.nn import functional as F

--- a/backend/src/nodes/impl/pytorch/architecture/timm/helpers.py
+++ b/backend/src/nodes/impl/pytorch/architecture/timm/helpers.py
@@ -1,8 +1,8 @@
 """ Layer/Module Helpers
 Hacked together by / Copyright 2020 Ross Wightman
 """
-from itertools import repeat
 import collections.abc
+from itertools import repeat
 
 
 # From PyTorch internals

--- a/backend/src/nodes/impl/pytorch/architecture/timm/weight_init.py
+++ b/backend/src/nodes/impl/pytorch/architecture/timm/weight_init.py
@@ -1,8 +1,7 @@
 import math
 import warnings
+
 import torch
-
-
 from torch.nn.init import _calculate_fan_in_and_fan_out
 
 

--- a/backend/src/nodes/impl/pytorch/auto_split.py
+++ b/backend/src/nodes/impl/pytorch/auto_split.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 import gc
 
-import torch
 import numpy as np
+import torch
 
+from ..upscale.auto_split import Split, Tiler, auto_split
 from .types import PyTorchModel
-
-from ..upscale.auto_split import auto_split, Split, Tiler
-from .utils import tensor2np, np2tensor
+from .utils import np2tensor, tensor2np
 
 
 @torch.inference_mode()

--- a/backend/src/nodes/impl/pytorch/utils.py
+++ b/backend/src/nodes/impl/pytorch/utils.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
+
 from typing import Type
 
+import numpy as np
 import torch
 from torch import Tensor
-import numpy as np
 
 from ...utils.exec_options import ExecutionOptions
 from ..image_utils import as_3d
-from ..onnx.np_tensor_utils import np_denorm, MAX_VALUES_BY_DTYPE
+from ..onnx.np_tensor_utils import MAX_VALUES_BY_DTYPE, np_denorm
 
 
 def to_pytorch_execution_options(options: ExecutionOptions):

--- a/backend/src/nodes/impl/rembg/pymatting/estimate_alpha_cf.py
+++ b/backend/src/nodes/impl/rembg/pymatting/estimate_alpha_cf.py
@@ -1,8 +1,9 @@
-from .util import sanity_check_image, trimap_split
-from .cf_laplacian import cf_laplacian
-from .ichol import ichol
-from .cg import cg
 import numpy as np
+
+from .cf_laplacian import cf_laplacian
+from .cg import cg
+from .ichol import ichol
+from .util import sanity_check_image, trimap_split
 
 
 def estimate_alpha_cf(  # pylint: disable=dangerous-default-value

--- a/backend/src/nodes/impl/rembg/pymatting/util.py
+++ b/backend/src/nodes/impl/rembg/pymatting/util.py
@@ -1,5 +1,6 @@
-import numpy as np
 import warnings
+
+import numpy as np
 
 
 def sanity_check_image(image):

--- a/backend/src/nodes/impl/tile.py
+++ b/backend/src/nodes/impl/tile.py
@@ -1,7 +1,8 @@
-from enum import Enum
 import math
-import numpy as np
+from enum import Enum
+
 import cv2
+import numpy as np
 
 from ..utils.utils import get_h_w_c
 

--- a/backend/src/nodes/impl/upscale/auto_split.py
+++ b/backend/src/nodes/impl/upscale/auto_split.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
-from typing import Callable, Optional, Union
+
 import math
+from typing import Callable, Optional, Union
 
 import numpy as np
 from sanic.log import logger
 
-from ...utils.utils import get_h_w_c, Region, Size
+from ...utils.utils import Region, Size, get_h_w_c
 from .exact_split import exact_split
 from .tiler import Tiler
 

--- a/backend/src/nodes/impl/upscale/auto_split_tiles.py
+++ b/backend/src/nodes/impl/upscale/auto_split_tiles.py
@@ -1,9 +1,10 @@
 from typing import Callable, NewType
+
 import numpy as np
 from sanic.log import logger
 
 from ...utils.utils import get_h_w_c
-from .tiler import Tiler, MaxTileSize, NoTiling
+from .tiler import MaxTileSize, NoTiling, Tiler
 
 
 def estimate_tile_size(

--- a/backend/src/nodes/impl/upscale/convenient_upscale.py
+++ b/backend/src/nodes/impl/upscale/convenient_upscale.py
@@ -2,8 +2,8 @@ from typing import Callable, Tuple
 
 import numpy as np
 
-from ..image_utils import as_target_channels
 from ...utils.utils import get_h_w_c
+from ..image_utils import as_target_channels
 
 
 def clipped(upscale: Callable[[np.ndarray], np.ndarray]) -> Callable:

--- a/backend/src/nodes/impl/upscale/exact_split.py
+++ b/backend/src/nodes/impl/upscale/exact_split.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-from typing import Callable, Optional, Tuple, List
 import math
 from dataclasses import dataclass
+from typing import Callable, List, Optional, Tuple
 
 import numpy as np
 from sanic.log import logger
 
-from ...utils.utils import get_h_w_c, Region, Padding, Size
-from ..image_utils import create_border, BorderType
+from ...utils.utils import Padding, Region, Size, get_h_w_c
+from ..image_utils import BorderType, create_border
 
 
 def _pad_image(img: np.ndarray, min_size: Size):

--- a/backend/src/nodes/node_base.py
+++ b/backend/src/nodes/node_base.py
@@ -4,11 +4,9 @@ from typing import Any, Dict, List, Literal, Optional, Union
 from base_types import InputId, OutputId
 
 from .category import Category
-from .group import Group, GroupInfo, GroupId
-
+from .group import Group, GroupId, GroupInfo
 from .properties.inputs.base_input import BaseInput
 from .properties.outputs.base_output import BaseOutput
-
 
 NodeType = Literal["regularNode", "iterator", "iteratorHelper"]
 

--- a/backend/src/nodes/node_cache.py
+++ b/backend/src/nodes/node_cache.py
@@ -4,7 +4,7 @@ import os
 import tempfile
 import time
 from enum import Enum
-from typing import List, Dict, Tuple, Optional
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 from sanic.log import logger

--- a/backend/src/nodes/nodes/builtin_categories.py
+++ b/backend/src/nodes/nodes/builtin_categories.py
@@ -1,15 +1,14 @@
+from .external_stable_diffusion import category as ExternalStableDiffusionCategory
 from .image import category as ImageCategory
 from .image_adjustment import category as ImageAdjustmentCategory
-from .image_filter import category as ImageFilterCategory
-from .image_dimension import category as ImageDimensionCategory
 from .image_channel import category as ImageChannelCategory
+from .image_dimension import category as ImageDimensionCategory
+from .image_filter import category as ImageFilterCategory
 from .image_utility import category as ImageUtilityCategory
-from .external_stable_diffusion import category as ExternalStableDiffusionCategory
-from .utility import category as UtilityCategory
-from .pytorch import category as PyTorchCategory
 from .ncnn import category as NCNNCategory
 from .onnx import category as ONNXCategory
-
+from .pytorch import category as PyTorchCategory
+from .utility import category as UtilityCategory
 
 builtin_categories = [
     ImageCategory,

--- a/backend/src/nodes/nodes/external_stable_diffusion/img2img.py
+++ b/backend/src/nodes/nodes/external_stable_diffusion/img2img.py
@@ -4,31 +4,31 @@ from typing import Optional
 
 import numpy as np
 
-from . import category as ExternalStableDiffusionCategory
 from ...impl.external_stable_diffusion import (
-    decode_base64_image,
-    SamplerName,
+    RESIZE_MODE_LABELS,
     SAMPLER_NAME_LABELS,
     STABLE_DIFFUSION_IMG2IMG_URL,
-    post,
+    ResizeMode,
+    SamplerName,
+    decode_base64_image,
     encode_base64_image,
     nearest_valid_size,
-    ResizeMode,
-    RESIZE_MODE_LABELS,
+    post,
     verify_api_connection,
 )
 from ...node_base import NodeBase, group
 from ...node_cache import cached
 from ...node_factory import NodeFactory
 from ...properties.inputs import (
-    TextInput,
-    NumberInput,
-    SliderInput,
     EnumInput,
     ImageInput,
+    NumberInput,
+    SliderInput,
+    TextInput,
 )
 from ...properties.outputs import ImageOutput
 from ...utils.utils import get_h_w_c
+from . import category as ExternalStableDiffusionCategory
 
 verify_api_connection()
 

--- a/backend/src/nodes/nodes/external_stable_diffusion/interrogate.py
+++ b/backend/src/nodes/nodes/external_stable_diffusion/interrogate.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 import numpy as np
 
-from . import category as ExternalStableDiffusionCategory
 from ...impl.external_stable_diffusion import (
     STABLE_DIFFUSION_INTERROGATE_URL,
-    post,
     encode_base64_image,
+    post,
     verify_api_connection,
 )
 from ...node_base import NodeBase
@@ -14,6 +13,7 @@ from ...node_cache import cached
 from ...node_factory import NodeFactory
 from ...properties.inputs import ImageInput
 from ...properties.outputs import TextOutput
+from . import category as ExternalStableDiffusionCategory
 
 verify_api_connection()
 

--- a/backend/src/nodes/nodes/external_stable_diffusion/outpainting.py
+++ b/backend/src/nodes/nodes/external_stable_diffusion/outpainting.py
@@ -6,34 +6,34 @@ from typing import Optional
 
 import numpy as np
 
-from . import category as ExternalStableDiffusionCategory
+from ...groups import conditional_group
 from ...impl.external_stable_diffusion import (
-    decode_base64_image,
-    SamplerName,
+    RESIZE_MODE_LABELS,
     SAMPLER_NAME_LABELS,
     STABLE_DIFFUSION_IMG2IMG_URL,
-    post,
+    InpaintingFill,
+    ResizeMode,
+    SamplerName,
+    decode_base64_image,
     encode_base64_image,
     nearest_valid_size,
-    ResizeMode,
-    RESIZE_MODE_LABELS,
-    InpaintingFill,
+    post,
     verify_api_connection,
 )
-from ...groups import conditional_group
 from ...node_base import NodeBase, group
 from ...node_cache import cached
 from ...node_factory import NodeFactory
 from ...properties.inputs import (
-    TextInput,
-    NumberInput,
-    SliderInput,
+    BoolInput,
     EnumInput,
     ImageInput,
-    BoolInput,
+    NumberInput,
+    SliderInput,
+    TextInput,
 )
 from ...properties.outputs import ImageOutput
 from ...utils.utils import get_h_w_c
+from . import category as ExternalStableDiffusionCategory
 
 verify_api_connection()
 

--- a/backend/src/nodes/nodes/external_stable_diffusion/txt2img.py
+++ b/backend/src/nodes/nodes/external_stable_diffusion/txt2img.py
@@ -4,27 +4,22 @@ from typing import Optional
 
 import numpy as np
 
-from . import category as ExternalStableDiffusionCategory
 from ...impl.external_stable_diffusion import (
-    decode_base64_image,
-    SamplerName,
     SAMPLER_NAME_LABELS,
     STABLE_DIFFUSION_TEXT2IMG_URL,
-    post,
+    SamplerName,
+    decode_base64_image,
     nearest_valid_size,
+    post,
     verify_api_connection,
 )
 from ...node_base import NodeBase, group
 from ...node_cache import cached
 from ...node_factory import NodeFactory
-from ...properties.inputs import (
-    TextInput,
-    NumberInput,
-    SliderInput,
-    EnumInput,
-)
+from ...properties.inputs import EnumInput, NumberInput, SliderInput, TextInput
 from ...properties.outputs import ImageOutput
 from ...utils.utils import get_h_w_c
+from . import category as ExternalStableDiffusionCategory
 
 verify_api_connection()
 

--- a/backend/src/nodes/nodes/image/external_preview.py
+++ b/backend/src/nodes/nodes/image/external_preview.py
@@ -10,10 +10,10 @@ import cv2
 import numpy as np
 from sanic.log import logger
 
-from . import category as ImageCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import ImageInput
+from . import category as ImageCategory
 
 
 @NodeFactory.register("chainner:image:preview")

--- a/backend/src/nodes/nodes/image/image_file_iterator.py
+++ b/backend/src/nodes/nodes/image/image_file_iterator.py
@@ -1,25 +1,21 @@
 from __future__ import annotations
 
 import os
-from typing import Tuple, List
+from typing import List, Tuple
 
 import numpy as np
-from process import IteratorContext
 from sanic.log import logger
 
-from . import category as ImageCategory
-from ..image.load_image import ImReadNode
+from process import IteratorContext
+
+from ...impl.image_formats import get_available_image_formats
 from ...node_base import IteratorNodeBase, NodeBase
 from ...node_factory import NodeFactory
-from ...properties.inputs import IteratorInput, DirectoryInput
-from ...properties.outputs import (
-    ImageOutput,
-    DirectoryOutput,
-    TextOutput,
-    NumberOutput,
-)
-from ...impl.image_formats import get_available_image_formats
+from ...properties.inputs import DirectoryInput, IteratorInput
+from ...properties.outputs import DirectoryOutput, ImageOutput, NumberOutput, TextOutput
 from ...utils.utils import list_all_files_sorted
+from ..image.load_image import ImReadNode
+from . import category as ImageCategory
 
 IMAGE_ITERATOR_NODE_ID = "chainner:image:file_iterator_load"
 

--- a/backend/src/nodes/nodes/image/load_image.py
+++ b/backend/src/nodes/nodes/image/load_image.py
@@ -1,23 +1,23 @@
 from __future__ import annotations
 
 import os
-from typing import Tuple, Union
 import platform
+from typing import Tuple, Union
 
 import cv2
 import numpy as np
 from PIL import Image
 from sanic.log import logger
 
-from . import category as ImageCategory
-from ...node_base import NodeBase
-from ...node_factory import NodeFactory
-from ...properties.inputs import ImageFileInput
-from ...properties.outputs import LargeImageOutput, DirectoryOutput, FileNameOutput
 from ...impl.dds.texconv import dds_to_png_texconv
 from ...impl.image_formats import get_opencv_formats, get_pil_formats
 from ...impl.image_utils import normalize
+from ...node_base import NodeBase
+from ...node_factory import NodeFactory
+from ...properties.inputs import ImageFileInput
+from ...properties.outputs import DirectoryOutput, FileNameOutput, LargeImageOutput
 from ...utils.utils import get_h_w_c, split_file_path
+from . import category as ImageCategory
 
 
 @NodeFactory.register("chainner:image:load")

--- a/backend/src/nodes/nodes/image/paired_image_file_iterator.py
+++ b/backend/src/nodes/nodes/image/paired_image_file_iterator.py
@@ -1,25 +1,21 @@
 from __future__ import annotations
 
 import os
-from typing import Tuple, List
+from typing import List, Tuple
 
 import numpy as np
-from process import IteratorContext
 from sanic.log import logger
 
-from . import category as ImageCategory
-from ..image.load_image import ImReadNode
+from process import IteratorContext
+
+from ...impl.image_formats import get_available_image_formats
 from ...node_base import IteratorNodeBase, NodeBase
 from ...node_factory import NodeFactory
-from ...properties.inputs import IteratorInput, DirectoryInput
-from ...properties.outputs import (
-    ImageOutput,
-    DirectoryOutput,
-    TextOutput,
-    NumberOutput,
-)
-from ...impl.image_formats import get_available_image_formats
+from ...properties.inputs import DirectoryInput, IteratorInput
+from ...properties.outputs import DirectoryOutput, ImageOutput, NumberOutput, TextOutput
 from ...utils.utils import list_all_files_sorted
+from ..image.load_image import ImReadNode
+from . import category as ImageCategory
 
 PAIRED_IMAGE_ITERATOR_NODE_ID = "chainner:image:paired_file_iterator_load"
 

--- a/backend/src/nodes/nodes/image/save_image.py
+++ b/backend/src/nodes/nodes/image/save_image.py
@@ -1,40 +1,40 @@
 from __future__ import annotations
-from enum import Enum
 
 import os
+from enum import Enum
+
 import cv2
 import numpy as np
 from PIL import Image
 from sanic.log import logger
 
-from . import category as ImageCategory
 from ...groups import conditional_group
-from ...node_base import NodeBase
-from ...node_factory import NodeFactory
-from ...properties.inputs import (
-    SUPPORTED_DDS_FORMATS,
-    ImageInput,
-    DirectoryInput,
-    TextInput,
-    ImageExtensionDropdown,
-    SliderInput,
-    DdsFormatDropdown,
-    BoolInput,
-    EnumInput,
-    DdsMipMapsDropdown,
-)
-from ...utils.utils import get_h_w_c
-from ...impl.image_utils import cv_save_image
 from ...impl.dds.format import (
-    BC123_FORMATS,
     BC7_FORMATS,
+    BC123_FORMATS,
     LEGACY_TO_DXGI,
     WITH_ALPHA,
     DDSFormat,
     to_dxgi,
 )
 from ...impl.dds.texconv import save_as_dds
-
+from ...impl.image_utils import cv_save_image
+from ...node_base import NodeBase
+from ...node_factory import NodeFactory
+from ...properties.inputs import (
+    SUPPORTED_DDS_FORMATS,
+    BoolInput,
+    DdsFormatDropdown,
+    DdsMipMapsDropdown,
+    DirectoryInput,
+    EnumInput,
+    ImageExtensionDropdown,
+    ImageInput,
+    SliderInput,
+    TextInput,
+)
+from ...utils.utils import get_h_w_c
+from . import category as ImageCategory
 
 SUPPORTED_FORMATS = {f for f, _ in SUPPORTED_DDS_FORMATS}
 SUPPORTED_BC7_FORMATS = list(SUPPORTED_FORMATS.intersection(BC7_FORMATS))

--- a/backend/src/nodes/nodes/image/sprite_sheet_iterator.py
+++ b/backend/src/nodes/nodes/image/sprite_sheet_iterator.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
 
-from typing import Tuple, List
+from typing import List, Tuple
 
 import numpy as np
+
 from process import IteratorContext
 
-from . import category as ImageCategory
 from ...node_base import IteratorNodeBase, NodeBase
 from ...node_factory import NodeFactory
-from ...properties.inputs import IteratorInput, ImageInput, NumberInput
+from ...properties.inputs import ImageInput, IteratorInput, NumberInput
 from ...properties.outputs import ImageOutput, NumberOutput
 from ...utils.utils import get_h_w_c
+from . import category as ImageCategory
 
 SPRITESHEET_ITERATOR_INPUT_NODE_ID = "chainner:image:spritesheet_iterator_load"
 SPRITESHEET_ITERATOR_OUTPUT_NODE_ID = "chainner:image:spritesheet_iterator_save"

--- a/backend/src/nodes/nodes/image/video_frame_iterator.py
+++ b/backend/src/nodes/nodes/image/video_frame_iterator.py
@@ -1,33 +1,34 @@
 from __future__ import annotations
-from dataclasses import dataclass
 
 import os
-from typing import Tuple
+from dataclasses import dataclass
 from subprocess import Popen
+from typing import Tuple
 
-import numpy as np
 import cv2
-from process import IteratorContext
-from sanic.log import logger
 import ffmpeg
+import numpy as np
+from sanic.log import logger
 
-from . import category as ImageCategory
+from process import IteratorContext
+
+from ...impl.image_utils import normalize
 from ...node_base import IteratorNodeBase, NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import (
-    IteratorInput,
-    ImageInput,
+    BoolInput,
     DirectoryInput,
+    ImageInput,
+    IteratorInput,
+    SliderInput,
     TextInput,
-    VideoTypeDropdown,
     VideoFileInput,
     VideoPresetDropdown,
-    SliderInput,
-    BoolInput,
+    VideoTypeDropdown,
 )
-from ...properties.outputs import ImageOutput, NumberOutput, TextOutput, DirectoryOutput
-from ...impl.image_utils import normalize
+from ...properties.outputs import DirectoryOutput, ImageOutput, NumberOutput, TextOutput
 from ...utils.utils import get_h_w_c, split_file_path
+from . import category as ImageCategory
 
 VIDEO_ITERATOR_INPUT_NODE_ID = "chainner:image:simple_video_frame_iterator_load"
 VIDEO_ITERATOR_OUTPUT_NODE_ID = "chainner:image:simple_video_frame_iterator_save"

--- a/backend/src/nodes/nodes/image/view_image.py
+++ b/backend/src/nodes/nodes/image/view_image.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import numpy as np
 
-from . import category as ImageCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import ImageInput
 from ...properties.outputs import LargeImageOutput
+from . import category as ImageCategory
 
 
 @NodeFactory.register("chainner:image:view")

--- a/backend/src/nodes/nodes/image_adjustment/brightness_and_contrast.py
+++ b/backend/src/nodes/nodes/image_adjustment/brightness_and_contrast.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import numpy as np
 
-from . import category as ImageAdjustmentCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import ImageInput, SliderInput
 from ...properties.outputs import ImageOutput
 from ...utils.utils import get_h_w_c
+from . import category as ImageAdjustmentCategory
 
 
 @NodeFactory.register("chainner:image:brightness_and_contrast")

--- a/backend/src/nodes/nodes/image_adjustment/color_levels.py
+++ b/backend/src/nodes/nodes/image_adjustment/color_levels.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import numpy as np
 
-from . import category as ImageAdjustmentCategory
+from ...impl.image_utils import as_3d
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
-from ...properties.inputs import ImageInput, SliderInput, BoolInput
+from ...properties.inputs import BoolInput, ImageInput, SliderInput
 from ...properties.outputs import ImageOutput
-from ...impl.image_utils import as_3d
 from ...utils.utils import get_h_w_c
+from . import category as ImageAdjustmentCategory
 
 
 @NodeFactory.register("chainner:image:color_levels")

--- a/backend/src/nodes/nodes/image_adjustment/gamma.py
+++ b/backend/src/nodes/nodes/image_adjustment/gamma.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import numpy as np
 
-from . import category as ImageAdjustmentCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
-from ...properties.inputs import ImageInput, NumberInput, BoolInput
+from ...properties.inputs import BoolInput, ImageInput, NumberInput
 from ...properties.outputs import ImageOutput
 from ...utils.utils import get_h_w_c
+from . import category as ImageAdjustmentCategory
 
 
 @NodeFactory.register("chainner:image:gamma")

--- a/backend/src/nodes/nodes/image_adjustment/hue_and_saturation.py
+++ b/backend/src/nodes/nodes/image_adjustment/hue_and_saturation.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import cv2
 import numpy as np
 
-from . import category as ImageAdjustmentCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import ImageInput, SliderInput
 from ...properties.outputs import ImageOutput
 from ...utils.utils import get_h_w_c
+from . import category as ImageAdjustmentCategory
 
 
 @NodeFactory.register("chainner:image:hue_and_saturation")

--- a/backend/src/nodes/nodes/image_adjustment/invert.py
+++ b/backend/src/nodes/nodes/image_adjustment/invert.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import numpy as np
 
-from . import category as ImageAdjustmentCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import ImageInput
 from ...properties.outputs import ImageOutput
 from ...utils.utils import get_h_w_c
+from . import category as ImageAdjustmentCategory
 
 
 @NodeFactory.register("chainner:image:invert")

--- a/backend/src/nodes/nodes/image_adjustment/opacity.py
+++ b/backend/src/nodes/nodes/image_adjustment/opacity.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import numpy as np
 
-from . import category as ImageAdjustmentCategory
+from ...impl.pil_utils import convert_to_BGRA
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
+from ...properties import expression
 from ...properties.inputs import ImageInput, SliderInput
 from ...properties.outputs import ImageOutput
-from ...properties import expression
 from ...utils.utils import get_h_w_c
-from ...impl.pil_utils import convert_to_BGRA
+from . import category as ImageAdjustmentCategory
 
 
 @NodeFactory.register("chainner:image:opacity")

--- a/backend/src/nodes/nodes/image_adjustment/threshold.py
+++ b/backend/src/nodes/nodes/image_adjustment/threshold.py
@@ -4,11 +4,11 @@ import cv2
 import numpy as np
 from sanic.log import logger
 
-from . import category as ImageAdjustmentCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import ImageInput, SliderInput, ThresholdInput
 from ...properties.outputs import ImageOutput
+from . import category as ImageAdjustmentCategory
 
 
 @NodeFactory.register("chainner:image:threshold")

--- a/backend/src/nodes/nodes/image_adjustment/threshold_adaptive.py
+++ b/backend/src/nodes/nodes/image_adjustment/threshold_adaptive.py
@@ -3,17 +3,17 @@ from __future__ import annotations
 import cv2
 import numpy as np
 
-from . import category as ImageAdjustmentCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import (
-    ImageInput,
-    SliderInput,
     AdaptiveMethodInput,
     AdaptiveThresholdInput,
+    ImageInput,
     NumberInput,
+    SliderInput,
 )
 from ...properties.outputs import ImageOutput
+from . import category as ImageAdjustmentCategory
 
 
 @NodeFactory.register("chainner:image:threshold_adaptive")

--- a/backend/src/nodes/nodes/image_channel/combine_rgba.py
+++ b/backend/src/nodes/nodes/image_channel/combine_rgba.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
+
 from typing import Union
 
 import numpy as np
 
-from . import category as ImageChannelCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
+from ...properties import expression
 from ...properties.inputs import ImageInput
 from ...properties.outputs import ImageOutput
-from ...properties import expression
+from . import category as ImageChannelCategory
 
 
 @NodeFactory.register("chainner:image:combine_rgba")

--- a/backend/src/nodes/nodes/image_channel/fill_alpha.py
+++ b/backend/src/nodes/nodes/image_channel/fill_alpha.py
@@ -1,19 +1,20 @@
 from __future__ import annotations
+
 from enum import Enum
 
 import numpy as np
 
-from . import category as ImageChannelCategory
-from ...node_base import NodeBase
-from ...node_factory import NodeFactory
-from ...properties.inputs import ImageInput, EnumInput
-from ...properties.outputs import ImageOutput
-from ...properties import expression
 from ...impl.fill_alpha import (
     convert_to_binary_alpha,
-    fill_alpha_fragment_blur,
     fill_alpha_edge_extend,
+    fill_alpha_fragment_blur,
 )
+from ...node_base import NodeBase
+from ...node_factory import NodeFactory
+from ...properties import expression
+from ...properties.inputs import EnumInput, ImageInput
+from ...properties.outputs import ImageOutput
+from . import category as ImageChannelCategory
 
 
 class AlphaFillMethod(Enum):

--- a/backend/src/nodes/nodes/image_channel/palette_extraction.py
+++ b/backend/src/nodes/nodes/image_channel/palette_extraction.py
@@ -4,18 +4,18 @@ from enum import Enum
 
 import numpy as np
 
-from . import category as ImageChannelCategory
+from ...groups import conditional_group
 from ...impl.dithering.palette import (
     distinct_colors_palette,
     kmeans_palette,
     median_cut_palette,
 )
-from ...groups import conditional_group
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties import expression
-from ...properties.inputs import ImageInput, EnumInput, NumberInput
+from ...properties.inputs import EnumInput, ImageInput, NumberInput
 from ...properties.outputs import ImageOutput
+from . import category as ImageChannelCategory
 
 
 class PaletteExtractionMethod(Enum):

--- a/backend/src/nodes/nodes/image_channel/rgba_merge.py
+++ b/backend/src/nodes/nodes/image_channel/rgba_merge.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
+
 from typing import Union
 
-import numpy as np
 import cv2
+import numpy as np
 
-from . import category as ImageChannelCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
+from ...properties import expression
 from ...properties.inputs import ImageInput
 from ...properties.outputs import ImageOutput
-from ...properties import expression
 from ...utils.utils import get_h_w_c
+from . import category as ImageChannelCategory
 
 
 @NodeFactory.register("chainner:image:merge_channels")

--- a/backend/src/nodes/nodes/image_channel/rgba_separate.py
+++ b/backend/src/nodes/nodes/image_channel/rgba_separate.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
+
 from typing import Tuple
 
 import numpy as np
 
-from . import category as ImageChannelCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
+from ...properties import expression
 from ...properties.inputs import ImageInput
 from ...properties.outputs import ImageOutput
-from ...properties import expression
 from ...utils.utils import get_h_w_c
+from . import category as ImageChannelCategory
 
 
 @NodeFactory.register("chainner:image:split_channels")

--- a/backend/src/nodes/nodes/image_channel/transparency_merge.py
+++ b/backend/src/nodes/nodes/image_channel/transparency_merge.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
+import cv2
 import numpy as np
 from sanic.log import logger
-import cv2
 
-from . import category as ImageChannelCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
+from ...properties import expression
 from ...properties.inputs import ImageInput
 from ...properties.outputs import ImageOutput
-from ...properties import expression
+from . import category as ImageChannelCategory
 
 
 @NodeFactory.register("chainner:image:merge_transparency")

--- a/backend/src/nodes/nodes/image_channel/transparency_split.py
+++ b/backend/src/nodes/nodes/image_channel/transparency_split.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
+
 from typing import Tuple
 
 import numpy as np
 
-from . import category as ImageChannelCategory
+from ...impl.image_utils import as_target_channels
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
+from ...properties import expression
 from ...properties.inputs import ImageInput
 from ...properties.outputs import ImageOutput
-from ...properties import expression
-from ...impl.image_utils import as_target_channels
+from . import category as ImageChannelCategory
 
 
 @NodeFactory.register("chainner:image:split_transparency")

--- a/backend/src/nodes/nodes/image_dimension/crop_border.py
+++ b/backend/src/nodes/nodes/image_dimension/crop_border.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import numpy as np
 
-from . import category as ImageDimensionCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
+from ...properties import expression
 from ...properties.inputs import ImageInput, NumberInput
 from ...properties.outputs import ImageOutput
-from ...properties import expression
 from ...utils.utils import get_h_w_c
+from . import category as ImageDimensionCategory
 
 
 @NodeFactory.register("chainner:image:crop_border")

--- a/backend/src/nodes/nodes/image_dimension/crop_content.py
+++ b/backend/src/nodes/nodes/image_dimension/crop_content.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import numpy as np
 
-from . import category as ImageDimensionCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import ImageInput, SliderInput
 from ...properties.outputs import ImageOutput
 from ...utils.utils import get_h_w_c
+from . import category as ImageDimensionCategory
 
 
 @NodeFactory.register("chainner:image:crop_content")

--- a/backend/src/nodes/nodes/image_dimension/crop_edges.py
+++ b/backend/src/nodes/nodes/image_dimension/crop_edges.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import numpy as np
 
-from . import category as ImageDimensionCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
+from ...properties import expression
 from ...properties.inputs import ImageInput, NumberInput
 from ...properties.outputs import ImageOutput
-from ...properties import expression
 from ...utils.utils import get_h_w_c
+from . import category as ImageDimensionCategory
 
 
 @NodeFactory.register("chainner:image:crop_edges")

--- a/backend/src/nodes/nodes/image_dimension/crop_offsets.py
+++ b/backend/src/nodes/nodes/image_dimension/crop_offsets.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import numpy as np
 
-from . import category as ImageDimensionCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
+from ...properties import expression
 from ...properties.inputs import ImageInput, NumberInput
 from ...properties.outputs import ImageOutput
-from ...properties import expression
 from ...utils.utils import get_h_w_c
+from . import category as ImageDimensionCategory
 
 
 @NodeFactory.register("chainner:image:crop_offsets")

--- a/backend/src/nodes/nodes/image_dimension/get_dimensions.py
+++ b/backend/src/nodes/nodes/image_dimension/get_dimensions.py
@@ -4,12 +4,12 @@ from typing import Tuple
 
 import numpy as np
 
-from . import category as ImageDimensionCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import ImageInput
 from ...properties.outputs import NumberOutput
 from ...utils.utils import get_h_w_c
+from . import category as ImageDimensionCategory
 
 
 @NodeFactory.register("chainner:image:get_dims")

--- a/backend/src/nodes/nodes/image_dimension/resize_factor.py
+++ b/backend/src/nodes/nodes/image_dimension/resize_factor.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 import numpy as np
 from sanic.log import logger
 
-from . import category as ImageDimensionCategory
+from ...impl.pil_utils import InterpolationMethod, resize
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
-from ...properties.inputs import ImageInput, NumberInput, InterpolationInput
-from ...properties.outputs import ImageOutput
 from ...properties import expression
-from ...impl.pil_utils import resize, InterpolationMethod
+from ...properties.inputs import ImageInput, InterpolationInput, NumberInput
+from ...properties.outputs import ImageOutput
 from ...utils.utils import get_h_w_c, round_half_up
+from . import category as ImageDimensionCategory
 
 
 @NodeFactory.register("chainner:image:resize_factor")

--- a/backend/src/nodes/nodes/image_dimension/resize_resolution.py
+++ b/backend/src/nodes/nodes/image_dimension/resize_resolution.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import numpy as np
 from sanic.log import logger
 
-from . import category as ImageDimensionCategory
+from ...impl.pil_utils import InterpolationMethod, resize
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
-from ...properties.inputs import ImageInput, NumberInput, InterpolationInput
-from ...properties.outputs import ImageOutput
 from ...properties import expression
-from ...impl.pil_utils import resize, InterpolationMethod
+from ...properties.inputs import ImageInput, InterpolationInput, NumberInput
+from ...properties.outputs import ImageOutput
+from . import category as ImageDimensionCategory
 
 
 @NodeFactory.register("chainner:image:resize_resolution")

--- a/backend/src/nodes/nodes/image_dimension/resize_to_side.py
+++ b/backend/src/nodes/nodes/image_dimension/resize_to_side.py
@@ -1,22 +1,18 @@
 from __future__ import annotations
+
 from enum import Enum
 from typing import Tuple
 
 import numpy as np
 from sanic.log import logger
 
-from . import category as ImageDimensionCategory
+from ...impl.pil_utils import InterpolationMethod, resize
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
-from ...properties.inputs import (
-    ImageInput,
-    NumberInput,
-    InterpolationInput,
-    EnumInput,
-)
+from ...properties.inputs import EnumInput, ImageInput, InterpolationInput, NumberInput
 from ...properties.outputs import ImageOutput
-from ...impl.pil_utils import resize, InterpolationMethod
 from ...utils.utils import get_h_w_c, round_half_up
+from . import category as ImageDimensionCategory
 
 
 class SideSelection(Enum):

--- a/backend/src/nodes/nodes/image_dimension/tile_fill.py
+++ b/backend/src/nodes/nodes/image_dimension/tile_fill.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import numpy as np
 
-from . import category as ImageDimensionCategory
+from ...impl.tile import TileMode, tile_image
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
-from ...properties.inputs import ImageInput, NumberInput, EnumInput
-from ...properties.outputs import ImageOutput
 from ...properties import expression
-from ...impl.tile import tile_image, TileMode
+from ...properties.inputs import EnumInput, ImageInput, NumberInput
+from ...properties.outputs import ImageOutput
+from . import category as ImageDimensionCategory
 
 
 @NodeFactory.register("chainner:image:tile_fill")

--- a/backend/src/nodes/nodes/image_filter/add_noise.py
+++ b/backend/src/nodes/nodes/image_filter/add_noise.py
@@ -1,21 +1,22 @@
 from __future__ import annotations
+
 from enum import Enum
 
 import numpy as np
 
-from . import category as ImageFilterCategory
+from ...impl.noise import (
+    NoiseColor,
+    gaussian_noise,
+    poisson_noise,
+    salt_and_pepper_noise,
+    speckle_noise,
+    uniform_noise,
+)
 from ...node_base import NodeBase, group
 from ...node_factory import NodeFactory
-from ...properties.inputs import ImageInput, SliderInput, EnumInput, NumberInput
+from ...properties.inputs import EnumInput, ImageInput, NumberInput, SliderInput
 from ...properties.outputs import ImageOutput
-from ...impl.noise import (
-    gaussian_noise,
-    uniform_noise,
-    salt_and_pepper_noise,
-    poisson_noise,
-    speckle_noise,
-    NoiseColor,
-)
+from . import category as ImageFilterCategory
 
 
 class NoiseType(Enum):

--- a/backend/src/nodes/nodes/image_filter/avg_color_fix.py
+++ b/backend/src/nodes/nodes/image_filter/avg_color_fix.py
@@ -5,12 +5,12 @@ from math import ceil
 import cv2
 import numpy as np
 
-from . import category as ImageFilterCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import ImageInput, NumberInput
 from ...properties.outputs import ImageOutput
 from ...utils.utils import get_h_w_c
+from . import category as ImageFilterCategory
 
 
 @NodeFactory.register("chainner:image:average_color_fix")

--- a/backend/src/nodes/nodes/image_filter/blur_bilateral.py
+++ b/backend/src/nodes/nodes/image_filter/blur_bilateral.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import cv2
 import numpy as np
 
-from . import category as ImageFilterCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import ImageInput, NumberInput, SliderInput
 from ...properties.outputs import ImageOutput
 from ...utils.utils import get_h_w_c
+from . import category as ImageFilterCategory
 
 
 @NodeFactory.register("chainner:image:bilateral_blur")

--- a/backend/src/nodes/nodes/image_filter/blur_box.py
+++ b/backend/src/nodes/nodes/image_filter/blur_box.py
@@ -5,11 +5,11 @@ from math import ceil
 import cv2
 import numpy as np
 
-from . import category as ImageFilterCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import ImageInput, NumberInput
 from ...properties.outputs import ImageOutput
+from . import category as ImageFilterCategory
 
 
 @NodeFactory.register("chainner:image:blur")

--- a/backend/src/nodes/nodes/image_filter/blur_gauss.py
+++ b/backend/src/nodes/nodes/image_filter/blur_gauss.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import cv2
 import numpy as np
 
-from . import category as ImageFilterCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import ImageInput, NumberInput
 from ...properties.outputs import ImageOutput
+from . import category as ImageFilterCategory
 
 
 @NodeFactory.register("chainner:image:gaussian_blur")

--- a/backend/src/nodes/nodes/image_filter/blur_lens.py
+++ b/backend/src/nodes/nodes/image_filter/blur_lens.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
-import cv2
 import math
-from typing import Dict, List, Literal, Tuple
 from functools import reduce
+from typing import Dict, List, Literal, Tuple
+
+import cv2
 import numpy as np
 
-from . import category as ImageFilterCategory
+from ...impl.image_utils import as_3d
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import ImageInput, NumberInput, SliderInput
 from ...properties.outputs import ImageOutput
-from ...impl.image_utils import as_3d
+from . import category as ImageFilterCategory
 
 # Lens blur adapted from GIMP Lens Blur
 # Copyright (c) 2019 Davide Sandona'

--- a/backend/src/nodes/nodes/image_filter/blur_median.py
+++ b/backend/src/nodes/nodes/image_filter/blur_median.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import cv2
 import numpy as np
 
-from . import category as ImageFilterCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import ImageInput, NumberInput
 from ...properties.outputs import ImageOutput
+from . import category as ImageFilterCategory
 
 
 @NodeFactory.register("chainner:image:median_blur")

--- a/backend/src/nodes/nodes/image_filter/color_transfer.py
+++ b/backend/src/nodes/nodes/image_filter/color_transfer.py
@@ -2,17 +2,13 @@ from __future__ import annotations
 
 import numpy as np
 
-from . import category as ImageFilterCategory
+from ...impl.color_transfer import OverflowMethod, TransferColorSpace, color_transfer
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
-from ...properties.inputs import (
-    ImageInput,
-    EnumInput,
-    BoolInput,
-)
+from ...properties.inputs import BoolInput, EnumInput, ImageInput
 from ...properties.outputs import ImageOutput
-from ...impl.color_transfer import color_transfer, TransferColorSpace, OverflowMethod
 from ...utils.utils import get_h_w_c
+from . import category as ImageFilterCategory
 
 
 @NodeFactory.register("chainner:image:color_transfer")

--- a/backend/src/nodes/nodes/image_filter/distance_transform.py
+++ b/backend/src/nodes/nodes/image_filter/distance_transform.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import cv2
 import numpy as np
 
-from . import category as ImageFilterCategory
 from ...impl.dithering.common import dtype_to_uint8
 from ...impl.image_utils import as_3d
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import ImageInput, NumberInput
 from ...properties.outputs import ImageOutput
+from . import category as ImageFilterCategory
 
 
 @NodeFactory.register("chainner:image:distance_transform")

--- a/backend/src/nodes/nodes/image_filter/dither.py
+++ b/backend/src/nodes/nodes/image_filter/dither.py
@@ -4,22 +4,22 @@ from enum import Enum
 
 import numpy as np
 
-from . import category as ImageFilterCategory
+from ...groups import conditional_group
 from ...impl.dithering.color_distance import batch_nearest_uniform_color
 from ...impl.dithering.constants import (
-    ErrorDiffusionMap,
     ERROR_PROPAGATION_MAP_LABELS,
-    ThresholdMap,
     THRESHOLD_MAP_LABELS,
+    ErrorDiffusionMap,
+    ThresholdMap,
 )
 from ...impl.dithering.diffusion import uniform_error_diffusion_dither
 from ...impl.dithering.ordered import ordered_dither
 from ...impl.dithering.riemersma import uniform_riemersma_dither
-from ...groups import conditional_group
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
-from ...properties.inputs import ImageInput, NumberInput, EnumInput
+from ...properties.inputs import EnumInput, ImageInput, NumberInput
 from ...properties.outputs import ImageOutput
+from . import category as ImageFilterCategory
 
 
 class UniformDitherAlgorithm(Enum):

--- a/backend/src/nodes/nodes/image_filter/dither_palette.py
+++ b/backend/src/nodes/nodes/image_filter/dither_palette.py
@@ -4,17 +4,17 @@ from enum import Enum
 
 import numpy as np
 
-from . import category as ImageFilterCategory
+from ...groups import conditional_group
 from ...impl.dithering.color_distance import batch_nearest_palette_color
-from ...impl.dithering.constants import ErrorDiffusionMap, ERROR_PROPAGATION_MAP_LABELS
+from ...impl.dithering.constants import ERROR_PROPAGATION_MAP_LABELS, ErrorDiffusionMap
 from ...impl.dithering.diffusion import palette_error_diffusion_dither
 from ...impl.dithering.riemersma import palette_riemersma_dither
-from ...groups import conditional_group
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties import expression
-from ...properties.inputs import ImageInput, EnumInput, NumberInput
+from ...properties.inputs import EnumInput, ImageInput, NumberInput
 from ...properties.outputs import ImageOutput
+from . import category as ImageFilterCategory
 
 
 class PaletteDitherAlgorithm(Enum):

--- a/backend/src/nodes/nodes/image_filter/high_boost_sharpen.py
+++ b/backend/src/nodes/nodes/image_filter/high_boost_sharpen.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from enum import Enum
 
 import cv2

--- a/backend/src/nodes/nodes/image_filter/normal_addition.py
+++ b/backend/src/nodes/nodes/image_filter/normal_addition.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import numpy as np
 
-from . import category as ImageFilterCategory
+from ...impl.normals.addition import AdditionMethod, add_normals
+from ...impl.normals.util import xyz_to_bgr
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
-from ...properties.inputs import ImageInput, SliderInput, EnumInput
-from ...properties.outputs import ImageOutput
 from ...properties import expression
-from ...impl.normals.addition import add_normals, AdditionMethod
-from ...impl.normals.util import xyz_to_bgr
+from ...properties.inputs import EnumInput, ImageInput, SliderInput
+from ...properties.outputs import ImageOutput
+from . import category as ImageFilterCategory
 
 
 @NodeFactory.register("chainner:image:add_normals")

--- a/backend/src/nodes/nodes/image_filter/normal_convert.py
+++ b/backend/src/nodes/nodes/image_filter/normal_convert.py
@@ -2,20 +2,20 @@ from __future__ import annotations
 
 import numpy as np
 
-from . import category as ImageFilterCategory
-from ...node_base import NodeBase
-from ...node_factory import NodeFactory
-from ...properties.inputs import ImageInput, EnumInput
-from ...properties.outputs import ImageOutput
-from ...properties import expression
 from ...impl.image_utils import NormalMapType
 from ...impl.normals.util import (
+    XYZ,
     gr_to_xyz,
     octahedral_gr_to_xyz,
     xyz_to_bgr,
     xyz_to_octahedral_bgr,
-    XYZ,
 )
+from ...node_base import NodeBase
+from ...node_factory import NodeFactory
+from ...properties import expression
+from ...properties.inputs import EnumInput, ImageInput
+from ...properties.outputs import ImageOutput
+from . import category as ImageFilterCategory
 
 
 @NodeFactory.register("chainner:image:convert_normal_map")

--- a/backend/src/nodes/nodes/image_filter/normal_generator.py
+++ b/backend/src/nodes/nodes/image_filter/normal_generator.py
@@ -1,23 +1,24 @@
 from __future__ import annotations
+
 from enum import Enum
 
 import cv2
 import numpy as np
 
-from . import category as ImageFilterCategory
+from ...impl.image_utils import get_h_w_c
+from ...impl.normals.edge_filter import EdgeFilter, get_filter_kernels
+from ...impl.normals.height import HeightSource, get_height_map
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
+from ...properties import expression
 from ...properties.inputs import (
-    ImageInput,
-    SliderInput,
-    NormalChannelInvertInput,
     EnumInput,
+    ImageInput,
+    NormalChannelInvertInput,
+    SliderInput,
 )
 from ...properties.outputs import ImageOutput
-from ...properties import expression
-from ...impl.normals.edge_filter import EdgeFilter, get_filter_kernels
-from ...impl.normals.height import get_height_map, HeightSource
-from ...impl.image_utils import get_h_w_c
+from . import category as ImageFilterCategory
 
 
 class AlphaOutput(Enum):

--- a/backend/src/nodes/nodes/image_filter/normalize_normal_map.py
+++ b/backend/src/nodes/nodes/image_filter/normalize_normal_map.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import numpy as np
 
-from . import category as ImageFilterCategory
+from ...impl.normals.util import gr_to_xyz, xyz_to_bgr
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
+from ...properties import expression
 from ...properties.inputs import ImageInput
 from ...properties.outputs import ImageOutput
-from ...properties import expression
-from ...impl.normals.util import gr_to_xyz, xyz_to_bgr
+from . import category as ImageFilterCategory
 
 
 @NodeFactory.register("chainner:image:normalize_normal_map")

--- a/backend/src/nodes/nodes/image_filter/sharpen.py
+++ b/backend/src/nodes/nodes/image_filter/sharpen.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import cv2
 import numpy as np
 
-from . import category as ImageFilterCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import ImageInput, NumberInput, SliderInput
 from ...properties.outputs import ImageOutput
+from . import category as ImageFilterCategory
 
 
 @NodeFactory.register("chainner:image:sharpen")

--- a/backend/src/nodes/nodes/image_utility/blend.py
+++ b/backend/src/nodes/nodes/image_utility/blend.py
@@ -3,16 +3,16 @@ from __future__ import annotations
 import cv2
 import numpy as np
 
-from . import category as ImageUtilityCategory
-from ...node_base import NodeBase
-from ...node_factory import NodeFactory
-from ...properties.inputs import ImageInput, BlendModeDropdown
-from ...properties.outputs import ImageOutput
-from ...properties import expression
-from ...impl.blend import blend_images, BlendMode
+from ...impl.blend import BlendMode, blend_images
 from ...impl.image_utils import as_2d_grayscale
 from ...impl.pil_utils import convert_to_BGRA
+from ...node_base import NodeBase
+from ...node_factory import NodeFactory
+from ...properties import expression
+from ...properties.inputs import BlendModeDropdown, ImageInput
+from ...properties.outputs import ImageOutput
 from ...utils.utils import get_h_w_c
+from . import category as ImageUtilityCategory
 
 
 @NodeFactory.register("chainner:image:blend")

--- a/backend/src/nodes/nodes/image_utility/canny_edge_detection.py
+++ b/backend/src/nodes/nodes/image_utility/canny_edge_detection.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import cv2
 import numpy as np
 
-from . import category as ImageUtilityCategory
+from ...impl.image_utils import normalize
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
+from ...properties import expression
 from ...properties.inputs import ImageInput, NumberInput
 from ...properties.outputs import ImageOutput
-from ...properties import expression
-from ...impl.image_utils import normalize
+from . import category as ImageUtilityCategory
 
 
 @NodeFactory.register("chainner:image:canny_edge_detection")

--- a/backend/src/nodes/nodes/image_utility/caption.py
+++ b/backend/src/nodes/nodes/image_utility/caption.py
@@ -2,17 +2,12 @@ from __future__ import annotations
 
 import numpy as np
 
-from . import category as ImageUtilityCategory
+from ...impl.caption import CaptionPosition, add_caption
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
-from ...properties.inputs import (
-    ImageInput,
-    TextInput,
-    NumberInput,
-    EnumInput,
-)
+from ...properties.inputs import EnumInput, ImageInput, NumberInput, TextInput
 from ...properties.outputs import ImageOutput
-from ...impl.caption import add_caption, CaptionPosition
+from . import category as ImageUtilityCategory
 
 
 @NodeFactory.register("chainner:image:caption")

--- a/backend/src/nodes/nodes/image_utility/convert_color.py
+++ b/backend/src/nodes/nodes/image_utility/convert_color.py
@@ -2,24 +2,24 @@ from __future__ import annotations
 
 import numpy as np
 
-from . import category as ImageUtilityCategory
 from ...groups import conditional_group
-from ...node_base import NodeBase, group
-from ...node_factory import NodeFactory
-from ...properties.inputs import (
-    ImageInput,
-    ColorSpaceDetectorInput,
-    ColorSpaceInput,
-    BoolInput,
-)
-from ...properties.outputs import ImageOutput
-from ...properties import expression
-from ...impl.color.convert_data import color_spaces, get_alpha_partner
 from ...impl.color.convert import (
-    convert,
     color_space_from_id,
     color_space_or_detector_from_id,
+    convert,
 )
+from ...impl.color.convert_data import color_spaces, get_alpha_partner
+from ...node_base import NodeBase, group
+from ...node_factory import NodeFactory
+from ...properties import expression
+from ...properties.inputs import (
+    BoolInput,
+    ColorSpaceDetectorInput,
+    ColorSpaceInput,
+    ImageInput,
+)
+from ...properties.outputs import ImageOutput
+from . import category as ImageUtilityCategory
 
 COLOR_SPACES_WITH_ALPHA_PARTNER = [
     c.id for c in color_spaces if get_alpha_partner(c) is not None

--- a/backend/src/nodes/nodes/image_utility/convolve.py
+++ b/backend/src/nodes/nodes/image_utility/convolve.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import cv2
 import numpy as np
 
-from . import category as ImageUtilityCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
-from ...properties.inputs import ImageInput, NumberInput, NoteTextAreaInput
+from ...properties.inputs import ImageInput, NoteTextAreaInput, NumberInput
 from ...properties.outputs import ImageOutput
+from . import category as ImageUtilityCategory
 
 
 @NodeFactory.register("chainner:image:image_convolve")

--- a/backend/src/nodes/nodes/image_utility/create_border.py
+++ b/backend/src/nodes/nodes/image_utility/create_border.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import numpy as np
 
-from . import category as ImageUtilityCategory
+from ...impl.image_utils import BorderType, create_border
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
-from ...properties.inputs import ImageInput, BorderInput, NumberInput
-from ...properties.outputs import ImageOutput
 from ...properties import expression
-from ...impl.image_utils import create_border, BorderType
+from ...properties.inputs import BorderInput, ImageInput, NumberInput
+from ...properties.outputs import ImageOutput
 from ...utils.utils import Padding
+from . import category as ImageUtilityCategory
 
 
 @NodeFactory.register("chainner:image:create_border")

--- a/backend/src/nodes/nodes/image_utility/create_color_gray.py
+++ b/backend/src/nodes/nodes/image_utility/create_color_gray.py
@@ -2,15 +2,12 @@ from __future__ import annotations
 
 import numpy as np
 
-from . import category as ImageUtilityCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
-from ...properties.inputs import (
-    NumberInput,
-    SliderInput,
-)
-from ...properties.outputs import ImageOutput
 from ...properties import expression
+from ...properties.inputs import NumberInput, SliderInput
+from ...properties.outputs import ImageOutput
+from . import category as ImageUtilityCategory
 
 
 @NodeFactory.register("chainner:image:create_color_gray")

--- a/backend/src/nodes/nodes/image_utility/create_color_rgb.py
+++ b/backend/src/nodes/nodes/image_utility/create_color_rgb.py
@@ -2,15 +2,12 @@ from __future__ import annotations
 
 import numpy as np
 
-from . import category as ImageUtilityCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
-from ...properties.inputs import (
-    NumberInput,
-    SliderInput,
-)
-from ...properties.outputs import ImageOutput
 from ...properties import expression
+from ...properties.inputs import NumberInput, SliderInput
+from ...properties.outputs import ImageOutput
+from . import category as ImageUtilityCategory
 
 
 @NodeFactory.register("chainner:image:create_color_rgb")

--- a/backend/src/nodes/nodes/image_utility/create_color_rgba.py
+++ b/backend/src/nodes/nodes/image_utility/create_color_rgba.py
@@ -2,15 +2,12 @@ from __future__ import annotations
 
 import numpy as np
 
-from . import category as ImageUtilityCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
-from ...properties.inputs import (
-    NumberInput,
-    SliderInput,
-)
-from ...properties.outputs import ImageOutput
 from ...properties import expression
+from ...properties.inputs import NumberInput, SliderInput
+from ...properties.outputs import ImageOutput
+from . import category as ImageUtilityCategory
 
 
 @NodeFactory.register("chainner:image:create_color_rgba")

--- a/backend/src/nodes/nodes/image_utility/create_edges.py
+++ b/backend/src/nodes/nodes/image_utility/create_edges.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import numpy as np
 
-from . import category as ImageUtilityCategory
+from ...impl.image_utils import BorderType, create_border
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
-from ...properties.inputs import ImageInput, BorderInput, NumberInput
-from ...properties.outputs import ImageOutput
 from ...properties import expression
-from ...impl.image_utils import create_border, BorderType
+from ...properties.inputs import BorderInput, ImageInput, NumberInput
+from ...properties.outputs import ImageOutput
 from ...utils.utils import Padding
+from . import category as ImageUtilityCategory
 
 
 @NodeFactory.register("chainner:image:create_edges")

--- a/backend/src/nodes/nodes/image_utility/create_gradient.py
+++ b/backend/src/nodes/nodes/image_utility/create_gradient.py
@@ -4,24 +4,19 @@ from enum import Enum
 
 import numpy as np
 
-from . import category as ImageUtilityCategory
 from ...impl.gradients import (
-    horizontal_gradient,
-    vertical_gradient,
-    diagonal_gradient,
-    radial_gradient,
     conic_gradient,
+    diagonal_gradient,
+    horizontal_gradient,
+    radial_gradient,
+    vertical_gradient,
 )
 from ...node_base import NodeBase, group
 from ...node_factory import NodeFactory
 from ...properties import expression
-from ...properties.inputs import (
-    NumberInput,
-    EnumInput,
-    SliderInput,
-    BoolInput,
-)
+from ...properties.inputs import BoolInput, EnumInput, NumberInput, SliderInput
 from ...properties.outputs import ImageOutput
+from . import category as ImageUtilityCategory
 
 
 class GradientStyle(Enum):

--- a/backend/src/nodes/nodes/image_utility/dilate.py
+++ b/backend/src/nodes/nodes/image_utility/dilate.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
+
 from enum import Enum
 
 import cv2
 import numpy as np
 
-from . import category as ImageUtilityCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
-from ...properties.inputs import ImageInput, NumberInput, EnumInput
+from ...properties.inputs import EnumInput, ImageInput, NumberInput
 from ...properties.outputs import ImageOutput
+from . import category as ImageUtilityCategory
 
 
 class MorphShape(Enum):

--- a/backend/src/nodes/nodes/image_utility/erode.py
+++ b/backend/src/nodes/nodes/image_utility/erode.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
+
 from enum import Enum
 
 import cv2
 import numpy as np
 
-from . import category as ImageUtilityCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
-from ...properties.inputs import ImageInput, NumberInput, EnumInput
+from ...properties.inputs import EnumInput, ImageInput, NumberInput
 from ...properties.outputs import ImageOutput
+from . import category as ImageUtilityCategory
 
 
 class MorphShape(Enum):

--- a/backend/src/nodes/nodes/image_utility/flip.py
+++ b/backend/src/nodes/nodes/image_utility/flip.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import numpy as np
 
-from . import category as ImageUtilityCategory
+from ...impl.image_utils import FlipAxis
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
-from ...properties.inputs import ImageInput, EnumInput
+from ...properties.inputs import EnumInput, ImageInput
 from ...properties.outputs import ImageOutput
-from ...impl.image_utils import FlipAxis
+from . import category as ImageUtilityCategory
 
 
 @NodeFactory.register("chainner:image:flip")

--- a/backend/src/nodes/nodes/image_utility/inpaint.py
+++ b/backend/src/nodes/nodes/image_utility/inpaint.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
+
 from enum import Enum
 
 import cv2
 import numpy as np
 
-from . import category as ImageUtilityCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties import expression
-from ...properties.inputs import ImageInput, NumberInput, EnumInput
+from ...properties.inputs import EnumInput, ImageInput, NumberInput
 from ...properties.outputs import ImageOutput
+from . import category as ImageUtilityCategory
 
 
 class InpaintAlgorithm(Enum):

--- a/backend/src/nodes/nodes/image_utility/lut.py
+++ b/backend/src/nodes/nodes/image_utility/lut.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
+
 import numpy as np
 
-from . import category as ImageUtilityCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
+from ...properties import expression
 from ...properties.inputs import ImageInput
 from ...properties.outputs import ImageOutput
-from ...properties import expression
 from ...utils.utils import get_h_w_c
+from . import category as ImageUtilityCategory
 
 
 def quantize(img: np.ndarray, levels: int) -> np.ndarray:

--- a/backend/src/nodes/nodes/image_utility/metal_to_specular.py
+++ b/backend/src/nodes/nodes/image_utility/metal_to_specular.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
+
 from typing import Tuple
 
 import numpy as np
 
-from . import category as ImageUtilityCategory
+from ...impl.pil_utils import InterpolationMethod, resize
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
+from ...properties import expression
 from ...properties.inputs import ImageInput
 from ...properties.outputs import ImageOutput
-from ...properties import expression
-from ...impl.pil_utils import resize, InterpolationMethod
 from ...utils.utils import get_h_w_c
+from . import category as ImageUtilityCategory
 
 
 def get_size(img: np.ndarray) -> Tuple[int, int]:

--- a/backend/src/nodes/nodes/image_utility/metrics.py
+++ b/backend/src/nodes/nodes/image_utility/metrics.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
-from typing import Tuple
+
 import math
+from typing import Tuple
 
-import numpy as np
 import cv2
+import numpy as np
 
-from . import category as ImageUtilityCategory
+from ...impl.image_utils import calculate_ssim
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import ImageInput
 from ...properties.outputs import NumberOutput
-from ...impl.image_utils import calculate_ssim
 from ...utils.utils import get_h_w_c
+from . import category as ImageUtilityCategory
 
 
 @NodeFactory.register("chainner:image:image_metrics")

--- a/backend/src/nodes/nodes/image_utility/rotate.py
+++ b/backend/src/nodes/nodes/image_utility/rotate.py
@@ -2,23 +2,23 @@ from __future__ import annotations
 
 import numpy as np
 
-from . import category as ImageUtilityCategory
+from ...impl.pil_utils import (
+    FillColor,
+    RotateSizeChange,
+    RotationInterpolationMethod,
+    rotate,
+)
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import (
-    ImageInput,
-    SliderInput,
-    RotateInterpolationInput,
     EnumInput,
     FillColorDropdown,
+    ImageInput,
+    RotateInterpolationInput,
+    SliderInput,
 )
 from ...properties.outputs import ImageOutput
-from ...impl.pil_utils import (
-    rotate,
-    RotateSizeChange,
-    FillColor,
-    RotationInterpolationMethod,
-)
+from . import category as ImageUtilityCategory
 
 
 @NodeFactory.register("chainner:image:rotate")

--- a/backend/src/nodes/nodes/image_utility/shift.py
+++ b/backend/src/nodes/nodes/image_utility/shift.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import numpy as np
 
-from . import category as ImageUtilityCategory
+from ...impl.image_utils import FillColor, shift
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
-from ...properties.inputs import ImageInput, FillColorDropdown, NumberInput
-from ...properties.outputs import ImageOutput
 from ...properties import expression
-from ...impl.image_utils import shift, FillColor
+from ...properties.inputs import FillColorDropdown, ImageInput, NumberInput
+from ...properties.outputs import ImageOutput
+from . import category as ImageUtilityCategory
 
 
 @NodeFactory.register("chainner:image:shift")

--- a/backend/src/nodes/nodes/image_utility/specular_to_metal.py
+++ b/backend/src/nodes/nodes/image_utility/specular_to_metal.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
+
 from typing import Tuple
 
 import numpy as np
 
-from . import category as ImageUtilityCategory
+from ...impl.pil_utils import InterpolationMethod, resize
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
+from ...properties import expression
 from ...properties.inputs import ImageInput, SliderInput
 from ...properties.outputs import ImageOutput
-from ...properties import expression
-from ...impl.pil_utils import resize, InterpolationMethod
 from ...utils.utils import get_h_w_c
+from . import category as ImageUtilityCategory
 
 
 def get_size(img: np.ndarray) -> Tuple[int, int]:

--- a/backend/src/nodes/nodes/image_utility/stack.py
+++ b/backend/src/nodes/nodes/image_utility/stack.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
+
 from enum import Enum
 from typing import List
 
 import cv2
 import numpy as np
 
-from . import category as ImageUtilityCategory
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
-from ...properties.inputs import ImageInput, EnumInput
+from ...properties.inputs import EnumInput, ImageInput
 from ...properties.outputs import ImageOutput
 from ...utils.utils import get_h_w_c, round_half_up
+from . import category as ImageUtilityCategory
 
 
 class Orientation(Enum):

--- a/backend/src/nodes/nodes/ncnn/get_scale.py
+++ b/backend/src/nodes/nodes/ncnn/get_scale.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from . import category as NcnnCategory
+from ...impl.ncnn.model import NcnnModelWrapper
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import NcnnModelInput
 from ...properties.outputs import NumberOutput
-from ...impl.ncnn.model import NcnnModelWrapper
+from . import category as NcnnCategory
 
 
 @NodeFactory.register("chainner:ncnn:model_dim")

--- a/backend/src/nodes/nodes/ncnn/interpolate_models.py
+++ b/backend/src/nodes/nodes/ncnn/interpolate_models.py
@@ -4,12 +4,12 @@ from typing import Tuple
 
 import numpy as np
 
+from ...impl.ncnn.model import NcnnModelWrapper
+from ...impl.upscale.auto_split_tiles import NO_TILING
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import NcnnModelInput, SliderInput
 from ...properties.outputs import NcnnModelOutput, NumberOutput
-from ...impl.upscale.auto_split_tiles import NO_TILING
-from ...impl.ncnn.model import NcnnModelWrapper
 from . import category as NCNNCategory
 from .upscale_image import NcnnUpscaleImageNode
 

--- a/backend/src/nodes/nodes/ncnn/load_model.py
+++ b/backend/src/nodes/nodes/ncnn/load_model.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from typing import Tuple
 
+from ...impl.ncnn.model import NcnnModel, NcnnModelWrapper
+from ...impl.ncnn.optimizer import NcnnOptimizer
 from ...node_base import NodeBase, group
 from ...node_factory import NodeFactory
 from ...properties.inputs import BinFileInput, ParamFileInput
-from ...properties.outputs import NcnnModelOutput, FileNameOutput
-from ...impl.ncnn.model import NcnnModel, NcnnModelWrapper
-from ...impl.ncnn.optimizer import NcnnOptimizer
+from ...properties.outputs import FileNameOutput, NcnnModelOutput
 from ...utils.utils import split_file_path
 from . import category as NCNNCategory
 

--- a/backend/src/nodes/nodes/ncnn/model_file_iterator.py
+++ b/backend/src/nodes/nodes/ncnn/model_file_iterator.py
@@ -3,21 +3,22 @@ from __future__ import annotations
 import os
 
 from sanic.log import logger
+
 from process import IteratorContext
 
-from .load_model import NcnnLoadModelNode
-from . import category as NcnnCategory
-from ...node_base import NodeBase, IteratorNodeBase
+from ...impl.ncnn.model import NcnnModelWrapper
+from ...node_base import IteratorNodeBase, NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import *
 from ...properties.outputs import (
-    NcnnModelOutput,
     DirectoryOutput,
-    TextOutput,
+    NcnnModelOutput,
     NumberOutput,
+    TextOutput,
 )
-from ...impl.ncnn.model import NcnnModelWrapper
 from ...utils.utils import list_all_files_sorted
+from . import category as NcnnCategory
+from .load_model import NcnnLoadModelNode
 
 NCNN_ITERATOR_NODE_ID = "chainner:ncnn:model_iterator_load"
 

--- a/backend/src/nodes/nodes/ncnn/save_model.py
+++ b/backend/src/nodes/nodes/ncnn/save_model.py
@@ -2,10 +2,10 @@ import os
 
 from sanic.log import logger
 
+from ...impl.ncnn.model import NcnnModelWrapper
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import DirectoryInput, NcnnModelInput, TextInput
-from ...impl.ncnn.model import NcnnModelWrapper
 from . import category as NCNNCategory
 
 

--- a/backend/src/nodes/nodes/ncnn/upscale_image.py
+++ b/backend/src/nodes/nodes/ncnn/upscale_image.py
@@ -7,21 +7,21 @@ import numpy as np
 from ncnn_vulkan import ncnn
 from sanic.log import logger
 
+from ...impl.ncnn.auto_split import ncnn_auto_split
+from ...impl.ncnn.model import NcnnModelWrapper
+from ...impl.ncnn.session import get_ncnn_net
+from ...impl.upscale.auto_split_tiles import (
+    TileSize,
+    estimate_tile_size,
+    parse_tile_size_input,
+)
+from ...impl.upscale.convenient_upscale import convenient_upscale
+from ...impl.upscale.tiler import MaxTileSize
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import ImageInput, NcnnModelInput, TileSizeDropdown
 from ...properties.outputs import ImageOutput
-from ...impl.upscale.tiler import MaxTileSize
-from ...impl.upscale.auto_split_tiles import (
-    estimate_tile_size,
-    parse_tile_size_input,
-    TileSize,
-)
-from ...impl.upscale.convenient_upscale import convenient_upscale
 from ...utils.exec_options import get_execution_options
-from ...impl.ncnn.auto_split import ncnn_auto_split
-from ...impl.ncnn.model import NcnnModelWrapper
-from ...impl.ncnn.session import get_ncnn_net
 from ...utils.utils import get_h_w_c
 from . import category as NCNNCategory
 

--- a/backend/src/nodes/nodes/onnx/convert_to_ncnn.py
+++ b/backend/src/nodes/nodes/onnx/convert_to_ncnn.py
@@ -4,15 +4,15 @@ from typing import Tuple
 
 import onnx
 
-from . import category as ONNXCategory
-from ...node_base import NodeBase
-from ...node_factory import NodeFactory
-from ...properties.inputs import OnnxModelInput, OnnxFpDropdown
-from ...properties.outputs import NcnnModelOutput, TextOutput
 from ...impl.ncnn.model import NcnnModelWrapper
 from ...impl.onnx.model import OnnxModel
 from ...impl.onnx.onnx_to_ncnn import Onnx2NcnnConverter
 from ...impl.onnx.utils import safely_optimize_onnx_model
+from ...node_base import NodeBase
+from ...node_factory import NodeFactory
+from ...properties.inputs import OnnxFpDropdown, OnnxModelInput
+from ...properties.outputs import NcnnModelOutput, TextOutput
+from . import category as ONNXCategory
 
 FP_MODE_32 = 0
 

--- a/backend/src/nodes/nodes/onnx/interpolate_models.py
+++ b/backend/src/nodes/nodes/onnx/interpolate_models.py
@@ -5,14 +5,13 @@ from typing import List, Tuple
 
 import numpy as np
 import onnx
-
 from google.protobuf.internal.containers import RepeatedCompositeFieldContainer
 from onnx import numpy_helper as onph
 from sanic.log import logger
 
 from ...impl.onnx.model import OnnxModel, load_onnx_model
-from ...impl.upscale.auto_split_tiles import NO_TILING
 from ...impl.onnx.utils import safely_optimize_onnx_model
+from ...impl.upscale.auto_split_tiles import NO_TILING
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import OnnxModelInput, SliderInput

--- a/backend/src/nodes/nodes/onnx/model_file_iterator.py
+++ b/backend/src/nodes/nodes/onnx/model_file_iterator.py
@@ -3,21 +3,22 @@ from __future__ import annotations
 import os
 
 from sanic.log import logger
+
 from process import IteratorContext
 
-from .load_model import OnnxLoadModelNode
-from . import category as OnnxCategory
-from ...node_base import NodeBase, IteratorNodeBase
+from ...impl.onnx.model import OnnxModel
+from ...node_base import IteratorNodeBase, NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import *
 from ...properties.outputs import (
-    OnnxModelOutput,
     DirectoryOutput,
-    TextOutput,
     NumberOutput,
+    OnnxModelOutput,
+    TextOutput,
 )
-from ...impl.onnx.model import OnnxModel
 from ...utils.utils import list_all_files_sorted
+from . import category as OnnxCategory
+from .load_model import OnnxLoadModelNode
 
 ONNX_ITERATOR_NODE_ID = "chainner:onnx:model_iterator_load"
 

--- a/backend/src/nodes/nodes/onnx/rembg.py
+++ b/backend/src/nodes/nodes/onnx/rembg.py
@@ -4,10 +4,10 @@ from typing import Tuple
 
 import numpy as np
 
+from ...groups import conditional_group
 from ...impl.onnx.model import OnnxRemBg
 from ...impl.onnx.session import get_onnx_session
 from ...impl.rembg.bg import remove_bg
-from ...groups import conditional_group
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties import expression

--- a/backend/src/nodes/nodes/onnx/save_model.py
+++ b/backend/src/nodes/nodes/onnx/save_model.py
@@ -4,11 +4,11 @@ import os
 
 from sanic.log import logger
 
-from . import category as ONNXCategory
+from ...impl.onnx.model import OnnxModel
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
-from ...properties.inputs import OnnxModelInput, DirectoryInput, TextInput
-from ...impl.onnx.model import OnnxModel
+from ...properties.inputs import DirectoryInput, OnnxModelInput, TextInput
+from . import category as ONNXCategory
 
 
 @NodeFactory.register("chainner:onnx:save_model")

--- a/backend/src/nodes/nodes/onnx/upscale_image.py
+++ b/backend/src/nodes/nodes/onnx/upscale_image.py
@@ -10,9 +10,9 @@ from ...impl.onnx.auto_split import onnx_auto_split
 from ...impl.onnx.model import OnnxModel
 from ...impl.onnx.session import get_onnx_session
 from ...impl.onnx.utils import get_input_shape, get_output_shape
-from ...impl.upscale.tiler import ExactTileSize
 from ...impl.upscale.auto_split_tiles import TileSize, parse_tile_size_input
 from ...impl.upscale.convenient_upscale import convenient_upscale
+from ...impl.upscale.tiler import ExactTileSize
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import ImageInput, OnnxGenericModelInput, TileSizeDropdown

--- a/backend/src/nodes/nodes/pytorch/convert_to_ncnn.py
+++ b/backend/src/nodes/nodes/pytorch/convert_to_ncnn.py
@@ -2,19 +2,18 @@ from __future__ import annotations
 
 from typing import Any
 
-from . import category as PyTorchCategory
+from ...impl.pytorch.architecture.Swin2SR import Swin2SR
+from ...impl.pytorch.architecture.SwinIR import SwinIR
+from ...impl.pytorch.types import PyTorchSRModel
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
-from ...properties.inputs import SrModelInput, OnnxFpDropdown
+from ...properties.inputs import OnnxFpDropdown, SrModelInput
 from ...properties.outputs import NcnnModelOutput, TextOutput
-from ...impl.pytorch.types import PyTorchSRModel
-from ...impl.pytorch.architecture.SwinIR import SwinIR
-from ...impl.pytorch.architecture.Swin2SR import Swin2SR
-
+from . import category as PyTorchCategory
 from .convert_to_onnx import ConvertTorchToONNXNode
 
 try:
-    from ..onnx.convert_to_ncnn import ConvertOnnxToNcnnNode, FP_MODE_32
+    from ..onnx.convert_to_ncnn import FP_MODE_32, ConvertOnnxToNcnnNode
 except:
     ConvertOnnxToNcnnNode = None
 

--- a/backend/src/nodes/nodes/pytorch/get_scale.py
+++ b/backend/src/nodes/nodes/pytorch/get_scale.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from . import category as PyTorchCategory
+from ...impl.pytorch.types import PyTorchModel
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import ModelInput
 from ...properties.outputs import NumberOutput
-from ...impl.pytorch.types import PyTorchModel
+from . import category as PyTorchCategory
 
 
 @NodeFactory.register("chainner:pytorch:model_dim")

--- a/backend/src/nodes/nodes/pytorch/inpaint.py
+++ b/backend/src/nodes/nodes/pytorch/inpaint.py
@@ -6,11 +6,7 @@ import numpy as np
 import torch
 
 from ...impl.pytorch.types import PyTorchInpaintModel
-from ...impl.pytorch.utils import (
-    np2tensor,
-    tensor2np,
-    to_pytorch_execution_options,
-)
+from ...impl.pytorch.utils import np2tensor, tensor2np, to_pytorch_execution_options
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties import expression

--- a/backend/src/nodes/nodes/pytorch/interpolate_models.py
+++ b/backend/src/nodes/nodes/pytorch/interpolate_models.py
@@ -3,18 +3,18 @@ from __future__ import annotations
 import gc
 from typing import Tuple
 
-import torch
 import numpy as np
+import torch
 from sanic.log import logger
 
-from . import category as PyTorchCategory
+from ...impl.pytorch.model_loading import load_state_dict
+from ...impl.pytorch.types import PyTorchModel
+from ...impl.pytorch.utils import np2tensor, tensor2np
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import ModelInput, SliderInput
 from ...properties.outputs import ModelOutput, NumberOutput
-from ...impl.pytorch.types import PyTorchModel
-from ...impl.pytorch.model_loading import load_state_dict
-from ...impl.pytorch.utils import np2tensor, tensor2np
+from . import category as PyTorchCategory
 
 
 @NodeFactory.register("chainner:pytorch:interpolate_models")

--- a/backend/src/nodes/nodes/pytorch/load_model.py
+++ b/backend/src/nodes/nodes/pytorch/load_model.py
@@ -6,17 +6,17 @@ from typing import Tuple
 import torch
 from sanic.log import logger
 
-from . import category as PyTorchCategory
+from ...impl.pytorch.model_loading import load_state_dict
+from ...impl.pytorch.types import PyTorchModel
+from ...impl.pytorch.utils import to_pytorch_execution_options
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import PthFileInput
-from ...properties.outputs import ModelOutput, DirectoryOutput, FileNameOutput
+from ...properties.outputs import DirectoryOutput, FileNameOutput, ModelOutput
 from ...utils.exec_options import get_execution_options
-from ...impl.pytorch.types import PyTorchModel
-from ...impl.pytorch.model_loading import load_state_dict
-from ...impl.pytorch.utils import to_pytorch_execution_options
 from ...utils.unpickler import RestrictedUnpickle
 from ...utils.utils import split_file_path
+from . import category as PyTorchCategory
 
 
 @NodeFactory.register("chainner:pytorch:load_model")

--- a/backend/src/nodes/nodes/pytorch/model_file_iterator.py
+++ b/backend/src/nodes/nodes/pytorch/model_file_iterator.py
@@ -3,16 +3,17 @@ from __future__ import annotations
 import os
 
 from sanic.log import logger
+
 from process import IteratorContext
 
-from .load_model import LoadModelNode
-from . import category as PyTorchCategory
-from ...node_base import NodeBase, IteratorNodeBase
+from ...impl.pytorch.types import PyTorchModel
+from ...node_base import IteratorNodeBase, NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import *
 from ...properties.outputs import *
-from ...impl.pytorch.types import PyTorchModel
 from ...utils.utils import list_all_files_sorted
+from . import category as PyTorchCategory
+from .load_model import LoadModelNode
 
 PYTORCH_ITERATOR_NODE_ID = "chainner:pytorch:model_iterator_load"
 

--- a/backend/src/nodes/nodes/pytorch/save_model.py
+++ b/backend/src/nodes/nodes/pytorch/save_model.py
@@ -5,11 +5,11 @@ import os
 import torch
 from sanic.log import logger
 
-from . import category as PyTorchCategory
+from ...impl.pytorch.types import PyTorchModel
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
-from ...properties.inputs import ModelInput, DirectoryInput, TextInput
-from ...impl.pytorch.types import PyTorchModel
+from ...properties.inputs import DirectoryInput, ModelInput, TextInput
+from . import category as PyTorchCategory
 
 
 @NodeFactory.register("chainner:pytorch:save_model")

--- a/backend/src/nodes/nodes/pytorch/upscale_face.py
+++ b/backend/src/nodes/nodes/pytorch/upscale_face.py
@@ -1,27 +1,25 @@
 from __future__ import annotations
+
 import os
 from typing import Union
 
+import cv2
 import numpy as np
 import torch
-from sanic.log import logger
-import cv2
-
-from torchvision.transforms.functional import normalize as tv_normalize
-from facexlib.utils.face_restoration_helper import FaceRestoreHelper
-
 from appdirs import user_data_dir
+from facexlib.utils.face_restoration_helper import FaceRestoreHelper
+from sanic.log import logger
+from torchvision.transforms.functional import normalize as tv_normalize
 
-from . import category as PyTorchCategory
+from ...impl.pytorch.types import PyTorchFaceModel
+from ...impl.pytorch.utils import np2tensor, tensor2np, to_pytorch_execution_options
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import FaceModelInput, ImageInput, NumberInput
 from ...properties.outputs import ImageOutput
-from ...utils.utils import get_h_w_c
-from ...impl.pytorch.utils import np2tensor, tensor2np
 from ...utils.exec_options import get_execution_options
-from ...impl.pytorch.types import PyTorchFaceModel
-from ...impl.pytorch.utils import to_pytorch_execution_options
+from ...utils.utils import get_h_w_c
+from . import category as PyTorchCategory
 
 
 @NodeFactory.register("chainner:pytorch:upscale_face")

--- a/backend/src/nodes/nodes/pytorch/upscale_image.py
+++ b/backend/src/nodes/nodes/pytorch/upscale_image.py
@@ -2,27 +2,27 @@ from __future__ import annotations
 
 from typing import Tuple
 
-import torch
 import numpy as np
+import torch
 from sanic.log import logger
 
-from . import category as PyTorchCategory
-from ...node_base import NodeBase
-from ...node_factory import NodeFactory
-from ...properties.inputs import SrModelInput, ImageInput, TileSizeDropdown
-from ...properties.outputs import ImageOutput
-from ...utils.exec_options import get_execution_options, ExecutionOptions
+from ...impl.pytorch.auto_split import pytorch_auto_split
 from ...impl.pytorch.types import PyTorchSRModel
+from ...impl.pytorch.utils import to_pytorch_execution_options
 from ...impl.upscale.auto_split_tiles import (
+    TileSize,
     estimate_tile_size,
     parse_tile_size_input,
-    TileSize,
 )
-from ...impl.upscale.tiler import MaxTileSize
 from ...impl.upscale.convenient_upscale import convenient_upscale
-from ...impl.pytorch.utils import to_pytorch_execution_options
-from ...impl.pytorch.auto_split import pytorch_auto_split
+from ...impl.upscale.tiler import MaxTileSize
+from ...node_base import NodeBase
+from ...node_factory import NodeFactory
+from ...properties.inputs import ImageInput, SrModelInput, TileSizeDropdown
+from ...properties.outputs import ImageOutput
+from ...utils.exec_options import ExecutionOptions, get_execution_options
 from ...utils.utils import get_h_w_c
+from . import category as PyTorchCategory
 
 
 @NodeFactory.register("chainner:pytorch:upscale_image")

--- a/backend/src/nodes/nodes/utility/copy_to_clipboard.py
+++ b/backend/src/nodes/nodes/utility/copy_to_clipboard.py
@@ -3,13 +3,11 @@ from __future__ import annotations
 from typing import Union
 
 from ...impl import clipboard
-
-from . import category as UtilityCategory
-
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import *
 from ...properties.outputs import *
+from . import category as UtilityCategory
 
 
 @NodeFactory.register("chainner:utility:copy_to_clipboard")

--- a/backend/src/nodes/nodes/utility/math_node.py
+++ b/backend/src/nodes/nodes/utility/math_node.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
-from enum import Enum
-import math
-from typing import Dict, Union
 
-from . import category as UtilityCategory
+import math
+from enum import Enum
+from typing import Dict, Union
 
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
-from ...properties.inputs import NumberInput, EnumInput
+from ...properties.inputs import EnumInput, NumberInput
 from ...properties.outputs import NumberOutput
+from . import category as UtilityCategory
 
 
 class MathOperation(Enum):

--- a/backend/src/nodes/nodes/utility/note.py
+++ b/backend/src/nodes/nodes/utility/note.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 from typing import Union
 
-from . import category as UtilityCategory
-
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import NoteTextAreaInput
+from . import category as UtilityCategory
 
 
 @NodeFactory.register("chainner:utility:note")

--- a/backend/src/nodes/nodes/utility/number.py
+++ b/backend/src/nodes/nodes/utility/number.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-from . import category as UtilityCategory
-
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import NumberInput
 from ...properties.outputs import NumberOutput
+from . import category as UtilityCategory
 
 
 @NodeFactory.register("chainner:utility:number")

--- a/backend/src/nodes/nodes/utility/pass_through.py
+++ b/backend/src/nodes/nodes/utility/pass_through.py
@@ -6,12 +6,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from . import category as UtilityCategory
-
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import AnyInput
 from ...properties.outputs import BaseOutput
+from . import category as UtilityCategory
 
 
 @NodeFactory.register("chainner:utility:pass_through")

--- a/backend/src/nodes/nodes/utility/random_number.py
+++ b/backend/src/nodes/nodes/utility/random_number.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
-from typing import Union
-from random import Random
 
-from . import category as UtilityCategory
+from random import Random
+from typing import Union
 
 from ...node_base import NodeBase, group
 from ...node_factory import NodeFactory
-from ...properties.inputs import NumberInput, BaseInput
+from ...properties.inputs import BaseInput, NumberInput
 from ...properties.outputs import NumberOutput
+from . import category as UtilityCategory
 
 
 @NodeFactory.register("chainner:utility:random_number")

--- a/backend/src/nodes/nodes/utility/text.py
+++ b/backend/src/nodes/nodes/utility/text.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-from . import category as UtilityCategory
-
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import TextInput
 from ...properties.outputs import TextOutput
+from . import category as UtilityCategory
 
 
 @NodeFactory.register("chainner:utility:text")

--- a/backend/src/nodes/nodes/utility/text_append.py
+++ b/backend/src/nodes/nodes/utility/text_append.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 from typing import List, Union
 
-from . import category as UtilityCategory
-
 from ...node_base import NodeBase, group
 from ...node_factory import NodeFactory
 from ...properties.inputs import TextInput
 from ...properties.outputs import TextOutput
 from ...utils.utils import ALPHABET
+from . import category as UtilityCategory
 
 
 @NodeFactory.register("chainner:utility:text_append")

--- a/backend/src/nodes/nodes/utility/text_pad.py
+++ b/backend/src/nodes/nodes/utility/text_pad.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
-from enum import Enum
 
-from . import category as UtilityCategory
+from enum import Enum
 
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
-from ...properties.inputs import TextInput, NumberInput, EnumInput
+from ...properties.inputs import EnumInput, NumberInput, TextInput
 from ...properties.outputs import TextOutput
+from . import category as UtilityCategory
 
 
 class PaddingAlignment(Enum):

--- a/backend/src/nodes/nodes/utility/text_pattern.py
+++ b/backend/src/nodes/nodes/utility/text_pattern.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 from typing import Union
 
-from . import category as UtilityCategory
-
 from ...node_base import NodeBase, group
 from ...node_factory import NodeFactory
 from ...properties.inputs import TextInput
 from ...properties.outputs import TextOutput
 from ...utils.replacement import ReplacementString
+from . import category as UtilityCategory
 
 
 @NodeFactory.register("chainner:utility:text_pattern")

--- a/backend/src/nodes/properties/expression.py
+++ b/backend/src/nodes/properties/expression.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from typing import Literal, Optional, Tuple, TypedDict, Union, List, Dict
 import math
-
+from typing import Dict, List, Literal, Optional, Tuple, TypedDict, Union
 
 NumberJson = Union[int, float, Literal["inf"], Literal["-inf"], Literal["NaN"]]
 

--- a/backend/src/nodes/properties/inputs/__init__.py
+++ b/backend/src/nodes/properties/inputs/__init__.py
@@ -1,7 +1,7 @@
 from .base_input import *
-from .image_dropdown_inputs import *
 from .file_inputs import *
 from .generic_inputs import *
+from .image_dropdown_inputs import *
 from .numeric_inputs import *
 from .numpy_inputs import *
 

--- a/backend/src/nodes/properties/inputs/base_input.py
+++ b/backend/src/nodes/properties/inputs/base_input.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
+
 from typing import Literal
+
 from base_types import InputId
+
 from .. import expression
 
 InputKind = Literal[

--- a/backend/src/nodes/properties/inputs/file_inputs.py
+++ b/backend/src/nodes/properties/inputs/file_inputs.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
-from typing import Literal, Union
 
 import os
+from typing import Literal, Union
 
 # pylint: disable=relative-beyond-top-level
 from ...impl.image_formats import get_available_image_formats

--- a/backend/src/nodes/properties/inputs/generic_inputs.py
+++ b/backend/src/nodes/properties/inputs/generic_inputs.py
@@ -1,21 +1,22 @@
 from __future__ import annotations
+
 from enum import Enum
-from typing import Dict, Generic, List, Literal, Tuple, Type, TypeVar, Union, TypedDict
+from typing import Dict, Generic, List, Literal, Tuple, Type, TypedDict, TypeVar, Union
+
 import numpy as np
 from sanic.log import logger
 
-from .. import expression
-
-from .base_input import BaseInput
 from ...impl.blend import BlendMode
 from ...impl.dds.format import DDSFormat
 from ...impl.image_utils import FillColor, normalize
 from ...utils.utils import (
-    split_snake_case,
-    split_pascal_case,
     join_pascal_case,
     join_space_case,
+    split_pascal_case,
+    split_snake_case,
 )
+from .. import expression
+from .base_input import BaseInput
 
 
 class UntypedOption(TypedDict):

--- a/backend/src/nodes/properties/inputs/image_dropdown_inputs.py
+++ b/backend/src/nodes/properties/inputs/image_dropdown_inputs.py
@@ -1,14 +1,15 @@
 import cv2
 
-# pylint: disable=relative-beyond-top-level
-from ...impl.image_utils import BorderType
-from ...impl.pil_utils import InterpolationMethod, RotationInterpolationMethod
 from ...impl.color.convert_data import (
     color_spaces,
     color_spaces_or_detectors,
-    is_alpha_partner,
     get_alpha_partner,
+    is_alpha_partner,
 )
+
+# pylint: disable=relative-beyond-top-level
+from ...impl.image_utils import BorderType
+from ...impl.pil_utils import InterpolationMethod, RotationInterpolationMethod
 from ..expression import named
 from .generic_inputs import DropDownInput, EnumInput
 

--- a/backend/src/nodes/properties/inputs/numeric_inputs.py
+++ b/backend/src/nodes/properties/inputs/numeric_inputs.py
@@ -1,8 +1,8 @@
-from typing import Union, Tuple, List, Literal
+from typing import List, Literal, Tuple, Union
 
-from .base_input import BaseInput, InputKind
 from ...utils.utils import round_half_up
 from .. import expression
+from .base_input import BaseInput, InputKind
 
 
 def clampNumber(

--- a/backend/src/nodes/properties/inputs/numpy_inputs.py
+++ b/backend/src/nodes/properties/inputs/numpy_inputs.py
@@ -1,10 +1,11 @@
 # pylint: disable=relative-beyond-top-level
 
 from typing import List, Optional, Union
-from ...impl.image_utils import normalize, get_h_w_c
+
+from ...impl.image_utils import get_h_w_c, normalize
 from ...utils.format import format_image_with_channels
-from .base_input import BaseInput
 from .. import expression
+from .base_input import BaseInput
 
 
 class AudioInput(BaseInput):

--- a/backend/src/nodes/properties/outputs/base_output.py
+++ b/backend/src/nodes/properties/outputs/base_output.py
@@ -1,5 +1,7 @@
-from typing import Union, Literal
+from typing import Literal, Union
+
 from base_types import OutputId
+
 from .. import expression
 
 OutputKind = Literal[

--- a/backend/src/nodes/properties/outputs/file_outputs.py
+++ b/backend/src/nodes/properties/outputs/file_outputs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
-from .base_output import BaseOutput, OutputKind
+
 from .. import expression
+from .base_output import BaseOutput, OutputKind
 
 
 class FileOutput(BaseOutput):

--- a/backend/src/nodes/properties/outputs/generic_outputs.py
+++ b/backend/src/nodes/properties/outputs/generic_outputs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
-from .base_output import BaseOutput, OutputKind
+
 from .. import expression
+from .base_output import BaseOutput, OutputKind
 
 
 class NumberOutput(BaseOutput):

--- a/backend/src/nodes/properties/outputs/numpy_outputs.py
+++ b/backend/src/nodes/properties/outputs/numpy_outputs.py
@@ -1,13 +1,14 @@
 import base64
 from typing import Optional, Tuple
-import numpy as np
-import cv2
 
-from ...utils.utils import get_h_w_c
+import cv2
+import numpy as np
+
+from ...impl.pil_utils import InterpolationMethod, resize
 from ...utils.format import format_image_with_channels
-from ...impl.pil_utils import resize, InterpolationMethod
-from .base_output import BaseOutput, OutputKind
+from ...utils.utils import get_h_w_c
 from .. import expression
+from .base_output import BaseOutput, OutputKind
 
 
 class NumPyOutput(BaseOutput):

--- a/backend/src/nodes/properties/outputs/pytorch_outputs.py
+++ b/backend/src/nodes/properties/outputs/pytorch_outputs.py
@@ -1,7 +1,6 @@
+from ...impl.pytorch.types import PyTorchModel
 from .. import expression
 from .base_output import BaseOutput, OutputKind
-
-from ...impl.pytorch.types import PyTorchModel
 
 
 class ModelOutput(BaseOutput):

--- a/backend/src/nodes/utils/exec_options.py
+++ b/backend/src/nodes/utils/exec_options.py
@@ -1,5 +1,6 @@
 import os
 from typing import TypedDict
+
 from sanic.log import logger
 
 

--- a/backend/src/nodes/utils/replacement.py
+++ b/backend/src/nodes/utils/replacement.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import re
 
 

--- a/backend/src/nodes/utils/utils.py
+++ b/backend/src/nodes/utils/utils.py
@@ -1,10 +1,10 @@
 # From https://github.com/victorca25/iNNfer/blob/main/utils/utils.py
 from __future__ import annotations
 
+import os
+import re
 from dataclasses import dataclass
 from typing import List, Tuple, Union
-import re
-import os
 
 import numpy as np
 from sanic.log import logger

--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import asyncio
-from concurrent.futures import ThreadPoolExecutor
 import functools
 import gc
-import uuid
 import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
 from typing import (
     Any,
     Callable,
@@ -18,20 +18,18 @@ from typing import (
     TypeVar,
     Union,
 )
+
 import numpy as np
-
 from sanic.log import logger
-from progress import ProgressToken, Aborted, ProgressController
-from events import EventQueue, Event, InputsDict
+
 from base_types import NodeId, OutputId
-
-from chain.chain import Chain, Node, FunctionNode, IteratorNode, SubChain
-from chain.cache import OutputCache, CacheStrategy, get_cache_strategies
-from chain.input import InputMap, EdgeInput
-
-from nodes.node_base import NodeBase
+from chain.cache import CacheStrategy, OutputCache, get_cache_strategies
+from chain.chain import Chain, FunctionNode, IteratorNode, Node, SubChain
+from chain.input import EdgeInput, InputMap
+from events import Event, EventQueue, InputsDict
 from nodes.impl.image_utils import get_h_w_c
-
+from nodes.node_base import NodeBase
+from progress import Aborted, ProgressController, ProgressToken
 
 Output = List[Any]
 

--- a/backend/src/progress.py
+++ b/backend/src/progress.py
@@ -1,5 +1,5 @@
-from abc import ABC, abstractmethod
 import asyncio
+from abc import ABC, abstractmethod
 
 
 class Aborted(Exception):

--- a/backend/src/response.py
+++ b/backend/src/response.py
@@ -1,7 +1,7 @@
 from typing import Literal, Optional, TypedDict, Union
 
-from process import NodeExecutionError
 from events import ExecutionErrorSource
+from process import NodeExecutionError
 
 
 class SuccessResponse(TypedDict):

--- a/backend/src/run.py
+++ b/backend/src/run.py
@@ -1,42 +1,41 @@
 import asyncio
-from concurrent.futures import ThreadPoolExecutor
 import functools
 import gc
+import importlib
 import logging
+import os
 import sys
 import traceback
+from concurrent.futures import ThreadPoolExecutor
 from json import dumps as stringify
 from typing import Any, Dict, List, Optional, TypedDict
-import importlib
-import os
 
 # pylint: disable-next=unused-import
 import cv2  # type: ignore
 from sanic import Sanic
-from sanic.log import logger, access_logger
+from sanic.log import access_logger, logger
 from sanic.request import Request
 from sanic.response import json
 from sanic_cors import CORS
 
-from nodes.node_factory import NodeFactory
-from nodes.utils.exec_options import (
-    set_execution_options,
-    parse_execution_options,
-    JsonExecutionOptions,
-)
-from nodes.nodes.builtin_categories import category_order
-from nodes.group import Group
-
 from base_types import NodeId, OutputId
 from chain.cache import OutputCache
-from chain.json import parse_json, JsonNode
+from chain.json import JsonNode, parse_json
 from chain.optimize import optimize
 from events import EventQueue, ExecutionErrorData
+from nodes.group import Group
+from nodes.node_factory import NodeFactory
+from nodes.nodes.builtin_categories import category_order
+from nodes.utils.exec_options import (
+    JsonExecutionOptions,
+    parse_execution_options,
+    set_execution_options,
+)
 from process import Executor, NodeExecutionError, Output, timed_supplier, to_output
 from progress import Aborted
 from response import (
-    errorResponse,
     alreadyRunningResponse,
+    errorResponse,
     noExecutorResponse,
     successResponse,
 )

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "lint": "npm run lint-js && npm run lint-py",
     "lint-js": "eslint . --ext \".js,.jsx,.ts,.tsx\" && stylelint src/**/*.scss",
     "lint-js-ci": "eslint . --ext \".js,.jsx,.ts,.tsx\" --max-warnings 0 && stylelint src/**/*.scss",
-    "lint-py": "black --check ./backend",
-    "lint-fix": "eslint . --fix --ext \".js,.jsx,.ts,.tsx\" && stylelint src/**/*.scss --fix && black ./backend",
+    "lint-py": "black --check ./backend && isort backend/ --check --profile=black --src=backend/src",
+    "lint-fix": "eslint . --fix --ext \".js,.jsx,.ts,.tsx\" && stylelint src/**/*.scss --fix && black ./backend && isort backend/ --profile=black --src=backend/src",
     "test-js": "jest",
     "test-py": "pytest ./backend/tests/",
     "test": "npm run test-js && npm run test-py"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ einops
 facexlib
 ffmpeg-python
 google-re2
+isort==5.11.5
 ncnn_vulkan
 numba!=0.49.0
 numpy


### PR DESCRIPTION
I got tired of import sorting being inconsistent, so I added [isort](https://github.com/PyCQA/isort). This PR includes the following:

- Make isort a dependency.
- Added VSCode editor config for isort.
- Added isort to npm scripts and GitHub CI.

Since isort changes around 70% of all python files, I will only run it on our code base after #1569 and #1568 to avoid conflicts.