### PR TITLE
Document useful commands

### DIFF
--- a/.github/workflows/lint-frontend.yml
+++ b/.github/workflows/lint-frontend.yml
@@ -33,6 +33,6 @@ jobs:
                   cache: 'npm'
             - run: npm ci --force
             - name: eslint
-              run: npm run lint-js-ci
+              run: npm run lint:js-ci
             - name: typescript
               run: npx tsc

--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -30,4 +30,4 @@ jobs:
                   node-version: 16
                   cache: 'npm'
             - run: npm ci --force
-            - run: npm run test-js
+            - run: npm run test:js

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
 	"version": "0.2.0",
 	"configurations": [
 		{
-			"name": "Attach Debugger",
+			"name": "Attach Debugger to chaiNNer",
 			"type": "python",
 			"request": "attach",
 			"connect": {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,17 @@ There are 2 way to run chaiNNer:
 
 Generally, use `npm run dev` when you want to develop the backend or the frontend, and use `npm start` you want to start chaiNNer in a more production-like mode.
 
+## Useful commands
+
+The following commands will only work after you have installed the dependencies of the frontend and the backend, so be sure to follow [Getting Started](#getting-started).
+
+-   `npm run dev` & `npm start` - See [Running the Application](#running-the-application)
+-   `npm run debug` - Same as `npm run dev`, but starts the backend with debugger support. You can attach a debugger to the backend by using the `Attach Debugger to chaiNNer` launch configuration in VSCode. This allows you to set breakpoints in the backend code.
+-   `npm run lint` - Runs the linter on the frontend and backend code.
+-   `npm run lint:fix` - Runs the linter on the frontend and backend code and fixes all fixable errors. This includes formatting, sorting imports, etc.
+-   `npm run test` - Runs the tests.
+-   `npm run test:update` - Runs the tests and updates any outdated snapshots.
+
 ## Project structure
 
 The project is split into 2 parts: the frontend and the backend. The frontend is located in the `src` folder and the backend is located in the `backend` folder.

--- a/package.json
+++ b/package.json
@@ -16,14 +16,15 @@
     "make-win-zip": "cross-env NODE_ENV=production electron-forge make --targets @electron-forge/maker-zip --platform win32",
     "make-mac-zip": "cross-env NODE_ENV=production electron-forge make --targets @electron-forge/maker-zip --platform darwin",
     "publish": "cross-env NODE_ENV=production electron-forge publish",
-    "lint": "npm run lint-js && npm run lint-py",
-    "lint-js": "eslint . --ext \".js,.jsx,.ts,.tsx\" && stylelint src/**/*.scss",
-    "lint-js-ci": "eslint . --ext \".js,.jsx,.ts,.tsx\" --max-warnings 0 && stylelint src/**/*.scss",
-    "lint-py": "black --check ./backend && isort backend/ --check --profile=black --src=backend/src",
-    "lint-fix": "eslint . --fix --ext \".js,.jsx,.ts,.tsx\" && stylelint src/**/*.scss --fix && black ./backend && isort backend/ --profile=black --src=backend/src",
-    "test-js": "jest",
-    "test-py": "pytest ./backend/tests/",
-    "test": "npm run test-js && npm run test-py"
+    "lint": "npm run lint:js && npm run lint:py",
+    "lint:js": "eslint . --ext \".js,.jsx,.ts,.tsx\" && stylelint src/**/*.scss",
+    "lint:js-ci": "eslint . --ext \".js,.jsx,.ts,.tsx\" --max-warnings 0 && stylelint src/**/*.scss",
+    "lint:py": "black --check ./backend && isort backend/ --check --profile=black --src=backend/src",
+    "lint:fix": "eslint . --fix --ext \".js,.jsx,.ts,.tsx\" && stylelint src/**/*.scss --fix && black ./backend && isort backend/ --profile=black --src=backend/src",
+    "test:js": "jest",
+    "test:py": "pytest ./backend/tests/",
+    "test:update": "npm run test:js -- -u",
+    "test": "npm run test:js && npm run test:py"
   },
   "keywords": [],
   "author": {


### PR DESCRIPTION
Changes:
- Documented useful commands.
- Changed some command names to use the more common `foo:bar` notation for sub commands. This is pretty much standard for npm scripts ([some even rely on it](https://github.com/mysticatea/npm-run-all)), and I always wondered by we used `foo-bar`.
- Renamed the debugger launch config to "Attach Debugger to chaiNNer."
- Added `test:update` command to update snapshots.