### PR TITLE
Auto refresh node schemata

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "start": "electron-forge start",
     "frontend": "electron-forge start -- --no-backend",
-    "dev": "concurrently \"cd backend/src && cross-env TYPE_CHECK_LEVEL=warn nodemon ./run.py 8000\" \"electron-forge start -- --no-backend\"",
-    "debug": "concurrently \"npm run debug:py\" \"electron-forge start -- --no-backend\"",
+    "dev": "concurrently \"cd backend/src && cross-env TYPE_CHECK_LEVEL=warn nodemon ./run.py 8000\" \"electron-forge start -- --no-backend --refresh\"",
+    "debug": "concurrently \"npm run debug:py\" \"electron-forge start -- --no-backend --refresh\"",
     "debug:py": "cd backend/src && nodemon --exec \"python -m debugpy --listen 5678\" ./run.py 8000",
     "package": "cross-env NODE_ENV=production electron-forge package",
     "make": "cross-env NODE_ENV=production electron-forge make",

--- a/src/common/safeIpc.ts
+++ b/src/common/safeIpc.ts
@@ -26,6 +26,7 @@ export interface InvokeChannels {
     'get-python': ChannelInfo<PythonInfo>;
     'get-port': ChannelInfo<number>;
     'get-localstorage-location': ChannelInfo<string>;
+    'refresh-nodes': ChannelInfo<boolean>;
     'get-app-version': ChannelInfo<Version>;
     'get-vram-usage': ChannelInfo<number | null>;
     'dir-select': ChannelInfo<Electron.OpenDialogReturnValue, [dirPath: string]>;

--- a/src/main/arguments.ts
+++ b/src/main/arguments.ts
@@ -3,6 +3,7 @@ import { assertNever } from '../common/util';
 
 interface ArgumentOptions {
     noBackend: boolean;
+    refresh: boolean;
 }
 export interface OpenArguments extends ArgumentOptions {
     command: 'open';
@@ -59,12 +60,20 @@ export const parseArgs = (args: readonly string[]): ParsedArguments => {
                     'An internal developer option to use a different backend. Do not use this as this is not a stable option and may change or disappear at any time',
                 hidden: true,
             },
+            refresh: {
+                type: 'boolean',
+                default: false,
+                description:
+                    'An internal developer option to use a different backend. Do not use this as this is not a stable option and may change or disappear at any time',
+                hidden: true,
+            },
         })
         .strict()
         .parseSync();
 
     const options: ArgumentOptions = {
         noBackend: !parsed.backend,
+        refresh: parsed.refresh,
     };
 
     const command = (parsed._[0] as ParsedArguments['command'] | undefined) ?? 'open';

--- a/src/main/gui/main-window.ts
+++ b/src/main/gui/main-window.ts
@@ -56,6 +56,7 @@ const registerEventHandlerPreSetup = (
     ipcMain.handle('get-appdata', () => getRootDirSync());
     ipcMain.handle('get-gpu-info', getGpuInfo);
     ipcMain.handle('get-localstorage-location', () => settingStorageLocation);
+    ipcMain.handle('refresh-nodes', () => args.refresh);
 
     // menu
     const menuData: MenuData = { openRecentRev: [] };

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -78,6 +78,21 @@ export const Main = memo(({ port }: MainProps) => {
     const [nodesRefreshCounter, setNodesRefreshCounter] = useState(0);
     const refreshNodes = useCallback(() => setNodesRefreshCounter((prev) => prev + 1), []);
 
+    const [periodicRefresh, setPeriodicRefresh] = useState(false);
+    useAsyncEffect(
+        () => ({
+            supplier: () => ipcRenderer.invoke('refresh-nodes'),
+            successEffect: setPeriodicRefresh,
+        }),
+        []
+    );
+
+    useEffect(() => {
+        if (!periodicRefresh) return;
+        const interval = setInterval(refreshNodes, 1000 * 3);
+        return () => clearInterval(interval);
+    }, [periodicRefresh, refreshNodes]);
+
     const { loading, error, data, response } = useFetch<BackendNodesResponse>(
         `http://localhost:${port}/nodes`,
         { cachePolicy: CachePolicies.NO_CACHE, cache: 'no-cache', retries: 25 },


### PR DESCRIPTION
This is a small productivity feature. With `npm run dev`, chainner will now automatically refresh node schemata data. This means that we no longer have to Ctrl+R after changing/adding/removing nodes to see the effect.