### PR TITLE
Add torch.DoubleStorage to restricted unpickler

### DIFF
--- a/backend/src/nodes/utils/unpickler.py
+++ b/backend/src/nodes/utils/unpickler.py
@@ -11,6 +11,7 @@ safe_list = {
     ("torch", "HalfStorage"),
     ("torch", "IntStorage"),
     ("torch", "LongStorage"),
+    ("torch", "DoubleStorage"),
 }
 
 


### PR DESCRIPTION
Should resolve #1811, but since I have no idea how those models got DoubleStorage in the first place, i'm not 100% confident in that