### PR TITLE
Fixed input conversions and use them on text inputs

### DIFF
--- a/backend/src/nodes/nodes/utility/derive_seed.py
+++ b/backend/src/nodes/nodes/utility/derive_seed.py
@@ -58,6 +58,11 @@ class RandomNumberNode(NodeBase):
         self.sub = "Random"
 
     def run(self, seed: Seed, *sources: Source | None) -> Seed:
+        if all([s is None for s in sources]):
+            # return seed as is if there are no sources of randomness
+            # this is useful for extracting out seeds
+            return seed
+
         h = hashlib.sha256()
 
         h.update(_to_bytes(seed))

--- a/backend/src/nodes/nodes/utility/parse_number.py
+++ b/backend/src/nodes/nodes/utility/parse_number.py
@@ -19,7 +19,7 @@ class ParseNumberNode(NodeBase):
         self.outputs = [
             NumberOutput(
                 "Value",
-                output_type="int & number::parseInt(toString(Input0), Input1)",
+                output_type="int & number::parseInt(Input0, Input1)",
             ).with_never_reason("The given text cannot be parsed into a number."),
         ]
 

--- a/backend/src/nodes/nodes/utility/text.py
+++ b/backend/src/nodes/nodes/utility/text.py
@@ -16,7 +16,7 @@ class TextValueNode(NodeBase):
             TextInput("Text", min_length=0),
         ]
         self.outputs = [
-            TextOutput("Text", output_type="toString(Input0)"),
+            TextOutput("Text", output_type="Input0"),
         ]
 
         self.category = UtilityCategory

--- a/backend/src/nodes/nodes/utility/text_append.py
+++ b/backend/src/nodes/nodes/utility/text_append.py
@@ -36,19 +36,19 @@ class TextAppendNode(NodeBase):
             TextOutput(
                 "Output Text",
                 output_type="""
-                let sep = toString(Input0);
+                let sep = Input0;
                 string::concat(
-                    toString(Input1),
+                    Input1,
                     sep,
-                    toString(Input2),
-                    match Input3 { null => "", _ as s => string::concat(sep, toString(s)) },
-                    match Input4 { null => "", _ as s => string::concat(sep, toString(s)) },
-                    match Input5 { null => "", _ as s => string::concat(sep, toString(s)) },
-                    match Input6 { null => "", _ as s => string::concat(sep, toString(s)) },
-                    match Input7 { null => "", _ as s => string::concat(sep, toString(s)) },
-                    match Input8 { null => "", _ as s => string::concat(sep, toString(s)) },
-                    match Input9 { null => "", _ as s => string::concat(sep, toString(s)) },
-                    match Input10 { null => "", _ as s => string::concat(sep, toString(s)) }
+                    Input2,
+                    match Input3 { null => "", _ as s => string::concat(sep, s) },
+                    match Input4 { null => "", _ as s => string::concat(sep, s) },
+                    match Input5 { null => "", _ as s => string::concat(sep, s) },
+                    match Input6 { null => "", _ as s => string::concat(sep, s) },
+                    match Input7 { null => "", _ as s => string::concat(sep, s) },
+                    match Input8 { null => "", _ as s => string::concat(sep, s) },
+                    match Input9 { null => "", _ as s => string::concat(sep, s) },
+                    match Input10 { null => "", _ as s => string::concat(sep, s) }
                 )
                 """,
             )

--- a/backend/src/nodes/nodes/utility/text_length.py
+++ b/backend/src/nodes/nodes/utility/text_length.py
@@ -16,7 +16,7 @@ class TextLengthNode(NodeBase):
             TextInput("Text", min_length=0),
         ]
         self.outputs = [
-            NumberOutput("Length", output_type="string::len(toString(Input0))"),
+            NumberOutput("Length", output_type="string::len(Input0)"),
         ]
 
         self.category = UtilityCategory

--- a/backend/src/nodes/nodes/utility/text_pad.py
+++ b/backend/src/nodes/nodes/utility/text_pad.py
@@ -37,11 +37,10 @@ class TextPaddingNode(NodeBase):
             TextOutput(
                 "Output Text",
                 output_type="""
-                let text = toString(Input0);
                 match Input3 {
-                    PaddingAlignment::Start => padStart(text, Input1, Input2),
-                    PaddingAlignment::End => padEnd(text, Input1, Input2),
-                    PaddingAlignment::Center => padCenter(text, Input1, Input2),
+                    PaddingAlignment::Start => padStart(Input0, Input1, Input2),
+                    PaddingAlignment::End => padEnd(Input0, Input1, Input2),
+                    PaddingAlignment::Center => padCenter(Input0, Input1, Input2),
                 }
                 """,
             )

--- a/backend/src/nodes/nodes/utility/text_pattern.py
+++ b/backend/src/nodes/nodes/utility/text_pattern.py
@@ -30,24 +30,17 @@ class TextPatternNode(NodeBase):
             TextOutput(
                 "Output Text",
                 output_type="""
-                def convert(value: string | number | null) {
-                    match value {
-                        number as n => toString(n),
-                        _ as v => v
-                    }
-                }
-
                 formatPattern(
-                    toString(Input0),
-                    convert(Input1),
-                    convert(Input2),
-                    convert(Input3),
-                    convert(Input4),
-                    convert(Input5),
-                    convert(Input6),
-                    convert(Input7),
-                    convert(Input8),
-                    convert(Input9)
+                    Input0,
+                    Input1,
+                    Input2,
+                    Input3,
+                    Input4,
+                    Input5,
+                    Input6,
+                    Input7,
+                    Input8,
+                    Input9
                 )
                 """,
             ).with_never_reason(

--- a/backend/src/nodes/nodes/utility/text_slice.py
+++ b/backend/src/nodes/nodes/utility/text_slice.py
@@ -59,7 +59,7 @@ class TextSliceNode(NodeBase):
             TextOutput(
                 "Output Text",
                 output_type="""
-                let text = toString(Input0);
+                let text = Input0;
                 let operation = Input1;
                 let start = Input2;
                 let length = Input3;

--- a/backend/src/nodes/properties/inputs/generic_inputs.py
+++ b/backend/src/nodes/properties/inputs/generic_inputs.py
@@ -291,8 +291,13 @@ class SeedInput(NumberInput):
         )
         self.has_handle = has_handle
 
-        self.input_type = "Seed"
-        self.input_conversion = None
+        self.input_type = "Seed | int"
+        self.input_conversion = """
+            match Input {
+                int => Seed,
+                _ as i => i
+            }
+        """
         self.input_adapt = """
             match Input {
                 int => Seed,

--- a/backend/src/nodes/properties/inputs/generic_inputs.py
+++ b/backend/src/nodes/properties/inputs/generic_inputs.py
@@ -200,7 +200,7 @@ class TextInput(BaseInput):
         default: Union[str, None] = None,
     ):
         super().__init__(
-            ["string", "number"] if allow_numbers else "string",
+            "string",
             label,
             has_handle=has_handle,
             kind="text-line",
@@ -209,6 +209,14 @@ class TextInput(BaseInput):
         self.max_length = max_length
         self.placeholder = placeholder
         self.default = default
+
+        if allow_numbers:
+            self.input_conversion = """
+                match Input {
+                    number => toString(Input),
+                    _ => Input
+                }
+            """
 
     def enforce(self, value) -> str:
         if isinstance(value, float) and int(value) == value:

--- a/backend/src/nodes/properties/inputs/generic_inputs.py
+++ b/backend/src/nodes/properties/inputs/generic_inputs.py
@@ -17,7 +17,7 @@ from ...utils.utils import (
     split_snake_case,
 )
 from .. import expression
-from .base_input import BaseInput
+from .base_input import BaseInput, InputConversion
 from .numeric_inputs import NumberInput
 
 
@@ -211,12 +211,7 @@ class TextInput(BaseInput):
         self.default = default
 
         if allow_numbers:
-            self.input_conversion = """
-                match Input {
-                    number => toString(Input),
-                    _ => Input
-                }
-            """
+            self.input_conversions = [InputConversion("number", "toString(Input)")]
 
     def enforce(self, value) -> str:
         if isinstance(value, float) and int(value) == value:
@@ -261,12 +256,7 @@ class ClipboardInput(BaseInput):
 
     def __init__(self, label: str = "Clipboard input"):
         super().__init__(["Image", "string", "number"], label, kind="text-line")
-        self.input_conversion = """
-            match Input {
-                Image => "<Image>",
-                _ as i => i,
-            }
-        """
+        self.input_conversions = [InputConversion("Image", '"<Image>"')]
 
     def enforce(self, value):
         if isinstance(value, np.ndarray):
@@ -300,12 +290,7 @@ class SeedInput(NumberInput):
         self.has_handle = has_handle
 
         self.input_type = "Seed | int"
-        self.input_conversion = """
-            match Input {
-                int => Seed,
-                _ as i => i
-            }
-        """
+        self.input_conversions = [InputConversion("int", "Seed")]
         self.input_adapt = """
             match Input {
                 int => Seed,

--- a/backend/src/nodes/properties/inputs/numeric_inputs.py
+++ b/backend/src/nodes/properties/inputs/numeric_inputs.py
@@ -2,7 +2,7 @@ from typing import List, Literal, Tuple, Union
 
 from ...utils.utils import round_half_up
 from .. import expression
-from .base_input import BaseInput, InputKind
+from .base_input import BaseInput, InputConversion, InputKind
 
 
 def clampNumber(
@@ -73,12 +73,7 @@ class NumberInput(BaseInput):
             self.precision,
         )
         if self.precision == 0:
-            self.input_conversion = """
-                match Input {
-                    number as i => round(i),
-                    _ as i => i,
-                }
-            """
+            self.input_conversions = [InputConversion("number", "round(Input)")]
 
     def toDict(self):
         return {

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -23,18 +23,22 @@ export type GroupId = number & { readonly __groupId: never };
 
 export type InputValue = InputSchemaValue | undefined;
 export type InputSchemaValue = string | number;
+export interface InputConversionSchema {
+    readonly type: ExpressionJson;
+    readonly convert: ExpressionJson;
+}
 
 interface InputBase {
     readonly id: InputId;
     readonly type: ExpressionJson;
     /**
-     * Optional type conversion that occurs before the type system checks
-     * whether 2 types are compatible.
+     * A list of input conversions. Before checking for compatibility, the type
+     * system will attempt to convert any assigned type using input conversions.
      *
      * This can be used to implement e.g. number rounding or type wrapping for
      * edges.
      */
-    readonly conversion?: ExpressionJson | null;
+    readonly conversions: InputConversionSchema[];
     /**
      * Optional type conversion for adapting input data.
      *

--- a/src/common/nodes/connectedInputs.ts
+++ b/src/common/nodes/connectedInputs.ts
@@ -14,7 +14,18 @@ export const getConnectedInputs = (
     return new Set(targetedInputs);
 };
 
-export const getFirstPossibleInput = (fn: FunctionDefinition, type: Type): InputId | undefined =>
-    fn.schema.inputs.find((i) => i.hasHandle && fn.canAssignInput(i.id, type))?.id;
-export const getFirstPossibleOutput = (fn: FunctionDefinition, type: Type): OutputId | undefined =>
-    fn.schema.outputs.find((o) => o.hasHandle && fn.canAssignOutput(o.id, type))?.id;
+export const getFirstPossibleInput = (fn: FunctionDefinition, type: Type): InputId | undefined => {
+    return fn.schema.inputs.find((i) => i.hasHandle && fn.canAssignInput(i.id, type))?.id;
+};
+export const getFirstPossibleOutput = (
+    outputFn: FunctionDefinition,
+    inputFn: FunctionDefinition,
+    inputId: InputId
+): OutputId | undefined => {
+    for (const [id, type] of outputFn.outputDefaults) {
+        if (inputFn.canAssignInput(inputId, type)) {
+            return id;
+        }
+    }
+    return undefined;
+};

--- a/src/common/types/function.ts
+++ b/src/common/types/function.ts
@@ -1,6 +1,6 @@
 import {
-    AnyType,
     Expression,
+    NeverType,
     NonNeverType,
     NumberType,
     ParameterDefinition,
@@ -14,6 +14,7 @@ import {
     isDisjointWith,
     literal,
     union,
+    without,
 } from '@chainner/navi';
 import { Input, InputId, InputSchemaValue, NodeSchema, Output, OutputId } from '../common-types';
 import { EMPTY_MAP, lazyKeyed, topologicalSort } from '../util';
@@ -269,28 +270,78 @@ const getInputDataAdapters = (
     return adapters;
 };
 
-const getConversions = (schema: NodeSchema, scope: Scope): Map<InputId, Expression> => {
-    const result = new Map<InputId, Expression>();
+const getConversions = (schema: NodeSchema, scope: Scope): Map<InputId, InputConversion> => {
+    const result = new Map<InputId, InputConversion>();
     for (const input of schema.inputs) {
         // eslint-disable-next-line no-continue
-        if (!input.conversion) continue;
+        if (input.conversions.length === 0) continue;
 
-        const e = fromJson(input.conversion);
+        const conversions: InputConversionItem[] = [];
+        for (const item of input.conversions) {
+            try {
+                const type = evaluate(fromJson(item.type), scope);
+                const convert = fromJson(item.convert);
+                if (type.type === 'never') {
+                    throw new Error('Conversion type cannot be never');
+                }
 
-        // verify that it's a valid conversion
-        try {
-            const conversionScope = getConversionScope(scope);
-            conversionScope.assignParameter('Input', AnyType.instance);
-            evaluate(e, conversionScope);
-        } catch (error) {
-            const name = `${schema.name} (id: ${schema.schemaId}) > ${input.label} (id: ${input.id})`;
-            throw new Error(`The conversion of input ${name} is invalid: ${String(error)}`);
+                // verify that it's a valid conversion
+                const conversionScope = getConversionScope(scope);
+                conversionScope.assignParameter('Input', type);
+                evaluate(convert, conversionScope);
+
+                // eslint-disable-next-line @typescript-eslint/no-use-before-define
+                conversions.push(new InputConversionItem(type, convert));
+            } catch (error) {
+                const name = `${schema.name} (id: ${schema.schemaId}) > ${input.label} (id: ${input.id})`;
+                throw new Error(`The conversion of input ${name} is invalid: ${String(error)}`);
+            }
         }
 
-        result.set(input.id, e);
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define
+        result.set(input.id, new InputConversion(conversions, scope));
     }
     return result;
 };
+
+export class InputConversionItem {
+    readonly type: NonNeverType;
+
+    readonly convert: Expression;
+
+    constructor(type: NonNeverType, convert: Expression) {
+        this.type = type;
+        this.convert = convert;
+    }
+}
+export class InputConversion {
+    readonly convertibleTypes: Type;
+
+    readonly conversions: readonly InputConversionItem[];
+
+    private readonly scope: Scope;
+
+    constructor(conversions: InputConversionItem[], scope: Scope) {
+        this.conversions = conversions;
+        this.convertibleTypes = union(...conversions.map((c) => c.type));
+        this.scope = getConversionScope(scope);
+    }
+
+    convert(type: Type): Type {
+        const converted: Type[] = [];
+        for (const item of this.conversions) {
+            const i = intersect(item.type, type);
+            if (i.type !== 'never') {
+                this.scope.assignParameter('Input', i);
+                converted.push(evaluate(item.convert, this.scope));
+                // eslint-disable-next-line no-param-reassign
+                type = without(type, item.type);
+            }
+        }
+
+        return union(type, ...converted);
+    }
+}
 
 export class FunctionDefinition {
     readonly schema: NodeSchema;
@@ -299,13 +350,15 @@ export class FunctionDefinition {
 
     readonly inputDefaults: ReadonlyMap<InputId, NonNeverType>;
 
+    readonly inputConvertibleDefaults: ReadonlyMap<InputId, NonNeverType>;
+
     readonly inputExpressions: ReadonlyMap<InputId, Expression>;
 
     readonly inputGenerics: ReadonlySet<InputId>;
 
     readonly inputEvaluationOrder: readonly InputId[];
 
-    readonly inputConversions: ReadonlyMap<InputId, Expression>;
+    readonly inputConversions: ReadonlyMap<InputId, InputConversion>;
 
     readonly outputDefaults: ReadonlyMap<OutputId, NonNeverType>;
 
@@ -347,6 +400,12 @@ export class FunctionDefinition {
         );
         this.inputEvaluationOrder = inputs.ordered.map(({ input }) => input.id);
         this.inputConversions = getConversions(schema, scope);
+        this.inputConvertibleDefaults = new Map(
+            [...this.inputDefaults].map(([id, d]) => {
+                const c = this.inputConversions.get(id)?.convertibleTypes ?? NeverType.instance;
+                return [id, union(d, c)];
+            })
+        );
 
         // outputs
         const outputs = evaluateOutputs(schema, scope, this.inputDefaults);
@@ -378,10 +437,7 @@ export class FunctionDefinition {
         if (!conversion) {
             return type;
         }
-
-        const scope = getConversionScope(this.scope);
-        scope.assignParameter('Input', type);
-        return evaluate(conversion, scope);
+        return conversion.convert(type);
     }
 
     canAssignInput(inputId: InputId, type: Type): boolean {

--- a/src/common/types/function.ts
+++ b/src/common/types/function.ts
@@ -392,12 +392,8 @@ export class FunctionDefinition {
         return !isDisjointWith(inputType, this.convertInput(inputId, type));
     }
 
-    canAssignOutput(outputId: OutputId, type: Type): boolean {
-        const outputType = this.outputDefaults.get(outputId);
-        if (!outputType) {
-            throw new Error('Invalid output id');
-        }
-        return !isDisjointWith(outputType, type);
+    hasInput(inputId: InputId): boolean {
+        return this.inputDefaults.has(inputId);
     }
 }
 

--- a/src/renderer/components/ReactFlowBox.tsx
+++ b/src/renderer/components/ReactFlowBox.tsx
@@ -289,14 +289,16 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
                         return EMPTY_ARRAY;
                     }
                     const { inputId } = parseTargetHandle(e.targetHandle);
-                    const targetEdgeType = typeState.functions
-                        .get(e.target)
-                        ?.definition.inputDefaults.get(inputId);
-                    if (!targetEdgeType) {
+                    const targetEdgeDefinition = typeState.functions.get(e.target)?.definition;
+                    if (!targetEdgeDefinition || targetEdgeDefinition.hasInput(inputId)) {
                         return EMPTY_ARRAY;
                     }
                     const firstPossibleInput = getFirstPossibleInput(fn, edgeType);
-                    const firstPossibleOutput = getFirstPossibleOutput(fn, targetEdgeType);
+                    const firstPossibleOutput = getFirstPossibleOutput(
+                        fn,
+                        targetEdgeDefinition,
+                        inputId
+                    );
                     if (firstPossibleInput === undefined || firstPossibleOutput === undefined) {
                         return EMPTY_ARRAY;
                     }

--- a/src/renderer/components/inputs/InputContainer.tsx
+++ b/src/renderer/components/inputs/InputContainer.tsx
@@ -63,11 +63,11 @@ const Div = chakra('div', {
 export interface HandleWrapperProps {
     id: string;
     inputId: InputId;
-    definitionType: Type;
+    connectableType: Type;
 }
 
 export const HandleWrapper = memo(
-    ({ children, id, inputId, definitionType }: React.PropsWithChildren<HandleWrapperProps>) => {
+    ({ children, id, inputId, connectableType }: React.PropsWithChildren<HandleWrapperProps>) => {
         const { isValidConnection, edgeChanges, useConnectingFrom, typeState } =
             useContext(GlobalVolatileContext);
         const { getEdges, getNode } = useReactFlow();
@@ -110,7 +110,7 @@ export const HandleWrapper = memo(
 
         const { functionDefinitions } = useContext(BackendContext);
 
-        const handleColors = getTypeAccentColors(definitionType);
+        const handleColors = getTypeAccentColors(connectableType);
 
         const parentTypeColor = useMemo(() => {
             if (connectedEdge) {

--- a/src/renderer/components/inputs/SchemaInput.tsx
+++ b/src/renderer/components/inputs/SchemaInput.tsx
@@ -70,12 +70,13 @@ export const SchemaInput = memo(
             setNodeInputValue,
             useInputSize: useInputSizeContext,
         } = useContext(GlobalContext);
-        const definitionType = useContextSelector(
-            BackendContext,
-            (c) =>
-                c.functionDefinitions.get(schemaId)?.inputDefaults.get(inputId) ??
-                NeverType.instance
+
+        const functionDefinition = useContextSelector(BackendContext, (c) =>
+            c.functionDefinitions.get(schemaId)
         );
+        const definitionType = functionDefinition?.inputDefaults.get(inputId) ?? NeverType.instance;
+        const connectableType =
+            functionDefinition?.inputConvertibleDefaults.get(inputId) ?? NeverType.instance;
 
         const value = getNodeInputValue(inputId, inputData);
         const setValue = useCallback(
@@ -146,7 +147,7 @@ export const SchemaInput = memo(
             <InputContainer>
                 {hasHandle ? (
                     <HandleWrapper
-                        definitionType={definitionType}
+                        connectableType={connectableType}
                         id={nodeId}
                         inputId={inputId}
                     >

--- a/src/renderer/hooks/usePaneNodeSearchMenu.tsx
+++ b/src/renderer/hooks/usePaneNodeSearchMenu.tsx
@@ -304,8 +304,7 @@ const getConnectionTarget = (
             }
 
             const { inputId } = parseTargetHandle(connectingFrom.handleId);
-            const sourceType = sourceFn.inputDefaults.get(inputId);
-            if (!sourceType) {
+            if (!sourceFn.hasInput(inputId)) {
                 return undefined;
             }
 
@@ -314,7 +313,7 @@ const getConnectionTarget = (
                 return undefined;
             }
 
-            const output = getFirstPossibleOutput(targetFn, sourceType);
+            const output = getFirstPossibleOutput(targetFn, sourceFn, inputId);
             if (output === undefined) {
                 return undefined;
             }


### PR DESCRIPTION
Since `TextInput`s not using `string` as their type [got me here](https://github.com/chaiNNer-org/chaiNNer/pull/1621#discussion_r1126735567), I added an input conversion for `TextInput`s. This ensures that the `InputN` variables of all `TextInput`s have the type `string`, which simplifies a few output types.

I also fixed `getFirstPossibleOutput`. This method didn't account for input conversions at all.

---

This also includes a new declarative input conversion system. So input handles keep their current colors.
![image](https://user-images.githubusercontent.com/20878432/223229590-60443198-e935-4655-baa3-303d69a8fad9.png)
