### PR TITLE
Make iterators catch any exception

### DIFF
--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -232,7 +232,7 @@ class IteratorContext:
                 await self.run_iteration(index, length)
             except Aborted:
                 raise
-            except RuntimeError as e:
+            except Exception as e:
                 logger.error(e)
                 errors.append(str(e))
 


### PR DESCRIPTION
For some reason, we're only catching `RuntimeError`s here. This makes it so that a different kind of error, for example, an error reading a DDS file with texconv, does not get caught, and causes an error rather than waiting until the end of iteration.

I'm assuming right now that this wasn't an intentional choice. If it was, we can just add a few more exception types to this to catch the things we need, but I don't see a reason to not just catch everything.