### PR TITLE
Fix "copy audio" when input video does not have audio stream

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/video_frame_iterator.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/video_frame_iterator.py
@@ -264,14 +264,20 @@ async def SimpleVideoFrameIteratorNode(path: str, context: IteratorContext) -> N
         if "gif" not in ext.lower():
             full_out_path = f"{base}_audio{ext}"
             audio_stream = ffmpeg.input(path).audio
-            video_stream = ffmpeg.input(out_path)
-            output_video = ffmpeg.output(
-                audio_stream,
-                video_stream,
-                full_out_path,
-                vcodec="copy",
-            ).overwrite_output()
-            ffmpeg.run(output_video)
-            # delete original, rename new
-            os.remove(out_path)
-            os.rename(full_out_path, out_path)
+            try:
+                if audio_stream is not None:
+                    video_stream = ffmpeg.input(out_path)
+                    output_video = ffmpeg.output(
+                        audio_stream,
+                        video_stream,
+                        full_out_path,
+                        vcodec="copy",
+                    ).overwrite_output()
+                    ffmpeg.run(output_video)
+                    # delete original, rename new
+                    os.remove(out_path)
+                    os.rename(full_out_path, out_path)
+            except:
+                logger.warning(
+                    f"Failed to copy audio to video, input file probably contains no audio. Ignoring audio copy."
+                )


### PR DESCRIPTION
something i noticed when testing #1730. As far as I could tell, there was no good way to actually check if the audio stream container actually had an audio stream (it was logging some weird stuff) so I just wrapped it with a try/except