### PR TITLE
Allow numbers as seed and short circuit Derive seed

### DIFF
--- a/backend/src/nodes/nodes/utility/derive_seed.py
+++ b/backend/src/nodes/nodes/utility/derive_seed.py
@@ -58,6 +58,11 @@ class RandomNumberNode(NodeBase):
         self.sub = "Random"
 
     def run(self, seed: Seed, *sources: Source | None) -> Seed:
+        if all([s is None for s in sources]):
+            # return seed as is if there are no sources of randomness
+            # this is useful for extracting out seeds
+            return seed
+
         h = hashlib.sha256()
 
         h.update(_to_bytes(seed))

--- a/backend/src/nodes/properties/inputs/generic_inputs.py
+++ b/backend/src/nodes/properties/inputs/generic_inputs.py
@@ -291,8 +291,13 @@ class SeedInput(NumberInput):
         )
         self.has_handle = has_handle
 
-        self.input_type = "Seed"
-        self.input_conversion = None
+        self.input_type = "Seed | int"
+        self.input_conversion = """
+            match Input {
+                int => Seed,
+                _ as i => i
+            }
+        """
         self.input_adapt = """
             match Input {
                 int => Seed,


### PR DESCRIPTION
As requested on Discord. 

Number can new be used as seeds again, and Derive Seed will now pass through the seed if no sources of randomness are connected.