### PR TITLE
Fixed extension check to account for windows file systems

### DIFF
--- a/backend/src/nodes/nodes/pytorch/load_model.py
+++ b/backend/src/nodes/nodes/pytorch/load_model.py
@@ -53,7 +53,7 @@ class LoadModelNode(NodeBase):
         try:
             logger.debug(f"Reading state dict from path: {path}")
 
-            if os.path.splitext(path)[1] == ".pt":
+            if os.path.splitext(path)[1].lower() == ".pt":
                 state_dict = torch.jit.load(  # type: ignore
                     path, map_location=torch.device(exec_options.full_device)
                 ).state_dict()


### PR DESCRIPTION
Super minor fix for #1574. On Windows, all file names, including their extensions, ignore case, so we should lower the extension just in case.