### PR TITLE
Migrate most migrations to TS

### DIFF
--- a/src/common/migrations-legacy.js
+++ b/src/common/migrations-legacy.js
@@ -1,0 +1,256 @@
+/* eslint-disable prefer-destructuring */
+/* eslint-disable no-param-reassign */
+/* eslint-disable import/prefer-default-export */
+import log from 'electron-log';
+import { isEdge, isNode } from 'reactflow';
+
+// ==============
+//   pre-alpha
+// ==============
+
+const preAlpha = (data) => {
+    const newData = { ...data };
+    const newElements = newData.elements.map((element) => {
+        const newElement = { ...element };
+        if (newElement.type === 'ESRGAN::Load') {
+            newElement.type = 'Model::AutoLoad';
+            newElement.data.type = 'Model::AutoLoad';
+        } else if (newElement.type === 'ESRGAN::Run') {
+            newElement.type = 'Image::Upscale';
+            newElement.data.type = 'Image::Upscale';
+        }
+        return newElement;
+    });
+    newData.elements = newElements;
+    return newData;
+};
+
+// ==============
+//    v0.3.0
+// ==============
+
+const v03TypeMap = {
+    'Adjust::Blur': ['Image (Effect)', 'Blur'],
+    'Adjust::Brightness': ['Image (Effect)', 'Brightness & Contrast'],
+    'Adjust::Contrast': ['Image (Effect)', 'Brightness & Contrast'],
+    'Adjust::Shift': ['Image (Effect)', 'Shift'],
+    'Border::Make': ['Image (Utility)', 'Create Border'],
+    'Color::Convert': ['Image (Utility)', 'Change Colorspace'],
+    'Concat::Horizontal': ['Image (Utility)', 'Stack Images'],
+    'Concat::Vertical': ['Image (Utility)', 'Stack Images'],
+    'Image::Read': ['Image', 'Load Image'],
+    'Image::Show': ['Image', 'Preview Image'],
+    'Image::Write': ['Image', 'Save Image'],
+    'Resize::Factor': ['Image (Utility)', 'Resize (Factor)'],
+    'Resize::Resolution': ['Image (Utility)', 'Resize (Resolution)'],
+    'Threshold::Adaptive': ['Image (Effect)', 'Threshold (Adaptive)'],
+    'Threshold::Standard': ['Image (Effect)', 'Threshold'],
+    'Crop::Border': ['Image (Utility)', 'Crop (Border)'],
+    'Crop::Offsets': ['Image (Utility)', 'Crop (Offsets)'],
+    'Img::Channel::Merge': ['Image (Utility)', 'Merge Channels'],
+    'Img::Channel::Split': ['Image (Utility)', 'Split Channels'],
+    'Image::Upscale': ['PyTorch', 'Upscale Image'],
+    'Model::AutoLoad': ['PyTorch', 'Load Model'],
+    'Model::Interpolate': ['PyTorch', 'Interpolate Models'],
+    'Model::Read': ['PyTorch', 'Load Model'],
+    'Model::Save': ['PyTorch', 'Save Model'],
+};
+
+const toV03 = (data) => {
+    const newData = { ...data };
+    let newElements = [...newData.elements];
+    newElements.forEach((element) => {
+        if (isNode(element)) {
+            if (['Model::Read', 'Model::Interpolate'].includes(element.data.type)) {
+                // Find any connections coming out of a Model::Read
+                const edges = newData.elements.filter((e) => e.source === element.id);
+                if (edges) {
+                    edges.forEach((edge) => {
+                        // Find the targets of each connection
+                        const target = newElements.find((n) => n.id === edge.target);
+                        if (target.data.type === 'Model::AutoLoad') {
+                            // If target is an AutoLoad node, get the outgoing connections of it
+                            const targetEdges = newElements.filter((e) => e.source === target.id);
+                            // For each of the outgoing connections, replace the source with the output of the
+                            // new Load Model node
+                            targetEdges.forEach((targetEdge) => {
+                                targetEdge.source = element.id;
+                                targetEdge.sourceHandle = `${element.id}-0`;
+                            });
+                        }
+                    });
+                }
+            }
+        }
+    });
+    newElements = newElements
+        .filter((element) => !['Model::AutoLoad'].includes(element.data.type))
+        .map((element) => {
+            if (isNode(element)) {
+                const newElement = { ...element };
+                newElement.type = 'regularNode';
+                delete newElement.data.inputs;
+                delete newElement.data.outputs;
+                // Nobody should have these two things but me
+                delete newElement.data.icon;
+                delete newElement.data.subcategory;
+                // Move the contrast data to a B&C node at the right index
+                if (newElement.data.type === 'Adjust::Contrast') {
+                    newElement.data.inputData[1] = newElement.data.inputData[0];
+                    delete newElement.data.inputData[0];
+                } else if (newElement.data.type.includes('Concat')) {
+                    const newInputData = {};
+                    newInputData[4] =
+                        newElement.data.type === 'Concat::Horizontal' ? 'horizontal' : 'vertical';
+                    newElement.data.inputData = newInputData;
+                }
+                try {
+                    const [newCategory, newType] = v03TypeMap[newElement.data.type];
+                    newElement.data.type = newType;
+                    newElement.data.category = newCategory;
+                } catch (error) {
+                    log.warn(
+                        `File contains invalid node of type "${newElement.data.type}" that could not be converted.`
+                    );
+                }
+                return newElement;
+            }
+            return element;
+        });
+    newData.elements = newElements;
+    return newData;
+};
+
+// ==============
+//    v0.5.0
+// ==============
+
+const toV05 = (data) => {
+    const nodes = data.elements.filter((e) => isNode(e));
+    const edges = data.elements
+        .filter((e) => isEdge(e))
+        .map((e) => {
+            const newEdge = { ...e };
+            delete newEdge.style;
+            newEdge.data = {};
+            return newEdge;
+        });
+    const viewport = {
+        x: data.position[0],
+        y: data.position[1],
+        zoom: data.zoom,
+    };
+    const newData = {
+        nodes,
+        edges,
+        viewport,
+    };
+    return newData;
+};
+
+// ==============
+//    v0.5.2
+// ==============
+
+const toV052 = (data) => {
+    const newData = { ...data };
+    newData.nodes.forEach((node) => {
+        // Update any connections coming out of a Load Image or Load Image (Iterator)
+        if (['Load Image', 'Load Image (Iterator)'].includes(node.data.type)) {
+            const edges = newData.edges.filter((e) => e.source === node.id);
+            edges.forEach((edge) => {
+                const edgeIndex = edge.sourceHandle.slice(-2);
+                // Image Name node moves different amounts in different Load Image types
+                const newEdgeIndex = node.data.type === 'Load Image' ? '2' : '3';
+                if (edgeIndex === '-1') {
+                    edge.sourceHandle = edge.source.concat('-', newEdgeIndex);
+                }
+            });
+        }
+
+        // Update any connections and inputs to Save Image Node
+        if (node.data.type === 'Save Image') {
+            // Shift text input values >=2 down one place and set Relative Path to empty string
+            node.data.inputData[4] = node.data.inputData[3];
+            node.data.inputData[3] = node.data.inputData[2];
+            node.data.inputData[2] = '';
+            // Move Image Name connection if it exists
+            const edges = newData.edges.filter((e) => e.target === node.id);
+            edges.forEach((edge) => {
+                const edgeIndex = edge.targetHandle.slice(-2);
+                if (edgeIndex === '-2') {
+                    edge.targetHandle = edge.target.concat('-', '3');
+                }
+            });
+        }
+    });
+    return newData;
+};
+
+// ==============
+//    v0.7.0
+// ==============
+
+const v07TypeMap = {
+    'Image:Load Image': 'chainner:image:load',
+    'Image:Read Image': 'chainner:image:load', // For some reason some of my chains have this...
+    'Image:Save Image': 'chainner:image:save',
+    'Image:Preview Image': 'chainner:image:preview',
+    'Image:Image File Iterator': 'chainner:image:file_iterator',
+    'Image:Load Image (Iterator)': 'chainner:image:file_iterator_load',
+    'Image (Utility):Add Caption': 'chainner:image:caption',
+    'Image (Utility):Average Color Fix': 'chainner:image:average_color_fix',
+    'Image (Utility):Change Colorspace': 'chainner:image:change_colorspace',
+    'Image (Utility):Color Transfer': 'chainner:image:color_transfer',
+    'Image (Utility):Create Border': 'chainner:image:create_border',
+    'Image (Utility):Fill Alpha': 'chainner:image:fill_alpha',
+    'Image (Utility):Overlay Images': 'chainner:image:overlay',
+    'Image (Utility):Stack Images': 'chainner:image:stack',
+    'Image (Utility):Add Normals': 'chainner:image:add_normals',
+    'Image (Utility):Normalize': 'chainner:image:normalize_normal_map',
+    'Image (Utility):Crop (Border)': 'chainner:image:crop_border',
+    'Image (Utility):Crop (Edges)': 'chainner:image:crop_edges',
+    'Image (Utility):Crop (Offsets)': 'chainner:image:crop_offsets',
+    'Image (Utility):Resize (Factor)': 'chainner:image:resize_factor',
+    'Image (Utility):Resize (Resolution)': 'chainner:image:resize_resolution',
+    'Image (Utility):Merge Channels': 'chainner:image:merge_channels',
+    'Image (Utility):Merge Transparency': 'chainner:image:merge_transparency',
+    'Image (Utility):Split Channels': 'chainner:image:split_channels',
+    'Image (Utility):Split Transparency': 'chainner:image:split_transparency',
+    'Image (Effect):Blur': 'chainner:image:blur',
+    'Image (Effect):Brightness & Contrast': 'chainner:image:brightness_and_contrast',
+    'Image (Effect):Gaussian Blur': 'chainner:image:gaussian_blur',
+    'Image (Effect):Hue & Saturation': 'chainner:image:hue_and_saturation',
+    'Image (Effect):Sharpen': 'chainner:image:sharpen',
+    'Image (Effect):Shift': 'chainner:image:shift',
+    'Image (Effect):Threshold': 'chainner:image:threshold',
+    'Image (Effect):Threshold (Adaptive)': 'chainner:image:threshold_adaptive',
+    'PyTorch:Load Model': 'chainner:pytorch:load_model',
+    'PyTorch:Save Model': 'chainner:pytorch:save_model',
+    'PyTorch:Upscale Image': 'chainner:pytorch:upscale_image',
+    'PyTorch:Convert To ONNX': 'chainner:pytorch:convert_to_onnx',
+    'PyTorch:Interpolate Models': 'chainner:pytorch:interpolate_models',
+    'NCNN:Load Model': 'chainner:ncnn:load_model',
+    'NCNN:Save Model': 'chainner:ncnn:save_model',
+    'NCNN:Upscale Image': 'chainner:ncnn:upscale_image',
+    'NCNN:Interpolate Models': 'chainner:ncnn:interpolate_models',
+    'Utility:Note': 'chainner:utility:note',
+    'Utility:Text Append': 'chainner:utility:text_append',
+};
+
+const toV070 = (data) => {
+    data.nodes.forEach((node) => {
+        const oldType = `${node.data.category}:${node.data.type}`;
+        const newType = v07TypeMap[oldType];
+        if (newType) {
+            node.data.schemaId = newType;
+            delete node.data.category;
+            delete node.data.type;
+            delete node.data.icon;
+            delete node.data.subcategory;
+        }
+    });
+    return data;
+};
+
+export const legacyMigrations = [preAlpha, toV03, toV05, toV052, toV070];

--- a/src/common/migrations.ts
+++ b/src/common/migrations.ts
@@ -1,268 +1,36 @@
 /* eslint-disable prefer-destructuring */
 /* eslint-disable no-param-reassign */
-/* eslint-disable import/prefer-default-export */
+
 import log from 'electron-log';
-import { getConnectedEdges, getOutgoers, isEdge, isNode } from 'reactflow';
+import { Edge, Node, Viewport, getConnectedEdges, getOutgoers } from 'reactflow';
 import semver from 'semver';
+import { EdgeData, InputValue, Mutable, NodeData, SchemaId } from './common-types';
+import { legacyMigrations } from './migrations-legacy';
 import { deriveUniqueId, parseTargetHandle } from './util';
 
-// ==============
-//   pre-alpha
-// ==============
+interface ReadonlyNodeData extends Omit<NodeData, 'inputData'> {
+    inputData: Record<number | string, InputValue>;
+}
 
-const preAlpha = (data) => {
-    const newData = { ...data };
-    const newElements = newData.elements.map((element) => {
-        const newElement = { ...element };
-        if (newElement.type === 'ESRGAN::Load') {
-            newElement.type = 'Model::AutoLoad';
-            newElement.data.type = 'Model::AutoLoad';
-        } else if (newElement.type === 'ESRGAN::Run') {
-            newElement.type = 'Image::Upscale';
-            newElement.data.type = 'Image::Upscale';
-        }
-        return newElement;
-    });
-    newData.elements = newElements;
-    return newData;
-};
+type N = Node<Mutable<ReadonlyNodeData>>;
+type E = Edge<Mutable<EdgeData>>;
 
-// ==============
-//    v0.3.0
-// ==============
+export interface SaveData {
+    nodes: N[];
+    edges: E[];
+    viewport: Viewport;
+}
 
-const v03TypeMap = {
-    'Adjust::Blur': ['Image (Effect)', 'Blur'],
-    'Adjust::Brightness': ['Image (Effect)', 'Brightness & Contrast'],
-    'Adjust::Contrast': ['Image (Effect)', 'Brightness & Contrast'],
-    'Adjust::Shift': ['Image (Effect)', 'Shift'],
-    'Border::Make': ['Image (Utility)', 'Create Border'],
-    'Color::Convert': ['Image (Utility)', 'Change Colorspace'],
-    'Concat::Horizontal': ['Image (Utility)', 'Stack Images'],
-    'Concat::Vertical': ['Image (Utility)', 'Stack Images'],
-    'Image::Read': ['Image', 'Load Image'],
-    'Image::Show': ['Image', 'Preview Image'],
-    'Image::Write': ['Image', 'Save Image'],
-    'Resize::Factor': ['Image (Utility)', 'Resize (Factor)'],
-    'Resize::Resolution': ['Image (Utility)', 'Resize (Resolution)'],
-    'Threshold::Adaptive': ['Image (Effect)', 'Threshold (Adaptive)'],
-    'Threshold::Standard': ['Image (Effect)', 'Threshold'],
-    'Crop::Border': ['Image (Utility)', 'Crop (Border)'],
-    'Crop::Offsets': ['Image (Utility)', 'Crop (Offsets)'],
-    'Img::Channel::Merge': ['Image (Utility)', 'Merge Channels'],
-    'Img::Channel::Split': ['Image (Utility)', 'Split Channels'],
-    'Image::Upscale': ['PyTorch', 'Upscale Image'],
-    'Model::AutoLoad': ['PyTorch', 'Load Model'],
-    'Model::Interpolate': ['PyTorch', 'Interpolate Models'],
-    'Model::Read': ['PyTorch', 'Load Model'],
-    'Model::Save': ['PyTorch', 'Save Model'],
-};
+type ModernMigration = (data: SaveData) => SaveData;
 
-const toV03 = (data) => {
-    const newData = { ...data };
-    let newElements = [...newData.elements];
-    newElements.forEach((element) => {
-        if (isNode(element)) {
-            if (['Model::Read', 'Model::Interpolate'].includes(element.data.type)) {
-                // Find any connections coming out of a Model::Read
-                const edges = newData.elements.filter((e) => e.source === element.id);
-                if (edges) {
-                    edges.forEach((edge) => {
-                        // Find the targets of each connection
-                        const target = newElements.find((n) => n.id === edge.target);
-                        if (target.data.type === 'Model::AutoLoad') {
-                            // If target is an AutoLoad node, get the outgoing connections of it
-                            const targetEdges = newElements.filter((e) => e.source === target.id);
-                            // For each of the outgoing connections, replace the source with the output of the
-                            // new Load Model node
-                            targetEdges.forEach((targetEdge) => {
-                                targetEdge.source = element.id;
-                                targetEdge.sourceHandle = `${element.id}-0`;
-                            });
-                        }
-                    });
-                }
-            }
-        }
-    });
-    newElements = newElements
-        .filter((element) => !['Model::AutoLoad'].includes(element.data.type))
-        .map((element) => {
-            if (isNode(element)) {
-                const newElement = { ...element };
-                newElement.type = 'regularNode';
-                delete newElement.data.inputs;
-                delete newElement.data.outputs;
-                // Nobody should have these two things but me
-                delete newElement.data.icon;
-                delete newElement.data.subcategory;
-                // Move the contrast data to a B&C node at the right index
-                if (newElement.data.type === 'Adjust::Contrast') {
-                    newElement.data.inputData[1] = newElement.data.inputData[0];
-                    delete newElement.data.inputData[0];
-                } else if (newElement.data.type.includes('Concat')) {
-                    const newInputData = {};
-                    newInputData[4] =
-                        newElement.data.type === 'Concat::Horizontal' ? 'horizontal' : 'vertical';
-                    newElement.data.inputData = newInputData;
-                }
-                try {
-                    const [newCategory, newType] = v03TypeMap[newElement.data.type];
-                    newElement.data.type = newType;
-                    newElement.data.category = newCategory;
-                } catch (error) {
-                    log.warn(
-                        `File contains invalid node of type "${newElement.data.type}" that could not be converted.`
-                    );
-                }
-                return newElement;
-            }
-            return element;
-        });
-    newData.elements = newElements;
-    return newData;
-};
-
-// ==============
-//    v0.5.0
-// ==============
-
-const toV05 = (data) => {
-    const nodes = data.elements.filter((e) => isNode(e));
-    const edges = data.elements
-        .filter((e) => isEdge(e))
-        .map((e) => {
-            const newEdge = { ...e };
-            delete newEdge.style;
-            newEdge.data = {};
-            return newEdge;
-        });
-    const viewport = {
-        x: data.position[0],
-        y: data.position[1],
-        zoom: data.zoom,
-    };
-    const newData = {
-        nodes,
-        edges,
-        viewport,
-    };
-    return newData;
-};
-
-// ==============
-//    v0.5.2
-// ==============
-
-const toV052 = (data) => {
-    const newData = { ...data };
-    newData.nodes.forEach((node) => {
-        // Update any connections coming out of a Load Image or Load Image (Iterator)
-        if (['Load Image', 'Load Image (Iterator)'].includes(node.data.type)) {
-            const edges = newData.edges.filter((e) => e.source === node.id);
-            edges.forEach((edge) => {
-                const edgeIndex = edge.sourceHandle.slice(-2);
-                // Image Name node moves different amounts in different Load Image types
-                const newEdgeIndex = node.data.type === 'Load Image' ? '2' : '3';
-                if (edgeIndex === '-1') {
-                    edge.sourceHandle = edge.source.concat('-', newEdgeIndex);
-                }
-            });
-        }
-
-        // Update any connections and inputs to Save Image Node
-        if (node.data.type === 'Save Image') {
-            // Shift text input values >=2 down one place and set Relative Path to empty string
-            node.data.inputData[4] = node.data.inputData[3];
-            node.data.inputData[3] = node.data.inputData[2];
-            node.data.inputData[2] = '';
-            // Move Image Name connection if it exists
-            const edges = newData.edges.filter((e) => e.target === node.id);
-            edges.forEach((edge) => {
-                const edgeIndex = edge.targetHandle.slice(-2);
-                if (edgeIndex === '-2') {
-                    edge.targetHandle = edge.target.concat('-', '3');
-                }
-            });
-        }
-    });
-    return newData;
-};
-
-// ==============
-//    v0.7.0
-// ==============
-
-const v07TypeMap = {
-    'Image:Load Image': 'chainner:image:load',
-    'Image:Read Image': 'chainner:image:load', // For some reason some of my chains have this...
-    'Image:Save Image': 'chainner:image:save',
-    'Image:Preview Image': 'chainner:image:preview',
-    'Image:Image File Iterator': 'chainner:image:file_iterator',
-    'Image:Load Image (Iterator)': 'chainner:image:file_iterator_load',
-    'Image (Utility):Add Caption': 'chainner:image:caption',
-    'Image (Utility):Average Color Fix': 'chainner:image:average_color_fix',
-    'Image (Utility):Change Colorspace': 'chainner:image:change_colorspace',
-    'Image (Utility):Color Transfer': 'chainner:image:color_transfer',
-    'Image (Utility):Create Border': 'chainner:image:create_border',
-    'Image (Utility):Fill Alpha': 'chainner:image:fill_alpha',
-    'Image (Utility):Overlay Images': 'chainner:image:overlay',
-    'Image (Utility):Stack Images': 'chainner:image:stack',
-    'Image (Utility):Add Normals': 'chainner:image:add_normals',
-    'Image (Utility):Normalize': 'chainner:image:normalize_normal_map',
-    'Image (Utility):Crop (Border)': 'chainner:image:crop_border',
-    'Image (Utility):Crop (Edges)': 'chainner:image:crop_edges',
-    'Image (Utility):Crop (Offsets)': 'chainner:image:crop_offsets',
-    'Image (Utility):Resize (Factor)': 'chainner:image:resize_factor',
-    'Image (Utility):Resize (Resolution)': 'chainner:image:resize_resolution',
-    'Image (Utility):Merge Channels': 'chainner:image:merge_channels',
-    'Image (Utility):Merge Transparency': 'chainner:image:merge_transparency',
-    'Image (Utility):Split Channels': 'chainner:image:split_channels',
-    'Image (Utility):Split Transparency': 'chainner:image:split_transparency',
-    'Image (Effect):Blur': 'chainner:image:blur',
-    'Image (Effect):Brightness & Contrast': 'chainner:image:brightness_and_contrast',
-    'Image (Effect):Gaussian Blur': 'chainner:image:gaussian_blur',
-    'Image (Effect):Hue & Saturation': 'chainner:image:hue_and_saturation',
-    'Image (Effect):Sharpen': 'chainner:image:sharpen',
-    'Image (Effect):Shift': 'chainner:image:shift',
-    'Image (Effect):Threshold': 'chainner:image:threshold',
-    'Image (Effect):Threshold (Adaptive)': 'chainner:image:threshold_adaptive',
-    'PyTorch:Load Model': 'chainner:pytorch:load_model',
-    'PyTorch:Save Model': 'chainner:pytorch:save_model',
-    'PyTorch:Upscale Image': 'chainner:pytorch:upscale_image',
-    'PyTorch:Convert To ONNX': 'chainner:pytorch:convert_to_onnx',
-    'PyTorch:Interpolate Models': 'chainner:pytorch:interpolate_models',
-    'NCNN:Load Model': 'chainner:ncnn:load_model',
-    'NCNN:Save Model': 'chainner:ncnn:save_model',
-    'NCNN:Upscale Image': 'chainner:ncnn:upscale_image',
-    'NCNN:Interpolate Models': 'chainner:ncnn:interpolate_models',
-    'Utility:Note': 'chainner:utility:note',
-    'Utility:Text Append': 'chainner:utility:text_append',
-};
-
-const toV070 = (data) => {
-    data.nodes.forEach((node) => {
-        const oldType = `${node.data.category}:${node.data.type}`;
-        const newType = v07TypeMap[oldType];
-        if (newType) {
-            node.data.schemaId = newType;
-            delete node.data.category;
-            delete node.data.type;
-            delete node.data.icon;
-            delete node.data.subcategory;
-        }
-    });
-    return data;
-};
-
-const toV080 = (data) => {
+const toV080: ModernMigration = (data) => {
     data.nodes.forEach((node) => {
         // Convert Resize (Factor) and Average Color Fix to percentage
         if (node.data.schemaId === 'chainner:image:resize_factor') {
-            node.data.inputData['1'] *= 100.0;
+            node.data.inputData[1] = (node.data.inputData[1] as number) * 100.0;
         }
         if (node.data.schemaId === 'chainner:image:average_color_fix') {
-            node.data.inputData['2'] *= 100.0;
+            node.data.inputData[2] = (node.data.inputData[2] as number) * 100.0;
         }
         // Invert interpolation weight
         if (
@@ -270,58 +38,64 @@ const toV080 = (data) => {
                 node.data.schemaId
             )
         ) {
-            node.data.inputData['2'] = 100 - node.data.inputData['2'];
+            node.data.inputData[2] = 100 - (node.data.inputData[2] as number);
         }
     });
     return data;
 };
 
-const updateAdjustmentScale = (data) => {
+const updateAdjustmentScale: ModernMigration = (data) => {
     data.nodes.forEach((node) => {
         // Convert slider scales for several Adjustment nodes
         if (node.data.schemaId === 'chainner:image:hue_and_saturation') {
-            node.data.inputData['2'] = ((node.data.inputData['2'] / 255) * 100.0).toFixed(1);
+            node.data.inputData[2] = (((node.data.inputData[2] as number) / 255) * 100.0).toFixed(
+                1
+            );
         }
         if (node.data.schemaId === 'chainner:image:brightness_and_contrast') {
-            node.data.inputData['1'] = ((node.data.inputData['1'] / 255) * 100.0).toFixed(1);
-            node.data.inputData['2'] = ((node.data.inputData['2'] / 255) * 100.0).toFixed(1);
+            node.data.inputData[1] = (((node.data.inputData[1] as number) / 255) * 100.0).toFixed(
+                1
+            );
+            node.data.inputData[2] = (((node.data.inputData[2] as number) / 255) * 100.0).toFixed(
+                1
+            );
         }
     });
     return data;
 };
 
-const fixBlurNode = (data) => {
+const fixBlurNode: ModernMigration = (data) => {
     data.nodes.forEach((node) => {
         // Convert Blur Nodes to Gaussian Blur nodes
         if (node.data.schemaId === 'chainner:image:blur') {
-            node.data.schemaId = 'chainner:image:gaussian_blur';
-            node.data.inputData['1'] =
-                Math.round((1.16531 * node.data.inputData['1'] - 0.153601) * 10) / 10;
-            node.data.inputData['2'] =
-                Math.round((1.16531 * node.data.inputData['2'] - 0.153601) * 10) / 10;
+            node.data.schemaId = 'chainner:image:gaussian_blur' as SchemaId;
+            node.data.inputData[1] =
+                Math.round((1.16531 * (node.data.inputData[1] as number) - 0.153601) * 10) / 10;
+            node.data.inputData[2] =
+                Math.round((1.16531 * (node.data.inputData[2] as number) - 0.153601) * 10) / 10;
         }
     });
     return data;
 };
 
-const addBlendNode = (data) => {
+const addBlendNode: ModernMigration = (data) => {
     data.nodes.forEach((node) => {
         // Convert Difference Nodes to Blend Image Nodes
         if (node.data.schemaId === 'chainner:image:difference') {
-            node.data.schemaId = 'chainner:image:blend';
-            node.data.inputData['2'] = 100;
-            node.data.inputData['3'] = 100;
-            node.data.inputData['4'] = 10;
+            node.data.schemaId = 'chainner:image:blend' as SchemaId;
+            node.data.inputData[2] = 100;
+            node.data.inputData[3] = 100;
+            node.data.inputData[4] = 10;
         }
 
         // Convert Overlay Images Nodes to Blend Image Nodes
         if (node.data.schemaId === 'chainner:image:overlay') {
             const findEdgesToChange = () => {
-                const edgeList = {};
+                const edgeList: { input?: number; output?: number } = {};
                 data.edges.forEach((edge, index) => {
                     if (
                         edge.target === node.id &&
-                        edge.targetHandle.split('-').slice(-1)[0] === '3'
+                        edge.targetHandle?.split('-').slice(-1)[0] === '3'
                     ) {
                         edgeList.input = index;
                     } else if (edge.source === node.id) {
@@ -335,11 +109,11 @@ const addBlendNode = (data) => {
             // If there is a second overlay input, need to add second blend node and
             // update edges.
             if (edgesToChange.input !== undefined) {
-                const newID = deriveUniqueId(node.id + String(node.data.inputData['4']));
-                const newBlendNode = {
+                const newID = deriveUniqueId(node.id + String(node.data.inputData[4]));
+                const newBlendNode: N = {
                     data: {
-                        schemaId: 'chainner:image:blend',
-                        inputData: { 2: 100, 3: node.data.inputData['4'] },
+                        schemaId: 'chainner:image:blend' as SchemaId,
+                        inputData: { 2: 100, 3: node.data.inputData[4] },
                         id: newID,
                     },
                     id: newID,
@@ -372,44 +146,44 @@ const addBlendNode = (data) => {
                     type: 'main',
                     animated: false,
                     data: {},
-                    zIndex: node.zIndex - 1,
+                    zIndex: node.zIndex! - 1,
                 };
                 data.edges.push(newOutputEdge);
             }
 
-            node.data.schemaId = 'chainner:image:blend';
-            node.data.inputData['3'] = node.data.inputData['2'];
-            node.data.inputData['2'] =
-                node.data.inputData['5'] !== undefined ? node.data.inputData['5'] : 100;
-            node.data.inputData['4'] = 0;
+            node.data.schemaId = 'chainner:image:blend' as SchemaId;
+            node.data.inputData[3] = node.data.inputData[2];
+            node.data.inputData[2] =
+                node.data.inputData[5] !== undefined ? node.data.inputData[5] : 100;
+            node.data.inputData[4] = 0;
         }
     });
     return data;
 };
 
-const updateRotateNode = (data) => {
+const updateRotateNode: ModernMigration = (data) => {
     data.nodes.forEach((node) => {
         // Update rotation angle from dropdown to slider
         if (node.data.schemaId === 'chainner:image:rotate') {
-            const RotDeg = node.data.inputData['1'];
+            const RotDeg = node.data.inputData[1];
             if (RotDeg === 0) {
-                node.data.inputData['1'] = 90;
+                node.data.inputData[1] = 90;
             } else if (RotDeg === '1') {
-                node.data.inputData['1'] = 180;
+                node.data.inputData[1] = 180;
             } else {
-                node.data.inputData['1'] = 270;
+                node.data.inputData[1] = 270;
             }
         }
     });
     return data;
 };
 
-const addOpacityNode = (data) => {
-    const createOpacityNode = (node, opacityValue, yMoveDirection) => {
-        const newID = deriveUniqueId(node.id + yMoveDirection);
-        const newNode = {
+const addOpacityNode: ModernMigration = (data) => {
+    const createOpacityNode = (node: N, opacityValue: InputValue, yMoveDirection: number) => {
+        const newID = deriveUniqueId(node.id + String(yMoveDirection));
+        const newNode: N = {
             data: {
-                schemaId: 'chainner:image:opacity',
+                schemaId: 'chainner:image:opacity' as SchemaId,
                 inputData: { 1: opacityValue },
                 id: newID,
             },
@@ -428,12 +202,17 @@ const addOpacityNode = (data) => {
             newNode.parentNode = node.parentNode;
             newNode.data.parentNode = node.parentNode;
         }
-        return [newID, newNode];
+        return [newID, newNode] as const;
     };
 
-    const createOutputEdge = (opacityNodeID, blendNodeID, handleID, nodeZIndex) => {
+    const createOutputEdge = (
+        opacityNodeID: string,
+        blendNodeID: string,
+        handleID: number,
+        nodeZIndex: number
+    ) => {
         return {
-            id: deriveUniqueId(opacityNodeID + blendNodeID + handleID),
+            id: deriveUniqueId(opacityNodeID + blendNodeID + String(handleID)),
             sourceHandle: `${opacityNodeID}-0`,
             targetHandle: `${blendNodeID}-${handleID}`,
             source: opacityNodeID,
@@ -448,17 +227,17 @@ const addOpacityNode = (data) => {
     data.nodes.forEach((node) => {
         if (node.data.schemaId === 'chainner:image:blend') {
             const findEdgesToChange = () => {
-                const edgeList = {};
+                const edgeList: { baseInput?: number; ovInput?: number } = {};
                 data.edges.forEach((edge, index) => {
                     if (edge.target === node.id) {
                         if (
-                            edge.targetHandle.split('-').slice(-1)[0] === '0' &&
-                            node.data.inputData['2'] !== 100
+                            edge.targetHandle?.split('-').slice(-1)[0] === '0' &&
+                            node.data.inputData[2] !== 100
                         ) {
                             edgeList.baseInput = index;
                         } else if (
-                            edge.targetHandle.split('-').slice(-1)[0] === '1' &&
-                            node.data.inputData['3'] !== 100
+                            edge.targetHandle?.split('-').slice(-1)[0] === '1' &&
+                            node.data.inputData[3] !== 100
                         ) {
                             edgeList.ovInput = index;
                         }
@@ -468,48 +247,41 @@ const addOpacityNode = (data) => {
             };
             const edgesToChange = findEdgesToChange();
 
-            const newOpacityNodeIDs = {};
-            if (node.data.inputData['2'] !== 100) {
-                const [newID, newNode] = createOpacityNode(node, node.data.inputData['2'], -1);
-                newOpacityNodeIDs.baseOpacityNode = newID;
+            let baseOpacityNode;
+            if (node.data.inputData[2] !== 100) {
+                const [newID, newNode] = createOpacityNode(node, node.data.inputData[2], -1);
+                baseOpacityNode = newID;
                 data.nodes.push(newNode);
             }
-            if (node.data.inputData['3'] !== 100) {
-                const [newID, newNode] = createOpacityNode(node, node.data.inputData['3'], 1);
-                newOpacityNodeIDs.ovOpacityNode = newID;
+            let ovOpacityNode;
+            if (node.data.inputData[3] !== 100) {
+                const [newID, newNode] = createOpacityNode(node, node.data.inputData[3], 1);
+                ovOpacityNode = newID;
                 data.nodes.push(newNode);
             }
 
-            if (newOpacityNodeIDs.baseOpacityNode !== undefined) {
+            if (baseOpacityNode !== undefined) {
                 if (edgesToChange.baseInput !== undefined) {
-                    data.edges[edgesToChange.baseInput].target = newOpacityNodeIDs.baseOpacityNode;
-                    data.edges[
-                        edgesToChange.baseInput
-                    ].targetHandle = `${newOpacityNodeIDs.baseOpacityNode}-0`;
+                    data.edges[edgesToChange.baseInput].target = baseOpacityNode;
+                    data.edges[edgesToChange.baseInput].targetHandle = `${baseOpacityNode}-0`;
                 }
-                data.edges.push(
-                    createOutputEdge(newOpacityNodeIDs.baseOpacityNode, node.id, 0, node.zIndex - 1)
-                );
+                data.edges.push(createOutputEdge(baseOpacityNode, node.id, 0, node.zIndex! - 1));
             }
-            if (newOpacityNodeIDs.ovOpacityNode !== undefined) {
+            if (ovOpacityNode !== undefined) {
                 if (edgesToChange.ovInput !== undefined) {
-                    data.edges[edgesToChange.ovInput].target = newOpacityNodeIDs.ovOpacityNode;
-                    data.edges[
-                        edgesToChange.ovInput
-                    ].targetHandle = `${newOpacityNodeIDs.ovOpacityNode}-0`;
+                    data.edges[edgesToChange.ovInput].target = ovOpacityNode;
+                    data.edges[edgesToChange.ovInput].targetHandle = `${ovOpacityNode}-0`;
                 }
-                data.edges.push(
-                    createOutputEdge(newOpacityNodeIDs.ovOpacityNode, node.id, 1, node.zIndex - 1)
-                );
+                data.edges.push(createOutputEdge(ovOpacityNode, node.id, 1, node.zIndex! - 1));
             }
 
-            node.data.inputData['2'] = node.data.inputData['4'];
+            node.data.inputData[2] = node.data.inputData[4];
         }
     });
     return data;
 };
 
-const fixDropDownNumberValues = (data) => {
+const fixDropDownNumberValues: ModernMigration = (data) => {
     const needToConvert = new Set([
         'chainner:image:resize_factor/2',
         'chainner:image:resize_resolution/3',
@@ -542,12 +314,12 @@ const fixDropDownNumberValues = (data) => {
     return data;
 };
 
-const onnxConvertUpdate = (data) => {
-    const createOnnxSaveNode = (node, directory, modelName) => {
-        const newID = deriveUniqueId(node.id + directory + modelName);
-        const newNode = {
+const onnxConvertUpdate: ModernMigration = (data) => {
+    const createOnnxSaveNode = (node: N, directory: InputValue, modelName: InputValue) => {
+        const newID = deriveUniqueId(node.id + String(directory) + String(modelName));
+        const newNode: N = {
             data: {
-                schemaId: 'chainner:onnx:save_model',
+                schemaId: 'chainner:onnx:save_model' as SchemaId,
                 inputData: { 1: directory, 2: modelName },
                 id: newID,
             },
@@ -576,13 +348,13 @@ const onnxConvertUpdate = (data) => {
             type: 'main',
             animated: false,
             data: {},
-            zIndex: node.zIndex - 1,
+            zIndex: node.zIndex! - 1,
         };
-        return [newID, newNode, newEdge];
+        return [newID, newNode, newEdge] as const;
     };
 
-    const edgesToRemove = [];
-    const nodesToRemove = [];
+    const edgesToRemove: E[] = [];
+    const nodesToRemove: N[] = [];
     data.nodes.forEach((node) => {
         if (node.data.schemaId === 'chainner:pytorch:convert_to_onnx') {
             const connectedEdges = getConnectedEdges([node], data.edges);
@@ -603,8 +375,8 @@ const onnxConvertUpdate = (data) => {
                         } else if (loadEdge.sourceHandle === `${downstreamNode.id}-1`) {
                             data.nodes.forEach((modelNameAsInputNode) => {
                                 if (loadEdge.target === modelNameAsInputNode.id) {
-                                    const inputDataIndex = loadEdge.targetHandle
-                                        .split('-')
+                                    const inputDataIndex = loadEdge
+                                        .targetHandle!.split('-')
                                         .slice(-1)[0];
                                     modelNameAsInputNode.data.inputData[inputDataIndex] =
                                         node.data.inputData[2];
@@ -653,7 +425,7 @@ const onnxConvertUpdate = (data) => {
     return data;
 };
 
-const removeEmptyStrings = (data) => {
+const removeEmptyStrings: ModernMigration = (data) => {
     data.nodes.forEach((node) => {
         node.data.inputData = Object.fromEntries(
             Object.entries(node.data.inputData).filter(([, value]) => value !== '')
@@ -663,10 +435,10 @@ const removeEmptyStrings = (data) => {
     return data;
 };
 
-const blockSizeToRadius = (data) => {
+const blockSizeToRadius: ModernMigration = (data) => {
     data.nodes.forEach((node) => {
         if (node.data.schemaId === 'chainner:image:threshold_adaptive') {
-            const size = node.data.inputData[4] ?? 3;
+            const size = Number(node.data.inputData[4] ?? 3);
             node.data.inputData[4] = Math.floor((size - 1) / 2);
         }
     });
@@ -674,7 +446,7 @@ const blockSizeToRadius = (data) => {
     return data;
 };
 
-const removeTargetTileSize = (data) => {
+const removeTargetTileSize: ModernMigration = (data) => {
     data.nodes.forEach((node) => {
         if (
             ['chainner:ncnn:upscale_image', 'chainner:onnx:upscale_image'].includes(
@@ -688,7 +460,7 @@ const removeTargetTileSize = (data) => {
     return data;
 };
 
-const addTargetTileSizeAgain = (data) => {
+const addTargetTileSizeAgain: ModernMigration = (data) => {
     data.nodes.forEach((node) => {
         if (
             [
@@ -704,10 +476,10 @@ const addTargetTileSizeAgain = (data) => {
     return data;
 };
 
-const brightnessImplementationChange = (data) => {
-    const newNodes = [];
-    const newEdges = [];
-    const edgeMapping = new Map();
+const brightnessImplementationChange: ModernMigration = (data) => {
+    const newNodes: N[] = [];
+    const newEdges: E[] = [];
+    const edgeMapping = new Map<string, string>();
 
     data.nodes.forEach((node) => {
         if (node.data.schemaId === 'chainner:image:brightness_and_contrast') {
@@ -719,7 +491,7 @@ const brightnessImplementationChange = (data) => {
 
                 newNodes.push({
                     data: {
-                        schemaId: 'chainner:image:hue_and_saturation',
+                        schemaId: 'chainner:image:hue_and_saturation' as SchemaId,
                         inputData: { 1: 0, 2: 0, 3: brightness },
                         id,
                     },
@@ -747,7 +519,7 @@ const brightnessImplementationChange = (data) => {
         }
     });
     data.edges.forEach((edge) => {
-        const to = edgeMapping.get(edge.targetHandle);
+        const to = edgeMapping.get(edge.targetHandle!);
         if (to) {
             edge.targetHandle = to;
             edge.target = parseTargetHandle(to).nodeId;
@@ -760,15 +532,14 @@ const brightnessImplementationChange = (data) => {
     return data;
 };
 
-const convertColorSpaceFromTo = (data) => {
+const convertColorSpaceFromTo: ModernMigration = (data) => {
     const GRAY = 0;
     const RGB = 1;
     const RGBA = 2;
     const YUV = 3;
     const HSV = 4;
 
-    /** @type {Partial<Record<number, [number, number]>>} */
-    const mapping = {
+    const mapping: Partial<Record<number, [number, number]>> = {
         6: [RGB, GRAY],
         8: [GRAY, RGB],
         0: [RGB, RGBA],
@@ -782,7 +553,7 @@ const convertColorSpaceFromTo = (data) => {
     };
     data.nodes.forEach((node) => {
         if (node.data.schemaId === 'chainner:image:change_colorspace') {
-            const [from, to] = mapping[node.data.inputData[1]] ?? [RGB, RGB];
+            const [from, to] = mapping[node.data.inputData[1] as number] ?? [RGB, RGB];
             node.data.inputData[1] = from;
             node.data.inputData[2] = to;
         }
@@ -791,14 +562,13 @@ const convertColorSpaceFromTo = (data) => {
     return data;
 };
 
-const convertColorRGBLikeDetector = (data) => {
+const convertColorRGBLikeDetector: ModernMigration = (data) => {
     const GRAY = 0;
     const RGB = 1;
     const RGBA = 2;
     const RGB_LIKE = 1000;
 
-    /** @type {Partial<Record<number, number>>} */
-    const mapping = {
+    const mapping: Partial<Record<number, number>> = {
         [GRAY]: RGB_LIKE,
         [RGB]: RGB_LIKE,
         [RGBA]: RGB_LIKE,
@@ -806,14 +576,14 @@ const convertColorRGBLikeDetector = (data) => {
     data.nodes.forEach((node) => {
         if (node.data.schemaId === 'chainner:image:change_colorspace') {
             const from = node.data.inputData[1];
-            node.data.inputData[1] = mapping[from] ?? from;
+            node.data.inputData[1] = mapping[from as number] ?? from;
         }
     });
 
     return data;
 };
 
-const convertNormalGenerator = (data) => {
+const convertNormalGenerator: ModernMigration = (data) => {
     data.nodes.forEach((node) => {
         if (node.data.schemaId === 'chainner:image:normal_generator') {
             const old = { ...node.data.inputData };
@@ -830,7 +600,7 @@ const convertNormalGenerator = (data) => {
     return data;
 };
 
-const convertColorSpaceFromDetectors = (data) => {
+const convertColorSpaceFromDetectors: ModernMigration = (data) => {
     const YUV = 3;
     const HSV = 4;
     const HSL = 5;
@@ -838,8 +608,7 @@ const convertColorSpaceFromDetectors = (data) => {
     const HSV_LIKE = 1002;
     const HSL_LIKE = 1003;
 
-    /** @type {Partial<Record<number, [number, number]>>} */
-    const mapping = {
+    const mapping: Partial<Record<number, number>> = {
         [YUV]: YUV_LIKE,
         [HSV]: HSV_LIKE,
         [HSL]: HSL_LIKE,
@@ -848,18 +617,17 @@ const convertColorSpaceFromDetectors = (data) => {
     data.nodes.forEach((node) => {
         if (node.data.schemaId === 'chainner:image:change_colorspace') {
             const from = node.data.inputData[1];
-            node.data.inputData[1] = mapping[from] ?? from;
+            node.data.inputData[1] = mapping[from as number] ?? from;
         }
     });
 
     return data;
 };
 
-const fixNumbers = (data) => {
+const fixNumbers: ModernMigration = (data) => {
     // https://github.com/chaiNNer-org/chaiNNer/issues/1364
 
-    /** @type {Record<string, number[] | undefined>} */
-    const numbers = {
+    const numbers: Record<string, number[] | undefined> = {
         'chainner:image:save': [5],
         'chainner:image:spritesheet_iterator': [1, 2],
         'chainner:image:simple_video_frame_iterator_save': [5],
@@ -907,7 +675,6 @@ const fixNumbers = (data) => {
     data.nodes.forEach((node) => {
         const numberInputs = numbers[node.data.schemaId];
         if (Array.isArray(numberInputs)) {
-            // eslint-disable-next-line no-restricted-syntax
             for (const id of numberInputs) {
                 const value = Number(node.data.inputData[id] ?? NaN);
                 if (Number.isNaN(value)) {
@@ -922,7 +689,7 @@ const fixNumbers = (data) => {
     return data;
 };
 
-const clearEdgeData = (data) => {
+const clearEdgeData: ModernMigration = (data) => {
     data.edges.forEach((edge) => {
         edge.data = {};
     });
@@ -930,10 +697,10 @@ const clearEdgeData = (data) => {
     return data;
 };
 
-const gammaCheckbox = (data) => {
+const gammaCheckbox: ModernMigration = (data) => {
     data.nodes.forEach((node) => {
         if (node.data.schemaId === 'chainner:image:gamma') {
-            const from = /** @type {"normal" | "invert"} */ (node.data.inputData[2]);
+            const from = node.data.inputData[2] as 'normal' | 'invert';
             node.data.inputData[2] = from === 'invert' ? 1 : 0;
         }
     });
@@ -941,7 +708,7 @@ const gammaCheckbox = (data) => {
     return data;
 };
 
-const changeColorSpaceAlpha = (data) => {
+const changeColorSpaceAlpha: ModernMigration = (data) => {
     const RGB = 1;
     const RGBA = 2;
     const YUV = 3;
@@ -955,7 +722,7 @@ const changeColorSpaceAlpha = (data) => {
     const LCH = 12;
     const LCHA = 13;
 
-    const mapping = {
+    const mapping: Partial<Record<number, number>> = {
         [RGBA]: RGB,
         [YUVA]: YUV,
         [HSVA]: HSV,
@@ -966,7 +733,7 @@ const changeColorSpaceAlpha = (data) => {
 
     data.nodes.forEach((node) => {
         if (node.data.schemaId === 'chainner:image:change_colorspace') {
-            const to = node.data.inputData[2];
+            const to = node.data.inputData[2] as number;
             const mapped = mapping[to];
             if (mapped === undefined) {
                 node.data.inputData[2] = to;
@@ -983,7 +750,7 @@ const changeColorSpaceAlpha = (data) => {
 
 // ==============
 
-const versionToMigration = (version) => {
+const versionToMigration = (version: string) => {
     const versions = {
         '0.1.0': 0, // Legacy files
         '0.3.0': 1, // v0.1.x & v0.2.x to v0.3.0
@@ -993,7 +760,6 @@ const versionToMigration = (version) => {
         '0.8.0': 5,
     };
 
-    // eslint-disable-next-line no-restricted-syntax
     for (const [ver, migration] of Object.entries(versions)) {
         if (semver.lt(version, ver)) {
             return migration;
@@ -1003,11 +769,7 @@ const versionToMigration = (version) => {
 };
 
 const migrations = [
-    preAlpha,
-    toV03,
-    toV05,
-    toV052,
-    toV070,
+    ...legacyMigrations,
     toV080,
     updateAdjustmentScale,
     fixBlurNode,
@@ -1033,12 +795,12 @@ const migrations = [
 
 export const currentMigration = migrations.length;
 
-export const migrate = (version, data, migration) => {
+export const migrate = (version: string | null, data: unknown, migration?: number) => {
     version ||= '0.0.0';
     migration ??= versionToMigration(version);
 
     try {
-        return migrations.slice(migration).reduce((current, fn) => fn(current), data);
+        return migrations.slice(migration).reduce((current, fn) => fn(current as never), data);
     } catch (error) {
         log.error(error);
         throw error;


### PR DESCRIPTION
This PR migrates our migrations to TS, except for our legacy migrations (where the node and edge format constantly changed between versions). I intentionally made the types very permissive to change the existing migrations as little as possible (to avoid introducing bugs). 

This should make it a lot easier to write correct migrations.