### PR TITLE
Added CAS to High Boost Filter

### DIFF
--- a/backend/src/nodes/impl/cas.py
+++ b/backend/src/nodes/impl/cas.py
@@ -15,7 +15,7 @@ def _luminance(img: np.ndarray) -> np.ndarray:
     return np.dot(img[..., :3], [0.2126, 0.7152, 0.0722])
 
 
-def create_cas_mask(img: np.ndarray, kernel) -> np.ndarray:
+def create_cas_mask(img: np.ndarray, kernel, bias: float = 1) -> np.ndarray:
     """
     Uses contrast adaptive sharpening's method to create a mask to interpolate between the original
     and sharpened image.
@@ -23,10 +23,19 @@ def create_cas_mask(img: np.ndarray, kernel) -> np.ndarray:
     `kernel` is an element create by `cv2.getStructuringElement`. It determines the shape and size
     of each pixel's neighborhood.
 
+    `bias` is used to bias the mask towards the more sharpening. A value of 1 means no bias, a
+    value greater than 1 biases the mask towards the sharpened image, a value less than 1 biases
+    the mask towards the original image.
+
+    Note: The original work uses a bias of 2.0. We use a bias default of 1 to make the sharpening
+    less aggressive. This is more useful for chaiNNer, because users can blend with a
+    non-CAS-sharpened image to get a similar effect.
+
     Reference:
     Lou Kramer, FidelityFX CAS, AMD Developer Day 2019, https://gpuopen.com/wp-content/uploads/2019/07/FidelityFX-CAS.pptx
     https://www.shadertoy.com/view/wtlSWB#
     """
+    assert bias > 0, "Bias must be greater than or equal to 0."
 
     l = _luminance(img)
     min_l = cv2.erode(l, kernel)
@@ -35,12 +44,17 @@ def create_cas_mask(img: np.ndarray, kernel) -> np.ndarray:
     max_l += 1e-8
     min_d /= max_l
     mask = min_d
-    # no sqrt, because we only need that in linear color space
-    # mask = np.sqrt(mask, out=mask)
+    if bias != 1:
+        mask = np.power(mask, 1 / bias, out=mask)
     return mask
 
 
-def cas_mix(img: np.ndarray, sharpened: np.ndarray, kernel) -> np.ndarray:
-    mask = create_cas_mask(img, kernel)
+def cas_mix(
+    img: np.ndarray,
+    sharpened: np.ndarray,
+    kernel,
+    bias: float = 1,
+) -> np.ndarray:
+    mask = create_cas_mask(img, kernel, bias)
     mask = np.dstack((mask,) * get_h_w_c(sharpened)[2])
     return img * (1 - mask) + sharpened * mask

--- a/backend/src/nodes/impl/cas.py
+++ b/backend/src/nodes/impl/cas.py
@@ -34,7 +34,9 @@ def create_cas_mask(img: np.ndarray, kernel) -> np.ndarray:
     min_d = np.minimum(1.0 - max_l, min_l, out=min_l)
     max_l += 1e-8
     min_d /= max_l
-    mask = np.sqrt(min_d, out=min_d)
+    mask = min_d
+    # no sqrt, because we only need that in linear color space
+    # mask = np.sqrt(mask, out=mask)
     return mask
 
 

--- a/backend/src/nodes/impl/cas.py
+++ b/backend/src/nodes/impl/cas.py
@@ -1,0 +1,44 @@
+import cv2
+import numpy as np
+
+from ..utils.utils import get_h_w_c
+from .image_utils import as_2d_grayscale
+
+
+def _luminance(img: np.ndarray) -> np.ndarray:
+    """Returns the luminance of an image."""
+    _, _, c = get_h_w_c(img)
+    if c == 1:
+        return as_2d_grayscale(img)
+    if c == 2:
+        return img[..., 0]
+    return np.dot(img[..., :3], [0.2126, 0.7152, 0.0722])
+
+
+def create_cas_mask(img: np.ndarray, kernel) -> np.ndarray:
+    """
+    Uses contrast adaptive sharpening's method to create a mask to interpolate between the original
+    and sharpened image.
+
+    `kernel` is an element create by `cv2.getStructuringElement`. It determines the shape and size
+    of each pixel's neighborhood.
+
+    Reference:
+    Lou Kramer, FidelityFX CAS, AMD Developer Day 2019, https://gpuopen.com/wp-content/uploads/2019/07/FidelityFX-CAS.pptx
+    https://www.shadertoy.com/view/wtlSWB#
+    """
+
+    l = _luminance(img)
+    min_l = cv2.erode(l, kernel)
+    max_l = cv2.dilate(l, kernel, dst=l)
+    min_d = np.minimum(1.0 - max_l, min_l, out=min_l)
+    max_l += 1e-8
+    min_d /= max_l
+    mask = np.sqrt(min_d, out=min_d)
+    return mask
+
+
+def cas_mix(img: np.ndarray, sharpened: np.ndarray, kernel) -> np.ndarray:
+    mask = create_cas_mask(img, kernel)
+    mask = np.dstack((mask,) * get_h_w_c(sharpened)[2])
+    return img * (1 - mask) + sharpened * mask

--- a/backend/src/nodes/impl/cas.py
+++ b/backend/src/nodes/impl/cas.py
@@ -15,7 +15,7 @@ def _luminance(img: np.ndarray) -> np.ndarray:
     return np.dot(img[..., :3], [0.2126, 0.7152, 0.0722])
 
 
-def create_cas_mask(img: np.ndarray, kernel, bias: float = 1) -> np.ndarray:
+def create_cas_mask(img: np.ndarray, kernel, bias: float = 2) -> np.ndarray:
     """
     Uses contrast adaptive sharpening's method to create a mask to interpolate between the original
     and sharpened image.
@@ -26,10 +26,6 @@ def create_cas_mask(img: np.ndarray, kernel, bias: float = 1) -> np.ndarray:
     `bias` is used to bias the mask towards the more sharpening. A value of 1 means no bias, a
     value greater than 1 biases the mask towards the sharpened image, a value less than 1 biases
     the mask towards the original image.
-
-    Note: The original work uses a bias of 2.0. We use a bias default of 1 to make the sharpening
-    less aggressive. This is more useful for chaiNNer, because users can blend with a
-    non-CAS-sharpened image to get a similar effect.
 
     Reference:
     Lou Kramer, FidelityFX CAS, AMD Developer Day 2019, https://gpuopen.com/wp-content/uploads/2019/07/FidelityFX-CAS.pptx
@@ -53,7 +49,7 @@ def cas_mix(
     img: np.ndarray,
     sharpened: np.ndarray,
     kernel,
-    bias: float = 1,
+    bias: float = 2,
 ) -> np.ndarray:
     mask = create_cas_mask(img, kernel, bias)
     mask = np.dstack((mask,) * get_h_w_c(sharpened)[2])

--- a/backend/src/packages/chaiNNer_standard/image_filter/sharpen/high_boost_sharpen.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/sharpen/high_boost_sharpen.py
@@ -5,6 +5,7 @@ from enum import Enum
 import cv2
 import numpy as np
 
+from nodes.groups import if_enum_group
 from nodes.impl.cas import cas_mix
 from nodes.properties.inputs import BoolInput, EnumInput, ImageInput, SliderInput
 from nodes.properties.outputs import ImageOutput
@@ -34,7 +35,18 @@ class KernelType(Enum):
             controls_step=1,
             scale="log",
         ),
-        BoolInput("Contrast Adaptive", default=False),
+        BoolInput("Contrast Adaptive", default=False).with_id(3),
+        if_enum_group(3, 1)(
+            SliderInput(
+                "Contrast Adaptive Bias",
+                minimum=1,
+                maximum=3,
+                default=2,
+                precision=2,
+                controls_step=0.1,
+                slider_step=0.1,
+            )
+        ),
     ],
     outputs=[ImageOutput(image_type="Input0")],
 )
@@ -43,6 +55,7 @@ def sharpen_hbf_node(
     kernel_type: KernelType,
     amount: float,
     contrast_adaptive: bool,
+    bias: float,
 ) -> np.ndarray:
     if amount == 0:
         return img
@@ -61,6 +74,6 @@ def sharpen_hbf_node(
     if contrast_adaptive:
         shape = cv2.MORPH_RECT if kernel_type == KernelType.STRONG else cv2.MORPH_CROSS
         kernel = cv2.getStructuringElement(shape, (3, 3))
-        sharpened = cas_mix(img, sharpened, kernel)
+        sharpened = cas_mix(img, sharpened, kernel, bias)
 
     return sharpened


### PR DESCRIPTION
This adds support contrast adaptive sharpening to High Boost Filter. CAS is an addition to the classical high boost filter. Its main effect is that it prevents oversharpening artifacts in regions of high contrast. This causes the sharpening to be applied more evenly.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/c96f5891-afad-407c-8a1d-46bb503c3035)


Example:

| Original | High boost | High boost + CAS |
| --- | --- | --- |
| ![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/cb4fe01d-6a1e-41c0-9867-6124775d3944)  | ![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/4f6074f2-d735-46ce-8cfa-7470a94344fa) | ![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/a4a25702-d6dc-4c92-aa53-d9211e228d83) |
| ![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/c11621eb-3977-4b33-b296-76c23e906d48) | ![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/0bc179dc-898b-4603-87a9-e63702ef5298) | ![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/b121eb7e-a145-4d7f-bf0a-6e1532cb124a) |

CAS is normally implemented by adjusting the per-pixel sharpen kernel. This is not an option for us, because we how to implement this in python and not shader code. So I implemented CAS as a linear blend mask between the original and sharpened image. This seems to yield a good-enough effect, as can be seen in the examples above.
