### PR TITLE
Added type checking to inputs' `enforce`

### DIFF
--- a/backend/src/nodes/properties/inputs/base_input.py
+++ b/backend/src/nodes/properties/inputs/base_input.py
@@ -67,12 +67,12 @@ class BaseInput:
         self.id: InputId = InputId(-1)
 
     # This is the method that should be created by each input
-    def enforce(self, value):
+    def enforce(self, value: object):
         """Enforce the input type"""
         return value
 
     # This is the method that should be called by the processing code
-    def enforce_(self, value):
+    def enforce_(self, value: object | None):
         if self.optional and value is None:
             return None
         assert value is not None, (

--- a/backend/src/nodes/properties/inputs/file_inputs.py
+++ b/backend/src/nodes/properties/inputs/file_inputs.py
@@ -119,6 +119,7 @@ class DirectoryInput(BaseInput):
         """
 
     def enforce(self, value):
+        assert isinstance(value, str)
         assert os.path.exists(value), f"Directory {value} does not exist"
         return value
 

--- a/backend/src/nodes/properties/inputs/numeric_inputs.py
+++ b/backend/src/nodes/properties/inputs/numeric_inputs.py
@@ -92,6 +92,7 @@ class NumberInput(BaseInput):
         raise ValueError("NumberInput and SliderInput cannot be made optional")
 
     def enforce(self, value):
+        assert isinstance(value, (int, float))
         return clampNumber(value, self.precision, self.minimum, self.maximum)
 
 

--- a/backend/src/nodes/properties/inputs/numpy_inputs.py
+++ b/backend/src/nodes/properties/inputs/numpy_inputs.py
@@ -2,6 +2,8 @@
 
 from typing import List, Optional, Union
 
+import numpy as np
+
 from ...impl.image_utils import get_h_w_c, normalize
 from ...utils.format import format_image_with_channels
 from .. import expression
@@ -35,6 +37,7 @@ class ImageInput(BaseInput):
         )
 
     def enforce(self, value):
+        assert isinstance(value, np.ndarray)
         _, _, c = get_h_w_c(value)
 
         if self.channels is not None and c not in self.channels:

--- a/backend/src/nodes/properties/inputs/onnx_inputs.py
+++ b/backend/src/nodes/properties/inputs/onnx_inputs.py
@@ -1,4 +1,4 @@
-from ...impl.onnx.model import is_rembg_model
+from ...impl.onnx.model import OnnxModels, is_rembg_model
 from ...properties.expression import ExpressionJson, intersect
 from .base_input import BaseInput
 from .generic_inputs import DropDownInput
@@ -18,6 +18,7 @@ class OnnxGenericModelInput(OnnxModelInput):
         super().__init__(label, intersect(input_type, "OnnxGenericModel"))
 
     def enforce(self, value):
+        assert isinstance(value, OnnxModels)
         assert not is_rembg_model(value.bytes), "Expected a non-rembg model"
         return value
 
@@ -29,6 +30,7 @@ class OnnxRemBgModelInput(OnnxModelInput):
         super().__init__(label, intersect(input_type, "OnnxRemBgModel"))
 
     def enforce(self, value):
+        assert isinstance(value, OnnxModels)
         assert is_rembg_model(value.bytes), "Expected a rembg model"
         return value
 


### PR DESCRIPTION
I added `object` as the type hint for `value` in `enforce`. This forces all subclasses of `BaseInput` to check the type of `value` before using it. This makes all `enforce` implementations type-checkable, which is good for correctness. The forced type check also means that inputs enforce correct values better now.