### PR TITLE
Output normalization

### DIFF
--- a/backend/src/nodes/properties/inputs/numpy_inputs.py
+++ b/backend/src/nodes/properties/inputs/numpy_inputs.py
@@ -4,7 +4,7 @@ from typing import List, Optional, Union
 
 import numpy as np
 
-from ...impl.image_utils import get_h_w_c, normalize
+from ...impl.image_utils import get_h_w_c
 from ...utils.format import format_image_with_channels
 from .. import expression
 from .base_input import BaseInput
@@ -47,10 +47,10 @@ class ImageInput(BaseInput):
                 f"The input {self.label} only supports {expected} but was given {actual}."
             )
 
-        if c == 1 and value.ndim == 3:
-            value = value[:, :, 0]
+        assert value.dtype == np.float32, "Expected the input image to be normalized."
+        assert c != 1 or value.ndim == 2, "Expected single-channel images to be 2D."
 
-        return normalize(value)
+        return value
 
 
 class VideoInput(BaseInput):

--- a/backend/src/nodes/properties/inputs/numpy_inputs.py
+++ b/backend/src/nodes/properties/inputs/numpy_inputs.py
@@ -48,7 +48,9 @@ class ImageInput(BaseInput):
             )
 
         assert value.dtype == np.float32, "Expected the input image to be normalized."
-        assert c != 1 or value.ndim == 2, "Expected single-channel images to be 2D."
+
+        if c == 1 and value.ndim == 3:
+            value = value[:, :, 0]
 
         return value
 

--- a/backend/src/nodes/properties/outputs/base_output.py
+++ b/backend/src/nodes/properties/outputs/base_output.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal, Union
+from typing import Literal
 
 from base_types import OutputId
 
@@ -20,7 +20,7 @@ class BaseOutput:
         self.output_type: expression.ExpressionJson = output_type
         self.label: str = label
         self.id: OutputId = OutputId(-1)
-        self.never_reason: Union[str, None] = None
+        self.never_reason: str | None = None
         self.kind: OutputKind = kind
         self.has_handle: bool = has_handle
 
@@ -34,7 +34,7 @@ class BaseOutput:
             "hasHandle": self.has_handle,
         }
 
-    def with_id(self, output_id: Union[OutputId, int]):
+    def with_id(self, output_id: OutputId | int):
         self.id = OutputId(output_id)
         return self
 
@@ -54,5 +54,6 @@ class BaseOutput:
     def get_broadcast_type(self, _value) -> expression.ExpressionJson | None:
         return None
 
-    def validate(self, value) -> None:
+    def enforce(self, value: object) -> object:
         assert value is not None
+        return value

--- a/backend/src/nodes/properties/outputs/file_outputs.py
+++ b/backend/src/nodes/properties/outputs/file_outputs.py
@@ -10,6 +10,9 @@ class FileOutput(BaseOutput):
     def __init__(self, file_type: expression.ExpressionJson, label: str):
         super().__init__(file_type, label)
 
+    def get_broadcast_data(self, value: str):
+        return value
+
     def enforce(self, value) -> str:
         assert isinstance(value, str)
         return value

--- a/backend/src/nodes/properties/outputs/file_outputs.py
+++ b/backend/src/nodes/properties/outputs/file_outputs.py
@@ -10,11 +10,9 @@ class FileOutput(BaseOutput):
     def __init__(self, file_type: expression.ExpressionJson, label: str):
         super().__init__(file_type, label)
 
-    def get_broadcast_data(self, value: str):
-        return value
-
-    def validate(self, value) -> None:
+    def enforce(self, value) -> str:
         assert isinstance(value, str)
+        return value
 
 
 class DirectoryOutput(BaseOutput):
@@ -32,5 +30,6 @@ class DirectoryOutput(BaseOutput):
     def get_broadcast_type(self, value: str):
         return expression.named("Directory", {"path": expression.literal(value)})
 
-    def validate(self, value) -> None:
+    def enforce(self, value) -> str:
         assert isinstance(value, str)
+        return value

--- a/backend/src/nodes/properties/outputs/generic_outputs.py
+++ b/backend/src/nodes/properties/outputs/generic_outputs.py
@@ -16,8 +16,9 @@ class NumberOutput(BaseOutput):
     def get_broadcast_type(self, value: int | float):
         return expression.literal(value)
 
-    def validate(self, value) -> None:
+    def enforce(self, value) -> int | float:
         assert isinstance(value, (int, float))
+        return value
 
 
 class TextOutput(BaseOutput):
@@ -31,8 +32,9 @@ class TextOutput(BaseOutput):
     def get_broadcast_type(self, value: str):
         return expression.literal(value)
 
-    def validate(self, value) -> None:
+    def enforce(self, value) -> str:
         assert isinstance(value, str)
+        return value
 
 
 def FileNameOutput(label: str = "Name", of_input: int | None = None):
@@ -49,5 +51,6 @@ class SeedOutput(BaseOutput):
     def __init__(self, label: str = "Seed"):
         super().__init__(output_type="Seed", label=label, kind="generic")
 
-    def validate(self, value) -> None:
+    def enforce(self, value) -> Seed:
         assert isinstance(value, Seed)
+        return value

--- a/backend/src/nodes/properties/outputs/numpy_outputs.py
+++ b/backend/src/nodes/properties/outputs/numpy_outputs.py
@@ -4,7 +4,7 @@ from typing import Optional, Tuple
 import cv2
 import numpy as np
 
-from ...impl.image_utils import to_uint8
+from ...impl.image_utils import normalize, to_uint8
 from ...impl.pil_utils import InterpolationMethod, resize
 from ...utils.format import format_image_with_channels
 from ...utils.utils import get_h_w_c
@@ -24,8 +24,9 @@ class NumPyOutput(BaseOutput):
     ):
         super().__init__(output_type, label, kind=kind, has_handle=has_handle)
 
-    def validate(self, value) -> None:
+    def enforce(self, value) -> np.ndarray:
         assert isinstance(value, np.ndarray)
+        return value
 
 
 def AudioOutput():
@@ -41,6 +42,7 @@ class ImageOutput(NumPyOutput):
         kind: OutputKind = "image",
         has_handle: bool = True,
         channels: Optional[int] = None,
+        assume_normalized: bool = False,
     ):
         super().__init__(
             expression.intersect(image_type, expression.Image(channels=channels)),
@@ -50,6 +52,7 @@ class ImageOutput(NumPyOutput):
         )
 
         self.channels: Optional[int] = channels
+        self.assume_normalized: bool = assume_normalized
 
     def get_broadcast_data(self, value: np.ndarray):
         h, w, c = get_h_w_c(value)
@@ -63,9 +66,8 @@ class ImageOutput(NumPyOutput):
         h, w, c = get_h_w_c(value)
         return expression.Image(width=w, height=h, channels=c)
 
-    def validate(self, value) -> None:
+    def enforce(self, value) -> np.ndarray:
         assert isinstance(value, np.ndarray)
-        assert value.dtype == np.float32
 
         _, _, c = get_h_w_c(value)
 
@@ -77,6 +79,21 @@ class ImageOutput(NumPyOutput):
                 f" This is a bug in the implementation of the node."
                 f" Please report this bug."
             )
+
+        # flatting 3D single-channel images to 2D
+        if c == 1 and value.ndim == 3:
+            value = value[:, :, 0]
+
+        if self.assume_normalized:
+            assert value.dtype == np.float32, (
+                f"The output {self.label} did not return a normalized image."
+                f" This is a bug in the implementation of the node."
+                f" Please report this bug."
+                f"\n\nTo the author of this node: Either use `normalize` or remove `assume_normalized=True` from this output."
+            )
+            return value
+
+        return normalize(value)
 
 
 def preview_encode(

--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/video_frame_iterator.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/video_frame_iterator.py
@@ -10,7 +10,7 @@ import ffmpeg
 import numpy as np
 from sanic.log import logger
 
-from nodes.impl.image_utils import normalize, to_uint8
+from nodes.impl.image_utils import to_uint8
 from nodes.properties.inputs import (
     BoolInput,
     DirectoryInput,
@@ -73,7 +73,7 @@ class Writer:
 def VideoFrameIteratorFrameLoaderNode(
     img: np.ndarray, idx: int, video_dir: str, video_name: str
 ) -> Tuple[np.ndarray, int, str, str]:
-    return normalize(img), idx, video_dir, video_name
+    return img, idx, video_dir, video_name
 
 
 @batch_processing_group.register(

--- a/backend/src/packages/chaiNNer_standard/image/create_images/create_color_gray.py
+++ b/backend/src/packages/chaiNNer_standard/image/create_images/create_color_gray.py
@@ -31,7 +31,8 @@ from .. import create_images_group
                 width="Input0",
                 height="Input1",
                 channels="1",
-            )
+            ),
+            assume_normalized=True,
         )
     ],
 )

--- a/backend/src/packages/chaiNNer_standard/image/create_images/create_color_rgb.py
+++ b/backend/src/packages/chaiNNer_standard/image/create_images/create_color_rgb.py
@@ -45,7 +45,8 @@ from .. import create_images_group
                 width="Input0",
                 height="Input1",
                 channels="3",
-            )
+            ),
+            assume_normalized=True,
         )
     ],
 )

--- a/backend/src/packages/chaiNNer_standard/image/create_images/create_color_rgba.py
+++ b/backend/src/packages/chaiNNer_standard/image/create_images/create_color_rgba.py
@@ -52,7 +52,8 @@ from .. import create_images_group
                 width="Input0",
                 height="Input1",
                 channels="4",
-            )
+            ),
+            assume_normalized=True,
         )
     ],
 )

--- a/backend/src/packages/chaiNNer_standard/image/create_images/create_noise.py
+++ b/backend/src/packages/chaiNNer_standard/image/create_images/create_noise.py
@@ -200,4 +200,4 @@ def create_noise_node(
                 kwargs["seed"] = (kwargs["seed"] + 1) % (2**32)
         img /= total_brightness
 
-    return np.clip(img, 0, 1)
+    return img

--- a/backend/src/packages/chaiNNer_standard/image/io/load_image.py
+++ b/backend/src/packages/chaiNNer_standard/image/io/load_image.py
@@ -11,7 +11,6 @@ from sanic.log import logger
 
 from nodes.impl.dds.texconv import dds_to_png_texconv
 from nodes.impl.image_formats import get_opencv_formats, get_pil_formats
-from nodes.impl.image_utils import normalize
 from nodes.properties.inputs import ImageFileInput
 from nodes.properties.outputs import DirectoryOutput, FileNameOutput, LargeImageOutput
 from nodes.utils.utils import get_h_w_c, split_file_path
@@ -145,7 +144,5 @@ def load_image_node(path: str) -> Tuple[np.ndarray, str, str]:
         raise RuntimeError(
             f'The image "{path}" you are trying to read cannot be read by chaiNNer.'
         )
-
-    img = normalize(img)
 
     return img, dirname, basename

--- a/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/brightness_and_contrast.py
+++ b/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/brightness_and_contrast.py
@@ -64,4 +64,4 @@ def brightness_and_contrast_node(
             axis=2,
         )
 
-    return np.clip(img, 0, 1)
+    return img

--- a/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/color_levels.py
+++ b/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/color_levels.py
@@ -111,4 +111,4 @@ def color_levels_node(
         out_white_all - out_black_all  # type: ignore
     ) + out_black_all
 
-    return np.clip(img, 0, 1)
+    return img

--- a/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/invert.py
+++ b/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/invert.py
@@ -15,7 +15,7 @@ from .. import adjustments_group
     description="Inverts all colors in an image.",
     icon="MdInvertColors",
     inputs=[ImageInput()],
-    outputs=[ImageOutput(image_type="Input0")],
+    outputs=[ImageOutput(image_type="Input0", assume_normalized=True)],
 )
 def invert_node(img: np.ndarray) -> np.ndarray:
     c = get_h_w_c(img)[2]

--- a/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/opacity.py
+++ b/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/opacity.py
@@ -27,7 +27,13 @@ from .. import adjustments_group
             unit="%",
         ),
     ],
-    outputs=[ImageOutput(image_type=expression.Image(size_as="Input0"), channels=4)],
+    outputs=[
+        ImageOutput(
+            image_type=expression.Image(size_as="Input0"),
+            channels=4,
+            assume_normalized=True,
+        )
+    ],
 )
 def opacity_node(img: np.ndarray, opacity: float) -> np.ndarray:
     """Apply opacity adjustment to alpha channel"""

--- a/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/threshold_adaptive.py
+++ b/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/threshold_adaptive.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import cv2
 import numpy as np
 
-from nodes.impl.image_utils import normalize, to_uint8
+from nodes.impl.image_utils import to_uint8
 from nodes.properties.inputs import (
     AdaptiveMethodInput,
     AdaptiveThresholdInput,
@@ -61,4 +61,4 @@ def adaptive_threshold_node(
         c,
     )
 
-    return normalize(result)
+    return result

--- a/backend/src/packages/chaiNNer_standard/image_channel/all/combine_rgba.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/all/combine_rgba.py
@@ -32,6 +32,7 @@ from . import node_group
                 height="Input0.height & Input1.height & Input2.height & match Input3 { Image as i => i.height, _ => any }",
             ),
             channels=4,
+            assume_normalized=True,
         ).with_never_reason(
             "The input channels have different sizes but must all be the same size."
         )

--- a/backend/src/packages/chaiNNer_standard/image_channel/all/rgba_separate.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/all/rgba_separate.py
@@ -23,16 +23,28 @@ from . import node_group
     inputs=[ImageInput()],
     outputs=[
         ImageOutput(
-            "R Channel", image_type=expression.Image(size_as="Input0"), channels=1
+            "R Channel",
+            image_type=expression.Image(size_as="Input0"),
+            channels=1,
+            assume_normalized=True,
         ).with_id(2),
         ImageOutput(
-            "G Channel", image_type=expression.Image(size_as="Input0"), channels=1
+            "G Channel",
+            image_type=expression.Image(size_as="Input0"),
+            channels=1,
+            assume_normalized=True,
         ).with_id(1),
         ImageOutput(
-            "B Channel", image_type=expression.Image(size_as="Input0"), channels=1
+            "B Channel",
+            image_type=expression.Image(size_as="Input0"),
+            channels=1,
+            assume_normalized=True,
         ).with_id(0),
         ImageOutput(
-            "A Channel", image_type=expression.Image(size_as="Input0"), channels=1
+            "A Channel",
+            image_type=expression.Image(size_as="Input0"),
+            channels=1,
+            assume_normalized=True,
         ),
     ],
 )

--- a/backend/src/packages/chaiNNer_standard/image_channel/transparency/transparency_merge.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/transparency/transparency_merge.py
@@ -27,6 +27,7 @@ from . import node_group
                 height="Input0.height & Input1.height",
             ),
             channels=4,
+            assume_normalized=True,
         ).with_never_reason(
             "The RGB and alpha channels have different sizes but must have the same size."
         )

--- a/backend/src/packages/chaiNNer_standard/image_channel/transparency/transparency_split.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/transparency/transparency_split.py
@@ -23,11 +23,13 @@ from . import node_group
             "RGB Channels",
             image_type=expression.Image(size_as="Input0"),
             channels=3,
+            assume_normalized=True,
         ),
         ImageOutput(
             "Alpha Channel",
             image_type=expression.Image(size_as="Input0"),
             channels=1,
+            assume_normalized=True,
         ),
     ],
 )

--- a/backend/src/packages/chaiNNer_standard/image_dimension/border/create_border.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/border/create_border.py
@@ -27,7 +27,8 @@ from .. import border_group
                 width="Input0.width + Input2 * 2",
                 height="Input0.height + Input2 * 2",
                 channels="BorderType::getOutputChannels(Input1, Input0.channels)",
-            )
+            ),
+            assume_normalized=True,
         )
     ],
 )

--- a/backend/src/packages/chaiNNer_standard/image_dimension/border/create_edges.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/border/create_edges.py
@@ -30,7 +30,8 @@ from .. import border_group
                 width="Input0.width + Input3 + Input4",
                 height="Input0.height + Input2 + Input5",
                 channels="BorderType::getOutputChannels(Input1, Input0.channels)",
-            )
+            ),
+            assume_normalized=True,
         )
     ],
 )

--- a/backend/src/packages/chaiNNer_standard/image_dimension/crop/crop_border.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/crop/crop_border.py
@@ -27,7 +27,8 @@ from .. import crop_group
                 width="(Input0.width - Input1 * 2) & int(1..)",
                 height="(Input0.height - Input1 * 2) & int(1..)",
                 channels_as="Input0",
-            )
+            ),
+            assume_normalized=True,
         ).with_never_reason(
             "The cropped area would result in an image with no width or no height."
         )

--- a/backend/src/packages/chaiNNer_standard/image_dimension/crop/crop_content.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/crop/crop_content.py
@@ -38,7 +38,8 @@ from .. import crop_group
                         channels: Input0.channels
                     }
                 }
-                """
+                """,
+            assume_normalized=True,
         )
     ],
 )

--- a/backend/src/packages/chaiNNer_standard/image_dimension/crop/crop_edges.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/crop/crop_edges.py
@@ -28,7 +28,8 @@ from .. import crop_group
                 width="(Input0.width - (Input2 + Input3)) & int(1..)",
                 height="(Input0.height - (Input1 + Input4)) & int(1..)",
                 channels_as="Input0",
-            )
+            ),
+            assume_normalized=True,
         ).with_never_reason(
             "The cropped area would result in an image with no width or no height."
         )

--- a/backend/src/packages/chaiNNer_standard/image_dimension/crop/crop_offsets.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/crop/crop_offsets.py
@@ -28,7 +28,8 @@ from .. import crop_group
                 width="min(Input4, Input0.width - Input2) & int(1..)",
                 height="min(Input3, Input0.height - Input1) & int(1..)",
                 channels_as="Input0",
-            )
+            ),
+            assume_normalized=True,
         ).with_never_reason(
             "The cropped area would result in an image with no width or no height."
         )

--- a/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize_factor.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize_factor.py
@@ -37,7 +37,8 @@ from .. import resize_group
                 width="max(1, int & round(Input0.width * Input1 / 100))",
                 height="max(1, int & round(Input0.height * Input1 / 100))",
                 channels_as="Input0",
-            )
+            ),
+            assume_normalized=True,
         )
     ],
 )

--- a/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize_resolution.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize_resolution.py
@@ -31,7 +31,8 @@ from .. import resize_group
                 width="Input1",
                 height="Input2",
                 channels="Input0.channels",
-            )
+            ),
+            assume_normalized=True,
         )
     ],
 )

--- a/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize_to_side.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize_to_side.py
@@ -163,7 +163,8 @@ def resize_to_side_conditional(
                     height: outSize.height,
                     channels: Input0.channels
                 }
-                """
+                """,
+            assume_normalized=True,
         )
     ],
 )

--- a/backend/src/packages/chaiNNer_standard/image_dimension/resize/tile_fill.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/resize/tile_fill.py
@@ -27,7 +27,8 @@ from .. import resize_group
                 width="Input1",
                 height="Input2",
                 channels="Input0.channels",
-            )
+            ),
+            assume_normalized=True,
         )
     ],
 )

--- a/backend/src/packages/chaiNNer_standard/image_filter/blur/box_blur.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/blur/box_blur.py
@@ -47,6 +47,4 @@ def box_blur_node(
         kernel[:, -1] *= x_d
 
     # Linear filter with reflected padding
-    return np.clip(
-        cv2.filter2D(img, -1, kernel, borderType=cv2.BORDER_REFLECT_101), 0, 1
-    )
+    return cv2.filter2D(img, -1, kernel, borderType=cv2.BORDER_REFLECT_101)

--- a/backend/src/packages/chaiNNer_standard/image_filter/blur/gauss_blur.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/blur/gauss_blur.py
@@ -29,6 +29,4 @@ def gaussian_blur_node(
     if sigma_x == 0 and sigma_y == 0:
         return img
     else:
-        return np.clip(
-            cv2.GaussianBlur(img, (0, 0), sigmaX=sigma_x, sigmaY=sigma_y), 0, 1
-        )
+        return cv2.GaussianBlur(img, (0, 0), sigmaX=sigma_x, sigmaY=sigma_y)

--- a/backend/src/packages/chaiNNer_standard/image_filter/blur/median_blur.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/blur/median_blur.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import cv2
 import numpy as np
 
-from nodes.impl.image_utils import normalize, to_uint8
+from nodes.impl.image_utils import to_uint8
 from nodes.properties.inputs import ImageInput, NumberInput
 from nodes.properties.outputs import ImageOutput
 
@@ -29,8 +29,6 @@ def median_blur_node(
         return img
     else:
         if radius < 3:
-            blurred = cv2.medianBlur(img, 2 * radius + 1)
+            return cv2.medianBlur(img, 2 * radius + 1)
         else:  # cv2 requires uint8 for kernel size (2r+1) > 5
-            blurred = cv2.medianBlur(to_uint8(img, normalized=True), 2 * radius + 1)
-
-        return normalize(blurred)
+            return cv2.medianBlur(to_uint8(img, normalized=True), 2 * radius + 1)

--- a/backend/src/packages/chaiNNer_standard/image_filter/correction/avg_color_fix.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/correction/avg_color_fix.py
@@ -93,4 +93,4 @@ def average_color_fix_node(
     if alpha is not None:
         result = np.concatenate([result, alpha], axis=2)
 
-    return np.clip(result, 0, 1)
+    return result

--- a/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/canny_edge_detection.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/canny_edge_detection.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import cv2
 import numpy as np
 
-from nodes.impl.image_utils import normalize, to_uint8
+from nodes.impl.image_utils import to_uint8
 from nodes.properties import expression
 from nodes.properties.inputs import ImageInput, NumberInput
 from nodes.properties.outputs import ImageOutput
@@ -30,5 +30,4 @@ def canny_edge_detection_node(
     t_lower: int,
     t_upper: int,
 ) -> np.ndarray:
-    edges = cv2.Canny(to_uint8(img, normalized=True), t_lower, t_upper)
-    return normalize(edges)
+    return cv2.Canny(to_uint8(img, normalized=True), t_lower, t_upper)

--- a/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/high_pass.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/high_pass.py
@@ -47,4 +47,4 @@ def high_pass_filter_node(
     if alpha is not None:
         img = np.dstack((img, alpha))
 
-    return np.clip(img, 0, 1)
+    return img

--- a/backend/src/packages/chaiNNer_standard/image_filter/noise/add_noise.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/noise/add_noise.py
@@ -58,7 +58,8 @@ class NoiseType(Enum):
                         Input0.channels,
                         match Input2 { NoiseColor::Rgb => 3, NoiseColor::Gray => 1 }
                     )
-                }"""
+                }""",
+            assume_normalized=True,
         )
     ],
 )

--- a/backend/src/packages/chaiNNer_standard/image_filter/sharpen/high_boost_sharpen.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/sharpen/high_boost_sharpen.py
@@ -53,6 +53,4 @@ def sharpen_hbf_node(
         kernel = identity - np.array([[0, 1, 0], [1, 1, 1], [0, 1, 0]]) / 5
 
     kernel = kernel * amount + identity
-    filtered_img = cv2.filter2D(img, -1, kernel)
-
-    return np.clip(filtered_img, 0, 1)
+    return cv2.filter2D(img, -1, kernel)

--- a/backend/src/packages/chaiNNer_standard/image_filter/sharpen/sharpen.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/sharpen/sharpen.py
@@ -57,4 +57,4 @@ def sharpen_node(
         diff = np.sign(diff) * np.maximum(0, np.abs(diff) - threshold)
         img += diff * amount
 
-    return np.clip(img, 0, 1)
+    return img

--- a/backend/src/packages/chaiNNer_standard/image_utility/compositing/blend.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/compositing/blend.py
@@ -31,7 +31,8 @@ from .. import compositing_group
                 width="max(Input0.width, Input1.width)",
                 height="max(Input0.height, Input1.height)",
                 channels="max(Input0.channels, Input1.channels)",
-            )
+            ),
+            assume_normalized=True,
         ),
     ],
 )

--- a/backend/src/packages/chaiNNer_standard/image_utility/compositing/caption.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/compositing/caption.py
@@ -30,7 +30,8 @@ from .. import compositing_group
                     height: Input0.height + captionHeight,
                     channels: Input0.channels,
                 }
-                """
+                """,
+            assume_normalized=True,
         )
     ],
 )

--- a/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/convert_color.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/convert_color.py
@@ -55,7 +55,8 @@ COLOR_SPACES_WITH_ALPHA_PARTNER = [
                         Input2.channels
                     }
                     """,
-            )
+            ),
+            assume_normalized=True,
         )
     ],
 )

--- a/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/inpaint.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/inpaint.py
@@ -5,7 +5,7 @@ from enum import Enum
 import cv2
 import numpy as np
 
-from nodes.impl.image_utils import normalize, to_uint8
+from nodes.impl.image_utils import to_uint8
 from nodes.properties import expression
 from nodes.properties.inputs import EnumInput, ImageInput, NumberInput
 from nodes.properties.outputs import ImageOutput
@@ -65,6 +65,4 @@ def inpaint_node(
 
     img = to_uint8(img, normalized=True)
     mask = to_uint8(mask, normalized=True)
-    result = cv2.inpaint(img, mask, radius, inpaint_method.value)
-
-    return normalize(result)
+    return cv2.inpaint(img, mask, radius, inpaint_method.value)

--- a/backend/src/packages/chaiNNer_standard/image_utility/modification/flip.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/modification/flip.py
@@ -18,7 +18,7 @@ from .. import modification_group
         ImageInput("Image"),
         EnumInput(FlipAxis),
     ],
-    outputs=[ImageOutput(image_type="Input0")],
+    outputs=[ImageOutput(image_type="Input0", assume_normalized=True)],
 )
 def flip_node(img: np.ndarray, axis: FlipAxis) -> np.ndarray:
     return axis.flip(img)

--- a/backend/src/packages/chaiNNer_standard/image_utility/modification/rotate.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/modification/rotate.py
@@ -100,7 +100,8 @@ from .. import modification_group
                     },
                     channels: FillColor::getOutputChannels(Input4, Input0.channels)
                 }
-                """
+                """,
+            assume_normalized=True,
         )
     ],
 )

--- a/backend/src/packages/chaiNNer_standard/image_utility/modification/shift.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/modification/shift.py
@@ -27,7 +27,8 @@ from .. import modification_group
                 width="Input0.width",
                 height="Input0.height",
                 channels="FillColor::getOutputChannels(Input3, Input0.channels)",
-            )
+            ),
+            assume_normalized=True,
         )
     ],
 )

--- a/backend/src/packages/chaiNNer_standard/material_textures/normal_map/normal_generator.py
+++ b/backend/src/packages/chaiNNer_standard/material_textures/normal_map/normal_generator.py
@@ -170,4 +170,4 @@ def normal_map_generator_node(
 
     channels = (b, g, r) if a is None else (b, g, r, a)
 
-    return np.clip(cv2.merge(channels), 0, 1)
+    return cv2.merge(channels)

--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -57,7 +57,7 @@ def to_output(raw_output: Any, node: NodeData) -> Output:
 
     # output-specific validations
     for i, o in enumerate(node.outputs):
-        o.validate(output[i])
+        output[i] = o.enforce(output[i])
 
     return output
 


### PR DESCRIPTION
This adds the output normalization I recently mentioned on discord. The main change is that `ImageInput` no longer normalizes, `ImageOutput` does the normalization instead. This is more efficient because:

1. A single output can be connected to multiple inputs. Previously, each input would normalize the image, resulting in duplicate work.
2. We can tell the output that the returned image is already normalized (`assume_normalized=True`).

Only when an image output is not used is the new system less efficient. However, this case is relatively rare and can be made equally efficient with `assume_normalized=True` for already normalized images. Luckily, this trick can be used for Separate RGBA and Split Transparency.