### PR TITLE
Improved node docs

### DIFF
--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -143,7 +143,7 @@ export interface Output {
     readonly label: string;
     readonly kind: OutputKind;
     readonly hasHandle: boolean;
-    readonly description?: string;
+    readonly description?: string | null;
     readonly examples?: readonly string[] | null;
 }
 

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -2,7 +2,7 @@ import { constants } from 'fs';
 import fs from 'fs/promises';
 import { LocalStorage } from 'node-localstorage';
 import { v4 as uuid4, v5 as uuid5 } from 'uuid';
-import type { InputData, InputId, InputValue, NodeSchema, OutputId } from './common-types';
+import type { Input, InputData, InputId, InputValue, NodeSchema, OutputId } from './common-types';
 
 export const EMPTY_ARRAY: readonly never[] = [];
 export const EMPTY_SET: ReadonlySet<never> = new Set<never>();
@@ -273,3 +273,6 @@ export const getInputValue = <T extends NonNullable<InputValue>>(
 ): T | undefined => {
     return (inputData[inputId] ?? undefined) as T | undefined;
 };
+
+export const isAutoInput = (input: Input): boolean =>
+    input.kind === 'generic' && input.optional && !input.hasHandle;

--- a/src/renderer/components/NodeDocumentation/NodeDocs.tsx
+++ b/src/renderer/components/NodeDocumentation/NodeDocs.tsx
@@ -15,7 +15,7 @@ import {
     useMediaQuery,
 } from '@chakra-ui/react';
 import ChakraUIRenderer from 'chakra-ui-markdown-renderer';
-import { PropsWithChildren, memo, useCallback, useEffect, useState } from 'react';
+import { PropsWithChildren, memo, useCallback, useState } from 'react';
 import { ReactMarkdown } from 'react-markdown/lib/react-markdown';
 import { useContext } from 'use-context-selector';
 import { InputData, InputId, InputValue, NodeSchema, SchemaId } from '../../../common/common-types';
@@ -119,10 +119,6 @@ const FakeNodeExample = memo(({ accentColor, selectedSchema }: NodeExampleProps)
         },
         [selectedSchema]
     );
-
-    useEffect(() => {
-        console.log(state.inputData);
-    }, [state.inputData]);
 
     const inputData = state.schema === selectedSchema ? state.inputData : {};
     return (

--- a/src/renderer/components/NodeDocumentation/NodeDocs.tsx
+++ b/src/renderer/components/NodeDocumentation/NodeDocs.tsx
@@ -15,10 +15,10 @@ import {
     useMediaQuery,
 } from '@chakra-ui/react';
 import ChakraUIRenderer from 'chakra-ui-markdown-renderer';
-import { PropsWithChildren, memo } from 'react';
+import { PropsWithChildren, memo, useCallback, useEffect, useState } from 'react';
 import { ReactMarkdown } from 'react-markdown/lib/react-markdown';
 import { useContext } from 'use-context-selector';
-import { NodeSchema, SchemaId } from '../../../common/common-types';
+import { InputData, InputId, InputValue, NodeSchema, SchemaId } from '../../../common/common-types';
 import { DisabledStatus } from '../../../common/nodes/disabled';
 import { FunctionDefinition } from '../../../common/types/function';
 import { prettyPrintType } from '../../../common/types/pretty';
@@ -94,58 +94,87 @@ const customMarkdownTheme = {
     }),
 };
 
-const FakeNodeExample = memo(
-    ({ accentColor, selectedSchema }: { accentColor: string; selectedSchema: NodeSchema }) => {
-        return (
+interface NodeExampleProps {
+    accentColor: string;
+    selectedSchema: NodeSchema;
+}
+const FakeNodeExample = memo(({ accentColor, selectedSchema }: NodeExampleProps) => {
+    const [state, setState] = useState<{ inputData: InputData; schema: NodeSchema }>({
+        inputData: {},
+        schema: selectedSchema,
+    });
+
+    const setInputValue = useCallback(
+        (inputId: InputId, value: InputValue): void => {
+            setState((prev) => {
+                const inputData = prev.schema === selectedSchema ? prev.inputData : {};
+                return {
+                    inputData: {
+                        ...inputData,
+                        [inputId]: value,
+                    },
+                    schema: selectedSchema,
+                };
+            });
+        },
+        [selectedSchema]
+    );
+
+    useEffect(() => {
+        console.log(state.inputData);
+    }, [state.inputData]);
+
+    const inputData = state.schema === selectedSchema ? state.inputData : {};
+    return (
+        <Center
+            pointerEvents="none"
+            w="auto"
+        >
             <Center
-                pointerEvents="none"
-                w="auto"
+                bg="var(--node-bg-color)"
+                borderColor="var(--node-border-color)"
+                borderRadius="lg"
+                borderWidth="0.5px"
+                boxShadow="lg"
+                minWidth="240px"
+                overflow="hidden"
+                transition="0.15s ease-in-out"
             >
-                <Center
-                    bg="var(--node-bg-color)"
-                    borderColor="var(--node-border-color)"
-                    borderRadius="lg"
-                    borderWidth="0.5px"
-                    boxShadow="lg"
-                    minWidth="240px"
-                    overflow="hidden"
-                    transition="0.15s ease-in-out"
+                <VStack
+                    spacing={0}
+                    w="full"
                 >
                     <VStack
                         spacing={0}
                         w="full"
                     >
-                        <VStack
-                            spacing={0}
-                            w="full"
-                        >
-                            <NodeHeader
-                                accentColor={accentColor}
-                                disabledStatus={DisabledStatus.Enabled}
-                                icon={selectedSchema.icon}
-                                name={selectedSchema.name}
-                                parentNode={undefined}
-                                selected={false}
-                            />
-                            <NodeBody
-                                animated={false}
-                                id={selectedSchema.schemaId}
-                                inputData={{}}
-                                isLocked={false}
-                                schema={selectedSchema}
-                            />
-                        </VStack>
-                        <NodeFooter
+                        <NodeHeader
+                            accentColor={accentColor}
+                            disabledStatus={DisabledStatus.Enabled}
+                            icon={selectedSchema.icon}
+                            name={selectedSchema.name}
+                            parentNode={undefined}
+                            selected={false}
+                        />
+                        <NodeBody
                             animated={false}
-                            id={selectedSchema.schemaId}
-                            validity={{ isValid: true }}
+                            id="<fake node id>"
+                            inputData={inputData}
+                            isLocked={false}
+                            schema={selectedSchema}
+                            setInputValue={setInputValue}
                         />
                     </VStack>
-                </Center>
+                    <NodeFooter
+                        animated={false}
+                        id="<fake node id>"
+                        validity={{ isValid: true }}
+                    />
+                </VStack>
             </Center>
-        );
-    }
-);
+        </Center>
+    );
+});
 
 interface NodeInfoProps {
     schema: NodeSchema;

--- a/src/renderer/components/NodeDocumentation/NodeDocs.tsx
+++ b/src/renderer/components/NodeDocumentation/NodeDocs.tsx
@@ -1,3 +1,4 @@
+import { NeverType, Type } from '@chainner/navi';
 import {
     Box,
     Center,
@@ -21,6 +22,8 @@ import { NodeSchema, SchemaId } from '../../../common/common-types';
 import { DisabledStatus } from '../../../common/nodes/disabled';
 import { FunctionDefinition } from '../../../common/types/function';
 import { prettyPrintType } from '../../../common/types/pretty';
+import { withoutNull } from '../../../common/types/util';
+import { isAutoInput } from '../../../common/util';
 import { BackendContext } from '../../contexts/BackendContext';
 import { NodeDocumentationContext } from '../../contexts/NodeDocumentationContext';
 import { getCategoryAccentColor } from '../../helpers/accentColors';
@@ -28,6 +31,7 @@ import { IconFactory } from '../CustomIcons';
 import { NodeBody } from '../node/NodeBody';
 import { NodeFooter } from '../node/NodeFooter/NodeFooter';
 import { NodeHeader } from '../node/NodeHeader';
+import { TypeTag } from '../TypeTag';
 
 const customMarkdownTheme = {
     p: (props: PropsWithChildren<unknown>) => {
@@ -143,139 +147,152 @@ const FakeNodeExample = memo(
     }
 );
 
-const SingleNodeInfo = memo(
-    ({
-        schema,
-        accentColor,
-        functionDefinition,
-    }: {
-        schema: NodeSchema;
-        accentColor: string;
-        functionDefinition?: FunctionDefinition;
-    }) => {
-        return (
-            <VStack
-                alignItems="left"
-                display="block"
-                divider={<Divider />}
-                h="full"
-                maxH="full"
-                spacing={2}
-                textAlign="left"
-                w="full"
-            >
-                <Box userSelect="text">
-                    <HStack>
-                        <IconFactory
-                            accentColor={accentColor}
-                            boxSize={6}
-                            icon={schema.icon}
-                        />
-                        <Heading
-                            size="lg"
-                            userSelect="text"
-                        >
-                            {schema.name}
-                        </Heading>
-                    </HStack>
-                    <ReactMarkdown components={ChakraUIRenderer(customMarkdownTheme)}>
-                        {schema.description}
-                    </ReactMarkdown>
-                </Box>
-                <Box position="relative">
-                    <Heading
-                        mb={1}
-                        size="sm"
-                        userSelect="text"
-                    >
-                        Inputs
-                    </Heading>
-                    {schema.inputs.length > 0 ? (
-                        <UnorderedList
-                            alignItems="left"
-                            ml={0}
-                            pl={8}
-                            textAlign="left"
-                            userSelect="text"
-                            w="full"
-                        >
-                            {schema.inputs.map((input) => {
-                                const type = functionDefinition?.inputDefaults.get(input.id);
-                                return (
-                                    <ListItem key={input.id}>
-                                        <Text
-                                            fontWeight="bold"
-                                            userSelect="text"
-                                        >
-                                            {input.label}
-                                        </Text>
-                                        {input.description && (
-                                            <ReactMarkdown
-                                                components={ChakraUIRenderer(customMarkdownTheme)}
-                                            >
-                                                {input.description}
-                                            </ReactMarkdown>
-                                        )}
-                                        {type && (
-                                            <Code userSelect="text">{prettyPrintType(type)}</Code>
-                                        )}
-                                    </ListItem>
-                                );
-                            })}
-                        </UnorderedList>
-                    ) : (
-                        <Text>This node has no inputs.</Text>
-                    )}
-                </Box>
-                <Box position="relative">
-                    <Heading
-                        mb={1}
-                        size="sm"
-                        userSelect="text"
-                    >
-                        Outputs
-                    </Heading>
-                    {schema.outputs.length > 0 ? (
-                        <UnorderedList
-                            alignItems="left"
-                            ml={0}
-                            pl={8}
-                            textAlign="left"
-                            w="full"
-                        >
-                            {schema.outputs.map((output) => {
-                                const type = functionDefinition?.outputDefaults.get(output.id);
+interface NodeInfoProps {
+    schema: NodeSchema;
+    accentColor: string;
+    functionDefinition?: FunctionDefinition;
+}
+const SingleNodeInfo = memo(({ schema, accentColor, functionDefinition }: NodeInfoProps) => {
+    const inputs = schema.inputs.filter((i) => !isAutoInput(i));
+    const outputs = schema.outputs.filter((o) => o.hasHandle);
 
-                                return (
-                                    <ListItem key={output.id}>
-                                        <Text
-                                            fontWeight="bold"
-                                            userSelect="text"
-                                        >
-                                            {output.label}
-                                        </Text>
-                                        {output.description && (
-                                            <ReactMarkdown
-                                                components={ChakraUIRenderer(customMarkdownTheme)}
+    return (
+        <VStack
+            alignItems="left"
+            display="block"
+            divider={<Divider />}
+            h="full"
+            maxH="full"
+            spacing={2}
+            textAlign="left"
+            w="full"
+        >
+            <Box userSelect="text">
+                <HStack>
+                    <IconFactory
+                        accentColor={accentColor}
+                        boxSize={6}
+                        icon={schema.icon}
+                    />
+                    <Heading
+                        size="lg"
+                        userSelect="text"
+                    >
+                        {schema.name}
+                    </Heading>
+                </HStack>
+                <ReactMarkdown components={ChakraUIRenderer(customMarkdownTheme)}>
+                    {schema.description}
+                </ReactMarkdown>
+            </Box>
+            <Box position="relative">
+                <Heading
+                    mb={1}
+                    size="sm"
+                    userSelect="text"
+                >
+                    Inputs
+                </Heading>
+                {inputs.length > 0 ? (
+                    <UnorderedList
+                        alignItems="left"
+                        ml={0}
+                        pl={8}
+                        textAlign="left"
+                        userSelect="text"
+                        w="full"
+                    >
+                        {inputs.map((input) => {
+                            let type: Type =
+                                functionDefinition?.inputDefaults.get(input.id) ??
+                                NeverType.instance;
+                            if (input.optional) {
+                                type = withoutNull(type);
+                            }
+
+                            return (
+                                <ListItem key={input.id}>
+                                    <Text
+                                        fontWeight="bold"
+                                        userSelect="text"
+                                    >
+                                        {input.label}
+                                        {input.optional && (
+                                            <TypeTag
+                                                isOptional
+                                                fontSize="small"
+                                                height="auto"
+                                                mt="-0.2rem"
+                                                verticalAlign="middle"
                                             >
-                                                {output.description}
-                                            </ReactMarkdown>
+                                                optional
+                                            </TypeTag>
                                         )}
-                                        {type && (
-                                            <Code userSelect="text">{prettyPrintType(type)}</Code>
-                                        )}
-                                    </ListItem>
-                                );
-                            })}
-                        </UnorderedList>
-                    ) : (
-                        <Text>This node has no outputs.</Text>
-                    )}
-                </Box>
-            </VStack>
-        );
-    }
-);
+                                    </Text>
+                                    {input.description && (
+                                        <ReactMarkdown
+                                            components={ChakraUIRenderer(customMarkdownTheme)}
+                                        >
+                                            {input.description}
+                                        </ReactMarkdown>
+                                    )}
+                                    <Code userSelect="text">{prettyPrintType(type)}</Code>
+                                </ListItem>
+                            );
+                        })}
+                    </UnorderedList>
+                ) : (
+                    <Text>This node has no inputs.</Text>
+                )}
+            </Box>
+            <Box position="relative">
+                <Heading
+                    mb={1}
+                    size="sm"
+                    userSelect="text"
+                >
+                    Outputs
+                </Heading>
+                {outputs.length > 0 ? (
+                    <UnorderedList
+                        alignItems="left"
+                        ml={0}
+                        pl={8}
+                        textAlign="left"
+                        w="full"
+                    >
+                        {outputs.map((output) => {
+                            const type =
+                                functionDefinition?.outputDefaults.get(output.id) ??
+                                NeverType.instance;
+
+                            return (
+                                <ListItem key={output.id}>
+                                    <Text
+                                        fontWeight="bold"
+                                        userSelect="text"
+                                    >
+                                        {output.label}
+                                    </Text>
+                                    {output.description && (
+                                        <ReactMarkdown
+                                            components={ChakraUIRenderer(customMarkdownTheme)}
+                                        >
+                                            {output.description}
+                                        </ReactMarkdown>
+                                    )}
+                                    <Code userSelect="text">{prettyPrintType(type)}</Code>
+                                </ListItem>
+                            );
+                        })}
+                    </UnorderedList>
+                ) : (
+                    <Text>This node has no outputs.</Text>
+                )}
+            </Box>
+        </VStack>
+    );
+});
 
 export const NodeDocs = memo(() => {
     const { schemata, functionDefinitions, categories } = useContext(BackendContext);

--- a/src/renderer/components/groups/ConditionalGroup.tsx
+++ b/src/renderer/components/groups/ConditionalGroup.tsx
@@ -10,6 +10,7 @@ export const ConditionalGroup = memo(
     ({
         inputs,
         inputData,
+        setInputValue,
         inputSize,
         isLocked,
         nodeId,
@@ -48,6 +49,7 @@ export const ConditionalGroup = memo(
                         key={getUniqueKey(item)}
                         nodeId={nodeId}
                         schemaId={schemaId}
+                        setInputValue={setInputValue}
                     />
                 ))}
             </>

--- a/src/renderer/components/groups/FromToDropdownsGroup.tsx
+++ b/src/renderer/components/groups/FromToDropdownsGroup.tsx
@@ -1,27 +1,23 @@
 import { Box, HStack } from '@chakra-ui/react';
 import { memo, useCallback } from 'react';
 import { IoMdArrowForward } from 'react-icons/io';
-import { useContext } from 'use-context-selector';
-import { Input, InputData, OfKind } from '../../../common/common-types';
+import { Input, InputData, InputId, InputValue, OfKind } from '../../../common/common-types';
 import { getInputValue } from '../../../common/util';
-import { GlobalContext } from '../../contexts/GlobalNodeState';
 import { DropDown } from '../inputs/elements/Dropdown';
 import { InputContainer } from '../inputs/InputContainer';
 import { GroupProps } from './props';
 
 interface SmallDropDownProps {
-    nodeId: string;
     input: OfKind<Input, 'dropdown'>;
     inputData: InputData;
+    setInputValue: (inputId: InputId, value: InputValue) => void;
     isLocked: boolean;
 }
-const SmallDropDown = memo(({ nodeId, input, inputData, isLocked }: SmallDropDownProps) => {
-    const { setNodeInputValue } = useContext(GlobalContext);
-
+const SmallDropDown = memo(({ input, inputData, setInputValue, isLocked }: SmallDropDownProps) => {
     const value = getInputValue<string | number>(input.id, inputData);
     const setValue = useCallback(
-        (data?: string | number) => setNodeInputValue(nodeId, input.id, data ?? input.def),
-        [setNodeInputValue, nodeId, input]
+        (data?: string | number) => setInputValue(input.id, data ?? input.def),
+        [setInputValue, input]
     );
 
     return (
@@ -38,7 +34,7 @@ const SmallDropDown = memo(({ nodeId, input, inputData, isLocked }: SmallDropDow
 });
 
 export const FromToDropdownsGroup = memo(
-    ({ inputs, inputData, isLocked, nodeId }: GroupProps<'from-to-dropdowns'>) => {
+    ({ inputs, inputData, setInputValue, isLocked }: GroupProps<'from-to-dropdowns'>) => {
         const [from, to] = inputs;
 
         return (
@@ -52,7 +48,7 @@ export const FromToDropdownsGroup = memo(
                         input={from}
                         inputData={inputData}
                         isLocked={isLocked}
-                        nodeId={nodeId}
+                        setInputValue={setInputValue}
                     />
                     <Box>
                         <IoMdArrowForward />
@@ -61,7 +57,7 @@ export const FromToDropdownsGroup = memo(
                         input={to}
                         inputData={inputData}
                         isLocked={isLocked}
-                        nodeId={nodeId}
+                        setInputValue={setInputValue}
                     />
                 </HStack>
             </InputContainer>

--- a/src/renderer/components/groups/Group.tsx
+++ b/src/renderer/components/groups/Group.tsx
@@ -1,5 +1,13 @@
 import { memo } from 'react';
-import { Group, GroupKind, InputData, InputSize, SchemaId } from '../../../common/common-types';
+import {
+    Group,
+    GroupKind,
+    InputData,
+    InputId,
+    InputSize,
+    InputValue,
+    SchemaId,
+} from '../../../common/common-types';
 import { InputItem } from '../../../common/group-inputs';
 import { ConditionalGroup } from './ConditionalGroup';
 import { FromToDropdownsGroup } from './FromToDropdownsGroup';
@@ -27,6 +35,7 @@ interface GroupElementProps {
     nodeId: string;
     isLocked: boolean;
     inputData: InputData;
+    setInputValue: (inputId: InputId, value: InputValue) => void;
     inputSize: InputSize | undefined;
     ItemRenderer: InputItemRenderer;
 }
@@ -39,6 +48,7 @@ export const GroupElement = memo(
         nodeId,
         isLocked,
         inputData,
+        setInputValue,
         inputSize,
         ItemRenderer,
     }: GroupElementProps) => {
@@ -53,6 +63,7 @@ export const GroupElement = memo(
                 isLocked={isLocked}
                 nodeId={nodeId}
                 schemaId={schemaId}
+                setInputValue={setInputValue}
             />
         );
     }

--- a/src/renderer/components/groups/NcnnFileInputsGroup.tsx
+++ b/src/renderer/components/groups/NcnnFileInputsGroup.tsx
@@ -1,8 +1,6 @@
 import { memo, useEffect } from 'react';
-import { useContext } from 'use-context-selector';
 import { log } from '../../../common/log';
 import { checkFileExists, getInputValue } from '../../../common/util';
-import { GlobalContext } from '../../contexts/GlobalNodeState';
 import { SchemaInput } from '../inputs/SchemaInput';
 import { GroupProps } from './props';
 
@@ -27,6 +25,7 @@ export const NcnnFileInputsGroup = memo(
     ({
         inputs,
         inputData,
+        setInputValue,
         inputSize,
         isLocked,
         nodeId,
@@ -34,23 +33,17 @@ export const NcnnFileInputsGroup = memo(
     }: GroupProps<'ncnn-file-inputs'>) => {
         const [paramInput, binInput] = inputs;
 
-        const { setNodeInputValue } = useContext(GlobalContext);
-
         useEffect(() => {
             const paramPath = getInputValue(paramInput.id, inputData);
             const binPath = getInputValue(binInput.id, inputData);
 
             if (typeof paramPath === 'string' && binPath === undefined) {
-                ifOtherExists(paramPath, '.bin', (bin) =>
-                    setNodeInputValue(nodeId, binInput.id, bin)
-                );
+                ifOtherExists(paramPath, '.bin', (bin) => setInputValue(binInput.id, bin));
             }
             if (typeof binPath === 'string' && paramPath === undefined) {
-                ifOtherExists(binPath, '.param', (param) =>
-                    setNodeInputValue(nodeId, paramInput.id, param)
-                );
+                ifOtherExists(binPath, '.param', (param) => setInputValue(paramInput.id, param));
             }
-        }, [paramInput, binInput, inputData, nodeId, setNodeInputValue]);
+        }, [paramInput, binInput, inputData, setInputValue]);
 
         return (
             <>
@@ -61,11 +54,11 @@ export const NcnnFileInputsGroup = memo(
                     isLocked={isLocked}
                     nodeId={nodeId}
                     schemaId={schemaId}
-                    onSetValue={(file) => {
+                    setInputValue={(inputId, file) => {
+                        setInputValue(inputId, file);
+
                         if (typeof file === 'string') {
-                            ifOtherExists(file, '.bin', (bin) =>
-                                setNodeInputValue(nodeId, binInput.id, bin)
-                            );
+                            ifOtherExists(file, '.bin', (bin) => setInputValue(binInput.id, bin));
                         }
                     }}
                 />
@@ -76,10 +69,12 @@ export const NcnnFileInputsGroup = memo(
                     isLocked={isLocked}
                     nodeId={nodeId}
                     schemaId={schemaId}
-                    onSetValue={(file) => {
+                    setInputValue={(inputId, file) => {
+                        setInputValue(inputId, file);
+
                         if (typeof file === 'string') {
                             ifOtherExists(file, '.param', (param) =>
-                                setNodeInputValue(nodeId, paramInput.id, param)
+                                setInputValue(paramInput.id, param)
                             );
                         }
                     }}

--- a/src/renderer/components/groups/OptionalInputsGroup.tsx
+++ b/src/renderer/components/groups/OptionalInputsGroup.tsx
@@ -12,6 +12,7 @@ export const OptionalInputsGroup = memo(
     ({
         inputs,
         inputData,
+        setInputValue,
         inputSize,
         isLocked,
         nodeId,
@@ -56,6 +57,7 @@ export const OptionalInputsGroup = memo(
                         key={getUniqueKey(item)}
                         nodeId={nodeId}
                         schemaId={schemaId}
+                        setInputValue={setInputValue}
                     />
                 ))}
                 {showMoreButton && (

--- a/src/renderer/components/groups/RequiredGroup.tsx
+++ b/src/renderer/components/groups/RequiredGroup.tsx
@@ -12,6 +12,7 @@ export const RequiredGroup = memo(
     ({
         inputs,
         inputData,
+        setInputValue,
         inputSize,
         isLocked,
         nodeId,
@@ -44,6 +45,7 @@ export const RequiredGroup = memo(
                         key={getUniqueKey(item)}
                         nodeId={nodeId}
                         schemaId={schemaId}
+                        setInputValue={setInputValue}
                     />
                 ))}
             </>

--- a/src/renderer/components/groups/SeedGroup.tsx
+++ b/src/renderer/components/groups/SeedGroup.tsx
@@ -1,33 +1,33 @@
 import { IconButton, Tooltip } from '@chakra-ui/react';
 import { memo, useCallback } from 'react';
 import { HiOutlineRefresh } from 'react-icons/hi';
-import { useContext, useContextSelector } from 'use-context-selector';
-import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
+import { useContextSelector } from 'use-context-selector';
+import { GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { SchemaInput } from '../inputs/SchemaInput';
 import { GroupProps } from './props';
 
 export const SeedGroup = memo(
-    ({ inputs, inputData, inputSize, isLocked, nodeId, schemaId }: GroupProps<'seed'>) => {
+    ({
+        inputs,
+        inputData,
+        setInputValue,
+        inputSize,
+        isLocked,
+        nodeId,
+        schemaId,
+    }: GroupProps<'seed'>) => {
         const [input] = inputs;
-
-        const { setNodeInputValue } = useContext(GlobalContext);
 
         const isInputLocked = useContextSelector(GlobalVolatileContext, (c) => c.isNodeInputLocked)(
             nodeId,
             input.id
         );
 
-        const setValue = useCallback(
-            (data: number) => {
-                setNodeInputValue(nodeId, input.id, data);
-            },
-            [nodeId, input.id, setNodeInputValue]
-        );
-
         const setRandom = useCallback(() => {
             const RANDOM_MAX = 1e6;
-            setValue(Math.floor(Math.random() * RANDOM_MAX));
-        }, [setValue]);
+            const randomValue = Math.floor(Math.random() * RANDOM_MAX);
+            setInputValue(input.id, randomValue);
+        }, [input.id, setInputValue]);
 
         return (
             <SchemaInput
@@ -59,6 +59,7 @@ export const SeedGroup = memo(
                 isLocked={isLocked}
                 nodeId={nodeId}
                 schemaId={schemaId}
+                setInputValue={setInputValue}
             />
         );
     }

--- a/src/renderer/components/groups/props.ts
+++ b/src/renderer/components/groups/props.ts
@@ -2,7 +2,9 @@ import {
     Group,
     GroupKind,
     InputData,
+    InputId,
     InputSize,
+    InputValue,
     OfKind,
     SchemaId,
 } from '../../../common/common-types';
@@ -12,6 +14,7 @@ export type InputItemRenderer = (props: {
     item: InputItem;
     nodeId: string;
     inputData: InputData;
+    setInputValue: (inputId: InputId, value: InputValue) => void;
     inputSize?: InputSize;
     isLocked: boolean;
     schemaId: SchemaId;
@@ -24,6 +27,7 @@ export interface GroupProps<Kind extends GroupKind> {
     nodeId: string;
     isLocked: boolean;
     inputData: InputData;
+    setInputValue: (inputId: InputId, value: InputValue) => void;
     inputSize: InputSize | undefined;
     ItemRenderer: InputItemRenderer;
 }

--- a/src/renderer/components/inputs/NumberInput.tsx
+++ b/src/renderer/components/inputs/NumberInput.tsx
@@ -39,6 +39,12 @@ export const NumberInput = memo(
             });
         }, [value]);
 
+        useEffect(() => {
+            if (value === undefined) {
+                setValue(def);
+            }
+        }, [value, def, setValue]);
+
         const isInputConnected = useInputConnected();
         const inputType = useInputType();
         const typeNumberString = isNumericLiteral(inputType) ? inputType.toString() : '';

--- a/src/renderer/components/inputs/SchemaInput.tsx
+++ b/src/renderer/components/inputs/SchemaInput.tsx
@@ -5,6 +5,7 @@ import { useContext, useContextSelector } from 'use-context-selector';
 import {
     Input,
     InputData,
+    InputId,
     InputKind,
     InputSize,
     InputValue,
@@ -46,8 +47,8 @@ export interface SingleInputProps {
     nodeId: string;
     isLocked: boolean;
     inputData: InputData;
+    setInputValue: (inputId: InputId, value: InputValue) => void;
     inputSize: InputSize | undefined;
-    onSetValue?: (value: InputValue) => void;
     afterInput?: JSX.Element;
 }
 /**
@@ -60,13 +61,13 @@ export const SchemaInput = memo(
         nodeId,
         isLocked,
         inputData,
+        setInputValue,
         inputSize,
-        onSetValue,
         afterInput,
     }: SingleInputProps) => {
         const { id: inputId, kind, hasHandle } = input;
 
-        const { setNodeInputValue, useInputSize: useInputSizeContext } = useContext(GlobalContext);
+        const { useInputSize: useInputSizeContext } = useContext(GlobalContext);
 
         const functionDefinition = useContextSelector(BackendContext, (c) =>
             c.functionDefinitions.get(schemaId)
@@ -78,15 +79,13 @@ export const SchemaInput = memo(
         const value = getInputValue(inputId, inputData);
         const setValue = useCallback(
             (data: NonNullable<InputValue>) => {
-                setNodeInputValue(nodeId, inputId, data);
-                onSetValue?.(data);
+                setInputValue(inputId, data);
             },
-            [nodeId, inputId, setNodeInputValue, onSetValue]
+            [inputId, setInputValue]
         );
         const resetValue = useCallback(() => {
-            setNodeInputValue(nodeId, inputId, undefined);
-            onSetValue?.(undefined);
-        }, [nodeId, inputId, setNodeInputValue, onSetValue]);
+            setInputValue(inputId, undefined);
+        }, [inputId, setInputValue]);
 
         const useInputConnected = useCallback((): boolean => {
             // TODO: move the function call into the selector

--- a/src/renderer/components/node/IteratorHelperNode.tsx
+++ b/src/renderer/components/node/IteratorHelperNode.tsx
@@ -1,7 +1,7 @@
 import { Center, VStack } from '@chakra-ui/react';
-import { memo, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { memo, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useContext, useContextSelector } from 'use-context-selector';
-import { InputId, InputValue, NodeData } from '../../../common/common-types';
+import { NodeData } from '../../../common/common-types';
 import { DisabledStatus, getDisabledStatus } from '../../../common/nodes/disabled';
 import { BackendContext } from '../../contexts/BackendContext';
 import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
@@ -29,12 +29,7 @@ export const IteratorHelperNode = memo(({ data, selected }: IteratorHelperNodePr
     const { id, inputData, isLocked, parentNode, schemaId } = data;
     const animated = useContextSelector(GlobalVolatileContext, (c) => c.isAnimated(id));
 
-    const setInputValue = useCallback(
-        (inputId: InputId, value: InputValue): void => {
-            setNodeInputValue(id, inputId, value);
-        },
-        [id, setNodeInputValue]
-    );
+    const setInputValue = useMemo(() => setNodeInputValue.bind(null, id), [id, setNodeInputValue]);
 
     // We get inputs and outputs this way in case something changes with them in the future
     // This way, we have to do less in the migration file

--- a/src/renderer/components/node/IteratorHelperNode.tsx
+++ b/src/renderer/components/node/IteratorHelperNode.tsx
@@ -1,7 +1,7 @@
 import { Center, VStack } from '@chakra-ui/react';
-import { memo, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useContext, useContextSelector } from 'use-context-selector';
-import { NodeData } from '../../../common/common-types';
+import { InputId, InputValue, NodeData } from '../../../common/common-types';
 import { DisabledStatus, getDisabledStatus } from '../../../common/nodes/disabled';
 import { BackendContext } from '../../contexts/BackendContext';
 import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
@@ -23,11 +23,18 @@ export const IteratorHelperNode = memo(({ data, selected }: IteratorHelperNodePr
         GlobalVolatileContext,
         (c) => c.effectivelyDisabledNodes
     );
-    const { updateIteratorBounds, setHoveredNode } = useContext(GlobalContext);
+    const { updateIteratorBounds, setHoveredNode, setNodeInputValue } = useContext(GlobalContext);
     const { schemata, categories } = useContext(BackendContext);
 
     const { id, inputData, isLocked, parentNode, schemaId } = data;
     const animated = useContextSelector(GlobalVolatileContext, (c) => c.isAnimated(id));
+
+    const setInputValue = useCallback(
+        (inputId: InputId, value: InputValue): void => {
+            setNodeInputValue(id, inputId, value);
+        },
+        [id, setNodeInputValue]
+    );
 
     // We get inputs and outputs this way in case something changes with them in the future
     // This way, we have to do less in the migration file
@@ -104,6 +111,7 @@ export const IteratorHelperNode = memo(({ data, selected }: IteratorHelperNodePr
                         inputData={inputData}
                         isLocked={isLocked}
                         schema={schema}
+                        setInputValue={setInputValue}
                     />
                 </VStack>
                 <NodeFooter

--- a/src/renderer/components/node/IteratorNode.tsx
+++ b/src/renderer/components/node/IteratorNode.tsx
@@ -1,11 +1,11 @@
 import { Box, Center, Text, VStack } from '@chakra-ui/react';
-import { memo, useMemo, useRef } from 'react';
+import { memo, useCallback, useMemo, useRef } from 'react';
 import { useContext, useContextSelector } from 'use-context-selector';
-import { NodeData } from '../../../common/common-types';
+import { InputId, InputValue, NodeData } from '../../../common/common-types';
 import { DisabledStatus } from '../../../common/nodes/disabled';
 import { BackendContext } from '../../contexts/BackendContext';
 import { ExecutionContext } from '../../contexts/ExecutionContext';
-import { GlobalVolatileContext } from '../../contexts/GlobalNodeState';
+import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { getCategoryAccentColor } from '../../helpers/accentColors';
 import { shadeColor } from '../../helpers/colorTools';
 import { useDisabled } from '../../hooks/useDisabled';
@@ -33,8 +33,16 @@ export const IteratorNode = memo(({ data, selected }: IteratorNodeProps) => (
 const IteratorNodeInner = memo(({ data, selected }: IteratorNodeProps) => {
     const { schemata, categories } = useContext(BackendContext);
     const { getIteratorProgress } = useContext(ExecutionContext);
+    const { setNodeInputValue } = useContext(GlobalContext);
 
     const { id, inputData, isLocked, schemaId, iteratorSize, minWidth, minHeight } = data;
+
+    const setInputValue = useCallback(
+        (inputId: InputId, value: InputValue): void => {
+            setNodeInputValue(id, inputId, value);
+        },
+        [id, setNodeInputValue]
+    );
 
     const iteratorProgress = getIteratorProgress(id);
 
@@ -97,6 +105,7 @@ const IteratorNodeInner = memo(({ data, selected }: IteratorNodeProps) => {
                             inputData={inputData}
                             isLocked={isLocked}
                             schema={schema}
+                            setInputValue={setInputValue}
                         />
                     </Box>
                     <Center>

--- a/src/renderer/components/node/IteratorNode.tsx
+++ b/src/renderer/components/node/IteratorNode.tsx
@@ -1,7 +1,7 @@
 import { Box, Center, Text, VStack } from '@chakra-ui/react';
-import { memo, useCallback, useMemo, useRef } from 'react';
+import { memo, useMemo, useRef } from 'react';
 import { useContext, useContextSelector } from 'use-context-selector';
-import { InputId, InputValue, NodeData } from '../../../common/common-types';
+import { NodeData } from '../../../common/common-types';
 import { DisabledStatus } from '../../../common/nodes/disabled';
 import { BackendContext } from '../../contexts/BackendContext';
 import { ExecutionContext } from '../../contexts/ExecutionContext';
@@ -37,12 +37,7 @@ const IteratorNodeInner = memo(({ data, selected }: IteratorNodeProps) => {
 
     const { id, inputData, isLocked, schemaId, iteratorSize, minWidth, minHeight } = data;
 
-    const setInputValue = useCallback(
-        (inputId: InputId, value: InputValue): void => {
-            setNodeInputValue(id, inputId, value);
-        },
-        [id, setNodeInputValue]
-    );
+    const setInputValue = useMemo(() => setNodeInputValue.bind(null, id), [id, setNodeInputValue]);
 
     const iteratorProgress = getIteratorProgress(id);
 

--- a/src/renderer/components/node/Node.tsx
+++ b/src/renderer/components/node/Node.tsx
@@ -1,9 +1,9 @@
 import { Center, VStack } from '@chakra-ui/react';
 import path from 'path';
-import { DragEvent, memo, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { DragEvent, memo, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useReactFlow } from 'reactflow';
 import { useContext, useContextSelector } from 'use-context-selector';
-import { Input, NodeData } from '../../../common/common-types';
+import { Input, InputId, InputValue, NodeData } from '../../../common/common-types';
 import { DisabledStatus } from '../../../common/nodes/disabled';
 import {
     EMPTY_ARRAY,
@@ -62,6 +62,13 @@ const NodeInner = memo(({ data, selected }: NodeProps) => {
 
     const { id, inputData, inputSize, isLocked, parentNode, schemaId } = data;
     const animated = useContextSelector(GlobalVolatileContext, (c) => c.isAnimated(id));
+
+    const setInputValue = useCallback(
+        (inputId: InputId, value: InputValue): void => {
+            setNodeInputValue(id, inputId, value);
+        },
+        [id, setNodeInputValue]
+    );
 
     const { getEdge } = useReactFlow();
 
@@ -218,6 +225,7 @@ const NodeInner = memo(({ data, selected }: NodeProps) => {
                         inputSize={inputSize}
                         isLocked={isLocked}
                         schema={schema}
+                        setInputValue={setInputValue}
                     />
                 </VStack>
                 <NodeFooter

--- a/src/renderer/components/node/Node.tsx
+++ b/src/renderer/components/node/Node.tsx
@@ -1,9 +1,9 @@
 import { Center, VStack } from '@chakra-ui/react';
 import path from 'path';
-import { DragEvent, memo, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { DragEvent, memo, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useReactFlow } from 'reactflow';
 import { useContext, useContextSelector } from 'use-context-selector';
-import { Input, InputId, InputValue, NodeData } from '../../../common/common-types';
+import { Input, NodeData } from '../../../common/common-types';
 import { DisabledStatus } from '../../../common/nodes/disabled';
 import {
     EMPTY_ARRAY,
@@ -63,12 +63,7 @@ const NodeInner = memo(({ data, selected }: NodeProps) => {
     const { id, inputData, inputSize, isLocked, parentNode, schemaId } = data;
     const animated = useContextSelector(GlobalVolatileContext, (c) => c.isAnimated(id));
 
-    const setInputValue = useCallback(
-        (inputId: InputId, value: InputValue): void => {
-            setNodeInputValue(id, inputId, value);
-        },
-        [id, setNodeInputValue]
-    );
+    const setInputValue = useMemo(() => setNodeInputValue.bind(null, id), [id, setNodeInputValue]);
 
     const { getEdge } = useReactFlow();
 

--- a/src/renderer/components/node/NodeBody.tsx
+++ b/src/renderer/components/node/NodeBody.tsx
@@ -1,11 +1,9 @@
 import { Box } from '@chakra-ui/react';
 import { memo } from 'react';
-import { Input, InputData, InputSize, NodeSchema } from '../../../common/common-types';
+import { InputData, InputSize, NodeSchema } from '../../../common/common-types';
+import { isAutoInput } from '../../../common/util';
 import { NodeInputs } from './NodeInputs';
 import { NodeOutputs } from './NodeOutputs';
-
-const isAutoInput = (input: Input): boolean =>
-    input.kind === 'generic' && input.optional && !input.hasHandle;
 
 interface NodeBodyProps {
     id: string;

--- a/src/renderer/components/node/NodeBody.tsx
+++ b/src/renderer/components/node/NodeBody.tsx
@@ -1,6 +1,12 @@
 import { Box } from '@chakra-ui/react';
 import { memo } from 'react';
-import { InputData, InputSize, NodeSchema } from '../../../common/common-types';
+import {
+    InputData,
+    InputId,
+    InputSize,
+    InputValue,
+    NodeSchema,
+} from '../../../common/common-types';
 import { isAutoInput } from '../../../common/util';
 import { NodeInputs } from './NodeInputs';
 import { NodeOutputs } from './NodeOutputs';
@@ -9,13 +15,22 @@ interface NodeBodyProps {
     id: string;
     inputData: InputData;
     inputSize?: InputSize;
+    setInputValue: (inputId: InputId, value: InputValue) => void;
     isLocked?: boolean;
     schema: NodeSchema;
     animated?: boolean;
 }
 
 export const NodeBody = memo(
-    ({ schema, id, inputData, inputSize, isLocked, animated = false }: NodeBodyProps) => {
+    ({
+        schema,
+        id,
+        inputData,
+        setInputValue,
+        inputSize,
+        isLocked,
+        animated = false,
+    }: NodeBodyProps) => {
         const { inputs, outputs, schemaId } = schema;
 
         const autoInput = inputs.length === 1 && isAutoInput(inputs[0]);
@@ -34,6 +49,7 @@ export const NodeBody = memo(
                             inputSize={inputSize}
                             isLocked={isLocked}
                             schema={schema}
+                            setInputValue={setInputValue}
                         />
                     </Box>
                 )}

--- a/src/renderer/components/node/NodeInputs.tsx
+++ b/src/renderer/components/node/NodeInputs.tsx
@@ -1,7 +1,13 @@
 /* eslint-disable react/prop-types */
 import { memo } from 'react';
 import { useContext } from 'use-context-selector';
-import { InputData, InputSize, NodeSchema } from '../../../common/common-types';
+import {
+    InputData,
+    InputId,
+    InputSize,
+    InputValue,
+    NodeSchema,
+} from '../../../common/common-types';
 import { getUniqueKey } from '../../../common/group-inputs';
 import { BackendContext } from '../../contexts/BackendContext';
 import { GroupElement } from '../groups/Group';
@@ -12,12 +18,13 @@ interface NodeInputsProps {
     schema: NodeSchema;
     id: string;
     inputData: InputData;
+    setInputValue: (inputId: InputId, value: InputValue) => void;
     inputSize?: InputSize;
     isLocked?: boolean;
 }
 
 const ItemRenderer: InputItemRenderer = memo(
-    ({ item, inputData, inputSize, isLocked, nodeId, schemaId }) => {
+    ({ item, inputData, setInputValue, inputSize, isLocked, nodeId, schemaId }) => {
         if (item.kind === 'group') {
             const { group } = item;
             return (
@@ -30,6 +37,7 @@ const ItemRenderer: InputItemRenderer = memo(
                     isLocked={isLocked}
                     nodeId={nodeId}
                     schemaId={schemaId}
+                    setInputValue={setInputValue}
                 />
             );
         }
@@ -42,13 +50,14 @@ const ItemRenderer: InputItemRenderer = memo(
                 isLocked={isLocked}
                 nodeId={nodeId}
                 schemaId={schemaId}
+                setInputValue={setInputValue}
             />
         );
     }
 );
 
 export const NodeInputs = memo(
-    ({ schema, id, inputData, inputSize, isLocked = false }: NodeInputsProps) => {
+    ({ schema, id, inputData, setInputValue, inputSize, isLocked = false }: NodeInputsProps) => {
         const { schemaInputs } = useContext(BackendContext);
 
         const { schemaId } = schema;
@@ -66,6 +75,7 @@ export const NodeInputs = memo(
                         key={getUniqueKey(item)}
                         nodeId={id}
                         schemaId={schemaId}
+                        setInputValue={setInputValue}
                     />
                 ))}
             </>


### PR DESCRIPTION
You might to review this PR with whitespace changes hidden. Prettier went wild in some places.

Changes:
- Improved type printing. `false | true` will now be `bool`, and small integer intervals will now be unfolded (e.g. `1 | int(3..4)` -> `1 | 3 | 4`).
- Added "optional" tag for option inputs and removed `null` from type.
- Don't show outputs users can't connect to. This only affects the large image output of View Image.
- Don't show auto iterator input in helper nodes.
- Fixed example inputs not being the default inputs.

The last point needs a bit more explanation. The issue was that a number input always retained its previous value if the input id was the same as the in the previously looked-at node. E.g. go to Crop Edges and then to Crop Offsets and Width and Height were set to 0 (which is invalid). This was a bug in `NumberInput` and I fixed it.

But that wasn't good enough for me. Input still reset to their default values when we show example nodes. This changes the global node state, which really isn't ideal here. So to prevent future bugs, I changed the way groups and `SchemaInput` (= the abstraction layer on top of input components) set input data. They previously got `setNodeInputValue` from global node state, but now they get a `setInputValue` function passed in as a prop. This allows us to control the way `inputData` is modified. In the case of doc examples, we manage our own `inputData` state separate from global node state.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/afc20ce9-b34c-48f9-a3d1-1e5f1b9eb542)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/9f403070-3973-4cd9-9ea9-f94a7bdf5ae7)
