### PR TITLE
Larger settings modal

### DIFF
--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -691,15 +691,27 @@ export const SettingsModal = memo(({ isOpen, onClose }: SettingsModalProps) => {
             <ModalOverlay />
             <ModalContent
                 bgColor="var(--chain-editor-bg)"
-                maxH="500px"
-                maxW="750px"
-                minH="500px"
-                minW="750px"
+                h="min(100% - 7.5rem, 600px)"
+                maxW="unset"
+                my={0}
+                w="750px"
             >
                 <ModalHeader>Settings</ModalHeader>
                 <ModalCloseButton />
-                <ModalBody px={0}>
-                    <Tabs isFitted>
+                <ModalBody
+                    position="relative"
+                    px={0}
+                >
+                    <Tabs
+                        isFitted
+                        bottom={0}
+                        display="flex"
+                        flexDirection="column"
+                        left={0}
+                        position="absolute"
+                        right={0}
+                        top={0}
+                    >
                         <TabList>
                             <Tab>
                                 <HStack cursor="pointer">
@@ -727,8 +739,6 @@ export const SettingsModal = memo(({ isOpen, onClose }: SettingsModalProps) => {
                             </Tab>
                         </TabList>
                         <TabPanels
-                            maxH="300px"
-                            minH="300px"
                             overflowY="scroll"
                             px={4}
                         >


### PR DESCRIPTION
No more scroll! I also made it so that the height of the inner content is now determined by the modal's height. So we still retain the nice scrolling behavior we had before.

![image](https://user-images.githubusercontent.com/20878432/227552083-b25f598a-255c-43e9-842b-9825358eed61.png)
![image](https://user-images.githubusercontent.com/20878432/227552709-45a1585e-8cbd-4b5b-b38d-8a3056ef4447.png)
