### PR TITLE
Replace clear cache calls with safer version

### DIFF
--- a/backend/src/nodes/impl/pytorch/auto_split.py
+++ b/backend/src/nodes/impl/pytorch/auto_split.py
@@ -7,7 +7,7 @@ import torch
 
 from ..upscale.auto_split import Split, Tiler, auto_split
 from .types import PyTorchModel
-from .utils import np2tensor, tensor2np
+from .utils import np2tensor, safe_cuda_cache_empty, tensor2np
 
 
 @torch.inference_mode()
@@ -49,7 +49,7 @@ def pytorch_auto_split(
                         pass
                     del d_img
                 gc.collect()
-                torch.cuda.empty_cache()
+                safe_cuda_cache_empty()
                 return Split()
             else:
                 # Re-raise the exception if not an OOM error
@@ -61,4 +61,4 @@ def pytorch_auto_split(
         del model
         del device
         gc.collect()
-        torch.cuda.empty_cache()
+        safe_cuda_cache_empty()

--- a/backend/src/nodes/impl/pytorch/pix_transform/auto_split.py
+++ b/backend/src/nodes/impl/pytorch/pix_transform/auto_split.py
@@ -11,6 +11,7 @@ from ...upscale.auto_split import Split, auto_split
 from ...upscale.grayscale import SplitMode, grayscale_split
 from ...upscale.passthrough import passthrough_single_color
 from ...upscale.tiler import Tiler
+from ..utils import safe_cuda_cache_empty
 from .pix_transform import Params, PixTransform
 
 
@@ -82,7 +83,7 @@ def pix_transform_auto_split(
             if "allocate" in str(e) or "CUDA" in str(e):
                 # Collect garbage (clear VRAM)
                 gc.collect()
-                torch.cuda.empty_cache()
+                safe_cuda_cache_empty()
                 return Split()
             else:
                 # Re-raise the exception if not an OOM error
@@ -93,4 +94,4 @@ def pix_transform_auto_split(
     finally:
         del device
         gc.collect()
-        torch.cuda.empty_cache()
+        safe_cuda_cache_empty()

--- a/backend/src/nodes/impl/pytorch/utils.py
+++ b/backend/src/nodes/impl/pytorch/utils.py
@@ -175,3 +175,14 @@ def tensor2np(
 
     # has to be in range (0,255) before changing to np.uint8, else np.float32
     return img_np.astype(imtype)
+
+
+def safe_cuda_cache_empty():
+    """
+    Empties the CUDA cache if CUDA is available. Hopefully without causing any errors.
+    """
+    try:
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+    except:
+        pass

--- a/backend/src/nodes/nodes/pytorch/inpaint.py
+++ b/backend/src/nodes/nodes/pytorch/inpaint.py
@@ -8,7 +8,12 @@ import torch
 
 from ...impl.image_utils import as_3d
 from ...impl.pytorch.types import PyTorchInpaintModel
-from ...impl.pytorch.utils import np2tensor, tensor2np, to_pytorch_execution_options
+from ...impl.pytorch.utils import (
+    np2tensor,
+    safe_cuda_cache_empty,
+    tensor2np,
+    to_pytorch_execution_options,
+)
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties import expression
@@ -138,7 +143,7 @@ class InpaintNode(NodeBase):
                         pass
                     del d_mask
                 gc.collect()
-                torch.cuda.empty_cache()
+                safe_cuda_cache_empty()
 
                 raise
 

--- a/backend/src/nodes/nodes/pytorch/upscale_face.py
+++ b/backend/src/nodes/nodes/pytorch/upscale_face.py
@@ -12,7 +12,12 @@ from sanic.log import logger
 from torchvision.transforms.functional import normalize as tv_normalize
 
 from ...impl.pytorch.types import PyTorchFaceModel
-from ...impl.pytorch.utils import np2tensor, tensor2np, to_pytorch_execution_options
+from ...impl.pytorch.utils import (
+    np2tensor,
+    safe_cuda_cache_empty,
+    tensor2np,
+    to_pytorch_execution_options,
+)
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import FaceModelInput, ImageInput, NumberInput
@@ -128,7 +133,7 @@ class FaceUpscaleNode(NodeBase):
             face_helper.get_inverse_affine(None)
             restored_img = face_helper.paste_faces_to_input_image()
         del face_helper
-        torch.cuda.empty_cache()
+        safe_cuda_cache_empty()
 
         restored_img = np.clip(restored_img.astype("float32") / 255.0, 0, 1)
 
@@ -183,6 +188,6 @@ class FaceUpscaleNode(NodeBase):
             logger.error(f"Face Upscale failed: {e}")
             face_helper = None
             del face_helper
-            torch.cuda.empty_cache()
+            safe_cuda_cache_empty()
             # pylint: disable=raise-missing-from
             raise RuntimeError("Failed to run Face Upscale.")


### PR DESCRIPTION
Ideally will help the (at least) one person where this crashes for them.

Might also be worth trying to figure out if these are even worth doing. I'm not sure they _Actually_ do anything. I've read that calling clear cache is kinda useless since for the most part pytorch handles the garbage collection just fine, and doing this adds some slowness. However it probably is worth doing in all auto-split scenarios.