### PR TITLE
Better key for `RepresentativeNodeWrapper`

### DIFF
--- a/src/renderer/components/NodeSelectorPanel/RegularAccordionItem.tsx
+++ b/src/renderer/components/NodeSelectorPanel/RegularAccordionItem.tsx
@@ -94,7 +94,7 @@ export const Subcategories = memo(({ collapsed, subcategoryMap }: SubcategoriesP
                         {nodes.map((node) => (
                             <RepresentativeNodeWrapper
                                 collapsed={collapsed}
-                                key={node.name}
+                                key={node.schemaId}
                                 node={node}
                             />
                         ))}

--- a/src/renderer/components/NodeSelectorPanel/RepresentativeNodeWrapper.tsx
+++ b/src/renderer/components/NodeSelectorPanel/RepresentativeNodeWrapper.tsx
@@ -86,7 +86,6 @@ export const RepresentativeNodeWrapper = memo(
 
         return (
             <Box
-                key={node.name}
                 my={1.5}
                 onContextMenu={onContextMenu}
             >


### PR DESCRIPTION
While creating a new node and accidentally leaving the node name as that of another node, I noticed React screaming at me because two nodes had the same key.

This PR includes 2 changes:
1. Remove key from `RepresentativeNodeWrapper`'s `Box` because it's completely unnecessary.
2. Changed key from `node.name` to `node.schemaId`.