### PR TITLE
Fixed loading SRGB DDS

### DIFF
--- a/backend/src/nodes/impl/dds/texconv.py
+++ b/backend/src/nodes/impl/dds/texconv.py
@@ -73,6 +73,7 @@ def dds_to_png_texconv(path: str) -> str:
         [
             "-f",
             "rgba",
+            "-srgb",
             "-ft",
             "png",
             "-px",


### PR DESCRIPTION
It turned out that #1514 broke loading SRGB images, so I fixed that here. I tested it, and it seems to load all DDS formats correctly now. 

The only exception is BC5_SNORM. Texconv just seems to break with that format, I can't get it to load it at all. That being said, this might not be a huge issue. BC5_SNORM is used quite infrequently compared to BC5_UNORM.