### PR TITLE
Add ISNet support and fix normalization bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ chaiNNer currently supports a limited amount of neural network architectures. Mo
 #### Background Removal
 
 - [u2net](https://github.com/danielgatis/rembg) | [u2net](https://github.com/danielgatis/rembg/releases/download/v0.0.0/u2net.onnx), [u2netp](https://github.com/danielgatis/rembg/releases/download/v0.0.0/u2netp.onnx), [u2net_cloth_seg](https://github.com/danielgatis/rembg/releases/download/v0.0.0/u2net_cloth_seg.onnx), [u2net_human_seg](https://github.com/danielgatis/rembg/releases/download/v0.0.0/u2net_human_seg.onnx), [silueta](https://github.com/danielgatis/rembg/releases/download/v0.0.0/silueta.onnx)
+- [isnet](https://github.com/xuebinqin/DIS) | [isnet](https://github.com/danielgatis/rembg/releases/download/v0.0.0/isnet-general-use.onnx)
 
 ## Troubleshooting
 

--- a/backend/src/nodes/impl/onnx/model.py
+++ b/backend/src/nodes/impl/onnx/model.py
@@ -14,6 +14,9 @@ U2NET_CLOTH = re2.compile(
     re2_options,
 )
 U2NET_SILUETA = re2.compile(b"1808.+1827.+1828.+2296.+1831.+1850.+1958", re2_options)
+U2NET_ISNET = re2.compile(
+    b"/stage1/rebnconvin/conv_s1/Conv.+/stage1/rebnconvin/relu_s1/Relu", re2_options
+)
 
 
 class OnnxGeneric:
@@ -41,6 +44,7 @@ def is_rembg_model(model_as_bytes: bytes) -> bool:
         U2NET_STANDARD.search(model_as_bytes[-600:]) is not None
         or U2NET_CLOTH.search(model_as_bytes[-1000:]) is not None
         or U2NET_SILUETA.search(model_as_bytes[-600:]) is not None
+        or U2NET_ISNET.search(model_as_bytes[:10000]) is not None
     ):
         return True
     return False
@@ -50,6 +54,7 @@ def load_onnx_model(model_as_bytes: bytes) -> OnnxModel:
     if (
         U2NET_STANDARD.search(model_as_bytes[-1000:]) is not None
         or U2NET_SILUETA.search(model_as_bytes[-600:]) is not None
+        or U2NET_ISNET.search(model_as_bytes[:10000]) is not None
     ):
         model = OnnxRemBg(model_as_bytes)
     elif U2NET_CLOTH.search(model_as_bytes[-1000:]) is not None:

--- a/backend/src/nodes/impl/rembg/bg.py
+++ b/backend/src/nodes/impl/rembg/bg.py
@@ -18,6 +18,7 @@ from PIL import Image
 from PIL.Image import Image as PILImage
 from scipy.ndimage import binary_erosion
 
+from ...impl.image_utils import normalize
 from ...utils.utils import get_h_w_c
 from .pymatting.estimate_alpha_cf import estimate_alpha_cf
 from .pymatting.estimate_foreground_ml import estimate_foreground_ml
@@ -151,4 +152,4 @@ def remove_bg(
     if len(cutouts) > 0:
         cutout = get_concat_v_multi(cutouts)
 
-    return cvtColor(np.asarray(cutout), COLOR_RGBA2BGRA), np.asarray(mask)  # type: ignore  pylint: disable=undefined-loop-variable
+    return cvtColor(normalize(np.asarray(cutout)), COLOR_RGBA2BGRA), normalize(np.asarray(mask))  # type: ignore  pylint: disable=undefined-loop-variable

--- a/backend/src/nodes/impl/rembg/session_base.py
+++ b/backend/src/nodes/impl/rembg/session_base.py
@@ -1,6 +1,5 @@
 from typing import Dict, List, Tuple
 
-import cv2
 import numpy as np
 import onnxruntime as ort
 from PIL import Image

--- a/backend/src/nodes/impl/rembg/session_base.py
+++ b/backend/src/nodes/impl/rembg/session_base.py
@@ -1,5 +1,6 @@
 from typing import Dict, List, Tuple
 
+import cv2
 import numpy as np
 import onnxruntime as ort
 from PIL import Image
@@ -7,25 +8,27 @@ from PIL.Image import Image as PILImage
 
 
 class BaseSession:
-    def __init__(self, inner_session: ort.InferenceSession):
-        self.inner_session = inner_session
-
-    def normalize(
+    def __init__(
         self,
-        img: PILImage,
+        inner_session: ort.InferenceSession,
         mean: Tuple[float, float, float],
         std: Tuple[float, float, float],
         size: Tuple[int, int],
-    ) -> Dict[str, np.ndarray]:
-        im = img.convert("RGB").resize(size, Image.LANCZOS)
+    ):
+        self.inner_session = inner_session
+        self.mean = mean
+        self.std = std
+        self.size = size
 
+    def normalize(self, img: PILImage) -> Dict[str, np.ndarray]:
+        im = img.convert("RGB").resize(self.size, Image.LANCZOS)
         im_ary = np.array(im)
         im_ary = im_ary / np.max(im_ary)
 
         tmpImg = np.zeros((im_ary.shape[0], im_ary.shape[1], 3))
-        tmpImg[:, :, 0] = (im_ary[:, :, 0] - mean[0]) / std[0]
-        tmpImg[:, :, 1] = (im_ary[:, :, 1] - mean[1]) / std[1]
-        tmpImg[:, :, 2] = (im_ary[:, :, 2] - mean[2]) / std[2]
+        tmpImg[:, :, 0] = (im_ary[:, :, 0] - self.mean[0]) / self.std[0]
+        tmpImg[:, :, 1] = (im_ary[:, :, 1] - self.mean[1]) / self.std[1]
+        tmpImg[:, :, 2] = (im_ary[:, :, 2] - self.mean[2]) / self.std[2]
 
         tmpImg = tmpImg.transpose((2, 0, 1))
 

--- a/backend/src/nodes/impl/rembg/session_cloth.py
+++ b/backend/src/nodes/impl/rembg/session_cloth.py
@@ -55,9 +55,7 @@ pallete3 = [
 
 class ClothSession(BaseSession):
     def predict(self, img: PILImage) -> List[PILImage]:
-        ort_outs = self.inner_session.run(
-            None, self.normalize(img, (0.5, 0.5, 0.5), (0.5, 0.5, 0.5), (768, 768))
-        )
+        ort_outs = self.inner_session.run(None, self.normalize(img))
 
         pred = ort_outs
         pred = log_softmax(pred[0], 1)

--- a/backend/src/nodes/impl/rembg/session_factory.py
+++ b/backend/src/nodes/impl/rembg/session_factory.py
@@ -11,9 +11,27 @@ from .session_simple import SimpleSession
 def new_session(session: ort.InferenceSession) -> BaseSession:
     session_class: Type[BaseSession]
 
-    if get_input_shape(session)[2] == 768:
+    input_width = get_input_shape(session)[2]
+
+    # Using size to determine session type and norm parameters is fragile,
+    # but at the moment I don't know a better way to detect architecture due
+    # to the lack of consistency in naming and outputs across arches and repos.
+    # It works right now because of the limited number of models supported,
+    # but if that expands, it may become necessary to find an alternative.
+    mean = (0.485, 0.456, 0.406)
+    std = (0.229, 0.224, 0.225)
+    size = (input_width, input_width) if input_width is not None else (320, 320)
+    if input_width == 768:  # U2NET cloth model
         session_class = ClothSession
+        mean = (0.5, 0.5, 0.5)
+        std = (0.5, 0.5, 0.5)
     else:
         session_class = SimpleSession
+        if input_width == 1024:  # ISNET
+            mean = (0.5, 0.5, 0.5)
+            std = (1, 1, 1)
+        elif input_width == 512:  # Models trained using anime-segmentation repo
+            mean = (0, 0, 0)
+            std = (1, 1, 1)
 
-    return session_class(session)
+    return session_class(session, mean, std, size)

--- a/backend/src/nodes/impl/rembg/session_simple.py
+++ b/backend/src/nodes/impl/rembg/session_simple.py
@@ -9,12 +9,7 @@ from .session_base import BaseSession
 
 class SimpleSession(BaseSession):
     def predict(self, img: PILImage) -> List[PILImage]:
-        ort_outs = self.inner_session.run(
-            None,
-            self.normalize(
-                img, (0.485, 0.456, 0.406), (0.229, 0.224, 0.225), (320, 320)
-            ),
-        )
+        ort_outs = self.inner_session.run(None, self.normalize(img))
 
         pred = ort_outs[0][:, 0, :, :]
 


### PR DESCRIPTION
Remove Background node was broken due to the normalized output check being added. This adds normalization to the outputs, as well as adding support for ISNet, which was just recently added to the main rembg repo.

It also supports a model that user Zarxrax is working on and presumably other u2net models trained using the SkyTNT anime-segmentation code (so long as the input size is 512). While everything works currently, it may become necessary to revisit parts of this later if additional models supported in the future overlap in input size with currently supported models, but require different mean/std for normalization.

Closes #1684 