### PR TITLE
NCNN: Added model directory output

### DIFF
--- a/backend/src/nodes/nodes/ncnn/load_model.py
+++ b/backend/src/nodes/nodes/ncnn/load_model.py
@@ -8,7 +8,7 @@ from ...impl.ncnn.optimizer import NcnnOptimizer
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import BinFileInput, ParamFileInput
-from ...properties.outputs import FileNameOutput, NcnnModelOutput
+from ...properties.outputs import DirectoryOutput, FileNameOutput, NcnnModelOutput
 from ...utils.utils import split_file_path
 from . import category as NCNNCategory
 
@@ -26,7 +26,8 @@ class NcnnLoadModelNode(NodeBase):
         ]
         self.outputs = [
             NcnnModelOutput(kind="ncnn", should_broadcast=True),
-            FileNameOutput("Model Name", of_input=0),
+            DirectoryOutput("Model Directory", of_input=0).with_id(2),
+            FileNameOutput("Model Name", of_input=0).with_id(1),
         ]
 
         self.category = NCNNCategory
@@ -34,10 +35,10 @@ class NcnnLoadModelNode(NodeBase):
         self.icon = "NCNN"
         self.sub = "Input & Output"
 
-    def run(self, param_path: str, bin_path: str) -> Tuple[NcnnModelWrapper, str]:
+    def run(self, param_path: str, bin_path: str) -> Tuple[NcnnModelWrapper, str, str]:
         model = NcnnModel.load_from_file(param_path, bin_path)
         NcnnOptimizer(model).optimize()
 
-        _, model_name, _ = split_file_path(param_path)
+        model_dir, model_name, _ = split_file_path(param_path)
 
-        return NcnnModelWrapper(model), model_name
+        return NcnnModelWrapper(model), model_dir, model_name

--- a/backend/src/nodes/nodes/ncnn/model_file_iterator.py
+++ b/backend/src/nodes/nodes/ncnn/model_file_iterator.py
@@ -49,7 +49,7 @@ class ModelFileIteratorLoadModelNode(NodeBase):
     def run(
         self, param_path: str, bin_path: str, root_dir: str, index: int
     ) -> Tuple[NcnnModelWrapper, str, str, str, int]:
-        model, model_name = NcnnLoadModelNode().run(param_path, bin_path)
+        model, _, model_name = NcnnLoadModelNode().run(param_path, bin_path)
 
         dirname, _ = os.path.split(param_path)
 


### PR DESCRIPTION
This resolves a suggestion made on discord to add a directory output for NCNN's Load Model. The model name was already extracted from the .param file, so I used it for the directory too.