### PR TITLE
Fix default size for textarea inputs

### DIFF
--- a/src/renderer/components/inputs/TextAreaInput.tsx
+++ b/src/renderer/components/inputs/TextAreaInput.tsx
@@ -12,6 +12,8 @@ import { useContextMenu } from '../../hooks/useContextMenu';
 import { CopyOverrideIdSection } from './elements/CopyOverrideIdSection';
 import { InputProps } from './props';
 
+const DEFAULT_SIZE = { width: 240, height: 80 };
+
 export const TextAreaInput = memo(
     ({ value, setValue, input, isLocked, useInputSize, nodeId }: InputProps<'text', string>) => {
         const { label, resizable } = input;
@@ -28,7 +30,7 @@ export const TextAreaInput = memo(
 
         useEffect(() => {
             if (!size) {
-                setSize({ width: 240, height: 80 });
+                setSize(DEFAULT_SIZE);
             }
         }, [size, setSize]);
 
@@ -77,7 +79,7 @@ export const TextAreaInput = memo(
         return (
             <Resizable
                 className="nodrag"
-                defaultSize={size ?? { width: 240, height: 80 }}
+                defaultSize={size ?? DEFAULT_SIZE}
                 enable={{
                     top: false,
                     right: !isLocked && resizable,

--- a/src/renderer/components/inputs/TextAreaInput.tsx
+++ b/src/renderer/components/inputs/TextAreaInput.tsx
@@ -28,7 +28,7 @@ export const TextAreaInput = memo(
 
         useEffect(() => {
             if (!size) {
-                setSize({ width: 320, height: 240 });
+                setSize({ width: 240, height: 80 });
             }
         }, [size, setSize]);
 
@@ -77,7 +77,7 @@ export const TextAreaInput = memo(
         return (
             <Resizable
                 className="nodrag"
-                defaultSize={size}
+                defaultSize={size ?? { width: 240, height: 80 }}
                 enable={{
                     top: false,
                     right: !isLocked && resizable,


### PR DESCRIPTION
This ended up being a much easier fix than I thought. Turns out, the default value we were using was not the minimum value of the textarea, but a much larger value. I guess the default size when size was undefined would just be the minimum, but then the size would get set by the useEffect, so on refresh it was setting it to that default size we were setting, hence it getting randomly bigger.

So, I reduced the default size down and set a null condition for the default size.