### PR TITLE
Allow color inputs in merge transparency

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image_channel/transparency/transparency_merge.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/transparency/transparency_merge.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import cv2
 import numpy as np
 
 from nodes.impl.color.color import Color


### PR DESCRIPTION
Merge Transparency now allows color inputs.

I also switched to `as_target_channels` to convert the input RGB channels to RGB. This drops support for 2-channel images, but no node produces any right now anyway, so that's not a huge loss. If we decide to properly support 2-channel images in the future, we will add support for them to `as_target_channels` anyway, since this function is used everywhere.