### PR TITLE
Fix ESRGAN-2c2 scale detection

### DIFF
--- a/backend/src/nodes/impl/pytorch/architecture/RRDB.py
+++ b/backend/src/nodes/impl/pytorch/architecture/RRDB.py
@@ -82,7 +82,7 @@ class RRDBNet(nn.Module):
         c2x2 = False
         if self.state["model.0.weight"].shape[-2] == 2:
             c2x2 = True
-            self.scale = int((self.scale / 4) ** 1 / 2)
+            self.scale = int((self.scale / 4) ** 0.5)
             self.model_arch = "ESRGAN-2c2"
 
         self.supports_fp16 = True

--- a/backend/src/nodes/impl/pytorch/architecture/RRDB.py
+++ b/backend/src/nodes/impl/pytorch/architecture/RRDB.py
@@ -82,7 +82,7 @@ class RRDBNet(nn.Module):
         c2x2 = False
         if self.state["model.0.weight"].shape[-2] == 2:
             c2x2 = True
-            self.scale = math.ceil(self.scale ** (1.0 / 3))
+            self.scale = int((self.scale / 4) ** 1 / 2)
             self.model_arch = "ESRGAN-2c2"
 
         self.supports_fp16 = True

--- a/backend/src/nodes/impl/pytorch/architecture/RRDB.py
+++ b/backend/src/nodes/impl/pytorch/architecture/RRDB.py
@@ -82,7 +82,7 @@ class RRDBNet(nn.Module):
         c2x2 = False
         if self.state["model.0.weight"].shape[-2] == 2:
             c2x2 = True
-            self.scale = int((self.scale / 4) ** 0.5)
+            self.scale = math.round(math.sqrt(self.scale / 4))
             self.model_arch = "ESRGAN-2c2"
 
         self.supports_fp16 = True


### PR DESCRIPTION
I was doing a cube root, which worked perfectly fine for 4x, but broke at 2x. Turns out I actually needed to do a /4 then a sqrt. 