### PR TITLE
Consistently call it "Input Override ID"

### DIFF
--- a/src/common/input-override.ts
+++ b/src/common/input-override.ts
@@ -6,17 +6,17 @@ import { SchemaMap } from './SchemaMap';
 import { joinEnglish } from './util';
 import type { Edge, Node } from 'reactflow';
 
-export type OverrideInputId = string & { readonly __override_input_id?: never };
+export type InputOverrideId = string & { readonly __input_override_id?: never };
 
-export const createOverrideInputId = (nodeId: string, inputId: InputId): OverrideInputId => {
+export const createInputOverrideId = (nodeId: string, inputId: InputId): InputOverrideId => {
     if (nodeId.length !== 36)
         throw new Error('Expected node id to be a 36 character hexadecimal UUID.');
     return `#${nodeId}:${inputId}`;
 };
 
-const isValidOverrideInputId = (id: OverrideInputId) => /^#[a-f0-9-]{36}:\d+$/.test(id);
-export const parseOverrideInputId = (id: OverrideInputId): { nodeId: string; inputId: InputId } => {
-    if (!isValidOverrideInputId(id)) throw new Error(`"${id}" is not a valid override input id.`);
+const isValidInputOverrideId = (id: InputOverrideId) => /^#[a-f0-9-]{36}:\d+$/.test(id);
+export const parseInputOverrideId = (id: InputOverrideId): { nodeId: string; inputId: InputId } => {
+    if (!isValidInputOverrideId(id)) throw new Error(`"${id}" is not a valid input override id.`);
 
     const nodeId = id.substring(1, 37);
     const inputId = Number(id.slice(38)) as InputId;
@@ -25,7 +25,7 @@ export const parseOverrideInputId = (id: OverrideInputId): { nodeId: string; inp
 };
 
 export interface OverrideFile {
-    inputs?: Record<OverrideInputId, string | number | null>;
+    inputs?: Record<InputOverrideId, string | number | null>;
 }
 
 export const readOverrideFile = async (filePath: string): Promise<OverrideFile> => {
@@ -135,7 +135,7 @@ export const applyOverrides = (
 
     const overrides = new Map<string, Map<InputId, string | number | null>>();
     for (const [id, value] of Object.entries(overrideFile.inputs)) {
-        const { nodeId, inputId } = parseOverrideInputId(id);
+        const { nodeId, inputId } = parseInputOverrideId(id);
 
         let perNode = overrides.get(nodeId);
         if (perNode === undefined) {

--- a/src/common/locales/en/translation.json
+++ b/src/common/locales/en/translation.json
@@ -26,7 +26,7 @@
     "stopButton": "Stop button"
   },
   "inputs": {
-    "copyOverrideInputId": "Copy Override Input Id",
+    "copyInputOverrideId": "Copy Input Override Id",
     "directory": {
       "copyFullDirectoryPath": "Copy Full Directory Path",
       "openInFileExplorer": "Open in File Explorer",

--- a/src/renderer/components/inputs/elements/CopyOverrideIdSection.tsx
+++ b/src/renderer/components/inputs/elements/CopyOverrideIdSection.tsx
@@ -4,7 +4,7 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MdContentCopy } from 'react-icons/md';
 import { InputId } from '../../../../common/common-types';
-import { createOverrideInputId } from '../../../../common/input-override';
+import { createInputOverrideId } from '../../../../common/input-override';
 
 interface CopyOverrideIdSectionProps {
     nodeId: string | undefined;
@@ -24,10 +24,10 @@ export const CopyOverrideIdSection = memo(({ nodeId, inputId }: CopyOverrideIdSe
             <MenuItem
                 icon={<MdContentCopy />}
                 onClick={() => {
-                    clipboard.writeText(createOverrideInputId(nodeId, inputId));
+                    clipboard.writeText(createInputOverrideId(nodeId, inputId));
                 }}
             >
-                {t('inputs.copyOverrideInputId', 'Copy Override Input Id')}
+                {t('inputs.copyInputOverrideId', 'Copy Input Override Id')}
             </MenuItem>
         </>
     );


### PR DESCRIPTION
I noticed that I inconsistently called them "input override ID" and "override input ID". This PR fixes that.