### PR TITLE
Update generate_hash.py

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/generate_hash.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/generate_hash.py
@@ -36,6 +36,6 @@ from .. import miscellaneous_group
 )
 def run(img: np.ndarray, size: int) -> Tuple[str, str]:
     """Generate a hash from the input image. The digest size determines the length of the hash that is output."""
-    img = to_uint8(img)
+    img = np.ascontiguousarray(to_uint8(img))
     h = hashlib.blake2b(img, digest_size=size)  # type: ignore
     return h.hexdigest(), base64.urlsafe_b64encode(h.digest()).decode("utf-8")


### PR DESCRIPTION
When using generate hash after upscaling the image, it gives an error that "ndarray is not c-contiguous".
I use the function np.ascontiguousarray() to convert the data to a c-contiguous array now before trying to hash.