### PR TITLE
Added group for type conditional inputs

### DIFF
--- a/backend/src/nodes/groups.py
+++ b/backend/src/nodes/groups.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from typing import List, Tuple, Union
 
 from .group import Group, GroupId, GroupInfo
-from .node_base import NestedGroup
+from .node_base import NestedGroup, group
+from .properties.expression import ExpressionJson
 from .properties.inputs.base_input import BaseInput
 
 InputValue = Union[int, str]
@@ -22,3 +23,16 @@ def conditional_group(
         return Group(info, list(items))
 
     return ret
+
+
+def type_conditional_group(
+    input_id: int,
+    condition: ExpressionJson,
+):
+    return group(
+        "conditional-type",
+        {
+            "input": input_id,
+            "condition": condition,
+        },
+    )

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -179,6 +179,13 @@ interface ConditionalEnumGroup extends GroupBase {
         readonly conditions: readonly (readonly InputSchemaValue[] | InputSchemaValue)[];
     };
 }
+interface ConditionalTypeGroup extends GroupBase {
+    readonly kind: 'conditional-type';
+    readonly options: {
+        readonly input: InputId;
+        readonly condition: ExpressionJson;
+    };
+}
 interface SeedGroup extends GroupBase {
     readonly kind: 'seed';
     readonly options: Readonly<Record<string, never>>;
@@ -189,6 +196,7 @@ export type Group =
     | FromToDropdownsGroup
     | OptionalListGroup
     | ConditionalEnumGroup
+    | ConditionalTypeGroup
     | SeedGroup;
 
 export type OfKind<T extends { readonly kind: string }, Kind extends T['kind']> = T extends {

--- a/src/renderer/components/groups/ConditionalTypeGroup.tsx
+++ b/src/renderer/components/groups/ConditionalTypeGroup.tsx
@@ -1,0 +1,80 @@
+import { NeverType, evaluate, isDisjointWith } from '@chainner/navi';
+import { memo, useMemo } from 'react';
+import { useContext, useContextSelector } from 'use-context-selector';
+import { InputItem, getUniqueKey } from '../../../common/group-inputs';
+import { getChainnerScope } from '../../../common/types/chainner-scope';
+import { fromJson } from '../../../common/types/json';
+import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
+import { GroupProps } from './props';
+import { someInput } from './util';
+
+export const ConditionalTypeGroup = memo(
+    ({
+        inputs,
+        inputData,
+        inputSize,
+        isLocked,
+        nodeId,
+        schemaId,
+        group,
+        ItemRenderer,
+    }: GroupProps<'conditional-type'>) => {
+        const { getNodeInputValue } = useContext(GlobalContext);
+        const isNodeInputLocked = useContextSelector(
+            GlobalVolatileContext,
+            (c) => c.isNodeInputLocked
+        );
+        const typeState = useContextSelector(GlobalVolatileContext, (c) => c.typeState);
+        const fn = typeState.functions.get(nodeId);
+
+        const inputType = fn?.inputs.get(group.options.input) ?? NeverType.instance;
+        const inputHasDataValue = getNodeInputValue(group.options.input, inputData) !== undefined;
+
+        const conditionType = useMemo(() => {
+            return evaluate(fromJson(group.options.condition), getChainnerScope());
+        }, [group]);
+        const disjoint = useMemo(
+            () => isDisjointWith(inputType, conditionType),
+            [inputType, conditionType]
+        );
+
+        let isEnabled = true;
+        if (disjoint) {
+            // the condition is not met
+            isEnabled = false;
+        } else {
+            // If the input has not been assigned a value, then it will default to its declaration type.
+            // This means that the the condition is trivially met, but this isn't what we want.
+            // So we will only show the conditional inputs iff the input has been assigned a value.
+
+            // eslint-disable-next-line no-lonely-if
+            if (!inputHasDataValue && !typeState.isInputConnected(nodeId, group.options.input)) {
+                // the input type is the declaration type
+                isEnabled = false;
+            }
+        }
+
+        const showInput = (input: InputItem): boolean => {
+            if (isEnabled) return true;
+
+            // input or some input of the group is connected to another node
+            return someInput(input, ({ id }) => isNodeInputLocked(nodeId, id));
+        };
+
+        return (
+            <>
+                {inputs.filter(showInput).map((item) => (
+                    <ItemRenderer
+                        inputData={inputData}
+                        inputSize={inputSize}
+                        isLocked={isLocked}
+                        item={item}
+                        key={getUniqueKey(item)}
+                        nodeId={nodeId}
+                        schemaId={schemaId}
+                    />
+                ))}
+            </>
+        );
+    }
+);

--- a/src/renderer/components/groups/Group.tsx
+++ b/src/renderer/components/groups/Group.tsx
@@ -2,6 +2,7 @@ import { memo } from 'react';
 import { Group, GroupKind, InputData, InputSize, SchemaId } from '../../../common/common-types';
 import { InputItem } from '../../../common/group-inputs';
 import { ConditionalEnumGroup } from './ConditionalEnumGroup';
+import { ConditionalTypeGroup } from './ConditionalTypeGroup';
 import { FromToDropdownsGroup } from './FromToDropdownsGroup';
 import { NcnnFileInputsGroup } from './NcnnFileInputsGroup';
 import { OptionalInputsGroup } from './OptionalInputsGroup';
@@ -12,6 +13,7 @@ const GroupComponents: {
     readonly [K in GroupKind]: React.MemoExoticComponent<(props: GroupProps<K>) => JSX.Element>;
 } = {
     'conditional-enum': ConditionalEnumGroup,
+    'conditional-type': ConditionalTypeGroup,
     'from-to-dropdowns': FromToDropdownsGroup,
     'ncnn-file-inputs': NcnnFileInputsGroup,
     'optional-list': OptionalInputsGroup,


### PR DESCRIPTION
As discussed on Discord. The type conditional group is similar to the enum conditional group, but it works with types instead.

I had to change TypeState as well. It now also contains a list of all edges that were used to create it. This was necessary because the type state is updated with a slight delay for performance reasons. During this type, the type state is outdated and might disagree on which inputs are connected. This caused problems with the type conditional group, so now the type state is the only source of truth for the new group.

### Usage

In the following example, the boolean input will only be show if the input with id 0 is compatible with type `Image { channels: 4 }`.

```py
type_conditional_group(0, "Image { channels: 4 }")(
    BoolInput("Separate Alpha", False),
),
```