### PR TITLE
Extracted out handles into their own component and improved hitbox

### DIFF
--- a/src/renderer/components/Handle.tsx
+++ b/src/renderer/components/Handle.tsx
@@ -1,0 +1,129 @@
+import { Tooltip, chakra } from '@chakra-ui/react';
+import React, { memo } from 'react';
+import ReactMarkdown from 'react-markdown';
+import { Connection, Position, Handle as RFHandle } from 'reactflow';
+import { Validity } from '../../common/Validity';
+import { noContextMenu } from '../hooks/useContextMenu';
+
+export type HandleType = 'input' | 'output';
+
+interface HandleElementProps {
+    type: HandleType;
+    isValidConnection: (connection: Readonly<Connection>) => boolean;
+    validity: Validity;
+}
+
+// Had to do this garbage to prevent chakra from clashing the position prop
+const HandleElement = memo(
+    ({
+        children,
+        isValidConnection,
+        validity,
+        type,
+        ...props
+    }: React.PropsWithChildren<HandleElementProps>) => (
+        <Tooltip
+            hasArrow
+            borderRadius={8}
+            display={validity.isValid ? 'none' : 'block'}
+            label={
+                validity.isValid ? undefined : (
+                    <ReactMarkdown>{`Unable to connect: ${validity.reason}`}</ReactMarkdown>
+                )
+            }
+            mt={1}
+            opacity={validity.isValid ? 0 : 1}
+            openDelay={500}
+            px={2}
+            py={1}
+        >
+            <RFHandle
+                isConnectable
+                className={`${type}-handle`}
+                isValidConnection={isValidConnection}
+                position={type === 'input' ? Position.Left : Position.Right}
+                type={type === 'input' ? 'target' : 'source'}
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...props}
+            >
+                {children}
+            </RFHandle>
+        </Tooltip>
+    )
+);
+
+const Div = chakra('div', {
+    baseStyle: {},
+});
+
+export interface HandleProps {
+    id: string;
+    type: HandleType;
+    validity: Validity;
+    isValidConnection: (connection: Readonly<Connection>) => boolean;
+    handleColors: readonly string[];
+    connectedColor: string | undefined;
+}
+
+const getBackground = (colors: readonly string[]): string => {
+    if (colors.length === 1) return colors[0];
+
+    const handleColorString = colors
+        .map((color, index) => {
+            const percent = index / colors.length;
+            const nextPercent = (index + 1) / colors.length;
+            return `${color} ${percent * 100}% ${nextPercent * 100}%`;
+        })
+        .join(', ');
+    return `conic-gradient(from 90deg, ${handleColorString})`;
+};
+
+export const Handle = memo(
+    ({ id, type, validity, isValidConnection, handleColors, connectedColor }: HandleProps) => {
+        const isConnected = !!connectedColor;
+
+        const connectedBg = 'var(--connection-color)';
+
+        return (
+            <Div
+                _before={{
+                    content: '" "',
+                    position: 'absolute',
+                    top: '50%',
+                    left: '50%',
+                    height: '32px',
+                    width: '45px',
+                    cursor: 'crosshair',
+                    transform: 'translate(-50%, -50%)',
+                    borderRadius: '12px',
+                }}
+                _hover={{
+                    width: '22px',
+                    height: '22px',
+                    marginRight: '-3px',
+                    marginLeft: '-3px',
+                    opacity: validity.isValid ? 1 : 0,
+                }}
+                as={HandleElement}
+                className={`${type}-handle`}
+                id={id}
+                isValidConnection={isValidConnection}
+                sx={{
+                    width: '16px',
+                    height: '16px',
+                    borderWidth: isConnected ? '2px' : '0px',
+                    borderColor: isConnected ? connectedColor : 'transparent',
+                    transition: '0.15s ease-in-out',
+                    background: isConnected ? connectedBg : getBackground(handleColors),
+                    boxShadow: `${type === 'input' ? '+' : '-'}2px 2px 2px #00000014`,
+                    filter: validity.isValid ? undefined : 'grayscale(100%)',
+                    opacity: validity.isValid ? 1 : 0.3,
+                    position: 'relative',
+                }}
+                type={type}
+                validity={validity}
+                onContextMenu={noContextMenu}
+            />
+        );
+    }
+);

--- a/src/renderer/components/inputs/InputContainer.tsx
+++ b/src/renderer/components/inputs/InputContainer.tsx
@@ -1,64 +1,16 @@
 import { Type } from '@chainner/navi';
-import { Box, Center, HStack, Text, Tooltip, chakra } from '@chakra-ui/react';
+import { Box, Center, HStack, Text } from '@chakra-ui/react';
 import React, { memo, useCallback, useMemo } from 'react';
-import ReactMarkdown from 'react-markdown';
-import { Connection, Handle, Node, Position, useReactFlow } from 'reactflow';
+import { Connection, Node, useReactFlow } from 'reactflow';
 import { useContext } from 'use-context-selector';
 import { InputId, NodeData } from '../../../common/common-types';
 import { parseSourceHandle, parseTargetHandle, stringifyTargetHandle } from '../../../common/util';
-import { VALID, Validity, invalid } from '../../../common/Validity';
+import { VALID, invalid } from '../../../common/Validity';
 import { BackendContext } from '../../contexts/BackendContext';
 import { GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { defaultColor, getTypeAccentColors } from '../../helpers/accentColors';
-import { noContextMenu } from '../../hooks/useContextMenu';
+import { Handle } from '../Handle';
 import { TypeTag } from '../TypeTag';
-
-interface LeftHandleProps {
-    isValidConnection: (connection: Readonly<Connection>) => boolean;
-    validity: Validity;
-}
-
-// Had to do this garbage to prevent chakra from clashing the position prop
-const LeftHandle = memo(
-    ({
-        children,
-        isValidConnection,
-        validity,
-        ...props
-    }: React.PropsWithChildren<LeftHandleProps>) => (
-        <Tooltip
-            hasArrow
-            borderRadius={8}
-            display={validity.isValid ? 'none' : 'block'}
-            label={
-                validity.isValid ? undefined : (
-                    <ReactMarkdown>{`Unable to connect: ${validity.reason}`}</ReactMarkdown>
-                )
-            }
-            mt={1}
-            opacity={validity.isValid ? 0 : 1}
-            openDelay={500}
-            px={2}
-            py={1}
-        >
-            <Handle
-                isConnectable
-                className="input-handle"
-                isValidConnection={isValidConnection}
-                position={Position.Left}
-                type="target"
-                // eslint-disable-next-line react/jsx-props-no-spreading
-                {...props}
-            >
-                {children}
-            </Handle>
-        </Tooltip>
-    )
-);
-
-const Div = chakra('div', {
-    baseStyle: {},
-});
 
 export interface HandleWrapperProps {
     id: string;
@@ -134,17 +86,6 @@ export const HandleWrapper = memo(
             return null;
         }, [connectedEdge, functionDefinitions, typeState, getNode]);
 
-        // A conic gradient that uses all handle colors to give an even distribution of colors
-        const handleColorString = handleColors
-            .map((color, index) => {
-                const percent = index / handleColors.length;
-                const nextPercent = (index + 1) / handleColors.length;
-                return `${color} ${percent * 100}% ${nextPercent * 100}%`;
-            })
-            .join(', ');
-        const handleGradient = `conic-gradient(from 90deg, ${handleColorString})`;
-        const connectedColor = 'var(--connection-color)';
-
         return (
             <HStack h="full">
                 <Center
@@ -152,45 +93,15 @@ export const HandleWrapper = memo(
                     left="-6px"
                     position="absolute"
                 >
-                    <Div
-                        _before={{
-                            content: '" "',
-                            position: 'absolute',
-                            top: '50%',
-                            left: '50%',
-                            height: '30px',
-                            width: '45px',
-                            cursor: 'crosshair',
-                            transform: 'translate(-50%, -50%)',
-                            borderRadius: '100%',
-                        }}
-                        _hover={{
-                            width: '22px',
-                            height: '22px',
-                            marginLeft: '-3px',
-                            opacity: validity.isValid ? 1 : 0,
-                        }}
-                        as={LeftHandle}
-                        className="input-handle"
+                    <Handle
+                        connectedColor={
+                            isConnected ? parentTypeColor ?? handleColors[0] : undefined
+                        }
+                        handleColors={handleColors}
                         id={targetHandle}
                         isValidConnection={isValidConnectionForRf}
-                        sx={{
-                            width: '16px',
-                            height: '16px',
-                            borderWidth: isConnected ? '2px' : '0px',
-                            borderColor: parentTypeColor ?? 'none',
-                            transition: '0.15s ease-in-out',
-                            ...(handleColors.length > 1
-                                ? { background: isConnected ? connectedColor : handleGradient }
-                                : {}),
-                            backgroundColor: isConnected ? connectedColor : handleColors[0],
-                            boxShadow: '2px 2px 2px #00000014',
-                            filter: validity.isValid ? undefined : 'grayscale(100%)',
-                            opacity: validity.isValid ? 1 : 0.3,
-                            position: 'relative',
-                        }}
+                        type="input"
                         validity={validity}
-                        onContextMenu={noContextMenu}
                     />
                 </Center>
                 {children}

--- a/src/renderer/components/outputs/OutputContainer.tsx
+++ b/src/renderer/components/outputs/OutputContainer.tsx
@@ -1,15 +1,14 @@
 import { Type } from '@chainner/navi';
-import { Box, Center, HStack, Text, Tooltip, chakra } from '@chakra-ui/react';
+import { Box, Center, HStack, Text } from '@chakra-ui/react';
 import React, { memo, useCallback, useMemo } from 'react';
-import ReactMarkdown from 'react-markdown';
-import { Connection, Handle, Position, useReactFlow } from 'reactflow';
+import { Connection, useReactFlow } from 'reactflow';
 import { useContext, useContextSelector } from 'use-context-selector';
 import { OutputId } from '../../../common/common-types';
 import { parseSourceHandle, stringifySourceHandle } from '../../../common/util';
-import { VALID, Validity, invalid } from '../../../common/Validity';
+import { VALID, invalid } from '../../../common/Validity';
 import { GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { getTypeAccentColors } from '../../helpers/accentColors';
-import { noContextMenu } from '../../hooks/useContextMenu';
+import { Handle } from '../Handle';
 import { TypeTags } from '../TypeTag';
 
 interface OutputContainerProps {
@@ -20,53 +19,6 @@ interface OutputContainerProps {
     label: string;
     generic: boolean;
 }
-
-interface RightHandleProps {
-    isValidConnection: (connection: Readonly<Connection>) => boolean;
-    validity: Validity;
-}
-
-// Had to do this garbage to prevent chakra from clashing the position prop
-const RightHandle = memo(
-    ({
-        children,
-        isValidConnection,
-        validity,
-        ...props
-    }: React.PropsWithChildren<RightHandleProps>) => (
-        <Tooltip
-            hasArrow
-            borderRadius={8}
-            display={validity.isValid ? 'none' : 'block'}
-            label={
-                validity.isValid ? undefined : (
-                    <ReactMarkdown>{`Unable to connect: ${validity.reason}`}</ReactMarkdown>
-                )
-            }
-            mt={1}
-            opacity={validity.isValid ? 0 : 1}
-            openDelay={500}
-            px={2}
-            py={1}
-        >
-            <Handle
-                isConnectable
-                className="output-handle"
-                isValidConnection={isValidConnection}
-                position={Position.Right}
-                type="source"
-                // eslint-disable-next-line react/jsx-props-no-spreading
-                {...props}
-            >
-                {children}
-            </Handle>
-        </Tooltip>
-    )
-);
-
-const Div = chakra('div', {
-    baseStyle: {},
-});
 
 export const OutputContainer = memo(
     ({
@@ -122,8 +74,7 @@ export const OutputContainer = memo(
         }, [connectingFrom, id, outputId, isValidConnection]);
 
         let contents = children;
-        const [handleColor] = getTypeAccentColors(type || definitionType);
-        const connectedColor = 'var(--connection-color)';
+        const handleColors = getTypeAccentColors(type || definitionType);
         if (hasHandle) {
             contents = (
                 <HStack h="full">
@@ -132,42 +83,13 @@ export const OutputContainer = memo(
                         position="absolute"
                         right="-6px"
                     >
-                        <Div
-                            _before={{
-                                content: '" "',
-                                position: 'absolute',
-                                top: '50%',
-                                left: '50%',
-                                height: '30px',
-                                width: '45px',
-                                cursor: 'crosshair',
-                                transform: 'translate(-50%, -50%)',
-                                borderRadius: '100%',
-                            }}
-                            _hover={{
-                                width: '22px',
-                                height: '22px',
-                                marginRight: '-3px',
-                                opacity: validity.isValid ? 1 : 0,
-                            }}
-                            as={RightHandle}
-                            className="output-handle"
+                        <Handle
+                            connectedColor={isConnected ? handleColors[0] : undefined}
+                            handleColors={handleColors}
                             id={stringifySourceHandle({ nodeId: id, outputId })}
                             isValidConnection={isValidConnectionForRf}
-                            sx={{
-                                width: '16px',
-                                height: '16px',
-                                borderWidth: '2px',
-                                borderColor: handleColor,
-                                transition: '0.15s ease-in-out',
-                                background: isConnected ? connectedColor : handleColor,
-                                boxShadow: '-2px 2px 2px #00000014',
-                                filter: validity.isValid ? undefined : 'grayscale(100%)',
-                                opacity: validity.isValid ? 1 : 0.3,
-                                position: 'relative',
-                            }}
+                            type="output"
                             validity={validity}
-                            onContextMenu={noContextMenu}
                         />
                     </Center>
                 </HStack>


### PR DESCRIPTION
This PR includes 3 changes:

1. I factored out the common handle code into its own component.
2. I fixed a minor issue with handle animations. When you disconnected an input handle, its border would briefly flash white.
3. I improved the hitboxes of handles. The new hitboxes are denser and have more area but still don't overlap.

![image](https://user-images.githubusercontent.com/20878432/223448301-048195ec-97c0-4f06-a108-cf824e909a6a.png)
