### PR TITLE
Added `to_uint8` function

### DIFF
--- a/backend/src/nodes/impl/blend.py
+++ b/backend/src/nodes/impl/blend.py
@@ -4,7 +4,7 @@ import cv2
 import numpy as np
 
 from ..utils.utils import get_h_w_c
-from .image_utils import as_target_channels
+from .image_utils import as_target_channels, normalize, to_uint8
 
 
 class BlendMode(Enum):
@@ -144,11 +144,8 @@ class ImageBlender:
         return a + b - (a * b)  # type: ignore
 
     def __xor(self, a: np.ndarray, b: np.ndarray) -> np.ndarray:
-        return (
-            np.bitwise_xor(
-                (a * 255).astype(np.uint8), (b * 255).astype(np.uint8)
-            ).astype(np.float32)
-            / 255
+        return normalize(
+            np.bitwise_xor(to_uint8(a, normalized=True), to_uint8(b, normalized=True))
         )
 
     def __subtract(self, a: np.ndarray, b: np.ndarray) -> np.ndarray:

--- a/backend/src/nodes/impl/caption.py
+++ b/backend/src/nodes/impl/caption.py
@@ -7,6 +7,7 @@ import numpy as np
 from PIL import Image, ImageDraw, ImageFont
 
 from ..utils.utils import get_h_w_c
+from .image_utils import normalize, to_uint8
 
 
 class CaptionPosition(Enum):
@@ -30,7 +31,7 @@ def add_caption(
     else:
         raise RuntimeError(f"Unknown position {position}")
 
-    pimg = Image.fromarray((img * 255).astype("uint8"))
+    pimg = Image.fromarray(to_uint8(img))
     font_path = os.path.join(
         os.path.dirname(sys.modules["__main__"].__file__), "fonts/Roboto-Light.ttf"  # type: ignore
     )
@@ -58,6 +59,6 @@ def add_caption(
         fill=font_color,
     )
 
-    img = np.array(pimg).astype("float32") / 255
+    img = normalize(np.array(pimg))
 
     return img

--- a/backend/src/nodes/impl/clipboard/clipboard_base.py
+++ b/backend/src/nodes/impl/clipboard/clipboard_base.py
@@ -4,11 +4,13 @@ from typing import Tuple
 import cv2
 import numpy as np
 
+from ..image_utils import to_uint8
+
 
 class ClipboardBase(ABC):
     @staticmethod
     def prepare_image(image_array: np.ndarray) -> Tuple[bytes, np.ndarray]:
-        image_array = (np.clip(image_array, 0, 1) * 255).round().astype("uint8")
+        image_array = to_uint8(image_array)
 
         _, im_buff_arr = cv2.imencode(".png", image_array)
 

--- a/backend/src/nodes/impl/external_stable_diffusion.py
+++ b/backend/src/nodes/impl/external_stable_diffusion.py
@@ -13,7 +13,7 @@ from PIL import Image
 from sanic.log import logger
 
 from ..utils.utils import get_h_w_c
-from .image_utils import normalize
+from .image_utils import normalize, to_uint8
 
 STABLE_DIFFUSION_PROTOCOL = os.environ.get("STABLE_DIFFUSION_PROTOCOL", None)
 STABLE_DIFFUSION_HOST = os.environ.get("STABLE_DIFFUSION_HOST", "127.0.0.1")
@@ -155,7 +155,7 @@ def decode_base64_image(image_bytes: Union[bytes, str]) -> np.ndarray:
 
 
 def encode_base64_image(image_nparray: np.ndarray) -> str:
-    image_nparray = (np.clip(image_nparray, 0, 1) * 255).round().astype("uint8")
+    image_nparray = to_uint8(image_nparray)
     _, _, c = get_h_w_c(image_nparray)
     if c == 1:
         # PIL supports grayscale images just fine, so we don't need to do any conversion

--- a/backend/src/nodes/impl/image_utils.py
+++ b/backend/src/nodes/impl/image_utils.py
@@ -92,6 +92,38 @@ def normalize(img: np.ndarray) -> np.ndarray:
     return np.clip(img, 0, 1)
 
 
+def to_uint8(
+    img: np.ndarray,
+    normalized=False,
+    dither=False,
+) -> np.ndarray:
+    """
+    Returns a new uint8 image with the given image data.
+
+    If `normalized` is `False`, then the image will be normalized before being converted to uint8.
+
+    If `dither` is `True`, then dithering will be used to minimize the quantization error.
+    """
+    if img.dtype == np.uint8:
+        return img.copy()
+
+    if not normalized or img.dtype != np.float32:
+        img = normalize(img)
+
+    if not dither:
+        return (img * 255).round().astype(np.uint8)
+
+    # random dithering
+    truth = img * 255
+    quant = truth.round()
+
+    err = truth - quant
+    r = np.random.default_rng(0).uniform(0, 1, img.shape).astype(np.float32)
+    quant += np.sign(err) * (np.abs(err) > r)
+
+    return quant.astype(np.uint8)
+
+
 def shift(img: np.ndarray, amount_x: int, amount_y: int, fill: FillColor) -> np.ndarray:
     c = get_h_w_c(img)[2]
     if fill == FillColor.TRANSPARENT:

--- a/backend/src/nodes/impl/ncnn/auto_split.py
+++ b/backend/src/nodes/impl/ncnn/auto_split.py
@@ -7,22 +7,8 @@ from ncnn_vulkan import ncnn
 from sanic.log import logger
 
 from ...utils.utils import get_h_w_c
+from ..image_utils import to_uint8
 from ..upscale.auto_split import Split, Tiler, auto_split
-
-
-def fix_dtype_range(img):
-    dtype_max = 1
-    try:
-        dtype_max = np.iinfo(img.dtype).max
-    except:
-        logger.debug("img dtype is not an int")
-
-    img = (
-        (np.clip(img.astype("float32") / dtype_max, 0, 1) * 255)
-        .round()
-        .astype(np.uint8)
-    )
-    return img
 
 
 def ncnn_auto_split(
@@ -42,7 +28,7 @@ def ncnn_auto_split(
         # ex.set_light_mode(True)
         try:
             lr_c = get_h_w_c(img)[2]
-            lr_img_fix = fix_dtype_range(img)
+            lr_img_fix = to_uint8(img)
             if lr_c == 1:
                 pixel_type = ncnn.Mat.PixelType.PIXEL_GRAY
             elif lr_c == 3:

--- a/backend/src/nodes/impl/pil_utils.py
+++ b/backend/src/nodes/impl/pil_utils.py
@@ -5,7 +5,7 @@ import numpy as np
 from PIL import Image
 
 from ..utils.utils import get_h_w_c
-from .image_utils import FillColor, convert_to_BGRA
+from .image_utils import FillColor, convert_to_BGRA, normalize, to_uint8
 
 
 class InterpolationMethod(Enum):
@@ -57,9 +57,9 @@ def resize(
 
     resample = INTERPOLATION_METHODS_MAP[interpolation]
 
-    pimg = Image.fromarray((img * 255).astype("uint8"))
+    pimg = Image.fromarray(to_uint8(img, normalized=True))
     pimg = pimg.resize(out_dims, resample=resample)  # type: ignore
-    return np.array(pimg).astype("float32") / 255
+    return normalize(np.array(pimg))
 
 
 def rotate(
@@ -78,11 +78,11 @@ def rotate(
 
     resample = INTERPOLATION_METHODS_MAP[interpolation.interpolation_method]
 
-    pimg = Image.fromarray((img * 255).astype("uint8"))
+    pimg = Image.fromarray(to_uint8(img, normalized=True))
     pimg = pimg.rotate(
         angle,
         resample=resample,  # type: ignore
         expand=bool(expand.value),
         fillcolor=fill_color,
     )
-    return np.array(pimg).astype("float32") / 255
+    return normalize(np.array(pimg))

--- a/backend/src/nodes/nodes/image/external_preview.py
+++ b/backend/src/nodes/nodes/image/external_preview.py
@@ -10,6 +10,7 @@ import cv2
 import numpy as np
 from sanic.log import logger
 
+from ...impl.image_utils import to_uint8
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import ImageInput
@@ -33,16 +34,13 @@ class ImOpenNode(NodeBase):
     def run(self, img: np.ndarray) -> None:
         """Show image"""
 
-        # Put image back in int range
-        img = (np.clip(img, 0, 1) * 255).round().astype("uint8")
-
         tempdir = mkdtemp(prefix="chaiNNer-")
         logger.debug(f"Writing image to temp path: {tempdir}")
         im_name = f"{time.time()}.png"
         temp_save_dir = os.path.join(tempdir, im_name)
         status = cv2.imwrite(
             temp_save_dir,
-            img,
+            to_uint8(img, normalized=True),
         )
 
         if status:

--- a/backend/src/nodes/nodes/image/save_image.py
+++ b/backend/src/nodes/nodes/image/save_image.py
@@ -18,7 +18,7 @@ from ...impl.dds.format import (
     to_dxgi,
 )
 from ...impl.dds.texconv import save_as_dds
-from ...impl.image_utils import cv_save_image
+from ...impl.image_utils import cv_save_image, to_uint8
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import (
@@ -155,7 +155,7 @@ class ImWriteNode(NodeBase):
         logger.debug(f"Writing image to path: {full_path}")
 
         # Put image back in int range
-        img = (np.clip(img, 0, 1) * 255).round().astype("uint8")
+        img = to_uint8(img, normalized=True)
 
         os.makedirs(base_directory, exist_ok=True)
 

--- a/backend/src/nodes/nodes/image/video_frame_iterator.py
+++ b/backend/src/nodes/nodes/image/video_frame_iterator.py
@@ -12,7 +12,7 @@ from sanic.log import logger
 
 from process import IteratorContext
 
-from ...impl.image_utils import normalize
+from ...impl.image_utils import normalize, to_uint8
 from ...node_base import IteratorNodeBase, NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import (
@@ -165,7 +165,7 @@ class VideoFrameIteratorFrameWriterNode(NodeBase):
             except Exception as e:
                 logger.warning(f"Failed to open video writer: {e}")
 
-        out_frame = cv2.cvtColor((img * 255).astype(np.uint8), cv2.COLOR_BGR2RGB)
+        out_frame = cv2.cvtColor(to_uint8(img, normalized=True), cv2.COLOR_BGR2RGB)
         if writer.out is not None and writer.out.stdin is not None:
             writer.out.stdin.write(out_frame.tobytes())
         else:

--- a/backend/src/nodes/nodes/image_adjustment/threshold_adaptive.py
+++ b/backend/src/nodes/nodes/image_adjustment/threshold_adaptive.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import cv2
 import numpy as np
 
+from ...impl.image_utils import normalize, to_uint8
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import (
@@ -53,7 +54,7 @@ class AdaptiveThresholdNode(NodeBase):
         """Takes an image and applies an adaptive threshold to it"""
 
         # Adaptive threshold requires uint8 input
-        img = (img * 255).astype("uint8")
+        img = to_uint8(img, normalized=True)
 
         real_maxval = maxval / 100 * 255
 
@@ -66,4 +67,4 @@ class AdaptiveThresholdNode(NodeBase):
             c,
         )
 
-        return result.astype("float32") / 255
+        return normalize(result)

--- a/backend/src/nodes/nodes/image_filter/blur_median.py
+++ b/backend/src/nodes/nodes/image_filter/blur_median.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import cv2
 import numpy as np
 
+from ...impl.image_utils import normalize, to_uint8
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties.inputs import ImageInput, NumberInput
@@ -38,7 +39,6 @@ class MedianBlurNode(NodeBase):
             if radius < 3:
                 blurred = cv2.medianBlur(img, 2 * radius + 1)
             else:  # cv2 requires uint8 for kernel size (2r+1) > 5
-                img = (img * 255).astype("uint8")
-                blurred = cv2.medianBlur(img, 2 * radius + 1).astype("float32") / 255
+                blurred = cv2.medianBlur(to_uint8(img, normalized=True), 2 * radius + 1)
 
-            return np.clip(blurred, 0, 1)
+            return normalize(blurred)

--- a/backend/src/nodes/nodes/image_filter/canny_edge_detection.py
+++ b/backend/src/nodes/nodes/image_filter/canny_edge_detection.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import cv2
 import numpy as np
 
-from ...impl.image_utils import normalize
+from ...impl.image_utils import normalize, to_uint8
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties import expression
@@ -38,8 +38,5 @@ class CannyEdgeDetectionNode(NodeBase):
         t_lower: int,
         t_upper: int,
     ) -> np.ndarray:
-        img = (img * 255).astype(np.uint8)
-
-        edges = cv2.Canny(img, t_lower, t_upper)
-
+        edges = cv2.Canny(to_uint8(img, normalized=True), t_lower, t_upper)
         return normalize(edges)

--- a/backend/src/nodes/nodes/image_utility/inpaint.py
+++ b/backend/src/nodes/nodes/image_utility/inpaint.py
@@ -5,6 +5,7 @@ from enum import Enum
 import cv2
 import numpy as np
 
+from ...impl.image_utils import normalize, to_uint8
 from ...node_base import NodeBase
 from ...node_factory import NodeFactory
 from ...properties import expression
@@ -70,8 +71,8 @@ class InpaintNode(NodeBase):
             img.shape[:2] == mask.shape[:2]
         ), "Input image and mask must have the same resolution"
 
-        img = (img * 255).astype("uint8")
-        mask = (mask * 255).astype("uint8")
-        img = cv2.inpaint(img, mask, radius, inpaint_method.value)
+        img = to_uint8(img, normalized=True)
+        mask = to_uint8(mask, normalized=True)
+        result = cv2.inpaint(img, mask, radius, inpaint_method.value)
 
-        return img.astype("float32") / 255
+        return normalize(result)

--- a/backend/src/nodes/nodes/pytorch/upscale_face.py
+++ b/backend/src/nodes/nodes/pytorch/upscale_face.py
@@ -11,6 +11,7 @@ from facexlib.utils.face_restoration_helper import FaceRestoreHelper
 from sanic.log import logger
 from torchvision.transforms.functional import normalize as tv_normalize
 
+from ...impl.image_utils import to_uint8
 from ...impl.pytorch.types import PyTorchFaceModel
 from ...impl.pytorch.utils import (
     np2tensor,
@@ -60,7 +61,7 @@ class FaceUpscaleNode(NodeBase):
         self.sub = "Restoration"
 
     def denormalize(self, img: np.ndarray):
-        img = (img * 255).astype(np.uint8)
+        img = to_uint8(img, normalized=True)
         _, _, c = get_h_w_c(img)
         if c == 4:
             img = img[:, :, :3]

--- a/backend/src/nodes/properties/outputs/numpy_outputs.py
+++ b/backend/src/nodes/properties/outputs/numpy_outputs.py
@@ -4,6 +4,7 @@ from typing import Optional, Tuple
 import cv2
 import numpy as np
 
+from ...impl.image_utils import to_uint8
 from ...impl.pil_utils import InterpolationMethod, resize
 from ...utils.format import format_image_with_channels
 from ...utils.utils import get_h_w_c
@@ -105,7 +106,7 @@ def preview_encode(
 
     image_format = "png" if c > 3 or lossless else "jpg"
 
-    _, encoded_img = cv2.imencode(f".{image_format}", (img * 255).astype("uint8"))  # type: ignore
+    _, encoded_img = cv2.imencode(f".{image_format}", to_uint8(img, normalized=True))  # type: ignore
     base64_img = base64.b64encode(encoded_img).decode("utf8")
 
     return f"data:image/{image_format};base64,{base64_img}", img


### PR DESCRIPTION
`to_uint8` is intended as a sort of inverse operation to `normalize`. It takes an image and converts it to `dtype=np.uint8`. How it does the conversion is the interesting part. 

`to_uint8`'s primary purpose is to standardize uint8 conversions across the code base and to minimize the quantization error. It does this by (1) rounding and optionally (2) dithering. I implemented a simple version of random dithering (we may want to improve this by using blue noise in the future).

`to_uint8` is also very conservative when it comes to the input image. By default, it will `noramlize` the input image (which for float32 image is just one `np.clip`). As a performance optimization, the caller can also pass `normalized=True` to skip normalization.

Now, just adding `to_uint8` doesn't do any good, so I also used it everywhere in the entire code base.