### PR TITLE
(hotifx) Seed types should be cacheable

### DIFF
--- a/backend/src/nodes/node_cache.py
+++ b/backend/src/nodes/node_cache.py
@@ -48,6 +48,9 @@ class NodeOutputCache:
                 key.append(tuple(arg.shape))
                 key.append(arg.dtype.str)
                 key.append(hashlib.sha256(arg.tobytes()).digest())
+            elif hasattr(arg, "cache_key_func"):
+                key.append(arg.__class__.__name__)
+                key.append(arg.cache_key_func())
             else:
                 raise RuntimeError(f"Unexpected argument type {arg.__class__.__name__}")
         return tuple(key)

--- a/backend/src/nodes/utils/seed.py
+++ b/backend/src/nodes/utils/seed.py
@@ -30,3 +30,6 @@ class Seed:
         Returns the value of the seed as a 32bit unsigned integer.
         """
         return self.to_range(0, _U32_MAX - 1)
+
+    def cache_key_func(self):
+        return self.value


### PR DESCRIPTION
currently all SD nodes are broken, since they use the `SeedInput` and also the `@cached` decorator