### PR TITLE
Don't drag on optional add button

### DIFF
--- a/src/renderer/components/groups/OptionalInputsGroup.tsx
+++ b/src/renderer/components/groups/OptionalInputsGroup.tsx
@@ -71,6 +71,7 @@ export const OptionalInputsGroup = memo(
                                 }}
                                 aria-label="Add Input"
                                 bg="var(--bg-700)"
+                                className="nodrag"
                                 height="auto"
                                 mb={-1}
                                 minWidth={0}


### PR DESCRIPTION
I noticed that we allow dragging on the add button of optional lists. This doesn't feel good, so I changed it.

![image](https://user-images.githubusercontent.com/20878432/221951253-e0974efe-9a53-483f-88b7-6b7e1baf7d3c.png)
