### PR TITLE
Fixed iterator progress

### DIFF
--- a/src/renderer/contexts/ExecutionContext.tsx
+++ b/src/renderer/contexts/ExecutionContext.tsx
@@ -181,10 +181,10 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
 
                 if (runningNodes && status === ExecutionStatus.RUNNING) {
                     animate(runningNodes);
-                    setIteratorProgressImpl(iteratorId, { percent, eta, index, total });
                 } else if (status !== ExecutionStatus.RUNNING) {
                     unAnimate();
                 }
+                setIteratorProgressImpl(iteratorId, { percent, eta, index, total });
             }
         },
         [animate, setIteratorProgressImpl, status, unAnimate]


### PR DESCRIPTION
> [...] it was getting stuck at length - 1. Putting it after fixed it. Can't really explain that

@joeyballentine Here's the explanation: iterator progress was ignored unless we also sent a list of running nodes. This was a bug you introduced in the first commit of #1730. So the last event you sent to set it to 100% was ignored. 

Changes:
- Fixed that progress updates were ignored unless they included a list of nodes.
- Fixed the length+1 in `__finish_progress`.
- Send progress updates before the running the iteration. This has better behavior than doing it after it.
- Fixed the length passed to `__finish_progress` in `run_while`.
- Record iteration duration even if the iteration errors.

I haven't tested it with video frame iterator yet (no videos on the disk of my laptop), so please verify that it behaves correctly there as well.