### PR TITLE
Create float32 ones and zeros

### DIFF
--- a/backend/src/nodes/impl/dithering/color_distance.py
+++ b/backend/src/nodes/impl/dithering/color_distance.py
@@ -75,9 +75,9 @@ def batch_nearest_palette_color(
         )
 
     output = np.zeros(
-        (image.shape[0], image.shape[1], palette.shape[2]), dtype="float32"
+        (image.shape[0], image.shape[1], palette.shape[2]), dtype=np.float32
     )
-    low_water_mark = np.zeros((image.shape[0], image.shape[1]), dtype="float32")
+    low_water_mark = np.zeros((image.shape[0], image.shape[1]), dtype=np.float32)
 
     for idx in range(palette.shape[1]):
         color = palette[0, idx, :]

--- a/backend/src/nodes/impl/ncnn/optimizer.py
+++ b/backend/src/nodes/impl/ncnn/optimizer.py
@@ -105,7 +105,7 @@ class NcnnOptimizer:
                 if layer.params[bias_term].value == 0:
                     # init bias as zero
                     layer.params[bias_term] = 1
-                    layer.add_weight("bias", np.zeros(channels, np.float32))
+                    layer.add_weight("bias", np.zeros(channels, dtype=np.float32))
 
                 weight = layer.weight_data["weight"].weight
                 layer.weight_data["weight"].weight = weight * (

--- a/backend/src/nodes/impl/normals/util.py
+++ b/backend/src/nodes/impl/normals/util.py
@@ -88,6 +88,6 @@ def xyz_to_octahedral_bgr(xyz: XYZ) -> np.ndarray:
 
     r = (r + 1) * 0.5
     g = (g + 1) * 0.5
-    b = np.zeros(x.shape)
+    b = np.zeros(x.shape, dtype=np.float32)
 
     return np.dstack((b, g, r))

--- a/backend/src/packages/chaiNNer_standard/image/create_images/create_noise.py
+++ b/backend/src/packages/chaiNNer_standard/image/create_images/create_noise.py
@@ -161,7 +161,7 @@ def create_noise_node(
             seed=seed.to_u32(),
         ).astype(np.float32) / (width * height - 1)
 
-    img = np.zeros((height, width), dtype="float32")
+    img = np.zeros((height, width), dtype=np.float32)
     brightness /= 100
 
     kwargs = {

--- a/backend/src/packages/chaiNNer_standard/image_channel/all/combine_rgba.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/all/combine_rgba.py
@@ -55,7 +55,7 @@ def combine_rgba_node(
         img_b,
         img_g,
         img_r,
-        img_a if img_a is not None else np.ones(start_shape),
+        img_a if img_a is not None else np.ones(start_shape, dtype=np.float32),
     ]
 
     return np.stack(channels, axis=2)

--- a/backend/src/packages/chaiNNer_standard/image_channel/all/rgba_separate.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/all/rgba_separate.py
@@ -40,7 +40,7 @@ def separate_rgba(
     img: np.ndarray,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     h, w, c = get_h_w_c(img)
-    safe_out = np.ones((h, w))
+    safe_out = np.ones((h, w), dtype=np.float32)
 
     if img.ndim == 2:
         return img, safe_out, safe_out, safe_out

--- a/backend/src/packages/chaiNNer_standard/image_utility/compositing/stack.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/compositing/stack.py
@@ -123,7 +123,7 @@ def stack_node(
 
         # Expand channel dims if necessary
         if c < max_c:
-            temp_img = np.ones((max_h, max_w, max_c))
+            temp_img = np.ones((max_h, max_w, max_c), dtype=np.float32)
             temp_img[:, :, :c] = fixed_img
             fixed_img = temp_img
 


### PR DESCRIPTION
Rayan discovered a bug that prevented Combine RGBA from working if no alpha channel was given. The issue was `np.ones()` with `dtype` return a float64 image. This caused `np.stack` to promote all channels float64, so the output image was float64. Since #1655 this causes an error.

About #1655, I am currently working on output normalizing with an option to opt out of it. So hopefully stuff like this won't be an issue for much longer.