### PR TITLE
More efficient execution

### DIFF
--- a/backend/src/chain/cache.py
+++ b/backend/src/chain/cache.py
@@ -1,5 +1,5 @@
 import gc
-from typing import Dict, Generic, Iterable, Optional, Set, TypeVar
+from typing import Dict, Generic, Optional, Set, TypeVar
 
 from sanic.log import logger
 
@@ -70,11 +70,11 @@ class OutputCache(Generic[T]):
         self.__counted: Dict[NodeId, _CacheEntry[T]] = {}
         self.parent: Optional[OutputCache[T]] = parent
 
-    def keys(self) -> Iterable[NodeId]:
+    def keys(self) -> Set[NodeId]:
         keys: Set[NodeId] = set()
-        keys.union(self.__static.keys(), self.__counted.keys())
+        keys.update(self.__static.keys(), self.__counted.keys())
         if self.parent:
-            keys.union(self.parent.keys())
+            keys.update(self.parent.keys())
         return keys
 
     def has(self, node_id: NodeId) -> bool:

--- a/backend/src/response.py
+++ b/backend/src/response.py
@@ -37,8 +37,8 @@ def errorResponse(
 ) -> ErrorResponse:
     if source is None and isinstance(exception, NodeExecutionError):
         source = {
-            "nodeId": exception.node.id,
-            "schemaId": exception.node.schema_id,
+            "nodeId": exception.node_id,
+            "schemaId": exception.node_data.schema_id,
             "inputs": exception.inputs,
         }
     return {


### PR DESCRIPTION
This PR make node execution more efficient and fixes a few bugs:

Changes:
- Fixed `Cache#keys()` using `keys.union` instead of `keys.update`. `set#union` doesn't modify the set it is called on, so `Cache#keys()` always returned an empty set.
- Moved the code for actually calling node run functions and enforcing inputs and outputs into their own functions. This allows for greater code reuse. As a side effect, node execution time now included the time it takes to enforce inputs and outputs, which is good. 
- Only send a single `node-finish` event for cached inputs.
- Instead of calling `gc.collect` after every node, we now call it after finishing the whole chain. Operations that are likely to produce a lot of garbage typically call `gc.collect` also, so the frequent `gc.collect`s were unnecessary and costly.
- Fixed a bug in `run_individual` where it would not use enforced inputs.
- Less `Any`.