### PR TITLE
Ctlr+Click button to export viewport to clipboard

### DIFF
--- a/src/renderer/components/ReactFlowBox.tsx
+++ b/src/renderer/components/ReactFlowBox.tsx
@@ -186,6 +186,7 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
         setEdgesRef,
         removeEdgeById,
         exportViewportScreenshot,
+        exportViewportScreenshotToClipboard,
     } = useContext(GlobalContext);
     const { schemata, functionDefinitions } = useContext(BackendContext);
 
@@ -665,8 +666,14 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
                 <Controls>
                     <ControlButton
                         disabled={nodes.length === 0}
-                        title="Export viewport as PNG"
-                        onClick={exportViewportScreenshot}
+                        title={'Export viewport as PNG\nCtrl+Click to export to clipboard instead'}
+                        onClick={(e) => {
+                            if (e.ctrlKey) {
+                                exportViewportScreenshotToClipboard();
+                            } else {
+                                exportViewportScreenshot();
+                            }
+                        }}
                     >
                         <FaFileExport />
                     </ControlButton>

--- a/src/renderer/contexts/GlobalNodeState.tsx
+++ b/src/renderer/contexts/GlobalNodeState.tsx
@@ -143,6 +143,7 @@ interface Global {
     setCollidingNode: (value: string | undefined) => void;
     setZoom: SetState<number>;
     exportViewportScreenshot: () => void;
+    exportViewportScreenshotToClipboard: () => void;
     setManualOutputType: (nodeId: string, outputId: OutputId, type: Expression | undefined) => void;
     typeStateRef: Readonly<React.MutableRefObject<TypeState>>;
     releaseNodeFromParent: (id: string) => void;
@@ -1373,6 +1374,7 @@ export const GlobalProvider = memo(
             setNodeDisabled,
             setZoom,
             exportViewportScreenshot,
+            exportViewportScreenshotToClipboard,
             setManualOutputType,
             typeStateRef,
             releaseNodeFromParent,


### PR DESCRIPTION
This implements a suggestion by Rayan to export to clipboard on Ctrl+Click. This should make it easier for people to (1) know that export to clipboard exists and (2) use this feature.

![image](https://user-images.githubusercontent.com/20878432/225474648-70a03b1e-c601-4bf0-8ce6-d71a7caaf97e.png)
