### PR TITLE
Assume normalized in View Image

### DIFF
--- a/backend/src/nodes/properties/outputs/numpy_outputs.py
+++ b/backend/src/nodes/properties/outputs/numpy_outputs.py
@@ -133,8 +133,15 @@ class LargeImageOutput(ImageOutput):
         image_type: expression.ExpressionJson = "Image",
         kind: OutputKind = "large-image",
         has_handle: bool = True,
+        assume_normalized: bool = False,
     ):
-        super().__init__(label, image_type, kind=kind, has_handle=has_handle)
+        super().__init__(
+            label,
+            image_type,
+            kind=kind,
+            has_handle=has_handle,
+            assume_normalized=assume_normalized,
+        )
 
     def get_broadcast_data(self, value: np.ndarray):
         img = value

--- a/backend/src/packages/chaiNNer_standard/image/io/view_image.py
+++ b/backend/src/packages/chaiNNer_standard/image/io/view_image.py
@@ -14,7 +14,14 @@ from .. import io_group
     description="See an inline preview of the image in the editor.",
     icon="BsEyeFill",
     inputs=[ImageInput()],
-    outputs=[LargeImageOutput("Preview", image_type="Input0", has_handle=False)],
+    outputs=[
+        LargeImageOutput(
+            "Preview",
+            image_type="Input0",
+            has_handle=False,
+            assume_normalized=True,
+        ),
+    ],
     side_effects=True,
 )
 def view_image_node(img: np.ndarray):


### PR DESCRIPTION
Image passed into nodes are already guaranteed to be normalized, so we don't need the image output of View Image to do it again.