### PR TITLE
No deep copies

### DIFF
--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -259,7 +259,7 @@ export interface NodeData {
     readonly groupState?: GroupState;
     readonly inputSize?: InputSize;
     readonly invalid?: boolean;
-    readonly iteratorSize?: IteratorSize;
+    readonly iteratorSize?: Readonly<IteratorSize>;
     readonly percentComplete?: number;
     readonly minWidth?: number;
     readonly minHeight?: number;

--- a/src/renderer/contexts/GlobalNodeState.tsx
+++ b/src/renderer/contexts/GlobalNodeState.tsx
@@ -59,12 +59,13 @@ import {
 import {
     NodeProto,
     copyEdges,
-    copyNode,
     copyNodes,
     createNode as createNodeImpl,
     defaultIteratorSize,
     expandSelection,
     setSelected,
+    withNewData,
+    withNewDataMap,
 } from '../helpers/reactFlowUtil';
 import { GetSetState, SetState } from '../helpers/types';
 import { useAsyncEffect } from '../hooks/useAsyncEffect';
@@ -931,12 +932,10 @@ export const GlobalProvider = memo(
                         return old;
                     }
 
-                    const nodeCopy = copyNode(old);
-                    nodeCopy.data.inputData = {
-                        ...nodeCopy.data.inputData,
+                    return withNewData(old, 'inputData', {
+                        ...old.data.inputData,
                         [inputId]: value,
-                    };
-                    return nodeCopy;
+                    });
                 });
                 addInputDataChanges();
             },
@@ -952,9 +951,8 @@ export const GlobalProvider = memo(
                 const currentSize = inputSize?.[inputId];
                 const setInputSize = (size: Readonly<Size>) => {
                     modifyNode(id, (old) => {
-                        const nodeCopy = copyNode(old);
-                        const newInputSize: Record<string, Size> = {
-                            ...nodeCopy.data.inputSize,
+                        const newInputSize: Record<string, Readonly<Size>> = {
+                            ...old.data.inputSize,
                             [inputId]: size,
                         };
                         Object.entries(newInputSize).forEach(([key, value]) => {
@@ -963,8 +961,7 @@ export const GlobalProvider = memo(
                                 width: size.width,
                             };
                         });
-                        nodeCopy.data.inputSize = newInputSize;
-                        return nodeCopy;
+                        return withNewData(old, 'inputSize', newInputSize);
                     });
                 };
                 return [currentSize, setInputSize] as const;
@@ -1023,13 +1020,14 @@ export const GlobalProvider = memo(
 
         const toggleNodeLock = useCallback(
             (id: string) => {
-                modifyNode(id, (old) => {
+                modifyNode(id, (old): Node<NodeData> => {
                     const isLocked = old.data.isLocked ?? false;
-                    const newNode = copyNode(old);
-                    newNode.draggable = isLocked;
-                    newNode.connectable = isLocked;
-                    newNode.data.isLocked = !isLocked;
-                    return newNode;
+                    return {
+                        ...old,
+                        draggable: isLocked,
+                        connectable: isLocked,
+                        data: { ...old.data, isLocked: !isLocked },
+                    };
                 });
             },
             [modifyNode]
@@ -1051,9 +1049,7 @@ export const GlobalProvider = memo(
         const setIteratorSize = useCallback(
             (id: string, size: IteratorSize) => {
                 modifyNode(id, (old) => {
-                    const newNode = copyNode(old);
-                    newNode.data.iteratorSize = size;
-                    return newNode;
+                    return withNewData(old, 'iteratorSize', size);
                 });
             },
             [modifyNode]
@@ -1078,36 +1074,34 @@ export const GlobalProvider = memo(
                             );
                         });
                         const newNodes = nodesToUpdate.map((n) => {
-                            const newNode = copyNode(n);
                             const wBound = width - (n.width ?? dimensions?.width ?? 0) + offsetLeft;
                             const hBound =
                                 height - (n.height ?? dimensions?.height ?? 0) + offsetTop;
-                            newNode.extent = [
-                                [offsetLeft, offsetTop],
-                                [wBound, hBound],
-                            ];
-                            newNode.position.x = Math.min(
-                                Math.max(newNode.position.x, offsetLeft),
-                                wBound
-                            );
-                            newNode.position.y = Math.min(
-                                Math.max(newNode.position.y, offsetTop),
-                                hBound
-                            );
+                            const newNode: Node<NodeData> = {
+                                ...n,
+                                extent: [
+                                    [offsetLeft, offsetTop],
+                                    [wBound, hBound],
+                                ],
+                                position: {
+                                    x: Math.min(Math.max(n.position.x, offsetLeft), wBound),
+                                    y: Math.min(Math.max(n.position.y, offsetTop), hBound),
+                                },
+                            };
                             return newNode;
                         });
 
-                        const newIteratorNode = copyNode(iteratorNode);
-
-                        newIteratorNode.data.minWidth = minWidth;
-                        newIteratorNode.data.minHeight = minHeight;
-                        // TODO: prove that those non-null assertions are valid or make them unnecessary
-                        newIteratorNode.data.iteratorSize!.width =
-                            width < minWidth ? minWidth : width;
-                        newIteratorNode.data.iteratorSize!.height =
-                            height < minHeight ? minHeight : height;
                         return [
-                            newIteratorNode,
+                            withNewDataMap(iteratorNode, {
+                                minWidth,
+                                minHeight,
+                                iteratorSize: {
+                                    offsetTop,
+                                    offsetLeft,
+                                    width: Math.max(width, minWidth),
+                                    height: Math.max(height, minHeight),
+                                },
+                            }),
                             ...nodes.filter((n) => n.parentNode !== id && n.id !== id),
                             ...newNodes,
                         ];
@@ -1124,8 +1118,7 @@ export const GlobalProvider = memo(
                 rfSetNodes((nodes) => {
                     const foundNode = nodes.find((n) => n.id === id);
                     if (foundNode) {
-                        const newNode = copyNode(foundNode);
-                        newNode.data.percentComplete = percent;
+                        const newNode = withNewData(foundNode, 'percentComplete', percent);
                         return [...nodes.filter((n) => n.id !== id), newNode];
                     }
                     return nodes;
@@ -1195,9 +1188,11 @@ export const GlobalProvider = memo(
             (ids: readonly string[]) => {
                 ids.forEach((id) => {
                     modifyNode(id, (old) => {
-                        const newNode = copyNode(old);
-                        newNode.data.inputData = schemata.getDefaultInput(old.data.schemaId);
-                        return newNode;
+                        return withNewData(
+                            old,
+                            'inputData',
+                            schemata.getDefaultInput(old.data.schemaId)
+                        );
                     });
                     outputDataActions.delete(id);
                     addInputDataChanges();
@@ -1210,9 +1205,7 @@ export const GlobalProvider = memo(
         const setNodeDisabled = useCallback(
             (id: string, isDisabled: boolean): void => {
                 modifyNode(id, (n) => {
-                    const newNode = copyNode(n);
-                    newNode.data.isDisabled = isDisabled;
-                    return newNode;
+                    return withNewData(n, 'isDisabled', isDisabled);
                 });
             },
             [modifyNode]

--- a/src/renderer/helpers/reactFlowUtil.ts
+++ b/src/renderer/helpers/reactFlowUtil.ts
@@ -87,6 +87,19 @@ export const isSnappedToGrid = (
 ): boolean => position.x % snapToGridAmount === 0 && position.y % snapToGridAmount === 0;
 
 export const copyNode = (node: Readonly<Node<NodeData>>): Node<Mutable<NodeData>> => deepCopy(node);
+export const withNewData = <K extends keyof NodeData>(
+    node: Node<NodeData>,
+    key: K,
+    value: NodeData[K]
+): Node<NodeData> => {
+    if (node.data[key] === value) {
+        return node;
+    }
+    return { ...node, data: { ...node.data, [key]: value } };
+};
+export const withNewDataMap = (node: Node<NodeData>, update: Partial<NodeData>): Node<NodeData> => {
+    return { ...node, data: { ...node.data, ...update } };
+};
 
 export const setSelected = <T extends { selected?: boolean }>(
     selectable: readonly T[],


### PR DESCRIPTION
We used `copyNode` (which does a deep copy) all over the place. This caused suboptimal memoization, which caused the "Load Model in iterators endlessly reload" bug. 

The issue was as follows:
1. A new file watcher was registered whenever `inputData` changed.
2. Because of #1702, this caused the node to reload.
3. Reloading caused the size of the node to be updated.
4. This caused the iterator bounds check to update the bounds of the node, which created a deep copy.
5. Since the node was deep-copied, `inputData` is now a different object, so it changed. Go to step 1.

So while I was figuring that out, I removed all deep copies with shallow copies that only update what is absolutely necessary. This should make a few operations more efficient.