### PR TITLE
Make scipy mandatory

### DIFF
--- a/src/common/dependencies.ts
+++ b/src/common/dependencies.ts
@@ -165,6 +165,10 @@ export const requiredDependencies: Dependency[] = [
         name: 're2',
         packages: [{ packageName: 'google-re2', version: '1.0.0', sizeEstimate: 275 * KB }],
     },
+    {
+        name: 'scipy',
+        packages: [{ packageName: 'scipy', version: '1.9.3', sizeEstimate: 42 * MB }],
+    },
 ];
 
 if (isMac && !isArmMac) {


### PR DESCRIPTION
something requires scipy now, which got added to requirements.txt but not dependencies.ts :/ 