### PR TITLE
Fixed double loading because of file watcher

### DIFF
--- a/src/renderer/hooks/useWatchFiles.ts
+++ b/src/renderer/hooks/useWatchFiles.ts
@@ -17,6 +17,7 @@ const callListeners = (file: string) => {
 const watcher = new FSWatcher({
     disableGlobbing: true,
     awaitWriteFinish: true,
+    ignoreInitial: true,
     persistent: false,
 });
 watcher.on('error', (e) => log.error(e));


### PR DESCRIPTION
When making a new Load Image or Load Model node, the file watcher will no longer cause the selected file to be loaded twice.