### PR TITLE
Fixed `@cached` ignoring first argument

### DIFF
--- a/backend/src/nodes/node_cache.py
+++ b/backend/src/nodes/node_cache.py
@@ -149,11 +149,11 @@ def cached(run):
     cache = NodeOutputCache()
 
     @functools.wraps(run)
-    def _run(obj, *args):
+    def _run(*args):
         out = cache.get(args)
         if out is not None:
             return out
-        output = run(obj, *args)
+        output = run(*args)
         cache.put(args, output)
         return output
 


### PR DESCRIPTION
Fixes #1755
Fixes #1751
Fixes #1765 

`obj` used to be the `self` argument, but not anymore.

Note: I haven't tested this because I can't have the SD backend installed. Please, someone test this.