### PR TITLE
Added nearest color mode for Fill Alpha

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image_channel/misc/fill_alpha.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/misc/fill_alpha.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from enum import Enum
 
 import numpy as np
-from chainner_ext import fill_alpha_extend_color, fill_alpha_fragment_blur
+from chainner_ext import (
+    fill_alpha_extend_color,
+    fill_alpha_fragment_blur,
+    fill_alpha_nearest_color,
+)
 
 import navi
 from nodes.properties.inputs import EnumInput, ImageInput
@@ -15,6 +19,7 @@ from . import node_group
 class AlphaFillMethod(Enum):
     EXTEND_TEXTURE = 1
     EXTEND_COLOR = 2
+    NEAREST_COLOR = 3
 
 
 @node_group.register(
@@ -47,6 +52,13 @@ def fill_alpha_node(img: np.ndarray, method: AlphaFillMethod) -> np.ndarray:
         img = fill_alpha_extend_color(img, threshold=0.05, iterations=100_000)
     elif method == AlphaFillMethod.EXTEND_COLOR:
         img = fill_alpha_extend_color(img, threshold=0.05, iterations=100_000)
+    elif method == AlphaFillMethod.NEAREST_COLOR:
+        img = fill_alpha_nearest_color(
+            img,
+            threshold=0.05,
+            min_radius=100_000,
+            anti_aliasing=True,
+        )
     else:
         assert False, f"Invalid alpha fill method {method}"
 


### PR DESCRIPTION
Nearest Color fills transparent pixels with the color of the nearest non-transparent pixel. In comparison, Extend Color is a crude but fast approximation of nearest color.

I already implemented this in chainner_ext a while ago, but just didn't add it to chainner yet.

### Example

Original:
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/77b45268-048c-4a14-b8bf-8e8545487aed)

Nearest Color:
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/9d03c2bc-5bed-461d-ad3b-579e3a5e50fe)

Extend Color:
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/03ec3714-be78-4a01-ae3b-b98b2d44c4e2)

Extend Texture (it uses Extend Color after a certain radius):
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/b28ea6b5-cfe1-4efc-a68d-6ee8c5753c52)
