### PR TITLE
Default all models to have supports_fp16 attribute (set to false)

### DIFF
--- a/backend/src/nodes/nodes/pytorch/load_model.py
+++ b/backend/src/nodes/nodes/pytorch/load_model.py
@@ -70,6 +70,8 @@ class LoadModelNode(NodeBase):
                 v.requires_grad = False
             model.eval()
             model = model.to(torch.device(exec_options.full_device))
+            if not hasattr(model, "supports_fp16"):
+                model.supports_fp16 = False  # type: ignore
             should_use_fp16 = exec_options.fp16 and model.supports_fp16
             if should_use_fp16:
                 model = model.half()


### PR DESCRIPTION
We should assume by default that models don't support fp16, in case we forget to add that attribute when adding model support. This should prevent any crashing due to this being forgotten, and be better than defaulting to True and causing black results 