### PR TITLE
Added unit to number inputs in error message

### DIFF
--- a/src/common/formatExecutionErrorMessage.ts
+++ b/src/common/formatExecutionErrorMessage.ts
@@ -29,6 +29,9 @@ export const formatExecutionErrorMessage = (
             valueStr = 'None';
         } else if (typeof value === 'number') {
             valueStr = String(value);
+            if ((i.kind === 'number' || i.kind === 'slider') && i.unit) {
+                valueStr += ` ${i.unit}`;
+            }
         } else if (typeof value === 'string') {
             valueStr = JSON.stringify(value);
         } else {

--- a/src/common/formatExecutionErrorMessage.ts
+++ b/src/common/formatExecutionErrorMessage.ts
@@ -30,7 +30,7 @@ export const formatExecutionErrorMessage = (
         } else if (typeof value === 'number') {
             valueStr = String(value);
             if ((i.kind === 'number' || i.kind === 'slider') && i.unit) {
-                valueStr += ` ${i.unit}`;
+                valueStr += i.unit;
             }
         } else if (typeof value === 'string') {
             valueStr = JSON.stringify(value);


### PR DESCRIPTION
A bug report in our discord showed an error message for Resize (Factor) and the factor did not have its % unit. This PR fixes that to make error messages easier to understand.