### PR TITLE
Common refactor

### DIFF
--- a/backend/src/nodes/impl/dithering/color_distance.py
+++ b/backend/src/nodes/impl/dithering/color_distance.py
@@ -4,7 +4,7 @@ import cv2
 import numpy as np
 
 from ..image_utils import as_3d
-from .common import dtype_to_float, float_to_dtype
+from .common import as_dtype, as_float32
 
 
 def nearest_uniform_color(value: np.ndarray, num_colors: int) -> np.ndarray:
@@ -12,8 +12,8 @@ def nearest_uniform_color(value: np.ndarray, num_colors: int) -> np.ndarray:
 
 
 def batch_nearest_uniform_color(image: np.ndarray, num_colors: int) -> np.ndarray:
-    return float_to_dtype(
-        np.floor(dtype_to_float(image) * (num_colors - 1) + 0.5) / (num_colors - 1),
+    return as_dtype(
+        np.floor(as_float32(image) * (num_colors - 1) + 0.5) / (num_colors - 1),
         image.dtype,
     )
 

--- a/backend/src/nodes/impl/dithering/common.py
+++ b/backend/src/nodes/impl/dithering/common.py
@@ -1,44 +1,38 @@
+from typing import Callable
+
 import numpy as np
 
 from ..image_utils import MAX_VALUES_BY_DTYPE
 
 
-def dtype_convert(image: np.ndarray, target_dtype: np.dtype):
+def as_dtype(image: np.ndarray, target_dtype: np.dtype):
     if image.dtype == target_dtype:
         return image
 
-    image = dtype_to_float(image)
-    return float_to_dtype(image, target_dtype)
+    image = as_float32(image)
+    return _float_to_dtype(image, target_dtype)
 
 
-def dtype_to_float(image: np.ndarray) -> np.ndarray:
+def as_float32(image: np.ndarray) -> np.ndarray:
     if image.dtype == np.float32:
         return image
     max_value = MAX_VALUES_BY_DTYPE[image.dtype]
     return image.astype(np.float32) / max_value
 
 
-def dtype_to_uint8(image: np.ndarray) -> np.ndarray:
-    return dtype_convert(image, np.dtype("uint8"))
-
-
-def float_to_dtype(image: np.ndarray, dtype: np.dtype) -> np.ndarray:
+def _float_to_dtype(image: np.ndarray, dtype: np.dtype) -> np.ndarray:
     if image.dtype == dtype:
         return image
     max_value = MAX_VALUES_BY_DTYPE[dtype]
     return (image * max_value).astype(dtype)
 
 
-def apply_to_all_channels(
-    one_channel_filter, image: np.ndarray, *args, **kwargs
+def map_channels(
+    image: np.ndarray, fn: Callable[[np.ndarray], np.ndarray]
 ) -> np.ndarray:
     if image.ndim == 2:
-        return one_channel_filter(image, *args, **kwargs)
-    output_image = np.stack(
-        [
-            one_channel_filter(image[:, :, channel], *args, **kwargs)
-            for channel in range(image.shape[2])
-        ],
-        axis=2,
-    )
-    return output_image
+        return fn(image)
+    else:
+        return np.dstack(
+            [fn(image[:, :, channel]) for channel in range(image.shape[2])],
+        )

--- a/backend/src/nodes/impl/dithering/diffusion.py
+++ b/backend/src/nodes/impl/dithering/diffusion.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from ..image_utils import as_3d
 from .color_distance import nearest_palette_color, nearest_uniform_color
-from .common import dtype_to_float, float_to_dtype
+from .common import as_dtype, as_float32
 from .constants import ERROR_DIFFUSION_MAPS, ErrorDiffusionMap
 
 
@@ -11,7 +11,7 @@ def error_diffusion_dither(
 ) -> np.ndarray:
     image = as_3d(image)
 
-    output_image = dtype_to_float(image)
+    output_image = as_float32(image)
     edm = ERROR_DIFFUSION_MAPS[error_diffusion_map]
     for row in range(output_image.shape[0]):
         for col in range(output_image.shape[1]):
@@ -25,7 +25,7 @@ def error_diffusion_dither(
                 ):
                     continue
                 output_image[row + delta_row, col + delta_col, :] += error * coefficient
-    return float_to_dtype(output_image, image.dtype)
+    return as_dtype(output_image, image.dtype)
 
 
 def uniform_error_diffusion_dither(
@@ -42,7 +42,7 @@ def palette_error_diffusion_dither(
     palette: np.ndarray,
     error_diffusion_map: ErrorDiffusionMap,
 ) -> np.ndarray:
-    palette = dtype_to_float(as_3d(palette))
+    palette = as_float32(as_3d(palette))
 
     cache = []
 

--- a/backend/src/nodes/impl/dithering/ordered.py
+++ b/backend/src/nodes/impl/dithering/ordered.py
@@ -2,7 +2,7 @@ from typing import Tuple
 
 import numpy as np
 
-from .common import apply_to_all_channels, dtype_to_float, float_to_dtype
+from .common import as_dtype, as_float32, map_channels
 from .constants import THRESHOLD_MAPS, ThresholdMap
 
 
@@ -30,9 +30,8 @@ def one_channel_ordered_dither(
     """
 
     tm = get_threshold_map(image.shape, threshold_map=threshold_map)
-    return float_to_dtype(
-        np.floor((dtype_to_float(image) + tm) * (num_colors - 1) + 0.5)
-        / (num_colors - 1),
+    return as_dtype(
+        np.floor((as_float32(image) + tm) * (num_colors - 1) + 0.5) / (num_colors - 1),
         image.dtype,
     )
 
@@ -40,9 +39,7 @@ def one_channel_ordered_dither(
 def ordered_dither(
     image: np.ndarray, threshold_map: ThresholdMap, num_colors: int
 ) -> np.ndarray:
-    return apply_to_all_channels(
-        one_channel_ordered_dither,
+    return map_channels(
         image,
-        threshold_map=threshold_map,
-        num_colors=num_colors,
+        lambda channel: one_channel_ordered_dither(channel, threshold_map, num_colors),
     )

--- a/backend/src/nodes/impl/dithering/palette.py
+++ b/backend/src/nodes/impl/dithering/palette.py
@@ -2,7 +2,7 @@ import cv2
 import numpy as np
 
 from ..image_utils import as_3d
-from .common import dtype_to_float
+from .common import as_float32
 
 
 def distinct_colors_palette(image: np.ndarray) -> np.ndarray:
@@ -14,7 +14,7 @@ def distinct_colors_palette(image: np.ndarray) -> np.ndarray:
 
 def kmeans_palette(image: np.ndarray, num_colors: int) -> np.ndarray:
     image = as_3d(image)
-    flat_image = dtype_to_float(image.reshape((-1, image.shape[2])))
+    flat_image = as_float32(image.reshape((-1, image.shape[2])))
 
     max_iter = 10
     epsilon = 1.0
@@ -55,7 +55,7 @@ class MedianCutBucket:
 
 def median_cut_palette(image: np.ndarray, num_colors: int) -> np.ndarray:
     image = as_3d(image)
-    flat_image = dtype_to_float(image.reshape((-1, image.shape[2])))
+    flat_image = as_float32(image.reshape((-1, image.shape[2])))
 
     buckets = [MedianCutBucket(flat_image)]
     while len(buckets) < num_colors:

--- a/backend/src/nodes/impl/dithering/riemersma.py
+++ b/backend/src/nodes/impl/dithering/riemersma.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from ..image_utils import as_3d
 from .color_distance import nearest_palette_color, nearest_uniform_color
-from .common import dtype_to_float, float_to_dtype
+from .common import as_dtype, as_float32
 from .hilbert import HilbertCurve
 
 
@@ -31,7 +31,7 @@ def riemersma_dither(
     curve_size = _next_power_of_two(max(image.shape))
 
     original_dtype = image.dtype
-    image = dtype_to_float(image)
+    image = as_float32(image)
 
     out = np.zeros_like(image)
     history = deque(maxlen=history_length)
@@ -45,7 +45,7 @@ def riemersma_dither(
         pixel = image[i, j, :] + es
         out[i, j, :] = nearest_color_func(pixel)
         history.appendleft(image[i, j, :] - out[i, j, :])  # type: ignore
-    return float_to_dtype(out, original_dtype)
+    return as_dtype(out, original_dtype)
 
 
 def uniform_riemersma_dither(
@@ -63,7 +63,7 @@ def palette_riemersma_dither(
     history_length: int,
     decay_ratio: float,
 ) -> np.ndarray:
-    palette = dtype_to_float(as_3d(palette))
+    palette = as_float32(as_3d(palette))
 
     cache = []
 

--- a/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/distance_transform.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/distance_transform.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import cv2
 import numpy as np
 
-from nodes.impl.dithering.common import dtype_to_uint8
-from nodes.impl.image_utils import as_3d
+from nodes.impl.image_utils import as_3d, to_uint8
 from nodes.properties.inputs import ImageInput, NumberInput
 from nodes.properties.outputs import ImageOutput
 
@@ -23,7 +22,7 @@ from .. import miscellaneous_group
     outputs=[ImageOutput(image_type="Input0")],
 )
 def distance_transform_node(img: np.ndarray, spread: int) -> np.ndarray:
-    img = as_3d(dtype_to_uint8(img))
+    img = as_3d(to_uint8(img, normalized=True))
     img[img < 128] = 0
     img[img >= 128] = 255
 


### PR DESCRIPTION
I took a look at dithering.common and changed a few things:

- Removed `dtype_to_uint8`. We can just use `to_uint8` from image_utils.
- Changed `apply_to_all_channels` (and renamed it to `map_channels`). Its API is now simpler and fully typed.
- Renamed `dtype_to_float` to `as_float32`. This name clarifies that we get a float32 array back, and that this method avoids copying if possible.
- Renamed `dtype_convert` to `as_dtype`. Same here. `convert` made it sounds like we always get back a new array, even though this isn't the case.
- Made `float_to_dtype` private. Just use `as_dtype`.

I wonder whether we should use these methods into image_utils, but we don't deal with arbitrary-dtype images anywhere else, so it'd be kinda strange to have them there.