### PR TITLE
Fixed first possible output

### DIFF
--- a/src/common/nodes/connectedInputs.ts
+++ b/src/common/nodes/connectedInputs.ts
@@ -22,10 +22,8 @@ export const getFirstPossibleOutput = (
     inputFn: FunctionDefinition,
     inputId: InputId
 ): OutputId | undefined => {
-    for (const [id, type] of outputFn.outputDefaults) {
-        if (inputFn.canAssignInput(inputId, type)) {
-            return id;
-        }
-    }
-    return undefined;
+    return outputFn.schema.outputs.find((o) => {
+        const type = outputFn.outputDefaults.get(o.id);
+        return o.hasHandle && type && inputFn.canAssignInput(inputId, type);
+    })?.id;
 };


### PR DESCRIPTION
`getFirstPossibleOutput` did not account for the fact that we have one output that you cannot connect to: the large image output of View Image. This made it possible to connect an image input with the output of View Image.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/e95cead3-08a9-4d7e-9cc8-8070f6243f33)
