### PR TITLE
Improved Get BB output type

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image_dimension/utility/get_bounding_box.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/utility/get_bounding_box.py
@@ -29,8 +29,8 @@ from .. import utility_group
         ),
     ],
     outputs=[
-        NumberOutput("X", output_type="min(uint, Input0.width - 1)"),
-        NumberOutput("Y", output_type="min(uint, Input0.height - 1)"),
+        NumberOutput("X", output_type="min(uint, Input0.width - 1) & 0.."),
+        NumberOutput("Y", output_type="min(uint, Input0.height - 1) & 0.."),
         NumberOutput("Width", output_type="min(uint, Input0.width) & 1.."),
         NumberOutput("Height", output_type="min(uint, Input0.height) & 1.."),
     ],


### PR DESCRIPTION
While going through the docs, I noticed that the output type for Get BB is wrong. It said that X/Y can be -1, which is not true. So I cast it into the range 0..inf.