### PR TITLE
Simplified output kinds

### DIFF
--- a/backend/src/nodes/nodes/ncnn/load_model.py
+++ b/backend/src/nodes/nodes/ncnn/load_model.py
@@ -25,7 +25,7 @@ class NcnnLoadModelNode(NodeBase):
             )
         ]
         self.outputs = [
-            NcnnModelOutput(kind="ncnn"),
+            NcnnModelOutput(kind="tagged"),
             DirectoryOutput("Model Directory", of_input=0).with_id(2),
             FileNameOutput("Model Name", of_input=0).with_id(1),
         ]

--- a/backend/src/nodes/nodes/onnx/load_model.py
+++ b/backend/src/nodes/nodes/onnx/load_model.py
@@ -24,7 +24,7 @@ class OnnxLoadModelNode(NodeBase):
         )
         self.inputs = [OnnxFileInput(primary_input=True)]
         self.outputs = [
-            OnnxModelOutput(kind="onnx"),
+            OnnxModelOutput(),
             DirectoryOutput("Model Directory", of_input=0).with_id(2),
             FileNameOutput("Model Name", of_input=0).with_id(1),
         ]

--- a/backend/src/nodes/nodes/pytorch/convert_to_onnx.py
+++ b/backend/src/nodes/nodes/pytorch/convert_to_onnx.py
@@ -27,11 +27,7 @@ class ConvertTorchToONNXNode(NodeBase):
             OnnxFpDropdown(),
         ]
         self.outputs = [
-            OnnxModelOutput(
-                model_type="OnnxGenericModel",
-                label="ONNX Model",
-                kind="onnx",
-            ),
+            OnnxModelOutput(model_type="OnnxGenericModel", label="ONNX Model"),
             TextOutput("FP Mode", "FpMode::toString(Input1)"),
         ]
 

--- a/backend/src/nodes/nodes/pytorch/load_model.py
+++ b/backend/src/nodes/nodes/pytorch/load_model.py
@@ -30,7 +30,7 @@ class LoadModelNode(NodeBase):
             Real-ESRGAN's SRVGG architecture, Swift-SRGAN, SwinIR, Swin2SR, and HAT."""
         self.inputs = [PthFileInput(primary_input=True)]
         self.outputs = [
-            ModelOutput(kind="pytorch"),
+            ModelOutput(kind="tagged"),
             DirectoryOutput("Model Directory", of_input=0).with_id(2),
             FileNameOutput("Model Name", of_input=0).with_id(1),
         ]

--- a/backend/src/nodes/properties/outputs/base_output.py
+++ b/backend/src/nodes/properties/outputs/base_output.py
@@ -6,9 +6,7 @@ from base_types import OutputId
 
 from .. import expression
 
-OutputKind = Literal[
-    "image", "large-image", "text", "directory", "pytorch", "generic", "ncnn", "onnx"
-]
+OutputKind = Literal["image", "large-image", "tagged", "generic"]
 
 
 class BaseOutput:

--- a/backend/src/nodes/properties/outputs/file_outputs.py
+++ b/backend/src/nodes/properties/outputs/file_outputs.py
@@ -1,19 +1,14 @@
 from __future__ import annotations
 
 from .. import expression
-from .base_output import BaseOutput, OutputKind
+from .base_output import BaseOutput
 
 
 class FileOutput(BaseOutput):
     """Output for saving a local file"""
 
-    def __init__(
-        self,
-        file_type: expression.ExpressionJson,
-        label: str,
-        kind: OutputKind = "generic",
-    ):
-        super().__init__(file_type, label, kind=kind)
+    def __init__(self, file_type: expression.ExpressionJson, label: str):
+        super().__init__(file_type, label)
 
     def get_broadcast_data(self, value: str):
         return value
@@ -32,7 +27,7 @@ class DirectoryOutput(BaseOutput):
             else f"splitFilePath(Input{of_input}.path).dir"
         )
 
-        super().__init__(directory_type, label, kind="directory")
+        super().__init__(directory_type, label)
 
     def get_broadcast_type(self, value: str):
         return expression.named("Directory", {"path": expression.literal(value)})

--- a/backend/src/nodes/properties/outputs/generic_outputs.py
+++ b/backend/src/nodes/properties/outputs/generic_outputs.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from ...utils.seed import Seed
 from .. import expression
-from .base_output import BaseOutput, OutputKind
+from .base_output import BaseOutput
 
 
 class NumberOutput(BaseOutput):
@@ -25,9 +25,8 @@ class TextOutput(BaseOutput):
         self,
         label: str,
         output_type: expression.ExpressionJson = "string",
-        kind: OutputKind = "text",
     ):
-        super().__init__(expression.intersect("string", output_type), label, kind=kind)
+        super().__init__(expression.intersect("string", output_type), label)
 
     def get_broadcast_type(self, value: str):
         return expression.literal(value)

--- a/backend/src/nodes/properties/outputs/onnx_outputs.py
+++ b/backend/src/nodes/properties/outputs/onnx_outputs.py
@@ -7,7 +7,9 @@ class OnnxModelOutput(BaseOutput):
     """Output for onnx model"""
 
     def __init__(
-        self, model_type: expression.ExpressionJson = "OnnxModel", label: str = "Model"
+        self,
+        model_type: expression.ExpressionJson = "OnnxModel",
+        label: str = "Model",
     ):
         super().__init__(model_type, label)
 

--- a/backend/src/nodes/properties/outputs/onnx_outputs.py
+++ b/backend/src/nodes/properties/outputs/onnx_outputs.py
@@ -1,18 +1,15 @@
 from ...impl.onnx.model import OnnxModel
 from ...properties import expression
-from .base_output import BaseOutput, OutputKind
+from .base_output import BaseOutput
 
 
 class OnnxModelOutput(BaseOutput):
     """Output for onnx model"""
 
     def __init__(
-        self,
-        model_type: expression.ExpressionJson = "OnnxModel",
-        label: str = "Model",
-        kind: OutputKind = "generic",
+        self, model_type: expression.ExpressionJson = "OnnxModel", label: str = "Model"
     ):
-        super().__init__(model_type, label, kind=kind)
+        super().__init__(model_type, label)
 
     def get_broadcast_type(self, value: OnnxModel):
         fields = {

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -128,15 +128,7 @@ export type Input =
     | SliderInput
     | NumberInput;
 
-export type OutputKind =
-    | 'image'
-    | 'large-image'
-    | 'text'
-    | 'directory'
-    | 'pytorch'
-    | 'ncnn'
-    | 'onnx'
-    | 'generic';
+export type OutputKind = 'image' | 'large-image' | 'tagged' | 'generic';
 
 export interface Output {
     readonly id: OutputId;

--- a/src/renderer/components/node/NodeOutputs.tsx
+++ b/src/renderer/components/node/NodeOutputs.tsx
@@ -27,21 +27,13 @@ const OutputComponents: Readonly<
 > = {
     image: DefaultImageOutput,
     'large-image': LargeImageOutput,
-    pytorch: TaggedOutput,
-    ncnn: TaggedOutput,
-    onnx: GenericOutput,
-    directory: GenericOutput,
-    text: GenericOutput,
+    tagged: TaggedOutput,
     generic: GenericOutput,
 };
 const OutputIsGeneric: Readonly<Record<OutputKind, boolean>> = {
     image: true,
     'large-image': false,
-    pytorch: false,
-    ncnn: false,
-    onnx: true,
-    directory: true,
-    text: true,
+    tagged: false,
     generic: true,
 };
 


### PR DESCRIPTION
This PR simplifies outputs for #1602. Since we have type broadcasts and `TaggedOutput`, pretty much all specific outputs became unnecessary. We may want to add more specific outputs in the future (e.g. special text outputs), but we can add them when needed later.