### PR TITLE
Possibly fix portable building on linux and macos

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -15,9 +15,8 @@ on:
 
 jobs:
   test-build-release:
-    # Set this to `true` to enable the workflow.
-    # This workflow is disabled by default because it takes multiple minutes in CI which slows down development.
-    if: false
+    # commit the word "build" to the commit message to enable this job
+    if: contains(github.event.head_commit.message, 'build')
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -36,3 +36,7 @@ jobs:
           sudo apt update && sudo apt install flatpak flatpak-builder elfutils
       - name: Build release
         run: npm run make
+      - uses: actions/upload-artifact@v3
+        with:
+          name: debug-build
+          path: out/

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   test-build-release:
     # commit the word "build" to the commit message to enable this job
-    if: contains(github.event.head_commit.message, 'build')
+    if: contains(${{ github.event.head_commit.message }}, 'build')
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -38,5 +38,5 @@ jobs:
         run: npm run make
       - uses: actions/upload-artifact@v3
         with:
-          name: debug-build
-          path: out/
+          name: debug-build-${{ matrix.os }}
+          path: out/make

--- a/forge.config.js
+++ b/forge.config.js
@@ -95,7 +95,19 @@ const config = {
             if (zipArtifact) {
                 // Add an empty `portable` file to the zip
                 const zip = new AdmZip(zipArtifact);
-                zip.addFile('portable', Buffer.alloc(0));
+                switch (process.platform) {
+                    case 'win32':
+                        zip.addFile('portable', Buffer.alloc(0));
+                        break;
+                    case 'darwin':
+                        zip.addFile('chaiNNer.app/Contents/MacOS/portable', Buffer.alloc(0));
+                        break;
+                    case 'linux':
+                        zip.addFile('chaiNNer-linux-x64/portable', Buffer.alloc(0));
+                        break;
+                    default:
+                        break;
+                }
                 zip.writeZip(zipArtifact);
             }
         },


### PR DESCRIPTION
- Places the `portable` file in (what I assume) is the correct path for macos and linux

To verify this, I needed to make it build and upload artifacts to CI, so this PR also:
- Makes it so we can run the build workflow by committing a commit with "build" in the message
- Makes it so the build workflow uploads artifacts to the action