### PR TITLE
Add checks for isDestroyed on window shows

### DIFF
--- a/src/main/gui/main-window.ts
+++ b/src/main/gui/main-window.ts
@@ -355,6 +355,16 @@ export const createMainWindow = async (args: OpenArguments) => {
         ipcMain.once('backend-ready', () => {
             progressController.submitProgress({ totalProgress: 1 });
 
+            if (mainWindow.isDestroyed()) {
+                dialog.showMessageBoxSync({
+                    type: 'error',
+                    title: 'Unable to start application',
+                    message: 'The main window was closed before the backend was ready.',
+                });
+                app.quit();
+                return;
+            }
+
             mainWindow.show();
             if (lastWindowSize?.maximized) {
                 mainWindow.maximize();

--- a/src/main/gui/splash.ts
+++ b/src/main/gui/splash.ts
@@ -69,9 +69,6 @@ export const addSplashScreen = (monitor: ProgressMonitor) => {
 
     monitor.addProgressListener((progress) => {
         lastProgress = { ...progress };
-        if (!splash.isDestroyed()) {
-            splash.webContents.send('splash-setup-progress', progress);
-        }
 
         if (progress.totalProgress === 1) {
             progressFinished = true;

--- a/src/main/gui/splash.ts
+++ b/src/main/gui/splash.ts
@@ -62,7 +62,9 @@ export const addSplashScreen = (monitor: ProgressMonitor) => {
     }, 100);
 
     splash.once('ready-to-show', () => {
-        splash.show();
+        if (!splash.isDestroyed()) {
+            splash.show();
+        }
     });
 
     monitor.addProgressListener((progress) => {

--- a/src/main/gui/splash.ts
+++ b/src/main/gui/splash.ts
@@ -69,7 +69,9 @@ export const addSplashScreen = (monitor: ProgressMonitor) => {
 
     monitor.addProgressListener((progress) => {
         lastProgress = { ...progress };
-        splash.webContents.send('splash-setup-progress', progress);
+        if (!splash.isDestroyed()) {
+            splash.webContents.send('splash-setup-progress', progress);
+        }
 
         if (progress.totalProgress === 1) {
             progressFinished = true;
@@ -82,7 +84,9 @@ export const addSplashScreen = (monitor: ProgressMonitor) => {
 
         let messageBoxOptions: MessageBoxOptions;
         if (interrupt.type === 'critical error') {
-            splash.hide();
+            if (!splash.isDestroyed()) {
+                splash.hide();
+            }
 
             messageBoxOptions = {
                 type: 'error',


### PR DESCRIPTION
I think what might be happening for #1665 #1691 and #1700 is the splash finishes before the DOM is ready, so it gets destroyed before it calls .show(). If that is what's happening, this should fix that. If that isn't what's happening, and it's the main window getting destroyed before the backend starts, we should get a more clear error message. Regardless, this is probably a good change.

closes #1665 
closes #1691 
closes #1700