### PR TITLE
Bump Sanic-Cors to 2.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ pytest
 pywin32 ; sys_platform=="win32"
 requests
 sanic==21.12.2
-sanic_cors==1.0.1
+sanic_cors==2.2.0
 scipy==1.9.3
 # torch
 # torchvision


### PR DESCRIPTION
There's an incompatibility between sanic-cors 1.0.1 and sanic 21.12.0

https://github.com/ashleysommer/sanic-cors/issues/56