### PR TITLE
Auto-detect SD webui endpoint

### DIFF
--- a/backend/src/nodes/impl/external_stable_diffusion.py
+++ b/backend/src/nodes/impl/external_stable_diffusion.py
@@ -4,7 +4,7 @@ import base64
 import io
 import os
 from enum import Enum
-from typing import Dict, Union, Optional
+from typing import Dict, Optional, Union
 
 import cv2
 import numpy as np

--- a/backend/src/nodes/impl/external_stable_diffusion.py
+++ b/backend/src/nodes/impl/external_stable_diffusion.py
@@ -4,7 +4,7 @@ import base64
 import io
 import os
 from enum import Enum
-from typing import Dict, Union
+from typing import Dict, Union, Optional
 
 import cv2
 import numpy as np
@@ -65,7 +65,7 @@ def _auto_detect_endpoint(timeout=0.5):
     )
     ports = [STABLE_DIFFUSION_PORT] if STABLE_DIFFUSION_PORT else ["7860", "7861"]
 
-    last_error = None
+    last_error: Optional[Exception] = None
     for STABLE_DIFFUSION_PROTOCOL in protocols:
         for STABLE_DIFFUSION_PORT in ports:
             try:
@@ -74,10 +74,13 @@ def _auto_detect_endpoint(timeout=0.5):
                     f"Found stable diffusion API at {STABLE_DIFFUSION_PROTOCOL}://{STABLE_DIFFUSION_HOST}:{STABLE_DIFFUSION_PORT}"
                 )
                 return
-            except ExternalServiceConnectionError as error:
+            except Exception as error:
                 last_error = error
 
-    raise last_error
+    if last_error:
+        raise last_error
+    else:
+        raise RuntimeError
 
 
 def get(path, timeout: float = STABLE_DIFFUSION_REQUEST_TIMEOUT) -> Dict:

--- a/backend/src/nodes/impl/external_stable_diffusion.py
+++ b/backend/src/nodes/impl/external_stable_diffusion.py
@@ -10,31 +10,35 @@ import cv2
 import numpy as np
 import requests
 from PIL import Image
+from sanic.log import logger
 
 from ..utils.utils import get_h_w_c
 from .image_utils import normalize
 
-STABLE_DIFFUSION_PROTOCOL = os.environ.get("STABLE_DIFFUSION_PROTOCOL", "http")
+STABLE_DIFFUSION_PROTOCOL = os.environ.get("STABLE_DIFFUSION_PROTOCOL", None)
 STABLE_DIFFUSION_HOST = os.environ.get("STABLE_DIFFUSION_HOST", "127.0.0.1")
-STABLE_DIFFUSION_PORT = os.environ.get("STABLE_DIFFUSION_PORT", "7860")
+STABLE_DIFFUSION_PORT = os.environ.get("STABLE_DIFFUSION_PORT", None)
 
 STABLE_DIFFUSION_REQUEST_TIMEOUT = float(
     os.environ.get("STABLE_DIFFUSION_REQUEST_TIMEOUT", "600")
 )  # 10 minutes
 
-STABLE_DIFFUSION_TEXT2IMG_URL = f"{STABLE_DIFFUSION_PROTOCOL}://{STABLE_DIFFUSION_HOST}:{STABLE_DIFFUSION_PORT}/sdapi/v1/txt2img"
-STABLE_DIFFUSION_IMG2IMG_URL = f"{STABLE_DIFFUSION_PROTOCOL}://{STABLE_DIFFUSION_HOST}:{STABLE_DIFFUSION_PORT}/sdapi/v1/img2img"
-STABLE_DIFFUSION_INTERROGATE_URL = f"{STABLE_DIFFUSION_PROTOCOL}://{STABLE_DIFFUSION_HOST}:{STABLE_DIFFUSION_PORT}/sdapi/v1/interrogate"
-STABLE_DIFFUSION_OPTIONS_URL = f"{STABLE_DIFFUSION_PROTOCOL}://{STABLE_DIFFUSION_HOST}:{STABLE_DIFFUSION_PORT}/sdapi/v1/options"
+STABLE_DIFFUSION_TEXT2IMG_PATH = f"/sdapi/v1/txt2img"
+STABLE_DIFFUSION_IMG2IMG_PATH = f"/sdapi/v1/img2img"
+STABLE_DIFFUSION_INTERROGATE_PATH = f"/sdapi/v1/interrogate"
+STABLE_DIFFUSION_OPTIONS_PATH = f"/sdapi/v1/options"
+
+
+def _stable_diffusion_url(path):
+    return f"{STABLE_DIFFUSION_PROTOCOL}://{STABLE_DIFFUSION_HOST}:{STABLE_DIFFUSION_PORT}{path}"
+
 
 ERROR_MSG = f"""
 If you want to use external stable diffusion nodes, run the Automatic1111 web ui with the --api flag, like so:
 
 ./webui.sh --api
 
-ChaiNNer is currently configured to look for the API at
-{STABLE_DIFFUSION_PROTOCOL}://{STABLE_DIFFUSION_HOST}:{STABLE_DIFFUSION_PORT}.
-If you have it running somewhere else, you can change this using the
+To manually set where ChaiNNer looks for the API, use the
 STABLE_DIFFUSION_PROTOCOL, STABLE_DIFFUSION_HOST, and STABLE_DIFFUSION_PORT
 environment variables.
 """
@@ -53,9 +57,32 @@ class ExternalServiceTimeout(Exception):
     pass
 
 
-def get(url, timeout: float = STABLE_DIFFUSION_REQUEST_TIMEOUT) -> Dict:
+def _auto_detect_endpoint(timeout=0.5):
+    global STABLE_DIFFUSION_PROTOCOL, STABLE_DIFFUSION_PORT  # pylint: disable=global-statement
+
+    protocols = (
+        [STABLE_DIFFUSION_PROTOCOL] if STABLE_DIFFUSION_PROTOCOL else ["http", "https"]
+    )
+    ports = [STABLE_DIFFUSION_PORT] if STABLE_DIFFUSION_PORT else ["7860", "7861"]
+
+    last_error = None
+    for STABLE_DIFFUSION_PROTOCOL in protocols:
+        for STABLE_DIFFUSION_PORT in ports:
+            try:
+                get(STABLE_DIFFUSION_OPTIONS_PATH, timeout=timeout)
+                logger.info(
+                    f"Found stable diffusion API at {STABLE_DIFFUSION_PROTOCOL}://{STABLE_DIFFUSION_HOST}:{STABLE_DIFFUSION_PORT}"
+                )
+                return
+            except ExternalServiceConnectionError as error:
+                last_error = error
+
+    raise last_error
+
+
+def get(path, timeout: float = STABLE_DIFFUSION_REQUEST_TIMEOUT) -> Dict:
     try:
-        response = requests.get(url, timeout=timeout)
+        response = requests.get(_stable_diffusion_url(path), timeout=timeout)
     except requests.ConnectionError as exc:
         raise ExternalServiceConnectionError(ERROR_MSG) from exc
     except requests.exceptions.ReadTimeout as exc:
@@ -63,10 +90,12 @@ def get(url, timeout: float = STABLE_DIFFUSION_REQUEST_TIMEOUT) -> Dict:
     return response.json()
 
 
-def post(url, json_data: Dict) -> Dict:
+def post(path, json_data: Dict) -> Dict:
     try:
         response = requests.post(
-            url, json=json_data, timeout=STABLE_DIFFUSION_REQUEST_TIMEOUT
+            _stable_diffusion_url(path),
+            json=json_data,
+            timeout=STABLE_DIFFUSION_REQUEST_TIMEOUT,
         )
     except requests.ConnectionError as exc:
         raise ExternalServiceConnectionError(ERROR_MSG) from exc
@@ -91,7 +120,7 @@ def verify_api_connection():
     global has_api_connection  # pylint: disable=global-statement
     if has_api_connection is None:
         has_api_connection = False
-        get(STABLE_DIFFUSION_OPTIONS_URL, timeout=0.5)
+        _auto_detect_endpoint()
         has_api_connection = True
 
     if not has_api_connection:

--- a/backend/src/nodes/impl/external_stable_diffusion.py
+++ b/backend/src/nodes/impl/external_stable_diffusion.py
@@ -14,6 +14,7 @@ from PIL import Image
 from ..utils.utils import get_h_w_c
 from .image_utils import normalize
 
+STABLE_DIFFUSION_PROTOCOL = os.environ.get("STABLE_DIFFUSION_PROTOCOL", "http")
 STABLE_DIFFUSION_HOST = os.environ.get("STABLE_DIFFUSION_HOST", "127.0.0.1")
 STABLE_DIFFUSION_PORT = os.environ.get("STABLE_DIFFUSION_PORT", "7860")
 
@@ -21,26 +22,20 @@ STABLE_DIFFUSION_REQUEST_TIMEOUT = float(
     os.environ.get("STABLE_DIFFUSION_REQUEST_TIMEOUT", "600")
 )  # 10 minutes
 
-STABLE_DIFFUSION_TEXT2IMG_URL = (
-    f"http://{STABLE_DIFFUSION_HOST}:{STABLE_DIFFUSION_PORT}/sdapi/v1/txt2img"
-)
-STABLE_DIFFUSION_IMG2IMG_URL = (
-    f"http://{STABLE_DIFFUSION_HOST}:{STABLE_DIFFUSION_PORT}/sdapi/v1/img2img"
-)
-STABLE_DIFFUSION_INTERROGATE_URL = (
-    f"http://{STABLE_DIFFUSION_HOST}:{STABLE_DIFFUSION_PORT}/sdapi/v1/interrogate"
-)
-STABLE_DIFFUSION_OPTIONS_URL = (
-    f"http://{STABLE_DIFFUSION_HOST}:{STABLE_DIFFUSION_PORT}/sdapi/v1/options"
-)
+STABLE_DIFFUSION_TEXT2IMG_URL = f"{STABLE_DIFFUSION_PROTOCOL}://{STABLE_DIFFUSION_HOST}:{STABLE_DIFFUSION_PORT}/sdapi/v1/txt2img"
+STABLE_DIFFUSION_IMG2IMG_URL = f"{STABLE_DIFFUSION_PROTOCOL}://{STABLE_DIFFUSION_HOST}:{STABLE_DIFFUSION_PORT}/sdapi/v1/img2img"
+STABLE_DIFFUSION_INTERROGATE_URL = f"{STABLE_DIFFUSION_PROTOCOL}://{STABLE_DIFFUSION_HOST}:{STABLE_DIFFUSION_PORT}/sdapi/v1/interrogate"
+STABLE_DIFFUSION_OPTIONS_URL = f"{STABLE_DIFFUSION_PROTOCOL}://{STABLE_DIFFUSION_HOST}:{STABLE_DIFFUSION_PORT}/sdapi/v1/options"
 
 ERROR_MSG = f"""
 If you want to use external stable diffusion nodes, run the Automatic1111 web ui with the --api flag, like so:
 
 ./webui.sh --api
 
-ChaiNNer is currently configured to look for the API at http://{STABLE_DIFFUSION_HOST}:{STABLE_DIFFUSION_PORT}.  If you
-have it running somewhere else, you can change this using the STABLE_DIFFUSION_HOST and STABLE_DIFFUSION_PORT
+ChaiNNer is currently configured to look for the API at
+{STABLE_DIFFUSION_PROTOCOL}://{STABLE_DIFFUSION_HOST}:{STABLE_DIFFUSION_PORT}.
+If you have it running somewhere else, you can change this using the
+STABLE_DIFFUSION_PROTOCOL, STABLE_DIFFUSION_HOST, and STABLE_DIFFUSION_PORT
 environment variables.
 """
 

--- a/backend/src/nodes/nodes/external_stable_diffusion/img2img.py
+++ b/backend/src/nodes/nodes/external_stable_diffusion/img2img.py
@@ -7,7 +7,7 @@ import numpy as np
 from ...impl.external_stable_diffusion import (
     RESIZE_MODE_LABELS,
     SAMPLER_NAME_LABELS,
-    STABLE_DIFFUSION_IMG2IMG_URL,
+    STABLE_DIFFUSION_IMG2IMG_PATH,
     ResizeMode,
     SamplerName,
     decode_base64_image,
@@ -141,7 +141,7 @@ class Img2Img(NodeBase):
             "resize_mode": resize_mode.value,
             "tiling": tiling,
         }
-        response = post(url=STABLE_DIFFUSION_IMG2IMG_URL, json_data=request_data)
+        response = post(path=STABLE_DIFFUSION_IMG2IMG_PATH, json_data=request_data)
         result = decode_base64_image(response["images"][0])
         h, w, _ = get_h_w_c(result)
         assert (w, h) == (

--- a/backend/src/nodes/nodes/external_stable_diffusion/interrogate.py
+++ b/backend/src/nodes/nodes/external_stable_diffusion/interrogate.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 
 from ...impl.external_stable_diffusion import (
-    STABLE_DIFFUSION_INTERROGATE_URL,
+    STABLE_DIFFUSION_INTERROGATE_PATH,
     encode_base64_image,
     post,
     verify_api_connection,
@@ -40,5 +40,5 @@ class Interrogate(NodeBase):
         request_data = {
             "image": encode_base64_image(image),
         }
-        response = post(url=STABLE_DIFFUSION_INTERROGATE_URL, json_data=request_data)
+        response = post(path=STABLE_DIFFUSION_INTERROGATE_PATH, json_data=request_data)
         return response["caption"]

--- a/backend/src/nodes/nodes/external_stable_diffusion/outpainting.py
+++ b/backend/src/nodes/nodes/external_stable_diffusion/outpainting.py
@@ -10,7 +10,7 @@ from ...groups import conditional_group
 from ...impl.external_stable_diffusion import (
     RESIZE_MODE_LABELS,
     SAMPLER_NAME_LABELS,
-    STABLE_DIFFUSION_IMG2IMG_URL,
+    STABLE_DIFFUSION_IMG2IMG_PATH,
     InpaintingFill,
     ResizeMode,
     SamplerName,
@@ -261,7 +261,7 @@ class Img2ImgOutpainting(NodeBase):
                 }
             )
 
-        response = post(url=STABLE_DIFFUSION_IMG2IMG_URL, json_data=request_data)
+        response = post(path=STABLE_DIFFUSION_IMG2IMG_PATH, json_data=request_data)
         result = decode_base64_image(response["images"][0])
         h, w, _ = get_h_w_c(result)
         assert (w, h) == (

--- a/backend/src/nodes/nodes/external_stable_diffusion/txt2img.py
+++ b/backend/src/nodes/nodes/external_stable_diffusion/txt2img.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from ...impl.external_stable_diffusion import (
     SAMPLER_NAME_LABELS,
-    STABLE_DIFFUSION_TEXT2IMG_URL,
+    STABLE_DIFFUSION_TEXT2IMG_PATH,
     SamplerName,
     decode_base64_image,
     nearest_valid_size,
@@ -116,7 +116,7 @@ class Txt2Img(NodeBase):
             "height": height,
             "tiling": tiling,
         }
-        response = post(url=STABLE_DIFFUSION_TEXT2IMG_URL, json_data=request_data)
+        response = post(path=STABLE_DIFFUSION_TEXT2IMG_PATH, json_data=request_data)
         result = decode_base64_image(response["images"][0])
         h, w, _ = get_h_w_c(result)
         assert (w, h) == (


### PR DESCRIPTION
Evidently, it is possible to run `webui.sh` with TLS, so people may need to configure chaiNNer to use HTTPS to find it.  This adds that capability, via an environment variable.