### PR TITLE
Added lazy outputs

### DIFF
--- a/backend/src/lazy.py
+++ b/backend/src/lazy.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Callable, Generic, TypeVar, cast
+
+from sanic.log import logger
+
+T = TypeVar("T")
+
+
+class Lazy(Generic[T]):
+    def __init__(self, compute: Callable[[], T], log: str | None = None) -> None:
+        super().__init__()
+
+        self.__compute = compute
+        self.__did_compute = False
+        self.__computed_value = None
+        self.__log = log
+
+    @property
+    def value(self) -> T:
+        if self.__did_compute:
+            return cast(T, self.__computed_value)
+
+        self.__computed_value = self.__compute()
+        if self.__log:
+            logger.info(f"Computed lazy value: {self.__log}")
+        self.__did_compute = True
+        return self.__computed_value

--- a/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/metrics.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/metrics.py
@@ -6,6 +6,7 @@ from typing import Tuple
 import cv2
 import numpy as np
 
+from lazy import Lazy
 from nodes.impl.image_utils import calculate_ssim
 from nodes.properties.inputs import ImageInput
 from nodes.properties.outputs import NumberOutput
@@ -33,7 +34,7 @@ from .. import miscellaneous_group
 )
 def image_metrics_node(
     orig_img: np.ndarray, comp_img: np.ndarray
-) -> Tuple[float, float, float]:
+) -> Tuple[Lazy[float], Lazy[float], Lazy[float]]:
     """Compute MSE, PSNR, and SSIM"""
 
     assert (
@@ -47,8 +48,8 @@ def image_metrics_node(
         orig_img = cv2.cvtColor(orig_img, cv2.COLOR_BGR2YCrCb)[:, :, 0]
         comp_img = cv2.cvtColor(comp_img, cv2.COLOR_BGR2YCrCb)[:, :, 0]
 
-    mse = round(np.mean((comp_img - orig_img) ** 2), 6)  # type: ignore
-    psnr = round(10 * math.log(1 / mse), 6)
-    ssim = round(calculate_ssim(comp_img, orig_img), 6)
+    mse = Lazy(lambda: round(float(np.mean((comp_img - orig_img) ** 2)), 6))  # type: ignore
+    psnr = Lazy(lambda: round(10 * math.log(1 / mse.value), 6))
+    ssim = Lazy(lambda: round(calculate_ssim(comp_img, orig_img), 6))
 
-    return (float(mse), float(psnr), ssim)
+    return (mse, psnr, ssim)


### PR DESCRIPTION
This adds support for lazily-computed node outputs via the new `Lazy[T]` class.

Caveats:
- Broadcasts are not supported for lazy outputs.
- Since lazy output values are computed by `enforce_input`, the time it takes to compute them counts towards the execution time of the target node. This might make measuring the performance of nodes a bit more confusing, because we have to keep in mind which outputs are eagerly and which are lazily computed.

@joeyballentine Have fun with type validation :)