### PR TITLE
Improved `/nodes` fetching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "react-i18next": "^12.0.0",
         "react-icons": "^4.7.1",
         "react-markdown": "^8.0.3",
+        "react-query": "^3.39.3",
         "react-time-ago": "^7.2.1",
         "reactflow": "^11.5.6",
         "rregex": "^1.5.1",
@@ -50,7 +51,6 @@
         "undici": "^5.22.1",
         "use-context-selector": "^1.4.0",
         "use-debounce": "^8.0.1",
-        "use-http": "^1.0.26",
         "uuid": "^8.3.2",
         "wcag-contrast": "^3.0.0",
         "yargs": "^17.5.1"
@@ -6587,8 +6587,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/base32-encode": {
       "version": "1.2.0",
@@ -6638,6 +6637,14 @@
       "funding": {
         "type": "individual",
         "url": "https://github.com/Pomax/bezierjs/blob/master/FUNDING.md"
+      }
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/big.js": {
@@ -7313,7 +7320,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -7328,6 +7334,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/broadcast-channel": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
+      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "detect-node": "^2.1.0",
+        "js-sha3": "0.8.0",
+        "microseconds": "0.2.0",
+        "nano-time": "1.0.0",
+        "oblivious-set": "1.0.0",
+        "rimraf": "3.0.2",
+        "unload": "2.2.0"
       }
     },
     "node_modules/browserslist": {
@@ -8159,8 +8180,7 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "node_modules/concurrently": {
       "version": "7.2.1",
@@ -9224,8 +9244,7 @@
     "node_modules/detect-node": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-      "dev": true
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
@@ -12279,8 +12298,7 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -12658,7 +12676,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -13787,7 +13804,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -16560,6 +16576,11 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -17284,6 +17305,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/match-sorter": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
+      "integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "remove-accents": "0.4.2"
       }
     },
     "node_modules/matcher": {
@@ -18114,6 +18144,11 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/microseconds": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
+      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
+    },
     "node_modules/mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -18191,7 +18226,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -18387,6 +18421,14 @@
       "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/nano-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
+      "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
+      "dependencies": {
+        "big-integer": "^1.6.16"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.4",
@@ -18880,6 +18922,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/oblivious-set": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
+      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
     },
     "node_modules/obuf": {
       "version": "1.1.2",
@@ -19407,7 +19454,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20387,6 +20433,31 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
       "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg=="
     },
+    "node_modules/react-query": {
+      "version": "3.39.3",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.3.tgz",
+      "integrity": "sha512-nLfLz7GiohKTJDuT4us4X3h/8unOh+00MLb2yJoGTPjxKs2bc1iDhkNx2bd5MKklXnOD3NrVZ+J2UXujA5In4g==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "broadcast-channel": "^3.4.1",
+        "match-sorter": "^6.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.13.0.tgz",
@@ -20735,6 +20806,11 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
+    },
     "node_modules/renderkid": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
@@ -20935,7 +21011,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -23401,6 +23476,15 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/unload": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
+      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
+      "dependencies": {
+        "@babel/runtime": "^7.6.2",
+        "detect-node": "^2.0.4"
+      }
+    },
     "node_modules/unorm": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
@@ -23527,38 +23611,6 @@
         "react": ">=16.8.0"
       }
     },
-    "node_modules/use-http": {
-      "version": "1.0.26",
-      "resolved": "https://registry.npmjs.org/use-http/-/use-http-1.0.26.tgz",
-      "integrity": "sha512-yB0dXX2S0Doyiti/kHqMsvlShL3tlI8YkoEARao1OVFKrGvyXejmWvrYkEI+oVTPvUqGzOsHbNROY0qKDC88Pg==",
-      "dependencies": {
-        "urs": "^0.0.8",
-        "use-ssr": "^1.0.24",
-        "utility-types": "^3.10.0"
-      },
-      "peerDependencies": {
-        "react": "^16.13.1 || ^17.0.0",
-        "react-dom": "^16.13.1 || ^17.0.0"
-      }
-    },
-    "node_modules/use-http/node_modules/urs": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/urs/-/urs-0.0.8.tgz",
-      "integrity": "sha512-LaSSPpr91XrVA3vW2zPupw4K6DSQEDKdL4yQZX1mO2fpljIMpB5zctrjRvxLurelWSgKsHsCmfHNCImscryirQ==",
-      "peerDependencies": {
-        "react": "^16.13.1 || ^17.0.0",
-        "react-dom": "^16.13.1 || ^17.0.0"
-      }
-    },
-    "node_modules/use-http/node_modules/use-ssr": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/use-ssr/-/use-ssr-1.0.24.tgz",
-      "integrity": "sha512-0MFps7ezL57/3o0yl4CvrHLlp9z20n1rQZV/lSRz7if+TUoM6POU1XdOvEjIgjgKeIhTEye1U0khrIYWCTWw4g==",
-      "peerDependencies": {
-        "react": "^16.13.1 || ^17.0.0",
-        "react-dom": "^16.13.1 || ^17.0.0"
-      }
-    },
     "node_modules/use-sidecar": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
@@ -23616,14 +23668,6 @@
       "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
       "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
       "dev": true
-    },
-    "node_modules/utility-types": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.10.0.tgz",
-      "integrity": "sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==",
-      "engines": {
-        "node": ">= 4"
-      }
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -29510,8 +29554,7 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "base32-encode": {
       "version": "1.2.0",
@@ -29544,6 +29587,11 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/bezier-js/-/bezier-js-6.1.0.tgz",
       "integrity": "sha512-oc8fkHqG0R+dQuNiXVbPMB0cc8iDqkLAjbA2gq26QmV8tZqW9GGI7iNEX1ioRWlZperQS7v5BX03+9FLVWZbSw=="
+    },
+    "big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg=="
     },
     "big.js": {
       "version": "5.2.2",
@@ -30127,7 +30175,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -30139,6 +30186,21 @@
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "requires": {
         "fill-range": "^7.0.1"
+      }
+    },
+    "broadcast-channel": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
+      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "detect-node": "^2.1.0",
+        "js-sha3": "0.8.0",
+        "microseconds": "0.2.0",
+        "nano-time": "1.0.0",
+        "oblivious-set": "1.0.0",
+        "rimraf": "3.0.2",
+        "unload": "2.2.0"
       }
     },
     "browserslist": {
@@ -30758,8 +30820,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concurrently": {
       "version": "7.2.1",
@@ -31518,8 +31579,7 @@
     "detect-node": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-      "dev": true
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "detect-node-es": {
       "version": "1.1.0",
@@ -33858,8 +33918,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "2.3.2",
@@ -34157,7 +34216,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -34981,7 +35039,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -37030,6 +37087,11 @@
         }
       }
     },
+    "js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -37604,6 +37666,15 @@
       "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
       "dev": true
     },
+    "match-sorter": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
+      "integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "remove-accents": "0.4.2"
+      }
+    },
     "matcher": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
@@ -38130,6 +38201,11 @@
         "picomatch": "^2.3.1"
       }
     },
+    "microseconds": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
+      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
+    },
     "mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -38185,7 +38261,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -38336,6 +38411,14 @@
       "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
       "dev": true,
       "optional": true
+    },
+    "nano-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
+      "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
+      "requires": {
+        "big-integer": "^1.6.16"
+      }
     },
     "nanoid": {
       "version": "3.3.4",
@@ -38699,6 +38782,11 @@
         "define-properties": "^1.1.3",
         "es-abstract": "^1.19.1"
       }
+    },
+    "oblivious-set": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
+      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
     },
     "obuf": {
       "version": "1.1.2",
@@ -39082,8 +39170,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "3.1.1",
@@ -39785,6 +39872,16 @@
         }
       }
     },
+    "react-query": {
+      "version": "3.39.3",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.3.tgz",
+      "integrity": "sha512-nLfLz7GiohKTJDuT4us4X3h/8unOh+00MLb2yJoGTPjxKs2bc1iDhkNx2bd5MKklXnOD3NrVZ+J2UXujA5In4g==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "broadcast-channel": "^3.4.1",
+        "match-sorter": "^6.0.2"
+      }
+    },
     "react-refresh": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.13.0.tgz",
@@ -40030,6 +40127,11 @@
         "unified": "^10.0.0"
       }
     },
+    "remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
+    },
     "renderkid": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
@@ -40185,7 +40287,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -42057,6 +42158,15 @@
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "dev": true
     },
+    "unload": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
+      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
+      "requires": {
+        "@babel/runtime": "^7.6.2",
+        "detect-node": "^2.0.4"
+      }
+    },
     "unorm": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
@@ -42125,30 +42235,6 @@
       "integrity": "sha512-6tGAFJKJ0qCalecaV7/gm/M6n238nmitNppvR89ff1yfwSFjwFKR7IQZzIZf1KZRQhqNireBzytzU6jgb29oVg==",
       "requires": {}
     },
-    "use-http": {
-      "version": "1.0.26",
-      "resolved": "https://registry.npmjs.org/use-http/-/use-http-1.0.26.tgz",
-      "integrity": "sha512-yB0dXX2S0Doyiti/kHqMsvlShL3tlI8YkoEARao1OVFKrGvyXejmWvrYkEI+oVTPvUqGzOsHbNROY0qKDC88Pg==",
-      "requires": {
-        "urs": "^0.0.8",
-        "use-ssr": "^1.0.24",
-        "utility-types": "^3.10.0"
-      },
-      "dependencies": {
-        "urs": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/urs/-/urs-0.0.8.tgz",
-          "integrity": "sha512-LaSSPpr91XrVA3vW2zPupw4K6DSQEDKdL4yQZX1mO2fpljIMpB5zctrjRvxLurelWSgKsHsCmfHNCImscryirQ==",
-          "requires": {}
-        },
-        "use-ssr": {
-          "version": "1.0.24",
-          "resolved": "https://registry.npmjs.org/use-ssr/-/use-ssr-1.0.24.tgz",
-          "integrity": "sha512-0MFps7ezL57/3o0yl4CvrHLlp9z20n1rQZV/lSRz7if+TUoM6POU1XdOvEjIgjgKeIhTEye1U0khrIYWCTWw4g==",
-          "requires": {}
-        }
-      }
-    },
     "use-sidecar": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
@@ -42189,11 +42275,6 @@
       "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
       "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
       "dev": true
-    },
-    "utility-types": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.10.0.tgz",
-      "integrity": "sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg=="
     },
     "utils-merge": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "react-i18next": "^12.0.0",
     "react-icons": "^4.7.1",
     "react-markdown": "^8.0.3",
+    "react-query": "^3.39.3",
     "react-time-ago": "^7.2.1",
     "reactflow": "^11.5.6",
     "rregex": "^1.5.1",
@@ -143,7 +144,6 @@
     "undici": "^5.22.1",
     "use-context-selector": "^1.4.0",
     "use-debounce": "^8.0.1",
-    "use-http": "^1.0.26",
     "uuid": "^8.3.2",
     "wcag-contrast": "^3.0.0",
     "yargs": "^17.5.1"

--- a/src/common/Backend.ts
+++ b/src/common/Backend.ts
@@ -97,6 +97,12 @@ export interface BackendError {
     error: string;
 }
 
+export interface ServerError {
+    message: string;
+    description: string;
+    status: number;
+}
+
 /**
  * A wrapper to communicate with the backend.
  *
@@ -147,7 +153,7 @@ export class Backend {
     /**
      * Gets a list of all nodes as well as the node information
      */
-    nodes(): Promise<BackendNodesResponse> {
+    nodes(): Promise<BackendNodesResponse | ServerError> {
         return this.fetchJson('/nodes', 'GET');
     }
 

--- a/src/main/cli/run.ts
+++ b/src/main/cli/run.ts
@@ -105,11 +105,15 @@ const getBackendNodes = async (backend: Backend): Promise<NodeSchema[]> => {
     for (let i = 0; i < maxTries; i += 1) {
         try {
             // eslint-disable-next-line no-await-in-loop
-            return (await backend.nodes()).nodes;
+            const response = await backend.nodes();
+            if ('nodes' in response) {
+                return response.nodes;
+            }
         } catch {
-            // eslint-disable-next-line no-await-in-loop
-            await delay(Math.max(maxSleep, startSleep * 2 ** i));
+            // ignore error
         }
+        // eslint-disable-next-line no-await-in-loop
+        await delay(Math.max(maxSleep, startSleep * 2 ** i));
     }
 
     throw new Error('Unable to connect to backend server');

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -1,6 +1,7 @@
 import electronLog from 'electron-log';
 import path from 'path';
 import { createRoot } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import { LEVEL_NAME, log } from '../common/log';
 import { ipcRenderer } from '../common/safeIpc';
 import { App } from './app';
@@ -23,6 +24,12 @@ ipcRenderer
         electronLog.error(err);
     });
 
+const queryClient = new QueryClient();
+
 const container = document.getElementById('root');
 const root = createRoot(container!);
-root.render(<App />);
+root.render(
+    <QueryClientProvider client={queryClient}>
+        <App />
+    </QueryClientProvider>
+);

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2,10 +2,10 @@ import { Box, Center, HStack, Text, VStack } from '@chakra-ui/react';
 import isDeepEqual from 'fast-deep-equal';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useQuery, useQueryClient } from 'react-query';
 import { EdgeTypes, NodeTypes, ReactFlowProvider } from 'reactflow';
 import { useContext } from 'use-context-selector';
-import useFetch, { CachePolicies } from 'use-http';
-import { BackendNodesResponse } from '../common/Backend';
+import { BackendNodesResponse, getBackend } from '../common/Backend';
 import { Category, NodeType, PythonInfo, SchemaId } from '../common/common-types';
 import { log } from '../common/log';
 import { parseFunctionDefinitions } from '../common/nodes/parseFunctionDefinitions';
@@ -22,7 +22,7 @@ import { IteratorNode } from './components/node/IteratorNode';
 import { Node } from './components/node/Node';
 import { NodeSelector } from './components/NodeSelectorPanel/NodeSelectorPanel';
 import { ReactFlowBox } from './components/ReactFlowBox';
-import { AlertBoxContext, AlertType } from './contexts/AlertBoxContext';
+import { AlertBoxContext, AlertId, AlertType } from './contexts/AlertBoxContext';
 import { BackendProvider } from './contexts/BackendContext';
 import { DependencyProvider } from './contexts/DependencyContext';
 import { ExecutionProvider } from './contexts/ExecutionContext';
@@ -68,15 +68,19 @@ interface MainProps {
 export const Main = memo(({ port }: MainProps) => {
     const { t, ready } = useTranslation();
 
-    const { sendAlert } = useContext(AlertBoxContext);
+    const { sendAlert, forgetAlert } = useContext(AlertBoxContext);
 
     const [nodesInfo, setNodesInfo] = useState<NodesInfo>();
 
     const reactFlowWrapper = useRef<HTMLDivElement>(null);
 
     const [backendReady, setBackendReady] = useState(false);
-    const [nodesRefreshCounter, setNodesRefreshCounter] = useState(0);
-    const refreshNodes = useCallback(() => setNodesRefreshCounter((prev) => prev + 1), []);
+
+    const queryClient = useQueryClient();
+    const refreshNodes = useCallback(() => {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        queryClient.invalidateQueries({ queryKey: ['nodes'] });
+    }, [queryClient]);
 
     const [periodicRefresh, setPeriodicRefresh] = useState(false);
     useAsyncEffect(
@@ -87,37 +91,60 @@ export const Main = memo(({ port }: MainProps) => {
         []
     );
 
-    useEffect(() => {
-        if (!periodicRefresh) return;
-        const interval = setInterval(refreshNodes, 1000 * 3);
-        return () => clearInterval(interval);
-    }, [periodicRefresh, refreshNodes]);
+    const nodesQuery = useQuery({
+        queryKey: ['nodes', port],
+        queryFn: async () => {
+            try {
+                const response = await getBackend(port).nodes();
+                if ('status' in response) {
+                    throw new Error(`${response.message}\n${response.description}`);
+                }
+                return response;
+            } catch (error) {
+                log.error(error);
+                throw error;
+            }
+        },
+        cacheTime: 0,
+        retry: 25,
+        refetchOnWindowFocus: false,
+        refetchInterval: periodicRefresh ? 1000 * 3 : false,
+    });
 
-    const { loading, error, data, response } = useFetch<BackendNodesResponse>(
-        `http://localhost:${port}/nodes`,
-        { cachePolicy: CachePolicies.NO_CACHE, cache: 'no-cache', retries: 25 },
-        [port, nodesRefreshCounter]
-    );
+    let nodeQueryError: unknown;
+    if (nodesQuery.status === 'error') {
+        nodeQueryError = nodesQuery.error;
+    } else if (nodesQuery.failureCount > 0) {
+        nodeQueryError = 'Failed to fetch backend nodes.';
+    }
+
+    const lastErrorAlert = useRef<AlertId>();
+    const forgetLastErrorAlert = useCallback(() => {
+        if (lastErrorAlert.current !== undefined) {
+            forgetAlert(lastErrorAlert.current);
+            lastErrorAlert.current = undefined;
+        }
+    }, [forgetAlert]);
 
     useEffect(() => {
-        if (error) {
-            sendAlert({
+        if (nodeQueryError) {
+            const message =
+                nodeQueryError instanceof Error ? nodeQueryError.message : String(nodeQueryError);
+            forgetLastErrorAlert();
+            lastErrorAlert.current = sendAlert({
                 type: AlertType.CRIT_ERROR,
                 message: `${t(
                     'error.message.criticalBackend',
                     'A critical error occurred while processing the node data returned by the backend.'
-                )} ${t('error.error', 'Error')}: ${error.message}`,
+                )}\n\n${t('error.error', 'Error')}: ${message}`,
             });
         }
-    }, [error, sendAlert, t]);
+    }, [nodeQueryError, sendAlert, forgetLastErrorAlert, t]);
 
     useEffect(() => {
-        if (loading) {
-            return;
-        }
-
-        if (response.ok && data && !error) {
-            const rawResponse = data;
+        if (nodesQuery.status === 'success') {
+            forgetLastErrorAlert();
+            const rawResponse = nodesQuery.data;
             setNodesInfo((prev) => {
                 if (isDeepEqual(prev?.rawResponse, rawResponse)) {
                     return prev;
@@ -127,7 +154,8 @@ export const Main = memo(({ port }: MainProps) => {
                     return processBackendResponse(rawResponse);
                 } catch (e) {
                     log.error(e);
-                    sendAlert({
+                    forgetLastErrorAlert();
+                    lastErrorAlert.current = sendAlert({
                         type: AlertType.CRIT_ERROR,
                         title: t(
                             'error.title.unableToProcessNodes',
@@ -143,11 +171,11 @@ export const Main = memo(({ port }: MainProps) => {
                 return prev;
             });
         }
-    }, [response, data, loading, error, backendReady, sendAlert, t]);
+    }, [nodesQuery.status, nodesQuery.data, backendReady, sendAlert, forgetLastErrorAlert, t]);
 
     useIpcRendererListener('backend-ready', () => {
         // Refresh the nodes once the backend is ready
-        setNodesRefreshCounter((prev) => prev + 1);
+        refreshNodes();
         if (!backendReady) {
             setBackendReady(true);
             ipcRenderer.send('backend-ready');
@@ -187,7 +215,7 @@ export const Main = memo(({ port }: MainProps) => {
         []
     );
 
-    if (error) return null;
+    if (nodesQuery.isError) return null;
 
     if (!nodesInfo || !pythonInfo || !ready) {
         return (


### PR DESCRIPTION
Changes:
- Use `react-query` for fetch instead of `use-http`.
- Implemented `refreshNodes` and periodic refresh using query invalidation.
- Fixed return type of `Backend#nodes`. Callers now have to explicitly handle server errors.
- Forget error alert if backend comes back on. The critical error alert will now just disappear when the backend is reachable again.

Since `/nodes` fetching is fundamental to chainner, I tested this quite a bit. Server error should be handled now. 

Retries finally make sense now. Previously, we did retry 25 times, but the critical alert we send out after the first error is *non-recoverable*. So users could just reload the frontend (Ctrl+R). The frontend will now just forget the critical alert if the backend is reachable again. This means that the critical alert will simply be closed without having any effect (critical alert force chainner to close otherwise).