### PR TITLE
Completely remove hw acceleration option and disable it compeltely

### DIFF
--- a/src/main/gui/create.ts
+++ b/src/main/gui/create.ts
@@ -2,7 +2,6 @@ import { BrowserWindow, app, dialog } from 'electron';
 import log from 'electron-log';
 import { lazy } from '../../common/util';
 import { OpenArguments } from '../arguments';
-import { settingStorage } from '../setting-storage';
 import { createMainWindow } from './main-window';
 
 const setupErrorHandling = () => {
@@ -48,10 +47,7 @@ const setupErrorHandling = () => {
 export const createGuiApp = (args: OpenArguments) => {
     setupErrorHandling();
 
-    const disableHardwareAcceleration = settingStorage.getItem('disable-hw-accel') === 'true';
-    if (disableHardwareAcceleration) {
-        app.disableHardwareAcceleration();
-    }
+    app.disableHardwareAcceleration();
 
     const hasInstanceLock = app.requestSingleInstanceLock();
     if (!hasInstanceLock) {

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -634,9 +634,7 @@ const PythonSettings = memo(() => {
 });
 
 const AdvancedSettings = memo(() => {
-    const { useDisHwAccel, useCheckUpdOnStrtUp, useExperimentalFeatures } =
-        useContext(SettingsContext);
-    const [isDisHwAccel, setIsDisHwAccel] = useDisHwAccel;
+    const { useCheckUpdOnStrtUp, useExperimentalFeatures } = useContext(SettingsContext);
     const [isCheckUpdOnStrtUp, setIsCheckUpdOnStrtUp] = useCheckUpdOnStrtUp;
     const [isExperimentalFeatures, setIsExperimentalFeatures] = useExperimentalFeatures;
 
@@ -645,14 +643,6 @@ const AdvancedSettings = memo(() => {
             divider={<StackDivider />}
             w="full"
         >
-            <Toggle
-                description="Disable GPU hardware acceleration for rendering chaiNNer's UI. Only disable this is you know hardware acceleration is causing you issues."
-                title="Disable Hardware Acceleration (requires restart)"
-                value={isDisHwAccel}
-                onToggle={() => {
-                    setIsDisHwAccel((prev) => !prev);
-                }}
-            />
             <Toggle
                 description="Toggles checking for updates on start-up."
                 title="Check for Update on Start-up"

--- a/src/renderer/contexts/SettingsContext.tsx
+++ b/src/renderer/contexts/SettingsContext.tsx
@@ -17,7 +17,6 @@ interface Settings {
     useOnnxShouldTensorRtCache: GetSetState<boolean>;
     useIsSystemPython: GetSetState<boolean>;
     useSystemPythonLocation: GetSetState<string | null>;
-    useDisHwAccel: GetSetState<boolean>;
     useCheckUpdOnStrtUp: GetSetState<boolean>;
     useSnapToGrid: readonly [
         snapToGrid: boolean,
@@ -57,7 +56,6 @@ export const SettingsProvider = memo(({ children }: React.PropsWithChildren<unkn
     const useSystemPythonLocation = useMemoArray(
         useLocalStorage<string | null>('system-python-location', null)
     );
-    const useDisHwAccel = useMemoArray(useLocalStorage('disable-hw-accel', false));
     const useCheckUpdOnStrtUp = useMemoArray(useLocalStorage('check-upd-on-strtup', true));
     const useStartupTemplate = useMemoArray(useLocalStorage('startup-template', ''));
 
@@ -107,7 +105,6 @@ export const SettingsProvider = memo(({ children }: React.PropsWithChildren<unkn
         useIsSystemPython,
         useSystemPythonLocation,
         useSnapToGrid,
-        useDisHwAccel,
         useCheckUpdOnStrtUp,
         useStartupTemplate,
         useIsDarkMode,


### PR DESCRIPTION
Due to how slow upscaling becomes when HW acceleration is enabled, I don't think anyone should ever use it. If we ever get a complaint about someone wanting to enable it, maybe we can add a new option to enable it specifically, but for now, I say we just have it off for performance reasons.

![image](https://user-images.githubusercontent.com/34788790/230683385-49f72ce6-6dbc-44c6-b9ad-5e8f44504cef.png)
