### PR TITLE
Fixed error reporting

### DIFF
--- a/backend/src/nodes/properties/inputs/numpy_inputs.py
+++ b/backend/src/nodes/properties/inputs/numpy_inputs.py
@@ -79,7 +79,10 @@ class ImageInput(BaseInput):
 
         return value
 
-    def get_error_value(self, value: np.ndarray | Color) -> ErrorValue:
+    def get_error_value(self, value: np.ndarray | Color | None) -> ErrorValue:
+        if value is None:
+            return super().get_error_value(value)
+
         def get_channels(channel: int) -> str:
             if channel == 1:
                 return "Grayscale"

--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -71,8 +71,14 @@ def run_node(node: NodeData, inputs: Iterable[object], node_id: NodeId) -> Outpu
         # collect information to provide good error messages
         input_dict: InputsDict = {}
         for index, node_input in enumerate(node.inputs):
-            input_value = enforced_inputs[index]
-            input_dict[node_input.id] = node_input.get_error_value(input_value)
+            try:
+                input_value = enforced_inputs[index]
+                input_dict[node_input.id] = node_input.get_error_value(input_value)
+            except Exception as inner_e:
+                logger.error(
+                    f"Error getting error value for input {node_input.label} (id {node_input.id})",
+                    inner_e,
+                )
 
         raise NodeExecutionError(node_id, node, str(e), input_dict) from e
 

--- a/src/common/Backend.ts
+++ b/src/common/Backend.ts
@@ -39,7 +39,7 @@ export type BackendErrorValue =
 export interface BackendExceptionSource {
     nodeId: string;
     schemaId: SchemaId;
-    inputs: Record<InputId, BackendErrorValue>;
+    inputs: Partial<Record<InputId, BackendErrorValue>>;
 }
 export interface BackendExceptionResponse {
     type: 'error';

--- a/src/common/formatExecutionErrorMessage.ts
+++ b/src/common/formatExecutionErrorMessage.ts
@@ -21,7 +21,9 @@ export const formatExecutionErrorMessage = (
         const inputValue = source.inputs[i.id];
 
         let valueStr: string;
-        if (inputValue.type === 'formatted') {
+        if (inputValue === undefined) {
+            valueStr = '*unknown*';
+        } else if (inputValue.type === 'formatted') {
             valueStr = inputValue.formatString;
         } else if (inputValue.type === 'unknown') {
             valueStr = `Value of type '${inputValue.typeModule}.${inputValue.typeName}'`;


### PR DESCRIPTION
This fixes 2 bugs:

1. The frontend assumes that all inputs have information about their current values. This is not the case. If the logic for deriving this information fails, we don't have it. If the node executor itself has a bug, we don't have this information either. Since error reporting must not fail, I choose to conservatively assume that we might not have values for everything.
2. `get_error_value` was implemented incorrectly for `ImageInput`. The value could be `None`, but this was not accounted for. This is the `'NoneType' object has no attribute 'shape'` we see [here](https://github.com/chaiNNer-org/chaiNNer/issues/1891#issuecomment-1618761073).

In addition to this, I also added a `try` around collection error data. It's better to have less data than for the collection itself to error and hide the original error.

Error reporting should now be a lot more robust.