### PR TITLE
Add "Get Bounding Box" node

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -111,5 +111,6 @@
         "source.organizeImports": true
     }
   },
-  "isort.args":["--profile", "black", "--src", "${workspaceFolder}/backend/src"]
+  "isort.args":["--profile", "black", "--src", "${workspaceFolder}/backend/src"],
+  "black-formatter.args": ["--line-length=88"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -111,6 +111,5 @@
         "source.organizeImports": true
     }
   },
-  "isort.args":["--profile", "black", "--src", "${workspaceFolder}/backend/src"],
-  "black-formatter.args": ["--line-length=88"]
+  "isort.args":["--profile", "black", "--src", "${workspaceFolder}/backend/src"]
 }

--- a/backend/src/packages/chaiNNer_standard/image_dimension/utility/get_bounding_box.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/utility/get_bounding_box.py
@@ -31,8 +31,8 @@ from .. import utility_group
     outputs=[
         NumberOutput("X", output_type="min(uint, Input0.width - 1)"),
         NumberOutput("Y", output_type="min(uint, Input0.height - 1)"),
-        NumberOutput("Width", output_type="min(uint, Input0.width)"),
-        NumberOutput("Height", output_type="min(uint, Input0.height)"),
+        NumberOutput("Width", output_type="min(uint, Input0.width) & 1.."),
+        NumberOutput("Height", output_type="min(uint, Input0.height) & 1.."),
     ],
 )
 def get_bounding_box_node(
@@ -45,14 +45,9 @@ def get_bounding_box_node(
     h, w, _ = get_h_w_c(img)
 
     r = np.any(img > thresh, 1)
-    if r.any():
-        c = np.any(img > thresh, 0)
-        x, y = c.argmax(), r.argmax()
-        return (
-            int(x),
-            int(y),
-            int(w - x - c[::-1].argmax()),
-            int(h - y - r[::-1].argmax()),
-        )
-    else:
-        return 0, 0, w, h
+    c = np.any(img > thresh, 0)
+    if not (r.any() and c.any()):
+        raise RuntimeError("Resulting bounding box is empty.")
+
+    x, y = c.argmax(), r.argmax()
+    return int(x), int(y), int(w - x - c[::-1].argmax()), int(h - y - r[::-1].argmax())

--- a/backend/src/packages/chaiNNer_standard/image_dimension/utility/get_bounding_box.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/utility/get_bounding_box.py
@@ -14,7 +14,7 @@ from .. import utility_group
 @utility_group.register(
     schema_id="chainner:image:get_bbox",
     name="Get Bounding Box",
-    description="Get the X, Y, Height, and Width of a bounding box in the image in px.",
+    description="Gets a bounding box (X, Y, Height, and Width) of the white area of a mask.",
     icon="BsRulers",
     inputs=[
         ImageInput(channels=1),

--- a/backend/src/packages/chaiNNer_standard/image_dimension/utility/get_bounding_box.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/utility/get_bounding_box.py
@@ -46,7 +46,7 @@ def get_bounding_box_node(
 
     r = np.any(img > thresh, 1)
     c = np.any(img > thresh, 0)
-    if not (r.any() and c.any()):
+    if not r.any():
         raise RuntimeError("Resulting bounding box is empty.")
 
     x, y = c.argmax(), r.argmax()

--- a/backend/src/packages/chaiNNer_standard/image_dimension/utility/get_bounding_box.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/utility/get_bounding_box.py
@@ -15,7 +15,7 @@ from .. import utility_group
     schema_id="chainner:image:get_bbox",
     name="Get Bounding Box",
     description="Gets a bounding box (X, Y, Height, and Width) of the white area of a mask.",
-    icon="BsRulers",
+    icon="BsBoundingBox",
     inputs=[
         ImageInput(channels=1),
         SliderInput(

--- a/backend/src/packages/chaiNNer_standard/image_dimension/utility/get_bounding_box.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/utility/get_bounding_box.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Tuple
+
+import cv2
+import numpy as np
+
+from nodes.properties.inputs import ImageInput, NumberInput, SliderInput
+from nodes.properties.outputs import NumberOutput
+from nodes.utils.utils import get_h_w_c
+
+from .. import utility_group
+
+
+@utility_group.register(
+    schema_id="chainner:image:get_bbox",
+    name="Get Bounding Box",
+    description="Get the X, Y, Height, and Width of a bounding box in the image in px.",
+    icon="BsRulers",
+    inputs=[
+        ImageInput(channels=1),
+        SliderInput(
+            "Threshold",
+            precision=1,
+            minimum=1,
+            controls_step=1,
+            slider_step=1,
+            default=1,
+        ),
+    ],
+    outputs=[
+        NumberOutput("X"),
+        NumberOutput("Y"),
+        NumberOutput("Width"),
+        NumberOutput("Height"),
+    ],
+)
+def get_dimensions_node(
+    img: np.ndarray,
+    thresh_val: float,
+) -> Tuple[int, int, int, int]:
+    # Threshold value 100 guarantees an empty image, so make sure the max
+    # is just below that.
+    thresh = min(thresh_val / 100, 0.99999)
+    h, w, _ = get_h_w_c(img)
+
+    r = np.any(img > thresh, 1)
+    if r.any():
+        c = np.any(img > thresh, 0)
+        x, y = c.argmax(), r.argmax()
+        return (
+            int(x),
+            int(y),
+            int(w - x - c[::-1].argmax()),
+            int(h - y - r[::-1].argmax()),
+        )
+    else:
+        return 0, 0, w, h

--- a/backend/src/packages/chaiNNer_standard/image_dimension/utility/get_bounding_box.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/utility/get_bounding_box.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 from typing import Tuple
 
-import cv2
 import numpy as np
 
-from nodes.properties.inputs import ImageInput, NumberInput, SliderInput
+from nodes.properties.inputs import ImageInput, SliderInput
 from nodes.properties.outputs import NumberOutput
 from nodes.utils.utils import get_h_w_c
 

--- a/backend/src/packages/chaiNNer_standard/image_dimension/utility/get_bounding_box.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/utility/get_bounding_box.py
@@ -21,20 +21,21 @@ from .. import utility_group
         SliderInput(
             "Threshold",
             precision=1,
-            minimum=1,
+            minimum=0,
+            maximum=100,
             controls_step=1,
             slider_step=1,
-            default=1,
+            default=0,
         ),
     ],
     outputs=[
-        NumberOutput("X"),
-        NumberOutput("Y"),
-        NumberOutput("Width"),
-        NumberOutput("Height"),
+        NumberOutput("X", output_type="min(uint, Input0.width - 1)"),
+        NumberOutput("Y", output_type="min(uint, Input0.height - 1)"),
+        NumberOutput("Width", output_type="min(uint, Input0.width)"),
+        NumberOutput("Height", output_type="min(uint, Input0.height)"),
     ],
 )
-def get_dimensions_node(
+def get_bounding_box_node(
     img: np.ndarray,
     thresh_val: float,
 ) -> Tuple[int, int, int, int]:


### PR DESCRIPTION
This essentially does the same thing as the 'crop content' node but instead returns the dimensions needed to do such an operation.
![box](https://github.com/chaiNNer-org/chaiNNer/assets/54873330/246e94b0-b7a1-4e25-8c61-ac4df874e27c)
The threshold represents the minimum value a pixel must be to be considered part of the mask.
This example uses the data to simply crop the original image, like 'crop content': ![simple-preview](https://github.com/chaiNNer-org/chaiNNer/assets/54873330/bd257fdc-e78e-4e7f-88f6-dc1b6fa3e368)
Having these as separate node operations give access to more complex node setups, like this version: 
![full-preview](https://github.com/chaiNNer-org/chaiNNer/assets/54873330/149ae16a-4eb9-4a00-a1b7-c03e9348f65b)
This crops the image, superscales the specific section then moves it back into place.

Edit: changed the complex example to use the mask as transparency.