### PR TITLE
Added name check for enum variants

### DIFF
--- a/backend/src/nodes/properties/inputs/generic_inputs.py
+++ b/backend/src/nodes/properties/inputs/generic_inputs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from enum import Enum
 from typing import Dict, Generic, List, Literal, Tuple, Type, TypedDict, TypeVar, Union
 
@@ -156,6 +157,9 @@ class EnumInput(Generic[T], DropDownInput):
         for variant in enum:
             value = variant.value
             assert isinstance(value, (int, str))
+            assert (
+                re.match(r"^[a-zA-Z0-9_]+$", variant.name) is not None
+            ), f"Expected the name of {enum.__name__}.{variant.name} to be snake case."
 
             name = split_snake_case(variant.name)
             variant_type = f"{type_name}::{join_pascal_case(name)}"

--- a/backend/src/nodes/properties/inputs/generic_inputs.py
+++ b/backend/src/nodes/properties/inputs/generic_inputs.py
@@ -158,7 +158,7 @@ class EnumInput(Generic[T], DropDownInput):
             value = variant.value
             assert isinstance(value, (int, str))
             assert (
-                re.match(r"^[a-zA-Z0-9_]+$", variant.name) is not None
+                re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", variant.name) is not None
             ), f"Expected the name of {enum.__name__}.{variant.name} to be snake case."
 
             name = split_snake_case(variant.name)


### PR DESCRIPTION
`EnumInput` will generate invalid Navi code if enum variants don't have snake case names, so I added a check to test for this.