### PR TITLE
update random number node

### DIFF
--- a/backend/src/nodes/nodes/utility/random_number.py
+++ b/backend/src/nodes/nodes/utility/random_number.py
@@ -40,4 +40,7 @@ class RandomNumberNode(NodeBase):
         self.sub = "Random"
 
     def run(self, min_val: int, max_val: int, seed: Seed) -> int:
-        return Random(seed.value).randint(min_val, max_val)
+        if seed.value == -1:
+            return Random().randint(min_val, max_val)
+        else:
+            return Random(seed.value).randint(min_val, max_val)


### PR DESCRIPTION
Add functionality so that if a seed of -1 is provided, it will generate a new random number each time the chain is run.
This was originally a feature when the random number node was created, but it was removed at the time due to issues with caching in iterators. The derive seed node resolved the issues around iterators, so it makes sense to add this back in.