### PR TITLE
Better way to set width of From To dropdowns

### DIFF
--- a/src/renderer/components/groups/FromToDropdownsGroup.tsx
+++ b/src/renderer/components/groups/FromToDropdownsGroup.tsx
@@ -24,7 +24,7 @@ const SmallDropDown = memo(({ nodeId, input, inputData, isLocked }: SmallDropDow
     );
 
     return (
-        <Box w="6em">
+        <Box w="full">
             <DropDown
                 isDisabled={isLocked}
                 options={input.options}


### PR DESCRIPTION
Instead of a fixed width, I changed it to 100%. This surprisingly works to fully fill all available space even across 2 elements.

Before:
![image](https://user-images.githubusercontent.com/20878432/222266436-966ffbe9-20c6-4529-b3bf-6f5c3c0254ad.png)

After:
![image](https://user-images.githubusercontent.com/20878432/222266400-1d55a825-5086-4224-a242-270230e28566.png)
