### PR TITLE
average_color_fix_node: Fix RGB contamination by transparent pixels

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image_filter/correction/average_color_fix.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/correction/average_color_fix.py
@@ -6,7 +6,7 @@ import cv2
 import numpy as np
 
 from nodes.impl.pil_utils import InterpolationMethod, resize
-from nodes.properties.inputs import ImageInput, NumberInput
+from nodes.properties.inputs import BoolInput, ImageInput, NumberInput
 from nodes.properties.outputs import ImageOutput
 from nodes.utils.utils import get_h_w_c
 
@@ -32,14 +32,87 @@ from .. import correction_group
             default=12.5,
             unit="%",
         ),
+        BoolInput("Separate Alpha", default=False),
     ],
     outputs=[ImageOutput(image_type="Input0")],
 )
 def average_color_fix_node(
-    input_img: np.ndarray, ref_img: np.ndarray, scale_factor: float
+    input_img: np.ndarray,
+    ref_img: np.ndarray,
+    scale_factor: float,
+    separate_alpha: bool,
 ) -> np.ndarray:
     """Fixes the average color of the input image"""
 
+    if separate_alpha:
+        return average_color_fix_separate_alpha(input_img, ref_img, scale_factor)
+
+    return average_color_fix_alpha_aware(input_img, ref_img, scale_factor)
+
+
+def average_color_fix_separate_alpha(
+    input_img: np.ndarray, ref_img: np.ndarray, scale_factor: float
+) -> np.ndarray:
+    if scale_factor != 100.0:
+        # Make sure reference image dims are not resized to 0
+        h, w, _ = get_h_w_c(ref_img)
+        out_dims = (
+            max(ceil(w * (scale_factor / 100)), 1),
+            max(ceil(h * (scale_factor / 100)), 1),
+        )
+
+        ref_img = cv2.resize(
+            ref_img,
+            out_dims,
+            interpolation=cv2.INTER_AREA,
+        )
+
+    input_h, input_w, input_c = get_h_w_c(input_img)
+    ref_h, ref_w, ref_c = get_h_w_c(ref_img)
+
+    assert (
+        ref_w < input_w and ref_h < input_h
+    ), "Image must be larger than Reference Image"
+
+    # adjust channels
+    alpha = None
+    if input_c > ref_c:
+        alpha = input_img[:, :, 3:4]
+        input_img = input_img[:, :, :ref_c]
+    elif ref_c > input_c:
+        ref_img = ref_img[:, :, :input_c]
+
+    # Find the diff of both images
+
+    # Downscale the input image
+    downscaled_input = cv2.resize(
+        input_img,
+        (ref_w, ref_h),
+        interpolation=cv2.INTER_AREA,
+    )
+
+    # Get difference between the reference image and downscaled input
+    downscaled_diff = ref_img - downscaled_input  # type: ignore
+
+    # Upsample the difference
+    diff = cv2.resize(
+        downscaled_diff,
+        (input_w, input_h),
+        interpolation=cv2.INTER_CUBIC,
+    )
+
+    result = input_img + diff
+
+    # add alpha back in
+    if alpha is not None:
+        result = np.concatenate([result, alpha], axis=2)
+
+    return result
+
+
+def average_color_fix_alpha_aware(
+    input_img: np.ndarray, ref_img: np.ndarray, scale_factor: float
+) -> np.ndarray:
     if scale_factor != 100.0:
         # Make sure reference image dims are not resized to 0
         h, w, _ = get_h_w_c(ref_img)

--- a/backend/src/packages/chaiNNer_standard/image_filter/correction/average_color_fix.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/correction/average_color_fix.py
@@ -6,7 +6,7 @@ import cv2
 import numpy as np
 
 from nodes.impl.pil_utils import InterpolationMethod, resize
-from nodes.properties.inputs import BoolInput, ImageInput, NumberInput
+from nodes.properties.inputs import ImageInput, NumberInput
 from nodes.properties.outputs import ImageOutput
 from nodes.utils.utils import get_h_w_c
 
@@ -32,87 +32,14 @@ from .. import correction_group
             default=12.5,
             unit="%",
         ),
-        BoolInput("Separate Alpha", default=False),
     ],
     outputs=[ImageOutput(image_type="Input0")],
 )
 def average_color_fix_node(
-    input_img: np.ndarray,
-    ref_img: np.ndarray,
-    scale_factor: float,
-    separate_alpha: bool,
+    input_img: np.ndarray, ref_img: np.ndarray, scale_factor: float
 ) -> np.ndarray:
     """Fixes the average color of the input image"""
 
-    if separate_alpha:
-        return average_color_fix_separate_alpha(input_img, ref_img, scale_factor)
-
-    return average_color_fix_alpha_aware(input_img, ref_img, scale_factor)
-
-
-def average_color_fix_separate_alpha(
-    input_img: np.ndarray, ref_img: np.ndarray, scale_factor: float
-) -> np.ndarray:
-    if scale_factor != 100.0:
-        # Make sure reference image dims are not resized to 0
-        h, w, _ = get_h_w_c(ref_img)
-        out_dims = (
-            max(ceil(w * (scale_factor / 100)), 1),
-            max(ceil(h * (scale_factor / 100)), 1),
-        )
-
-        ref_img = cv2.resize(
-            ref_img,
-            out_dims,
-            interpolation=cv2.INTER_AREA,
-        )
-
-    input_h, input_w, input_c = get_h_w_c(input_img)
-    ref_h, ref_w, ref_c = get_h_w_c(ref_img)
-
-    assert (
-        ref_w < input_w and ref_h < input_h
-    ), "Image must be larger than Reference Image"
-
-    # adjust channels
-    alpha = None
-    if input_c > ref_c:
-        alpha = input_img[:, :, 3:4]
-        input_img = input_img[:, :, :ref_c]
-    elif ref_c > input_c:
-        ref_img = ref_img[:, :, :input_c]
-
-    # Find the diff of both images
-
-    # Downscale the input image
-    downscaled_input = cv2.resize(
-        input_img,
-        (ref_w, ref_h),
-        interpolation=cv2.INTER_AREA,
-    )
-
-    # Get difference between the reference image and downscaled input
-    downscaled_diff = ref_img - downscaled_input  # type: ignore
-
-    # Upsample the difference
-    diff = cv2.resize(
-        downscaled_diff,
-        (input_w, input_h),
-        interpolation=cv2.INTER_CUBIC,
-    )
-
-    result = input_img + diff
-
-    # add alpha back in
-    if alpha is not None:
-        result = np.concatenate([result, alpha], axis=2)
-
-    return result
-
-
-def average_color_fix_alpha_aware(
-    input_img: np.ndarray, ref_img: np.ndarray, scale_factor: float
-) -> np.ndarray:
     if scale_factor != 100.0:
         # Make sure reference image dims are not resized to 0
         h, w, _ = get_h_w_c(ref_img)

--- a/backend/src/packages/chaiNNer_standard/image_filter/correction/average_color_fix.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/correction/average_color_fix.py
@@ -5,6 +5,7 @@ from math import ceil
 import cv2
 import numpy as np
 
+from nodes.impl.pil_utils import InterpolationMethod, resize
 from nodes.properties.inputs import ImageInput, NumberInput
 from nodes.properties.outputs import ImageOutput
 from nodes.utils.utils import get_h_w_c
@@ -47,10 +48,10 @@ def average_color_fix_node(
             max(ceil(h * (scale_factor / 100)), 1),
         )
 
-        ref_img = cv2.resize(
+        ref_img = resize(
             ref_img,
             out_dims,
-            interpolation=cv2.INTER_AREA,
+            interpolation=InterpolationMethod.BOX,
         )
 
     input_h, input_w, input_c = get_h_w_c(input_img)
@@ -60,25 +61,46 @@ def average_color_fix_node(
         ref_w < input_w and ref_h < input_h
     ), "Image must be larger than Reference Image"
 
-    # adjust channels
-    alpha = None
-    if input_c > ref_c:
-        alpha = input_img[:, :, 3:4]
-        input_img = input_img[:, :, :ref_c]
-    elif ref_c > input_c:
-        ref_img = ref_img[:, :, :input_c]
-
     # Find the diff of both images
 
     # Downscale the input image
-    downscaled_input = cv2.resize(
+    downscaled_input = resize(
         input_img,
         (ref_w, ref_h),
-        interpolation=cv2.INTER_AREA,
+        interpolation=InterpolationMethod.BOX,
     )
+
+    # adjust channels
+    alpha = None
+    downscaled_alpha = None
+    ref_alpha = None
+    if input_c > 3:
+        alpha = input_img[:, :, 3:4]
+        input_img = input_img[:, :, :3]
+        downscaled_alpha = downscaled_input[:, :, 3:4]
+        downscaled_input = downscaled_input[:, :, :3]
+    if ref_c > 3:
+        ref_alpha = ref_img[:, :, 3:4]
+        ref_img = ref_img[:, :, :3]
 
     # Get difference between the reference image and downscaled input
     downscaled_diff = ref_img - downscaled_input  # type: ignore
+
+    downscaled_alpha_diff = None
+    if ref_alpha is not None or downscaled_alpha is not None:
+        # Don't alter RGB pixels if either the input or reference pixel is
+        # fully transparent, since RGB diff is indeterminate for those pixels.
+        if ref_alpha is not None and downscaled_alpha is not None:
+            invalid_alpha_mask = (ref_alpha == 0) | (downscaled_alpha == 0)
+        elif ref_alpha is not None:
+            invalid_alpha_mask = ref_alpha == 0
+        else:
+            invalid_alpha_mask = downscaled_alpha == 0
+        invalid_alpha_indices = np.nonzero(invalid_alpha_mask)
+        downscaled_diff[invalid_alpha_indices] = 0
+
+        if ref_alpha is not None and downscaled_alpha is not None:
+            downscaled_alpha_diff = ref_alpha - downscaled_alpha  # type: ignore
 
     # Upsample the difference
     diff = cv2.resize(
@@ -87,7 +109,25 @@ def average_color_fix_node(
         interpolation=cv2.INTER_CUBIC,
     )
 
+    alpha_diff = None
+    if downscaled_alpha_diff is not None:
+        alpha_diff = cv2.resize(
+            downscaled_alpha_diff,
+            (input_w, input_h),
+            interpolation=cv2.INTER_CUBIC,
+        )
+        alpha_diff = np.expand_dims(alpha_diff, 2)
+
+    if alpha_diff is not None:
+        # Don't alter alpha pixels if the input pixel is fully transparent, since
+        # doing so would expose indeterminate RGB data.
+        invalid_rgb_mask = alpha == 0
+        invalid_rgb_indices = np.nonzero(invalid_rgb_mask)
+        alpha_diff[invalid_rgb_indices] = 0
+
     result = input_img + diff
+    if alpha_diff is not None:
+        alpha = alpha + alpha_diff
 
     # add alpha back in
     if alpha is not None:


### PR DESCRIPTION
The `average_color_fix_node` implementation was treating alpha as just another channel. Since the RGB values of transparent pixels are indeterminate, this behavior caused contamination when the RGB values of transparent pixels were mixed with RGB values of nontransparent pixels. The contamination can easily be demoed by taking an RGBA image, and setting its transparent pixels' RGB values to lime, like this:

```
magick in.png -background lime -alpha background out.png
```

Upscaling the resulting file and then applying an average color fix will yield a lime halo.

This PR fixes the contamination via 3 changes:

1. Downscale via PIL instead of OpenCV, since PIL handles alpha properly when downscaling.
2. Don't alter RGB values of pixels where either the input image or reference image has a transparent pixel there.
3. Don't alter alpha values of pixels where the input image has a transparent pixel there.
