### PR TITLE
Validate image dtype in ImageOutput

### DIFF
--- a/backend/src/nodes/properties/outputs/numpy_outputs.py
+++ b/backend/src/nodes/properties/outputs/numpy_outputs.py
@@ -67,6 +67,7 @@ class ImageOutput(NumPyOutput):
 
     def validate(self, value) -> None:
         assert isinstance(value, np.ndarray)
+        assert value.dtype == np.float32
 
         _, _, c = get_h_w_c(value)
 


### PR DESCRIPTION
All nodes should return float32 images, so I added a check for that.