### PR TITLE
Update prettier to 2.8.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -109,7 +109,7 @@
         "jest": "^29.5.0",
         "node-loader": "^2.0.0",
         "nodemon": "^2.0.16",
-        "prettier": "^2.6.2",
+        "prettier": "^2.8.8",
         "react-refresh": "^0.13.0",
         "sass": "^1.54.4",
         "sass-loader": "^13.0.2",
@@ -20320,9 +20320,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
-      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -40244,9 +40244,9 @@
       "optional": true
     },
     "prettier": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
-      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "jest": "^29.5.0",
     "node-loader": "^2.0.0",
     "nodemon": "^2.0.16",
-    "prettier": "^2.6.2",
+    "prettier": "^2.8.8",
     "react-refresh": "^0.13.0",
     "sass": "^1.54.4",
     "sass-loader": "^13.0.2",

--- a/src/renderer/components/CustomEdge/CustomEdge.scss
+++ b/src/renderer/components/CustomEdge/CustomEdge.scss
@@ -45,7 +45,7 @@
     stroke-dashoffset: 2;
     stroke-linecap: round;
     animation: 'none';
-    opacity: 0%;
+    opacity: 0;
 
     &.animated {
         stroke-dasharray: 1 10 !important;
@@ -57,7 +57,7 @@
 
     &.running {
         animation: 'dashdraw-chain 0.5s linear infinite';
-        opacity: 100%;
+        opacity: 1;
     }
 
     &.colliding {
@@ -69,7 +69,7 @@
         stroke-width: 3px;
 
         &.animated {
-            opacity: 100%;
+            opacity: 1;
         }
 
         &.hovered {
@@ -78,7 +78,7 @@
 
         &.running {
             animation: 'dashdraw-chain 0.5s linear infinite';
-            opacity: 100%;
+            opacity: 1;
         }
     }
 }


### PR DESCRIPTION
I wanted to use TS's `satisfies` operator but couldn't, because our version of prettier didn't support it. So I updated prettier and ran `npm run lint:fix`.