### PR TITLE
Settings: Reset dropdowns if the current value is not a valid option

### DIFF
--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -116,39 +116,59 @@ const Toggle = memo(({ title, description, isDisabled, value, onToggle }: Toggle
     );
 });
 
-interface DropdownProps extends SettingsItemProps {
+interface DropdownProps<T> extends SettingsItemProps {
     isDisabled?: boolean;
-    value: string | number;
-    options: { label: string; value: string | number }[];
-    onChange: React.ChangeEventHandler<HTMLSelectElement>;
+    value: T;
+    options: readonly { label: string; value: T }[];
+    onChange: (value: T) => void;
 }
 
-const Dropdown = memo(
-    ({ title, description, isDisabled, value, options, onChange }: DropdownProps) => {
-        return (
-            <SettingsItem
-                description={description}
-                title={title}
+// eslint-disable-next-line prefer-arrow-functions/prefer-arrow-functions, react-memo/require-memo
+function Dropdown<T>({
+    title,
+    description,
+    isDisabled,
+    value,
+    options,
+    onChange,
+}: DropdownProps<T>) {
+    const index = options.findIndex((o) => o.value === value);
+
+    useEffect(() => {
+        if (index === -1 && !isDisabled) {
+            if (options.length > 0) {
+                onChange(options[0].value);
+            }
+        }
+    }, [index, options, onChange, isDisabled]);
+
+    return (
+        <SettingsItem
+            description={description}
+            title={title}
+        >
+            <Select
+                isDisabled={isDisabled}
+                minWidth="350px"
+                value={index === -1 ? 0 : index}
+                onChange={(e) => {
+                    const optionIndex = Number(e.target.value);
+                    onChange(options[optionIndex].value);
+                }}
             >
-                <Select
-                    isDisabled={isDisabled}
-                    minWidth="350px"
-                    value={value}
-                    onChange={onChange}
-                >
-                    {options.map(({ label, value: v }) => (
-                        <option
-                            key={v}
-                            value={v}
-                        >
-                            {label}
-                        </option>
-                    ))}
-                </Select>
-            </SettingsItem>
-        );
-    }
-);
+                {options.map(({ label }, i) => (
+                    <option
+                        // eslint-disable-next-line react/no-array-index-key
+                        key={i}
+                        value={i}
+                    >
+                        {label}
+                    </option>
+                ))}
+            </Select>
+        </SettingsItem>
+    );
+}
 
 const AppearanceSettings = memo(() => {
     const { useSnapToGrid, useIsDarkMode, useAnimateChain, useViewportExportPadding } =
@@ -538,9 +558,7 @@ const PythonSettings = memo(() => {
                             }))}
                             title="PyTorch GPU"
                             value={pytorchGPU}
-                            onChange={(e) => {
-                                setPytorchGPU(Number(e.target.value));
-                            }}
+                            onChange={setPytorchGPU}
                         />
                     </VStack>
                 </TabPanel>
@@ -558,9 +576,7 @@ const PythonSettings = memo(() => {
                             }))}
                             title="NCNN GPU"
                             value={ncnnGPU}
-                            onChange={(e) => {
-                                setNcnnGPU(Number(e.target.value));
-                            }}
+                            onChange={setNcnnGPU}
                         />
                     </VStack>
                 </TabPanel>
@@ -578,18 +594,14 @@ const PythonSettings = memo(() => {
                             }))}
                             title="ONNX GPU"
                             value={onnxGPU}
-                            onChange={(e) => {
-                                setOnnxGPU(Number(e.target.value));
-                            }}
+                            onChange={setOnnxGPU}
                         />
                         <Dropdown
                             description="What provider to use for ONNX."
                             options={onnxExecutionProviders}
                             title="ONNX Execution Provider"
                             value={onnxExecutionProvider}
-                            onChange={(e) => {
-                                setOnnxExecutionProvider(String(e.target.value));
-                            }}
+                            onChange={setOnnxExecutionProvider}
                         />
                         {isUsingTensorRt && (
                             <HStack>


### PR DESCRIPTION
Fixes #1660.

I also made the `Dropdown` component generic over the value, which makes it easier to use. Unfortunately, `memo` messed up the generics, so I had to un-memo it.