### PR TITLE
Better generated error reports

### DIFF
--- a/src/main/gui/create.ts
+++ b/src/main/gui/create.ts
@@ -5,6 +5,10 @@ import { OpenArguments } from '../arguments';
 import { settingStorage } from '../setting-storage';
 import { createMainWindow } from './main-window';
 
+const mdCodeBlock = (code: string): string => {
+    return `\`\`\`\n${code}\n\`\`\``;
+};
+
 const setupErrorHandling = () => {
     log.catchErrors({
         showDialog: false,
@@ -19,10 +23,14 @@ const setupErrorHandling = () => {
                 })
                 .then((result) => {
                     if (result.response === 1) {
+                        const stack = error.stack
+                            ? `\n${error.stack.replace(String(error), '')}`
+                            : '';
+
                         submitIssue!('https://github.com/chaiNNer-org/chaiNNer/issues/new', {
                             title: `Error report: ${error.message}`,
                             body: [
-                                `\`\`\`\n${String(error)}\n\`\`\``,
+                                mdCodeBlock(String(error) + stack),
                                 `ChaiNNer: ${String(versions?.app)}`,
                                 `OS: ${String(versions?.os)}`,
                             ].join('\n'),
@@ -33,15 +41,6 @@ const setupErrorHandling = () => {
                 })
                 .catch((e) => log.error(e));
         },
-    });
-
-    process.on('uncaughtException', (error) => {
-        dialog.showMessageBoxSync({
-            type: 'error',
-            title: 'Error in Main process',
-            message: `Something failed: ${String(error)}`,
-        });
-        app.exit(1);
     });
 };
 
@@ -59,7 +58,11 @@ export const createGuiApp = (args: OpenArguments) => {
     }
 
     const createWindow = lazy(() => {
-        createMainWindow(args).catch((error) => log.error(error));
+        createMainWindow(args).catch((error) => {
+            log.error(error);
+            // rethrow to let the global error handler deal with it
+            return Promise.reject(error);
+        });
     });
 
     // This method will be called when Electron has finished

--- a/src/main/gui/menu.ts
+++ b/src/main/gui/menu.ts
@@ -6,7 +6,7 @@ import { isMac } from '../../common/env';
 import { links } from '../../common/links';
 import { BrowserWindowWithSafeIpc } from '../../common/safeIpc';
 import { openSaveFile } from '../../common/SaveFile';
-import { getRootDirSync } from '../platform';
+import { getLogsFolder } from '../platform';
 import { getCpuInfo, getGpuInfo } from '../systemInfo';
 
 export interface MenuData {
@@ -233,7 +233,7 @@ export const setMainMenu = ({ mainWindow, menuData, enabled = false }: MainMenuA
                 {
                     label: 'Open logs folder',
                     click: async () => {
-                        await shell.openPath(path.join(getRootDirSync(), 'logs'));
+                        await shell.openPath(getLogsFolder());
                     },
                 },
                 {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -8,13 +8,13 @@ import { parseArgs } from './arguments';
 import { createCli } from './cli/create';
 import { runChainInCli } from './cli/run';
 import { createGuiApp } from './gui/create';
-import { getRootDirSync } from './platform';
+import { getLogsFolder, getRootDirSync } from './platform';
 
 const startApp = () => {
     const args = parseArgs(process.argv.slice(app.isPackaged ? 1 : 2));
 
     log.transports.file.resolvePath = (variables) =>
-        path.join(getRootDirSync(), 'logs', variables.fileName!);
+        path.join(getLogsFolder(), variables.fileName!);
     log.transports.file.level = 'info';
 
     process.env.ELECTRON_DISABLE_SECURITY_WARNINGS = 'true';

--- a/src/main/platform.ts
+++ b/src/main/platform.ts
@@ -32,3 +32,7 @@ export const getRootDirSync = lazy((): string => {
     const rootDir = isPortable ? currentExecutableDir : app.getPath('userData');
     return rootDir;
 });
+
+export const getLogsFolder = lazy((): string => {
+    return path.join(getRootDirSync(), 'logs');
+});


### PR DESCRIPTION
Changes:
1. Added stack trace to generated error reports. This would have prevented the guess work around #1723.
2. `createWindow` now rethrows the error to delegate to the global error handler.
3. Removed `process.on('uncaughtException', ...)`. `log.catchErrors` already handles this, so uncaught exceptions produced 2 error dialogs.
4. Added `getLogsFolder`. I originally also wanted to include the logs directly into the generated GH issue, but that turned out to be not possible. (These generated issues work via URL params (e.g. `github.com/chainner/chainner/issues/new?body=my+body`) and GH has a hard limit on how long those URLs can be. The limit is around 1~2KB, which isn't a lot of characters and even less log file lines.) I thought that the change was good regardless, so I kept it.