### PR TITLE
Fix argument parsing to allow passthrough of extra args

### DIFF
--- a/src/main/arguments.ts
+++ b/src/main/arguments.ts
@@ -68,7 +68,7 @@ export const parseArgs = (args: readonly string[]): ParsedArguments => {
                 hidden: true,
             },
         })
-        .strict()
+        .parserConfiguration({ 'unknown-options-as-args': true })
         .parseSync();
 
     const options: ArgumentOptions = {


### PR DESCRIPTION
Theoretically fixes #1818 
For sure fixes #1746 and fixes #1735

I can't believe it was this easy all along....

Need to regression test CLI mode with this, but theoretically it should still work fine.