### PR TITLE
Use ES2022 TS lib

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,11 @@
   "compilerOptions": {
     "noEmit": true,
     "noImplicitAny": true,
+    "lib": [
+      "ES2022",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "module": "es6",
     "target": "es6",
     "jsx": "react-jsx",


### PR DESCRIPTION
`Intl.Segmenter` is typed in the lib for ES2022, which we apparently don't use. So I changed that.