### PR TITLE
New logger

### DIFF
--- a/src/common/SaveFile.ts
+++ b/src/common/SaveFile.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'crypto';
-import log from 'electron-log';
 import { readFile, writeFile } from 'fs/promises';
 import { EdgeData, FileOpenResult, NodeData, Version } from './common-types';
+import { log } from './log';
 import { currentMigration, migrate } from './migrations';
 import { versionGt } from './version';
 import type { Edge, Node, Viewport } from 'reactflow';

--- a/src/common/SchemaMap.ts
+++ b/src/common/SchemaMap.ts
@@ -1,5 +1,5 @@
-import log from 'electron-log';
 import { InputData, InputId, InputValue, NodeSchema, SchemaId } from './common-types';
+import { log } from './log';
 
 const BLANK_SCHEMA: NodeSchema = {
     inputs: [],

--- a/src/common/input-override.ts
+++ b/src/common/input-override.ts
@@ -1,7 +1,7 @@
-import log from 'electron-log';
 import { readFile } from 'fs/promises';
 import { extname } from 'path';
 import { EdgeData, InputData, InputId, InputValue, Mutable, NodeData } from './common-types';
+import { log } from './log';
 import { SchemaMap } from './SchemaMap';
 import { joinEnglish } from './util';
 import type { Edge, Node } from 'reactflow';

--- a/src/common/log.ts
+++ b/src/common/log.ts
@@ -1,0 +1,71 @@
+export enum LogLevel {
+    Error,
+    Warn,
+    Info,
+    Debug,
+}
+
+export const LEVEL_NAME = {
+    [LogLevel.Error]: 'error',
+    [LogLevel.Warn]: 'warn',
+    [LogLevel.Info]: 'info',
+    [LogLevel.Debug]: 'debug',
+} as const;
+
+export interface LogMessage {
+    level: LogLevel;
+    timestamp: number;
+    message: unknown;
+    additional: unknown[];
+    stack?: string;
+}
+
+export interface LogTransport {
+    level?: LogLevel;
+    log(message: LogMessage): Promise<void> | void;
+}
+
+const transports: LogTransport[] = [];
+const pendingTransports = new Set<Promise<void>>();
+const callTransports = (message: LogMessage): void => {
+    for (const transport of transports) {
+        if (transport.level === undefined || message.level <= transport.level) {
+            const result = transport.log(message);
+            if (result instanceof Promise) {
+                pendingTransports.add(result);
+                result
+                    .catch((e) => {
+                        // we are the logger, so what do we do when logging fails?
+                        // eslint-disable-next-line no-console
+                        console.error(e);
+                    })
+                    .finally(() => {
+                        pendingTransports.delete(result);
+                    });
+            }
+        }
+    }
+};
+
+const logInternal = (level: LogLevel, message: unknown, ...additional: unknown[]): void => {
+    const timestamp = Date.now();
+    const stack = new Error().stack?.replace(/^(?:[^\n]*\n){2}/, '');
+    const logMessage: LogMessage = { level, message, additional, timestamp, stack };
+    callTransports(logMessage);
+};
+
+export const log = {
+    error: logInternal.bind(null, LogLevel.Error),
+    warn: logInternal.bind(null, LogLevel.Warn),
+    info: logInternal.bind(null, LogLevel.Info),
+    debug: logInternal.bind(null, LogLevel.Debug),
+    addTransport: (...transport: LogTransport[]): void => {
+        transports.push(...transport);
+    },
+    /**
+     * Waits until all loggers have finished logging.
+     */
+    flush: async (): Promise<void> => {
+        await Promise.all(pendingTransports);
+    },
+} as const;

--- a/src/common/migrations-legacy.js
+++ b/src/common/migrations-legacy.js
@@ -1,8 +1,8 @@
 /* eslint-disable prefer-destructuring */
 /* eslint-disable no-param-reassign */
 /* eslint-disable import/prefer-default-export */
-import log from 'electron-log';
 import { isEdge, isNode } from 'reactflow';
+import { log } from './log';
 
 // ==============
 //   pre-alpha

--- a/src/common/migrations.ts
+++ b/src/common/migrations.ts
@@ -1,7 +1,6 @@
 /* eslint-disable prefer-destructuring */
 /* eslint-disable no-param-reassign */
 
-import log from 'electron-log';
 import { Edge, Node, Viewport, getConnectedEdges, getOutgoers } from 'reactflow';
 import semver from 'semver';
 import {
@@ -14,6 +13,7 @@ import {
     OutputId,
     SchemaId,
 } from './common-types';
+import { log } from './log';
 import { legacyMigrations } from './migrations-legacy';
 import {
     ParsedSourceHandle,

--- a/src/common/nodes/TypeState.ts
+++ b/src/common/nodes/TypeState.ts
@@ -1,6 +1,6 @@
 import { EvaluationError, NonNeverType, StructType, Type } from '@chainner/navi';
-import log from 'electron-log';
 import { EdgeData, InputId, NodeData, OutputId, SchemaId } from '../common-types';
+import { log } from '../log';
 import { FunctionDefinition, FunctionInstance } from '../types/function';
 import {
     EMPTY_ARRAY,

--- a/src/common/pip.ts
+++ b/src/common/pip.ts
@@ -1,9 +1,9 @@
 /* eslint-disable no-param-reassign */
 import { spawn } from 'child_process';
-import log from 'electron-log';
 import { PythonInfo, Version } from './common-types';
 import { Dependency } from './dependencies';
 import { sanitizedEnv } from './env';
+import { log } from './log';
 import { pipInstallWithProgress } from './pipInstallWithProgress';
 import { noop } from './util';
 

--- a/src/common/pipInstallWithProgress.ts
+++ b/src/common/pipInstallWithProgress.ts
@@ -1,5 +1,4 @@
 import { execSync, spawn } from 'child_process';
-import log from 'electron-log';
 import fs from 'fs';
 import https from 'https';
 import Downloader from 'nodejs-file-downloader';
@@ -8,6 +7,7 @@ import path from 'path';
 import { URL } from 'url';
 import { PyPiPackage } from './dependencies';
 import { sanitizedEnv } from './env';
+import { log } from './log';
 import { noop } from './util';
 
 export interface OnStdio {

--- a/src/main/backend/process.ts
+++ b/src/main/backend/process.ts
@@ -1,10 +1,10 @@
 import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
 import { app } from 'electron';
-import log from 'electron-log';
 import path from 'path';
 import { getBackend } from '../../common/Backend';
 import { PythonInfo } from '../../common/common-types';
 import { sanitizedEnv } from '../../common/env';
+import { log } from '../../common/log';
 
 const backendPath = app.isPackaged
     ? path.join(process.resourcesPath, 'src', 'run.py')

--- a/src/main/backend/setup.ts
+++ b/src/main/backend/setup.ts
@@ -1,4 +1,3 @@
-import log from 'electron-log';
 import { t } from 'i18next';
 import path from 'path';
 import portfinder from 'portfinder';
@@ -8,6 +7,7 @@ import {
     getOptionalDependencies,
     requiredDependencies,
 } from '../../common/dependencies';
+import { log } from '../../common/log';
 import { runPipInstall, runPipList } from '../../common/pip';
 import { CriticalError } from '../../common/ui/error';
 import { ProgressToken } from '../../common/ui/progress';

--- a/src/main/cli/create.ts
+++ b/src/main/cli/create.ts
@@ -1,5 +1,6 @@
 import { app } from 'electron';
-import log from 'electron-log';
+import electronLog from 'electron-log';
+import { log } from '../../common/log';
 import { Exit } from './exit';
 
 const fatalErrorInMain = (error: unknown) => {
@@ -9,7 +10,7 @@ const fatalErrorInMain = (error: unknown) => {
 };
 
 const setupErrorHandling = () => {
-    log.catchErrors({
+    electronLog.catchErrors({
         showDialog: false,
         onError: fatalErrorInMain,
     });

--- a/src/main/cli/run.ts
+++ b/src/main/cli/run.ts
@@ -1,5 +1,4 @@
 import { app } from 'electron';
-import log from 'electron-log';
 import EventSource from 'eventsource';
 import {
     Backend,
@@ -11,6 +10,7 @@ import { EdgeData, NodeData, NodeSchema, SchemaId } from '../../common/common-ty
 import { getOnnxTensorRtCacheLocation } from '../../common/env';
 import { formatExecutionErrorMessage } from '../../common/formatExecutionErrorMessage';
 import { applyOverrides, readOverrideFile } from '../../common/input-override';
+import { log } from '../../common/log';
 import { checkNodeValidity } from '../../common/nodes/checkNodeValidity';
 import { getConnectedInputs } from '../../common/nodes/connectedInputs';
 import { getEffectivelyDisabledNodes } from '../../common/nodes/disabled';

--- a/src/main/ffmpeg/ffmpeg.ts
+++ b/src/main/ffmpeg/ffmpeg.ts
@@ -1,12 +1,12 @@
 import { exec as _exec } from 'child_process';
 import decompress from 'decompress';
-import log from 'electron-log';
 import fs from 'fs/promises';
 import Downloader from 'nodejs-file-downloader';
 import path from 'path';
 import util from 'util';
 import { FfmpegInfo } from '../../common/common-types';
 import { isArmMac } from '../../common/env';
+import { log } from '../../common/log';
 import { assertNever, checkFileExists } from '../../common/util';
 import { SupportedPlatform, getPlatform } from '../platform';
 

--- a/src/main/gui/create.ts
+++ b/src/main/gui/create.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow, app, dialog } from 'electron';
-import log from 'electron-log';
+import electronLog from 'electron-log';
+import { log } from '../../common/log';
 import { lazy } from '../../common/util';
 import { OpenArguments } from '../arguments';
 import { createMainWindow } from './main-window';
@@ -9,7 +10,7 @@ const mdCodeBlock = (code: string): string => {
 };
 
 const setupErrorHandling = () => {
-    log.catchErrors({
+    electronLog.catchErrors({
         showDialog: false,
         onError: (error, versions, submitIssue) => {
             dialog
@@ -38,7 +39,7 @@ const setupErrorHandling = () => {
                         app.quit();
                     }
                 })
-                .catch((e) => log.error(e));
+                .catch(log.error);
         },
     });
 };

--- a/src/main/gui/main-window.ts
+++ b/src/main/gui/main-window.ts
@@ -1,8 +1,8 @@
 import { ChildProcessWithoutNullStreams } from 'child_process';
 import { BrowserWindow, app, dialog, nativeTheme, powerSaveBlocker, shell } from 'electron';
-import log from 'electron-log';
 import { t } from 'i18next';
 import { Version, WindowSize } from '../../common/common-types';
+import { log } from '../../common/log';
 import { BrowserWindowWithSafeIpc, ipcMain } from '../../common/safeIpc';
 import { SaveFile, openSaveFile } from '../../common/SaveFile';
 import { CriticalError } from '../../common/ui/error';
@@ -45,7 +45,7 @@ const checkForUpdate = () => {
                 await shell.openExternal(latest.releaseUrl);
             }
         })
-        .catch((reason) => log.error(reason));
+        .catch(log.error);
 };
 
 const registerEventHandlerPreSetup = (
@@ -173,7 +173,7 @@ const registerEventHandlerPreSetup = (
             // Focus main window if a second instance was attempted
             if (mainWindow.isMinimized()) mainWindow.restore();
             mainWindow.focus();
-        })().catch((error) => log.error(error));
+        })().catch(log.error);
     });
 };
 
@@ -376,7 +376,7 @@ export const createMainWindow = async (args: OpenArguments) => {
         });
 
         // and load the index.html of the app.
-        mainWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY).catch((error) => log.error(error));
+        mainWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY).catch(log.error);
     } catch (error) {
         if (error instanceof CriticalError) {
             await progressController.submitInterrupt(error.interrupt);

--- a/src/main/gui/splash.ts
+++ b/src/main/gui/splash.ts
@@ -1,5 +1,5 @@
 import { BrowserWindow, MessageBoxOptions, app, dialog, shell } from 'electron';
-import log from 'electron-log';
+import { log } from '../../common/log';
 import { BrowserWindowWithSafeIpc } from '../../common/safeIpc';
 import { Progress, ProgressMonitor } from '../../common/ui/progress';
 import { assertNever } from '../../common/util';

--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -1,7 +1,5 @@
-import log from 'electron-log';
 import i18n from 'i18next';
 import { DEFAULT_OPTIONS } from '../common/i18n';
+import { log } from '../common/log';
 
-i18n.init(DEFAULT_OPTIONS).catch((err) => {
-    log.error(err);
-});
+i18n.init(DEFAULT_OPTIONS).catch(log.error);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,9 +1,10 @@
 import { app } from 'electron';
-import log from 'electron-log';
+import electronLog from 'electron-log';
 import { readdirSync, rmSync } from 'fs';
 import os from 'os';
 import path from 'path';
 import './i18n';
+import { LEVEL_NAME, log } from '../common/log';
 import { parseArgs } from './arguments';
 import { createCli } from './cli/create';
 import { runChainInCli } from './cli/run';
@@ -13,9 +14,16 @@ import { getLogsFolder, getRootDirSync } from './platform';
 const startApp = () => {
     const args = parseArgs(process.argv.slice(app.isPackaged ? 1 : 2));
 
-    log.transports.file.resolvePath = (variables) =>
+    electronLog.transports.file.resolvePath = (variables) =>
         path.join(getLogsFolder(), variables.fileName!);
-    log.transports.file.level = 'info';
+    electronLog.transports.file.level = 'info';
+    electronLog.transports.console.level = 'debug';
+
+    log.addTransport({
+        log: ({ level, message, additional }) => {
+            electronLog[LEVEL_NAME[level]](message, ...additional);
+        },
+    });
 
     process.env.ELECTRON_DISABLE_SECURITY_WARNINGS = 'true';
 

--- a/src/main/nvidiaSmi.ts
+++ b/src/main/nvidiaSmi.ts
@@ -2,11 +2,11 @@
 // Changed to be asynchronous to avoid blocking
 
 import { exec as _exec, spawn } from 'child_process';
-import log from 'electron-log';
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
 import util from 'util';
+import { log } from '../common/log';
 import { lazy } from '../common/util';
 
 const exec = util.promisify(_exec);

--- a/src/main/python/checkPythonPaths.ts
+++ b/src/main/python/checkPythonPaths.ts
@@ -1,13 +1,11 @@
-import log from 'electron-log';
 import { PythonInfo } from '../../common/common-types';
+import { log } from '../../common/log';
 import { getPythonVersion, isSupportedPythonVersion } from './version';
 
 export const checkPythonPaths = async (pythonsToCheck: string[]): Promise<PythonInfo> => {
     for (const py of pythonsToCheck) {
         // eslint-disable-next-line no-await-in-loop
-        const version = await getPythonVersion(py).catch((err) => {
-            log.error(err);
-        });
+        const version = await getPythonVersion(py).catch(log.error);
         if (version && isSupportedPythonVersion(version)) {
             return { python: py, version };
         }

--- a/src/main/python/integratedPython.ts
+++ b/src/main/python/integratedPython.ts
@@ -1,10 +1,10 @@
 import decompress from 'decompress';
-import log from 'electron-log';
 import fs from 'fs/promises';
 import Downloader from 'nodejs-file-downloader';
 import path from 'path';
 import { PythonInfo } from '../../common/common-types';
 import { isArmMac } from '../../common/env';
+import { log } from '../../common/log';
 import { assertNever, checkFileExists } from '../../common/util';
 import { SupportedPlatform, getPlatform } from '../platform';
 import { checkPythonPaths } from './checkPythonPaths';

--- a/src/renderer/components/Header/KoFiButton.tsx
+++ b/src/renderer/components/Header/KoFiButton.tsx
@@ -1,8 +1,8 @@
 import { IconButton, Tooltip } from '@chakra-ui/react';
-import log from 'electron-log';
 import { memo } from 'react';
 import { SiKofi } from 'react-icons/si';
 import { links } from '../../../common/links';
+import { log } from '../../../common/log';
 import { ipcRenderer } from '../../../common/safeIpc';
 
 export const KoFiButton = memo(() => {

--- a/src/renderer/components/ReactFlowBox.tsx
+++ b/src/renderer/components/ReactFlowBox.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-shadow */
 import { Box } from '@chakra-ui/react';
 import { Bezier } from 'bezier-js';
-import log from 'electron-log';
 import { DragEvent, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FaFileExport } from 'react-icons/fa';
 import ReactFlow, {
@@ -26,6 +25,7 @@ import ReactFlow, {
 } from 'reactflow';
 import { useContext, useContextSelector } from 'use-context-selector';
 import { EdgeData, NodeData } from '../../common/common-types';
+import { log } from '../../common/log';
 import { getFirstPossibleInput, getFirstPossibleOutput } from '../../common/nodes/connectedInputs';
 import {
     EMPTY_ARRAY,

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -33,7 +33,6 @@ import {
     VStack,
     useDisclosure,
 } from '@chakra-ui/react';
-import log from 'electron-log';
 import { readdir, unlink } from 'fs/promises';
 import path from 'path';
 import {
@@ -49,6 +48,7 @@ import { BsFillPencilFill, BsPaletteFill } from 'react-icons/bs';
 import { FaPython, FaTools } from 'react-icons/fa';
 import { useContext } from 'use-context-selector';
 import { getOnnxTensorRtCacheLocation, hasTensorRt } from '../../common/env';
+import { log } from '../../common/log';
 import { ipcRenderer } from '../../common/safeIpc';
 import { BackendContext } from '../contexts/BackendContext';
 import { SettingsContext } from '../contexts/SettingsContext';
@@ -612,14 +612,10 @@ const PythonSettings = memo(() => {
                                                 for (const file of files) {
                                                     unlink(
                                                         path.join(onnxTensorRtCacheLocation, file)
-                                                    ).catch((error) => {
-                                                        log.error(error);
-                                                    });
+                                                    ).catch(log.error);
                                                 }
                                             })
-                                            .catch((err) => {
-                                                log.error(err);
-                                            });
+                                            .catch(log.error);
                                     }}
                                 >
                                     Clear Cache

--- a/src/renderer/components/groups/NcnnFileInputsGroup.tsx
+++ b/src/renderer/components/groups/NcnnFileInputsGroup.tsx
@@ -1,6 +1,6 @@
-import log from 'electron-log';
 import { memo, useEffect } from 'react';
 import { useContext } from 'use-context-selector';
+import { log } from '../../../common/log';
 import { checkFileExists, getInputValue } from '../../../common/util';
 import { GlobalContext } from '../../contexts/GlobalNodeState';
 import { SchemaInput } from '../inputs/SchemaInput';
@@ -13,7 +13,7 @@ const ifExists = (file: string, then: () => void) => {
                 then();
             }
         })
-        .catch((reason) => log.error(reason));
+        .catch(log.error);
 };
 
 const ifOtherExists = (file: string, extension: string, then: (other: string) => void) => {

--- a/src/renderer/components/inputs/ColorInput.tsx
+++ b/src/renderer/components/inputs/ColorInput.tsx
@@ -12,7 +12,6 @@ import {
     Text,
     VStack,
 } from '@chakra-ui/react';
-import log from 'electron-log';
 import { ReactNode, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { RgbColor } from 'react-colorful';
 import { toCssColor, toKind, toRgb } from '../../../common/color-json-util';
@@ -23,6 +22,7 @@ import {
     RgbColorJson,
     RgbaColorJson,
 } from '../../../common/common-types';
+import { log } from '../../../common/log';
 import { useColorModels } from '../../hooks/useColorModels';
 import { TypeTags } from '../TypeTag';
 import { ColorBoxButton } from './elements/ColorBoxButton';

--- a/src/renderer/components/node/NodeOutputs.tsx
+++ b/src/renderer/components/node/NodeOutputs.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable react/jsx-props-no-spreading */
 
 import { NeverType, Type, evaluate } from '@chainner/navi';
-import log from 'electron-log';
 import { memo, useCallback, useEffect } from 'react';
 import { useContext, useContextSelector } from 'use-context-selector';
 import { Output, OutputId, OutputKind, SchemaId } from '../../../common/common-types';
+import { log } from '../../../common/log';
 import { getChainnerScope } from '../../../common/types/chainner-scope';
 import { ExpressionJson, fromJson } from '../../../common/types/json';
 import { isStartingNode } from '../../../common/util';

--- a/src/renderer/contexts/AlertBoxContext.tsx
+++ b/src/renderer/contexts/AlertBoxContext.tsx
@@ -15,10 +15,10 @@ import {
     useToast,
 } from '@chakra-ui/react';
 import { app, clipboard, shell } from 'electron';
-import log from 'electron-log';
 import path from 'path';
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createContext, useContext, useContextSelector } from 'use-context-selector';
+import { log } from '../../common/log';
 import { ipcRenderer } from '../../common/safeIpc';
 import { assertNever, noop } from '../../common/util';
 import { useMemoObject } from '../hooks/useMemo';
@@ -235,7 +235,7 @@ export const AlertBoxProvider = memo(({ children }: React.PropsWithChildren<unkn
     );
     const sendAlert = useCallback(
         (message: AlertOptions) => {
-            showAlert(message).catch((reason) => log.error(reason));
+            showAlert(message).catch(log.error);
         },
         [showAlert]
     );

--- a/src/renderer/contexts/DependencyContext.tsx
+++ b/src/renderer/contexts/DependencyContext.tsx
@@ -30,13 +30,13 @@ import {
     VStack,
     useDisclosure,
 } from '@chakra-ui/react';
-import log from 'electron-log';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { BsQuestionCircle, BsTerminalFill } from 'react-icons/bs';
 import { createContext, useContext } from 'use-context-selector';
 import { Version } from '../../common/common-types';
 import { Dependency, PyPiPackage, getOptionalDependencies } from '../../common/dependencies';
 import { Integration, externalIntegrations } from '../../common/externalIntegrations';
+import { log } from '../../common/log';
 import { OnStdio, PipList, runPipInstall, runPipList, runPipUninstall } from '../../common/pip';
 import { ipcRenderer } from '../../common/safeIpc';
 import { noop } from '../../common/util';
@@ -348,7 +348,7 @@ export const DependencyProvider = memo(({ children }: React.PropsWithChildren<un
                 setInstallingPackage(null);
                 setUninstallingPackage(null);
                 setProgress(0);
-                restart().catch((reason) => log.error(reason));
+                restart().catch(log.error);
             });
     };
 
@@ -534,7 +534,7 @@ export const DependencyProvider = memo(({ children }: React.PropsWithChildren<un
 
                                                     uninstallPackage(dep);
                                                 })
-                                                .catch((error) => log.error(error));
+                                                .catch(log.error);
                                         };
 
                                         return (

--- a/src/renderer/contexts/ExecutionContext.tsx
+++ b/src/renderer/contexts/ExecutionContext.tsx
@@ -1,9 +1,9 @@
-import log from 'electron-log';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useReactFlow } from 'reactflow';
 import { createContext, useContext, useContextSelector } from 'use-context-selector';
 import { EdgeData, NodeData } from '../../common/common-types';
 import { formatExecutionErrorMessage } from '../../common/formatExecutionErrorMessage';
+import { log } from '../../common/log';
 import { checkNodeValidity } from '../../common/nodes/checkNodeValidity';
 import { getConnectedInputs } from '../../common/nodes/connectedInputs';
 import { getEffectivelyDisabledNodes } from '../../common/nodes/disabled';

--- a/src/renderer/contexts/GlobalNodeState.tsx
+++ b/src/renderer/contexts/GlobalNodeState.tsx
@@ -1,5 +1,4 @@
 import { Expression, Type, evaluate } from '@chainner/navi';
-import log from 'electron-log';
 import { dirname, parse } from 'path';
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
@@ -26,6 +25,7 @@ import {
     OutputId,
     Size,
 } from '../../common/common-types';
+import { log } from '../../common/log';
 import { getEffectivelyDisabledNodes } from '../../common/nodes/disabled';
 import { TypeState } from '../../common/nodes/TypeState';
 import { ipcRenderer } from '../../common/safeIpc';
@@ -513,7 +513,7 @@ export const GlobalProvider = memo(
                             ipcRenderer.send('exit-after-save');
                         }
                     })
-                    .catch((reason) => log.error(reason));
+                    .catch(log.error);
             }, [performSave])
         );
 
@@ -633,7 +633,7 @@ export const GlobalProvider = memo(
         useIpcRendererListener(
             'file-new',
             useCallback(() => {
-                clearState().catch((reason) => log.error(reason));
+                clearState().catch(log.error);
             }, [clearState])
         );
 
@@ -663,7 +663,7 @@ export const GlobalProvider = memo(
                     if (result.kind === 'Success') {
                         setStateFromJSONRef
                             .current(result.saveData, result.path, true)
-                            .catch((reason) => log.error(reason));
+                            .catch(log.error);
                     } else {
                         removeRecentPath(result.path);
                         sendAlert({
@@ -1181,7 +1181,7 @@ export const GlobalProvider = memo(
                     });
                     outputDataActions.delete(id);
                     addInputDataChanges();
-                    backend.clearNodeCacheIndividual(id).catch((error) => log.error(error));
+                    backend.clearNodeCacheIndividual(id).catch(log.error);
                 });
             },
             [modifyNode, addInputDataChanges, outputDataActions, backend, schemata]
@@ -1211,9 +1211,7 @@ export const GlobalProvider = memo(
 
                 takeScreenshot(currentFlowWrapper, currentReactFlowInstance, viewportExportPadding)
                     .then(saveAs)
-                    .catch((error) => {
-                        log.error(error);
-                    });
+                    .catch(log.error);
             },
             [reactFlowWrapper, currentReactFlowInstance, viewportExportPadding, sendToast]
         );

--- a/src/renderer/helpers/copyAndPaste.ts
+++ b/src/renderer/helpers/copyAndPaste.ts
@@ -1,11 +1,11 @@
 import { clipboard } from 'electron';
-import log from 'electron-log';
 import { writeFile } from 'fs/promises';
 import os from 'os';
 import path from 'path';
 import { Edge, Node, Project } from 'reactflow';
 import { v4 as uuid4 } from 'uuid';
 import { EdgeData, InputId, NodeData, SchemaId } from '../../common/common-types';
+import { log } from '../../common/log';
 import { createUniqueId, deriveUniqueId } from '../../common/util';
 import { NodeProto, copyEdges, copyNodes, expandSelection, setSelected } from './reactFlowUtil';
 import { SetState } from './types';

--- a/src/renderer/helpers/dataTransfer.ts
+++ b/src/renderer/helpers/dataTransfer.ts
@@ -1,7 +1,7 @@
-import log from 'electron-log';
 import { extname } from 'path';
 import { Edge, Node, XYPosition } from 'reactflow';
 import { EdgeData, NodeData, SchemaId } from '../../common/common-types';
+import { log } from '../../common/log';
 import { ipcRenderer } from '../../common/safeIpc';
 import { ParsedSaveData, openSaveFile } from '../../common/SaveFile';
 import { SchemaMap } from '../../common/SchemaMap';
@@ -127,7 +127,7 @@ const openChainnerFileProcessor: DataTransferProcessor = (dataTransfer) => {
                     // TODO: 1 is hard-coded. Find a better way
                     ipcRenderer.sendTo(1, 'file-open', result);
                 })
-                .catch((reason) => log.error(reason));
+                .catch(log.error);
 
             return true;
         }

--- a/src/renderer/helpers/nodeSearchFuncs.ts
+++ b/src/renderer/helpers/nodeSearchFuncs.ts
@@ -1,11 +1,11 @@
-import log from 'electron-log';
 import init, { RRegex } from 'rregex';
 import { NodeSchema } from '../../common/common-types';
+import { log } from '../../common/log';
 import { lazy } from '../../common/util';
 
 // This is not good, but I can't think of a better way.
 // We are racing loading the wasm module and using it.
-init().catch((reason) => log.error(reason));
+init().catch(log.error);
 
 const isLetter = lazy(() => new RRegex('(?is)^[a-z]$'));
 export const createSearchPredicate = (query: string): ((name: string) => boolean) => {

--- a/src/renderer/hooks/useAsyncEffect.ts
+++ b/src/renderer/hooks/useAsyncEffect.ts
@@ -1,5 +1,5 @@
-import log from 'electron-log';
 import { useEffect } from 'react';
+import { log } from '../../common/log';
 import { noop } from '../../common/util';
 
 /**

--- a/src/renderer/hooks/useBackendEventSource.ts
+++ b/src/renderer/hooks/useBackendEventSource.ts
@@ -4,8 +4,8 @@ import {
     useEventSource,
     useEventSourceListener,
 } from '@react-nano/use-event-source';
-import log from 'electron-log';
 import { BackendEventMap } from '../../common/Backend';
+import { log } from '../../common/log';
 
 export type BackendEventSource = EventSource & { readonly __backend?: never };
 

--- a/src/renderer/hooks/useBackendExecutionOptions.ts
+++ b/src/renderer/hooks/useBackendExecutionOptions.ts
@@ -1,8 +1,8 @@
-import log from 'electron-log';
 import { useEffect, useState } from 'react';
 import { useContext } from 'use-context-selector';
 import { BackendExecutionOptions } from '../../common/Backend';
 import { getOnnxTensorRtCacheLocation } from '../../common/env';
+import { log } from '../../common/log';
 import { ipcRenderer } from '../../common/safeIpc';
 import { SettingsContext } from '../contexts/SettingsContext';
 

--- a/src/renderer/hooks/useRunNode.ts
+++ b/src/renderer/hooks/useRunNode.ts
@@ -1,7 +1,7 @@
-import log from 'electron-log';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useContext } from 'use-context-selector';
 import { NodeData } from '../../common/common-types';
+import { log } from '../../common/log';
 import { delay, mapInputValues } from '../../common/util';
 import { AlertBoxContext } from '../contexts/AlertBoxContext';
 import { BackendContext } from '../contexts/BackendContext';
@@ -81,7 +81,7 @@ export const useRunNode = (
     useEffect(() => {
         return () => {
             if (didEverRun.current) {
-                backend.clearNodeCacheIndividual(id).catch((error) => log.error(error));
+                backend.clearNodeCacheIndividual(id).catch(log.error);
             }
         };
     }, [backend, id]);

--- a/src/renderer/hooks/useSystemUsage.ts
+++ b/src/renderer/hooks/useSystemUsage.ts
@@ -1,8 +1,8 @@
 import { exec as _exec } from 'child_process';
-import log from 'electron-log';
 import os from 'os-utils';
 import { useCallback, useState } from 'react';
 import util from 'util';
+import { log } from '../../common/log';
 import { ipcRenderer } from '../../common/safeIpc';
 import { useInterval } from './useInterval';
 import { useMemoObject } from './useMemo';
@@ -52,9 +52,7 @@ export const useSystemUsage = (delay: number): SystemUsage => {
 
     useInterval(
         useCallback(() => {
-            getSystemUsage()
-                .then(setUsage)
-                .catch((reason) => log.error(reason));
+            getSystemUsage().then(setUsage).catch(log.error);
         }, []),
         delay
     );

--- a/src/renderer/hooks/useWatchFiles.ts
+++ b/src/renderer/hooks/useWatchFiles.ts
@@ -1,6 +1,6 @@
 import { FSWatcher } from 'chokidar';
-import log from 'electron-log';
 import { useEffect } from 'react';
+import { log } from '../../common/log';
 
 const listeners = new Set<(file: string) => void>();
 const callListeners = (file: string) => {

--- a/src/renderer/i18n.ts
+++ b/src/renderer/i18n.ts
@@ -1,10 +1,6 @@
-import log from 'electron-log';
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import { DEFAULT_OPTIONS } from '../common/i18n';
+import { log } from '../common/log';
 
-i18n.use(initReactI18next)
-    .init(DEFAULT_OPTIONS)
-    .catch((err) => {
-        log.error(err);
-    });
+i18n.use(initReactI18next).init(DEFAULT_OPTIONS).catch(log.error);

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -1,18 +1,26 @@
-import log from 'electron-log';
+import electronLog from 'electron-log';
 import path from 'path';
 import { createRoot } from 'react-dom/client';
+import { LEVEL_NAME, log } from '../common/log';
 import { ipcRenderer } from '../common/safeIpc';
 import { App } from './app';
 
 ipcRenderer
     .invoke('get-appdata')
     .then((rootDir) => {
-        log.transports.file.resolvePath = (variables) =>
+        electronLog.transports.file.resolvePath = (variables) =>
             path.join(rootDir, 'logs', variables.fileName!);
-        log.transports.file.level = 'info';
+        electronLog.transports.file.level = 'info';
+        electronLog.transports.console.level = 'debug';
+
+        log.addTransport({
+            log: ({ level, message, additional }) => {
+                electronLog[LEVEL_NAME[level]](message, ...additional);
+            },
+        });
     })
     .catch((err) => {
-        log.error(err);
+        electronLog.error(err);
     });
 
 const container = document.getElementById('root');

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -1,5 +1,4 @@
 import { Box, Center, HStack, Text, VStack } from '@chakra-ui/react';
-import log from 'electron-log';
 import isDeepEqual from 'fast-deep-equal';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -8,6 +7,7 @@ import { useContext } from 'use-context-selector';
 import useFetch, { CachePolicies } from 'use-http';
 import { BackendNodesResponse } from '../common/Backend';
 import { Category, NodeType, PythonInfo, SchemaId } from '../common/common-types';
+import { log } from '../common/log';
 import { parseFunctionDefinitions } from '../common/nodes/parseFunctionDefinitions';
 import { ipcRenderer } from '../common/safeIpc';
 import { SchemaMap } from '../common/SchemaMap';


### PR DESCRIPTION
Step 1 of many to move CLI into its own thing. This PR adds a new custom logger. I went custom because (1) we don't have many requirements for our logger, so it's easy to implement and (2) the whole logger is like 50 LOC. 

The logger itself is very simple. It has a very small API surface and simply forwards messages to transports that do the actual logging. Right now, we only have one transport to electron log, but a standalone CLI app will use something else.

This also completely removes the dependency to electron log from `src/common`.

---

Also, I changed all `catch(e => log.error(e))` to `catch(log.error)`, because the new API allows it.