### PR TITLE
Consistent `NumberOutput` output type

### DIFF
--- a/backend/src/packages/chaiNNer_ncnn/ncnn/batch_processing/model_file_iterator.py
+++ b/backend/src/packages/chaiNNer_ncnn/ncnn/batch_processing/model_file_iterator.py
@@ -33,7 +33,7 @@ NCNN_ITERATOR_NODE_ID = "chainner:ncnn:model_iterator_load"
         DirectoryOutput("Model Directory"),
         TextOutput("Subdirectory Path"),
         TextOutput("Model Name"),
-        NumberOutput("Overall Index"),
+        NumberOutput("Overall Index", output_type="uint"),
     ],
     node_type="iteratorHelper",
     side_effects=True,

--- a/backend/src/packages/chaiNNer_ncnn/ncnn/utility/interpolate_models.py
+++ b/backend/src/packages/chaiNNer_ncnn/ncnn/utility/interpolate_models.py
@@ -44,8 +44,8 @@ def check_will_upscale(interp: NcnnModelWrapper):
     ],
     outputs=[
         NcnnModelOutput(),
-        NumberOutput("Amount A", "100 - Input2"),
-        NumberOutput("Amount B", "Input2"),
+        NumberOutput("Amount A", output_type="100 - Input2"),
+        NumberOutput("Amount B", output_type="Input2"),
     ],
 )
 def interpolate_models_node(

--- a/backend/src/packages/chaiNNer_onnx/onnx/batch_processing/model_file_iterator.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/batch_processing/model_file_iterator.py
@@ -33,7 +33,7 @@ ONNX_ITERATOR_NODE_ID = "chainner:onnx:model_iterator_load"
         DirectoryOutput("Model Directory"),
         TextOutput("Subdirectory Path"),
         TextOutput("Model Name"),
-        NumberOutput("Overall Index"),
+        NumberOutput("Overall Index", output_type="uint"),
     ],
     node_type="iteratorHelper",
     side_effects=True,

--- a/backend/src/packages/chaiNNer_onnx/onnx/utility/interpolate_models.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/utility/interpolate_models.py
@@ -78,8 +78,8 @@ def check_will_upscale(model: OnnxModel):
     ],
     outputs=[
         OnnxModelOutput(),
-        NumberOutput("Amount A", "100 - Input2"),
-        NumberOutput("Amount B", "Input2"),
+        NumberOutput("Amount A", output_type="100 - Input2"),
+        NumberOutput("Amount B", output_type="Input2"),
     ],
 )
 def interpolate_models_node(

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/iteration/model_file_iterator.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/iteration/model_file_iterator.py
@@ -33,7 +33,7 @@ PYTORCH_ITERATOR_NODE_ID = "chainner:pytorch:model_iterator_load"
         DirectoryOutput("Model Directory"),
         TextOutput("Subdirectory Path"),
         TextOutput("Model Name"),
-        NumberOutput("Overall Index"),
+        NumberOutput("Overall Index", output_type="uint"),
     ],
     node_type="iteratorHelper",
     side_effects=True,

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/utility/interpolate_models.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/utility/interpolate_models.py
@@ -82,8 +82,8 @@ def check_can_interp(model_a: dict, model_b: dict):
         ModelOutput(model_type="Input0 & Input1").with_never_reason(
             "Models must be of the same type and have the same parameters to be interpolated."
         ),
-        NumberOutput("Amount A", "100 - Input2"),
-        NumberOutput("Amount B", "Input2"),
+        NumberOutput("Amount A", output_type="100 - Input2"),
+        NumberOutput("Amount B", output_type="Input2"),
     ],
 )
 def interpolate_models_node(

--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/image_file_iterator.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/image_file_iterator.py
@@ -35,7 +35,7 @@ IMAGE_ITERATOR_NODE_ID = "chainner:image:file_iterator_load"
         DirectoryOutput("Image Directory"),
         TextOutput("Subdirectory Path"),
         TextOutput("Image Name"),
-        NumberOutput("Overall Index"),
+        NumberOutput("Overall Index", output_type="uint"),
     ],
     side_effects=True,
 )

--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/paired_image_file_iterator.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/paired_image_file_iterator.py
@@ -39,7 +39,7 @@ PAIRED_IMAGE_ITERATOR_NODE_ID = "chainner:image:paired_file_iterator_load"
         TextOutput("Subdirectory Path B"),
         TextOutput("Image Name A"),
         TextOutput("Image Name B"),
-        NumberOutput("Overall Index"),
+        NumberOutput("Overall Index", output_type="uint"),
     ],
     side_effects=True,
 )

--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/sprite_sheet_iterator.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/sprite_sheet_iterator.py
@@ -22,7 +22,10 @@ SPRITESHEET_ITERATOR_OUTPUT_NODE_ID = "chainner:image:spritesheet_iterator_save"
     icon="MdSubdirectoryArrowRight",
     node_type="iteratorHelper",
     inputs=[IteratorInput().make_optional()],
-    outputs=[ImageOutput(), NumberOutput("Overall Index")],
+    outputs=[
+        ImageOutput(),
+        NumberOutput("Overall Index", output_type="uint"),
+    ],
     side_effects=True,
 )
 def ImageSpriteSheetIteratorLoadImageNode(

--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/video_frame_iterator.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/video_frame_iterator.py
@@ -65,7 +65,7 @@ class Writer:
     inputs=[IteratorInput().make_optional()],
     outputs=[
         ImageOutput("Frame Image", channels=3),
-        NumberOutput("Frame Index"),
+        NumberOutput("Frame Index", output_type="uint"),
         DirectoryOutput("Video Directory"),
         TextOutput("Video Name"),
     ],


### PR DESCRIPTION
Changes:
- Added `uint` type to index outputs of iterators. This probably won't help much, but it felt like the right thing to do.
- Always use `output_type=` for the argument.