### PR TITLE
Include NCNN model resize scale when interp is last op

### DIFF
--- a/backend/src/nodes/impl/ncnn/model.py
+++ b/backend/src/nodes/impl/ncnn/model.py
@@ -731,7 +731,7 @@ class NcnnModelWrapper:
                     ):
                         scale *= checked_cast(float, layer.params[1].value)
                 except IndexError:
-                    pass
+                    scale *= checked_cast(float, layer.params[1].value)
             elif layer.op_type == "PixelShuffle":
                 scale *= checked_cast(int, layer.params[0].value)
                 pixel_shuffle *= checked_cast(int, layer.params[0].value)


### PR DESCRIPTION
The scale on realesranime_v3 was not being computed correctly because the resize scaling factor was only included when interp was not the last op. Added scale factor calculation into IndexError except statement to incorporate end-of-model resizes.

Closes #1697 