### PR TITLE
Consider output error for connectability

### DIFF
--- a/src/common/types/function.ts
+++ b/src/common/types/function.ts
@@ -606,4 +606,16 @@ export class FunctionInstance {
         // we say that types A is assignable to type B if they are not disjoint
         return !isDisjointWith(iType, this.definition.convertInput(inputId, type));
     }
+
+    /**
+     * Returns a new function instance with the given input assigned to the given type.
+     */
+    withInput(inputId: InputId, type: NonNeverType): FunctionInstance {
+        return FunctionInstance.fromPartialInputs(this.definition, (id) => {
+            if (id === inputId) {
+                return type;
+            }
+            return this.inputs.get(id);
+        });
+    }
 }


### PR DESCRIPTION
Resolves #1673.

If PR makes it so that inputs are not connectable of the assigned type would cause an output error. So if the target node is valid (no output errors), but the new connections would create output errors, then we don't allow that connection. Examples:

![image](https://user-images.githubusercontent.com/20878432/230741521-bc903502-bd8f-4466-a586-404d292736f6.png)
![image](https://user-images.githubusercontent.com/20878432/230741523-86e31b83-4775-4c2d-8aff-7830d07122ed.png)

While this enforces the general idea "if it's connectable, it's valid," it also makes it a little harder to edit chains.

E.g. in the Guided Upscale example, I initially had source and guide the other way around by accident. Chainner would not let me assign the other input with the intended value until I removed the old (invalid) connection.

Frankly, I don't know whether I like this. A new user might not realize that they have to remove old invalid connections before they can connect their intended value. This might "trap" new users and lead to frustration. But maybe I'm overthinking here.

**Please test this feature and see whether this feature is desirable.**