### PR TITLE
`setInputSize` and `NodeState`

### DIFF
--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -7,6 +7,7 @@ import type { Input, InputData, InputId, InputValue, NodeSchema, OutputId } from
 export const EMPTY_ARRAY: readonly never[] = [];
 export const EMPTY_SET: ReadonlySet<never> = new Set<never>();
 export const EMPTY_MAP: ReadonlyMap<never, never> = new Map<never, never>();
+export const EMPTY_OBJECT: Readonly<Record<string, never>> = Object.freeze({});
 
 export const noop = () => {};
 

--- a/src/renderer/components/NodeDocumentation/NodeDocs.tsx
+++ b/src/renderer/components/NodeDocumentation/NodeDocs.tsx
@@ -1,7 +1,6 @@
 import { NeverType, Type } from '@chainner/navi';
 import {
     Box,
-    Center,
     Code,
     Divider,
     Flex,
@@ -13,11 +12,10 @@ import {
     VStack,
     useMediaQuery,
 } from '@chakra-ui/react';
-import { memo, useCallback, useState } from 'react';
+import { memo } from 'react';
 import { ReactMarkdown } from 'react-markdown/lib/react-markdown';
 import { useContext } from 'use-context-selector';
-import { InputData, InputId, InputValue, NodeSchema } from '../../../common/common-types';
-import { DisabledStatus } from '../../../common/nodes/disabled';
+import { NodeSchema } from '../../../common/common-types';
 import { FunctionDefinition } from '../../../common/types/function';
 import { prettyPrintType } from '../../../common/types/pretty';
 import { withoutNull } from '../../../common/types/util';
@@ -26,90 +24,10 @@ import { BackendContext } from '../../contexts/BackendContext';
 import { NodeDocumentationContext } from '../../contexts/NodeDocumentationContext';
 import { getCategoryAccentColor } from '../../helpers/accentColors';
 import { IconFactory } from '../CustomIcons';
-import { NodeBody } from '../node/NodeBody';
-import { NodeFooter } from '../node/NodeFooter/NodeFooter';
-import { NodeHeader } from '../node/NodeHeader';
 import { TypeTag } from '../TypeTag';
 import { docsMarkdown } from './docsMarkdown';
+import { NodeExample } from './NodeExample';
 import { SchemaLink } from './SchemaLink';
-
-interface NodeExampleProps {
-    accentColor: string;
-    selectedSchema: NodeSchema;
-}
-const FakeNodeExample = memo(({ accentColor, selectedSchema }: NodeExampleProps) => {
-    const [state, setState] = useState<{ inputData: InputData; schema: NodeSchema }>({
-        inputData: {},
-        schema: selectedSchema,
-    });
-
-    const setInputValue = useCallback(
-        (inputId: InputId, value: InputValue): void => {
-            setState((prev) => {
-                const inputData = prev.schema === selectedSchema ? prev.inputData : {};
-                return {
-                    inputData: {
-                        ...inputData,
-                        [inputId]: value,
-                    },
-                    schema: selectedSchema,
-                };
-            });
-        },
-        [selectedSchema]
-    );
-
-    const inputData = state.schema === selectedSchema ? state.inputData : {};
-    return (
-        <Center
-            pointerEvents="none"
-            w="auto"
-        >
-            <Center
-                bg="var(--node-bg-color)"
-                borderColor="var(--node-border-color)"
-                borderRadius="lg"
-                borderWidth="0.5px"
-                boxShadow="lg"
-                minWidth="240px"
-                overflow="hidden"
-                transition="0.15s ease-in-out"
-            >
-                <VStack
-                    spacing={0}
-                    w="full"
-                >
-                    <VStack
-                        spacing={0}
-                        w="full"
-                    >
-                        <NodeHeader
-                            accentColor={accentColor}
-                            disabledStatus={DisabledStatus.Enabled}
-                            icon={selectedSchema.icon}
-                            name={selectedSchema.name}
-                            parentNode={undefined}
-                            selected={false}
-                        />
-                        <NodeBody
-                            animated={false}
-                            id="<fake node id>"
-                            inputData={inputData}
-                            isLocked={false}
-                            schema={selectedSchema}
-                            setInputValue={setInputValue}
-                        />
-                    </VStack>
-                    <NodeFooter
-                        animated={false}
-                        id="<fake node id>"
-                        validity={{ isValid: true }}
-                    />
-                </VStack>
-            </Center>
-        </Center>
-    );
-});
 
 interface InputOutputItemProps {
     label: string;
@@ -363,7 +281,7 @@ export const NodeDocs = memo(() => {
                         position="relative"
                     >
                         <VStack position="relative">
-                            <FakeNodeExample
+                            <NodeExample
                                 accentColor={selectedAccentColor}
                                 selectedSchema={selectedSchema}
                             />
@@ -371,7 +289,7 @@ export const NodeDocs = memo(() => {
                                 selectedSchema.defaultNodes.map((defaultNode) => {
                                     const nodeSchema = schemata.get(defaultNode.schemaId);
                                     return (
-                                        <FakeNodeExample
+                                        <NodeExample
                                             accentColor={selectedAccentColor}
                                             key={defaultNode.schemaId}
                                             selectedSchema={nodeSchema}

--- a/src/renderer/components/NodeDocumentation/NodeExample.tsx
+++ b/src/renderer/components/NodeDocumentation/NodeExample.tsx
@@ -28,12 +28,12 @@ const useStateForSchema = function <T>(
         (value: (prev: T) => T): void => {
             setState((prev) => {
                 return {
-                    value: value(prev.value),
+                    value: value(prev.schema === schema ? prev.value : defaultValue),
                     schema,
                 };
             });
         },
-        [schema]
+        [schema, defaultValue]
     );
 
     const value = state.schema === schema ? state.value : defaultValue;
@@ -64,6 +64,7 @@ export const NodeExample = memo(({ accentColor, selectedSchema }: NodeExamplePro
 
     return (
         <Center
+            key={selectedSchema.schemaId}
             pointerEvents="none"
             w="auto"
         >

--- a/src/renderer/components/NodeDocumentation/NodeExample.tsx
+++ b/src/renderer/components/NodeDocumentation/NodeExample.tsx
@@ -95,13 +95,16 @@ export const NodeExample = memo(({ accentColor, selectedSchema }: NodeExamplePro
                         />
                         <NodeBody
                             animated={false}
-                            id="<fake node id>"
-                            inputData={inputData}
-                            inputSize={inputSize}
-                            isLocked={false}
-                            schema={selectedSchema}
-                            setInputSize={setSingleInputSize}
-                            setInputValue={setInputValue}
+                            nodeState={{
+                                id: '<fake node id>',
+                                schemaId: selectedSchema.schemaId,
+                                schema: selectedSchema,
+                                inputData,
+                                setInputValue,
+                                inputSize,
+                                setInputSize: setSingleInputSize,
+                                isLocked: false,
+                            }}
                         />
                     </VStack>
                     <NodeFooter

--- a/src/renderer/components/NodeDocumentation/NodeExample.tsx
+++ b/src/renderer/components/NodeDocumentation/NodeExample.tsx
@@ -1,0 +1,116 @@
+import { Center, VStack } from '@chakra-ui/react';
+import { memo, useCallback, useState } from 'react';
+import {
+    InputData,
+    InputId,
+    InputSize,
+    InputValue,
+    NodeSchema,
+    Size,
+} from '../../../common/common-types';
+import { DisabledStatus } from '../../../common/nodes/disabled';
+import { EMPTY_OBJECT } from '../../../common/util';
+import { NodeBody } from '../node/NodeBody';
+import { NodeFooter } from '../node/NodeFooter/NodeFooter';
+import { NodeHeader } from '../node/NodeHeader';
+
+// eslint-disable-next-line prefer-arrow-functions/prefer-arrow-functions, func-names
+const useStateForSchema = function <T>(
+    schema: NodeSchema,
+    defaultValue: T
+): [T, (value: (prev: T) => T) => void] {
+    const [state, setState] = useState<{ value: T; schema: NodeSchema }>({
+        value: defaultValue,
+        schema,
+    });
+
+    const setValue = useCallback(
+        (value: (prev: T) => T): void => {
+            setState((prev) => {
+                return {
+                    value: value(prev.value),
+                    schema,
+                };
+            });
+        },
+        [schema]
+    );
+
+    const value = state.schema === schema ? state.value : defaultValue;
+
+    return [value, setValue];
+};
+
+interface NodeExampleProps {
+    accentColor: string;
+    selectedSchema: NodeSchema;
+}
+export const NodeExample = memo(({ accentColor, selectedSchema }: NodeExampleProps) => {
+    const [inputData, setInputData] = useStateForSchema<InputData>(selectedSchema, EMPTY_OBJECT);
+    const setInputValue = useCallback(
+        (inputId: InputId, value: InputValue): void => {
+            setInputData((prev) => ({ ...prev, [inputId]: value }));
+        },
+        [setInputData]
+    );
+
+    const [inputSize, setInputSize] = useStateForSchema<InputSize>(selectedSchema, EMPTY_OBJECT);
+    const setSingleInputSize = useCallback(
+        (inputId: InputId, size: Readonly<Size>): void => {
+            setInputSize((prev) => ({ ...prev, [inputId]: size }));
+        },
+        [setInputSize]
+    );
+
+    return (
+        <Center
+            pointerEvents="none"
+            w="auto"
+        >
+            <Center
+                bg="var(--node-bg-color)"
+                borderColor="var(--node-border-color)"
+                borderRadius="lg"
+                borderWidth="0.5px"
+                boxShadow="lg"
+                minWidth="240px"
+                overflow="hidden"
+                transition="0.15s ease-in-out"
+            >
+                <VStack
+                    spacing={0}
+                    w="full"
+                >
+                    <VStack
+                        spacing={0}
+                        w="full"
+                    >
+                        <NodeHeader
+                            accentColor={accentColor}
+                            disabledStatus={DisabledStatus.Enabled}
+                            icon={selectedSchema.icon}
+                            name={selectedSchema.name}
+                            parentNode={undefined}
+                            selected={false}
+                        />
+                        <NodeBody
+                            animated={false}
+                            id="<fake node id>"
+                            inputData={inputData}
+                            inputSize={inputSize}
+                            isLocked={false}
+                            schema={selectedSchema}
+                            setInputSize={setSingleInputSize}
+                            setInputValue={setInputValue}
+                        />
+                    </VStack>
+                    <NodeFooter
+                        animated={false}
+                        id="<fake node id>"
+                        validity={{ isValid: true }}
+                    />
+                </VStack>
+            </Center>
+        </Center>
+    );
+});

--- a/src/renderer/components/groups/ConditionalGroup.tsx
+++ b/src/renderer/components/groups/ConditionalGroup.tsx
@@ -7,18 +7,8 @@ import { GroupProps } from './props';
 import { someInput } from './util';
 
 export const ConditionalGroup = memo(
-    ({
-        inputs,
-        inputData,
-        setInputValue,
-        inputSize,
-        setInputSize,
-        isLocked,
-        nodeId,
-        schemaId,
-        group,
-        ItemRenderer,
-    }: GroupProps<'conditional'>) => {
+    ({ inputs, nodeState, group, ItemRenderer }: GroupProps<'conditional'>) => {
+        const { id: nodeId, inputData } = nodeState;
         const { condition } = group.options;
 
         const isNodeInputLocked = useContextSelector(
@@ -43,15 +33,9 @@ export const ConditionalGroup = memo(
             <>
                 {inputs.filter(showInput).map((item) => (
                     <ItemRenderer
-                        inputData={inputData}
-                        inputSize={inputSize}
-                        isLocked={isLocked}
                         item={item}
                         key={getUniqueKey(item)}
-                        nodeId={nodeId}
-                        schemaId={schemaId}
-                        setInputSize={setInputSize}
-                        setInputValue={setInputValue}
+                        nodeState={nodeState}
                     />
                 ))}
             </>

--- a/src/renderer/components/groups/ConditionalGroup.tsx
+++ b/src/renderer/components/groups/ConditionalGroup.tsx
@@ -12,6 +12,7 @@ export const ConditionalGroup = memo(
         inputData,
         setInputValue,
         inputSize,
+        setInputSize,
         isLocked,
         nodeId,
         schemaId,
@@ -49,6 +50,7 @@ export const ConditionalGroup = memo(
                         key={getUniqueKey(item)}
                         nodeId={nodeId}
                         schemaId={schemaId}
+                        setInputSize={setInputSize}
                         setInputValue={setInputValue}
                     />
                 ))}

--- a/src/renderer/components/groups/FromToDropdownsGroup.tsx
+++ b/src/renderer/components/groups/FromToDropdownsGroup.tsx
@@ -34,7 +34,8 @@ const SmallDropDown = memo(({ input, inputData, setInputValue, isLocked }: Small
 });
 
 export const FromToDropdownsGroup = memo(
-    ({ inputs, inputData, setInputValue, isLocked }: GroupProps<'from-to-dropdowns'>) => {
+    ({ inputs, nodeState }: GroupProps<'from-to-dropdowns'>) => {
+        const { inputData, setInputValue, isLocked } = nodeState;
         const [from, to] = inputs;
 
         return (

--- a/src/renderer/components/groups/Group.tsx
+++ b/src/renderer/components/groups/Group.tsx
@@ -7,6 +7,7 @@ import {
     InputSize,
     InputValue,
     SchemaId,
+    Size,
 } from '../../../common/common-types';
 import { InputItem } from '../../../common/group-inputs';
 import { ConditionalGroup } from './ConditionalGroup';
@@ -37,6 +38,7 @@ interface GroupElementProps {
     inputData: InputData;
     setInputValue: (inputId: InputId, value: InputValue) => void;
     inputSize: InputSize | undefined;
+    setInputSize: (inputId: InputId, size: Readonly<Size>) => void;
     ItemRenderer: InputItemRenderer;
 }
 
@@ -50,6 +52,7 @@ export const GroupElement = memo(
         inputData,
         setInputValue,
         inputSize,
+        setInputSize,
         ItemRenderer,
     }: GroupElementProps) => {
         const GroupType = GroupComponents[group.kind];
@@ -63,6 +66,7 @@ export const GroupElement = memo(
                 isLocked={isLocked}
                 nodeId={nodeId}
                 schemaId={schemaId}
+                setInputSize={setInputSize}
                 setInputValue={setInputValue}
             />
         );

--- a/src/renderer/components/groups/Group.tsx
+++ b/src/renderer/components/groups/Group.tsx
@@ -1,15 +1,7 @@
 import { memo } from 'react';
-import {
-    Group,
-    GroupKind,
-    InputData,
-    InputId,
-    InputSize,
-    InputValue,
-    SchemaId,
-    Size,
-} from '../../../common/common-types';
+import { Group, GroupKind } from '../../../common/common-types';
 import { InputItem } from '../../../common/group-inputs';
+import { NodeState } from '../../helpers/nodeState';
 import { ConditionalGroup } from './ConditionalGroup';
 import { FromToDropdownsGroup } from './FromToDropdownsGroup';
 import { NcnnFileInputsGroup } from './NcnnFileInputsGroup';
@@ -32,42 +24,19 @@ const GroupComponents: {
 interface GroupElementProps {
     group: Group;
     inputs: readonly InputItem[];
-    schemaId: SchemaId;
-    nodeId: string;
-    isLocked: boolean;
-    inputData: InputData;
-    setInputValue: (inputId: InputId, value: InputValue) => void;
-    inputSize: InputSize | undefined;
-    setInputSize: (inputId: InputId, size: Readonly<Size>) => void;
+    nodeState: NodeState;
     ItemRenderer: InputItemRenderer;
 }
 
 export const GroupElement = memo(
-    ({
-        group,
-        inputs,
-        schemaId,
-        nodeId,
-        isLocked,
-        inputData,
-        setInputValue,
-        inputSize,
-        setInputSize,
-        ItemRenderer,
-    }: GroupElementProps) => {
+    ({ group, inputs, nodeState, ItemRenderer }: GroupElementProps) => {
         const GroupType = GroupComponents[group.kind];
         return (
             <GroupType
                 ItemRenderer={ItemRenderer}
                 group={group as never}
-                inputData={inputData}
-                inputSize={inputSize}
                 inputs={inputs as never}
-                isLocked={isLocked}
-                nodeId={nodeId}
-                schemaId={schemaId}
-                setInputSize={setInputSize}
-                setInputValue={setInputValue}
+                nodeState={nodeState}
             />
         );
     }

--- a/src/renderer/components/groups/NcnnFileInputsGroup.tsx
+++ b/src/renderer/components/groups/NcnnFileInputsGroup.tsx
@@ -21,58 +21,42 @@ const ifOtherExists = (file: string, extension: string, then: (other: string) =>
     }
 };
 
-export const NcnnFileInputsGroup = memo(
-    ({
-        inputs,
-        inputData,
-        setInputValue,
-        inputSize,
-        setInputSize,
-        isLocked,
-        nodeId,
-        schemaId,
-    }: GroupProps<'ncnn-file-inputs'>) => {
-        const [paramInput, binInput] = inputs;
+export const NcnnFileInputsGroup = memo(({ inputs, nodeState }: GroupProps<'ncnn-file-inputs'>) => {
+    const { inputData, setInputValue } = nodeState;
+    const [paramInput, binInput] = inputs;
 
-        useEffect(() => {
-            const paramPath = getInputValue(paramInput.id, inputData);
-            const binPath = getInputValue(binInput.id, inputData);
+    useEffect(() => {
+        const paramPath = getInputValue(paramInput.id, inputData);
+        const binPath = getInputValue(binInput.id, inputData);
 
-            if (typeof paramPath === 'string' && binPath === undefined) {
-                ifOtherExists(paramPath, '.bin', (bin) => setInputValue(binInput.id, bin));
-            }
-            if (typeof binPath === 'string' && paramPath === undefined) {
-                ifOtherExists(binPath, '.param', (param) => setInputValue(paramInput.id, param));
-            }
-        }, [paramInput, binInput, inputData, setInputValue]);
+        if (typeof paramPath === 'string' && binPath === undefined) {
+            ifOtherExists(paramPath, '.bin', (bin) => setInputValue(binInput.id, bin));
+        }
+        if (typeof binPath === 'string' && paramPath === undefined) {
+            ifOtherExists(binPath, '.param', (param) => setInputValue(paramInput.id, param));
+        }
+    }, [paramInput, binInput, inputData, setInputValue]);
 
-        return (
-            <>
-                <SchemaInput
-                    input={paramInput}
-                    inputData={inputData}
-                    inputSize={inputSize}
-                    isLocked={isLocked}
-                    nodeId={nodeId}
-                    schemaId={schemaId}
-                    setInputSize={setInputSize}
-                    setInputValue={(inputId, file) => {
+    return (
+        <>
+            <SchemaInput
+                input={paramInput}
+                nodeState={{
+                    ...nodeState,
+                    setInputValue: (inputId, file) => {
                         setInputValue(inputId, file);
 
                         if (typeof file === 'string') {
                             ifOtherExists(file, '.bin', (bin) => setInputValue(binInput.id, bin));
                         }
-                    }}
-                />
-                <SchemaInput
-                    input={binInput}
-                    inputData={inputData}
-                    inputSize={inputSize}
-                    isLocked={isLocked}
-                    nodeId={nodeId}
-                    schemaId={schemaId}
-                    setInputSize={setInputSize}
-                    setInputValue={(inputId, file) => {
+                    },
+                }}
+            />
+            <SchemaInput
+                input={binInput}
+                nodeState={{
+                    ...nodeState,
+                    setInputValue: (inputId, file) => {
                         setInputValue(inputId, file);
 
                         if (typeof file === 'string') {
@@ -80,9 +64,9 @@ export const NcnnFileInputsGroup = memo(
                                 setInputValue(paramInput.id, param)
                             );
                         }
-                    }}
-                />
-            </>
-        );
-    }
-);
+                    },
+                }}
+            />
+        </>
+    );
+});

--- a/src/renderer/components/groups/NcnnFileInputsGroup.tsx
+++ b/src/renderer/components/groups/NcnnFileInputsGroup.tsx
@@ -27,6 +27,7 @@ export const NcnnFileInputsGroup = memo(
         inputData,
         setInputValue,
         inputSize,
+        setInputSize,
         isLocked,
         nodeId,
         schemaId,
@@ -54,6 +55,7 @@ export const NcnnFileInputsGroup = memo(
                     isLocked={isLocked}
                     nodeId={nodeId}
                     schemaId={schemaId}
+                    setInputSize={setInputSize}
                     setInputValue={(inputId, file) => {
                         setInputValue(inputId, file);
 
@@ -69,6 +71,7 @@ export const NcnnFileInputsGroup = memo(
                     isLocked={isLocked}
                     nodeId={nodeId}
                     schemaId={schemaId}
+                    setInputSize={setInputSize}
                     setInputValue={(inputId, file) => {
                         setInputValue(inputId, file);
 

--- a/src/renderer/components/groups/OptionalInputsGroup.tsx
+++ b/src/renderer/components/groups/OptionalInputsGroup.tsx
@@ -9,17 +9,9 @@ import { GroupProps } from './props';
 import { someInput } from './util';
 
 export const OptionalInputsGroup = memo(
-    ({
-        inputs,
-        inputData,
-        setInputValue,
-        inputSize,
-        setInputSize,
-        isLocked,
-        nodeId,
-        schemaId,
-        ItemRenderer,
-    }: GroupProps<'optional-list'>) => {
+    ({ inputs, nodeState, ItemRenderer }: GroupProps<'optional-list'>) => {
+        const { id: nodeId, inputData } = nodeState;
+
         const isNodeInputLocked = useContextSelector(
             GlobalVolatileContext,
             (c) => c.isNodeInputLocked
@@ -51,15 +43,9 @@ export const OptionalInputsGroup = memo(
             <>
                 {inputs.slice(0, uncovered).map((item) => (
                     <ItemRenderer
-                        inputData={inputData}
-                        inputSize={inputSize}
-                        isLocked={isLocked}
                         item={item}
                         key={getUniqueKey(item)}
-                        nodeId={nodeId}
-                        schemaId={schemaId}
-                        setInputSize={setInputSize}
-                        setInputValue={setInputValue}
+                        nodeState={nodeState}
                     />
                 ))}
                 {showMoreButton && (

--- a/src/renderer/components/groups/OptionalInputsGroup.tsx
+++ b/src/renderer/components/groups/OptionalInputsGroup.tsx
@@ -14,6 +14,7 @@ export const OptionalInputsGroup = memo(
         inputData,
         setInputValue,
         inputSize,
+        setInputSize,
         isLocked,
         nodeId,
         schemaId,
@@ -57,6 +58,7 @@ export const OptionalInputsGroup = memo(
                         key={getUniqueKey(item)}
                         nodeId={nodeId}
                         schemaId={schemaId}
+                        setInputSize={setInputSize}
                         setInputValue={setInputValue}
                     />
                 ))}

--- a/src/renderer/components/groups/RequiredGroup.tsx
+++ b/src/renderer/components/groups/RequiredGroup.tsx
@@ -4,28 +4,16 @@ import { GenericInput } from '../../../common/common-types';
 import { getUniqueKey } from '../../../common/group-inputs';
 import { testInputConditionTypeState } from '../../../common/nodes/condition';
 import { getRequireCondition } from '../../../common/nodes/required';
-import { BackendContext } from '../../contexts/BackendContext';
 import { GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { GroupProps } from './props';
 
 export const RequiredGroup = memo(
-    ({
-        inputs,
-        inputData,
-        setInputValue,
-        inputSize,
-        setInputSize,
-        isLocked,
-        nodeId,
-        schemaId,
-        group,
-        ItemRenderer,
-    }: GroupProps<'required'>) => {
-        const schema = useContextSelector(BackendContext, (c) => c.schemata.get(schemaId));
+    ({ inputs, nodeState, group, ItemRenderer }: GroupProps<'required'>) => {
+        const { id: nodeId, inputData, schema } = nodeState;
+
         const typeState = useContextSelector(GlobalVolatileContext, (c) => c.typeState);
 
         const condition = getRequireCondition(schema, group);
-
         const isRequired = useMemo(
             () => testInputConditionTypeState(condition, inputData, nodeId, typeState),
             [condition, nodeId, inputData, typeState]
@@ -39,15 +27,9 @@ export const RequiredGroup = memo(
             <>
                 {(isRequired ? requiredInputs : inputs).map((item) => (
                     <ItemRenderer
-                        inputData={inputData}
-                        inputSize={inputSize}
-                        isLocked={isLocked}
                         item={item}
                         key={getUniqueKey(item)}
-                        nodeId={nodeId}
-                        schemaId={schemaId}
-                        setInputSize={setInputSize}
-                        setInputValue={setInputValue}
+                        nodeState={nodeState}
                     />
                 ))}
             </>

--- a/src/renderer/components/groups/RequiredGroup.tsx
+++ b/src/renderer/components/groups/RequiredGroup.tsx
@@ -14,6 +14,7 @@ export const RequiredGroup = memo(
         inputData,
         setInputValue,
         inputSize,
+        setInputSize,
         isLocked,
         nodeId,
         schemaId,
@@ -45,6 +46,7 @@ export const RequiredGroup = memo(
                         key={getUniqueKey(item)}
                         nodeId={nodeId}
                         schemaId={schemaId}
+                        setInputSize={setInputSize}
                         setInputValue={setInputValue}
                     />
                 ))}

--- a/src/renderer/components/groups/SeedGroup.tsx
+++ b/src/renderer/components/groups/SeedGroup.tsx
@@ -6,63 +6,47 @@ import { GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { SchemaInput } from '../inputs/SchemaInput';
 import { GroupProps } from './props';
 
-export const SeedGroup = memo(
-    ({
-        inputs,
-        inputData,
-        setInputValue,
-        inputSize,
-        setInputSize,
-        isLocked,
+export const SeedGroup = memo(({ inputs, nodeState }: GroupProps<'seed'>) => {
+    const { id: nodeId, setInputValue, isLocked } = nodeState;
+    const [input] = inputs;
+
+    const isInputLocked = useContextSelector(GlobalVolatileContext, (c) => c.isNodeInputLocked)(
         nodeId,
-        schemaId,
-    }: GroupProps<'seed'>) => {
-        const [input] = inputs;
+        input.id
+    );
 
-        const isInputLocked = useContextSelector(GlobalVolatileContext, (c) => c.isNodeInputLocked)(
-            nodeId,
-            input.id
-        );
+    const setRandom = useCallback(() => {
+        const RANDOM_MAX = 1e6;
+        const randomValue = Math.floor(Math.random() * RANDOM_MAX);
+        setInputValue(input.id, randomValue);
+    }, [input.id, setInputValue]);
 
-        const setRandom = useCallback(() => {
-            const RANDOM_MAX = 1e6;
-            const randomValue = Math.floor(Math.random() * RANDOM_MAX);
-            setInputValue(input.id, randomValue);
-        }, [input.id, setInputValue]);
-
-        return (
-            <SchemaInput
-                afterInput={
-                    <Tooltip
-                        closeOnClick
-                        closeOnPointerDown
-                        hasArrow
-                        borderRadius={8}
-                        label="Random seed"
-                        openDelay={500}
-                    >
-                        <IconButton
-                            aria-label="Random Seed"
-                            h="2rem"
-                            icon={<HiOutlineRefresh />}
-                            isDisabled={isLocked || isInputLocked}
-                            minWidth={0}
-                            size="md"
-                            variant="outline"
-                            w="2.4rem"
-                            onClick={setRandom}
-                        />
-                    </Tooltip>
-                }
-                input={input}
-                inputData={inputData}
-                inputSize={inputSize}
-                isLocked={isLocked}
-                nodeId={nodeId}
-                schemaId={schemaId}
-                setInputSize={setInputSize}
-                setInputValue={setInputValue}
-            />
-        );
-    }
-);
+    return (
+        <SchemaInput
+            afterInput={
+                <Tooltip
+                    closeOnClick
+                    closeOnPointerDown
+                    hasArrow
+                    borderRadius={8}
+                    label="Random seed"
+                    openDelay={500}
+                >
+                    <IconButton
+                        aria-label="Random Seed"
+                        h="2rem"
+                        icon={<HiOutlineRefresh />}
+                        isDisabled={isLocked || isInputLocked}
+                        minWidth={0}
+                        size="md"
+                        variant="outline"
+                        w="2.4rem"
+                        onClick={setRandom}
+                    />
+                </Tooltip>
+            }
+            input={input}
+            nodeState={nodeState}
+        />
+    );
+});

--- a/src/renderer/components/groups/SeedGroup.tsx
+++ b/src/renderer/components/groups/SeedGroup.tsx
@@ -12,6 +12,7 @@ export const SeedGroup = memo(
         inputData,
         setInputValue,
         inputSize,
+        setInputSize,
         isLocked,
         nodeId,
         schemaId,
@@ -59,6 +60,7 @@ export const SeedGroup = memo(
                 isLocked={isLocked}
                 nodeId={nodeId}
                 schemaId={schemaId}
+                setInputSize={setInputSize}
                 setInputValue={setInputValue}
             />
         );

--- a/src/renderer/components/groups/props.ts
+++ b/src/renderer/components/groups/props.ts
@@ -1,36 +1,15 @@
-import {
-    Group,
-    GroupKind,
-    InputData,
-    InputId,
-    InputSize,
-    InputValue,
-    OfKind,
-    SchemaId,
-    Size,
-} from '../../../common/common-types';
+import { Group, GroupKind, OfKind } from '../../../common/common-types';
 import { GroupInputs, InputItem } from '../../../common/group-inputs';
+import { NodeState } from '../../helpers/nodeState';
 
 export type InputItemRenderer = (props: {
     item: InputItem;
-    nodeId: string;
-    inputData: InputData;
-    setInputValue: (inputId: InputId, value: InputValue) => void;
-    inputSize: InputSize | undefined;
-    setInputSize: (inputId: InputId, size: Readonly<Size>) => void;
-    isLocked: boolean;
-    schemaId: SchemaId;
+    nodeState: NodeState;
 }) => JSX.Element | null;
 
 export interface GroupProps<Kind extends GroupKind> {
     group: OfKind<Group, Kind>;
     inputs: GroupInputs[Kind];
-    schemaId: SchemaId;
-    nodeId: string;
-    isLocked: boolean;
-    inputData: InputData;
-    setInputValue: (inputId: InputId, value: InputValue) => void;
-    inputSize: InputSize | undefined;
-    setInputSize: (inputId: InputId, size: Readonly<Size>) => void;
+    nodeState: NodeState;
     ItemRenderer: InputItemRenderer;
 }

--- a/src/renderer/components/groups/props.ts
+++ b/src/renderer/components/groups/props.ts
@@ -7,6 +7,7 @@ import {
     InputValue,
     OfKind,
     SchemaId,
+    Size,
 } from '../../../common/common-types';
 import { GroupInputs, InputItem } from '../../../common/group-inputs';
 
@@ -15,7 +16,8 @@ export type InputItemRenderer = (props: {
     nodeId: string;
     inputData: InputData;
     setInputValue: (inputId: InputId, value: InputValue) => void;
-    inputSize?: InputSize;
+    inputSize: InputSize | undefined;
+    setInputSize: (inputId: InputId, size: Readonly<Size>) => void;
     isLocked: boolean;
     schemaId: SchemaId;
 }) => JSX.Element | null;
@@ -29,5 +31,6 @@ export interface GroupProps<Kind extends GroupKind> {
     inputData: InputData;
     setInputValue: (inputId: InputId, value: InputValue) => void;
     inputSize: InputSize | undefined;
+    setInputSize: (inputId: InputId, size: Readonly<Size>) => void;
     ItemRenderer: InputItemRenderer;
 }

--- a/src/renderer/components/inputs/SchemaInput.tsx
+++ b/src/renderer/components/inputs/SchemaInput.tsx
@@ -2,19 +2,11 @@ import { NeverType, Type } from '@chainner/navi';
 import { HStack } from '@chakra-ui/react';
 import { memo, useCallback } from 'react';
 import { useContextSelector } from 'use-context-selector';
-import {
-    Input,
-    InputData,
-    InputId,
-    InputKind,
-    InputSize,
-    InputValue,
-    SchemaId,
-    Size,
-} from '../../../common/common-types';
+import { Input, InputKind, InputValue, Size } from '../../../common/common-types';
 import { getInputValue } from '../../../common/util';
 import { BackendContext } from '../../contexts/BackendContext';
 import { GlobalVolatileContext } from '../../contexts/GlobalNodeState';
+import { NodeState } from '../../helpers/nodeState';
 import { ColorInput } from './ColorInput';
 import { DirectoryInput } from './DirectoryInput';
 import { DropDownInput } from './DropDownInput';
@@ -44,120 +36,111 @@ const InputComponents: {
 
 export interface SingleInputProps {
     input: Input;
-    schemaId: SchemaId;
-    nodeId: string;
-    isLocked: boolean;
-    inputData: InputData;
-    setInputValue: (inputId: InputId, value: InputValue) => void;
-    inputSize: InputSize | undefined;
-    setInputSize: (inputId: InputId, size: Readonly<Size>) => void;
+    nodeState: NodeState;
     afterInput?: JSX.Element;
 }
 /**
  * Represents a single input from a schema's input list.
  */
-export const SchemaInput = memo(
-    ({
-        input,
+export const SchemaInput = memo(({ input, nodeState, afterInput }: SingleInputProps) => {
+    const { id: inputId, kind, hasHandle } = input;
+    const {
         schemaId,
-        nodeId,
-        isLocked,
+        id: nodeId,
         inputData,
         setInputValue,
         inputSize,
         setInputSize,
-        afterInput,
-    }: SingleInputProps) => {
-        const { id: inputId, kind, hasHandle } = input;
+        isLocked,
+    } = nodeState;
 
-        const functionDefinition = useContextSelector(BackendContext, (c) =>
-            c.functionDefinitions.get(schemaId)
+    const functionDefinition = useContextSelector(BackendContext, (c) =>
+        c.functionDefinitions.get(schemaId)
+    );
+    const definitionType = functionDefinition?.inputDefaults.get(inputId) ?? NeverType.instance;
+    const connectableType =
+        functionDefinition?.inputConvertibleDefaults.get(inputId) ?? NeverType.instance;
+
+    const value = getInputValue(inputId, inputData);
+    const setValue = useCallback(
+        (newValue: NonNullable<InputValue>) => {
+            setInputValue(inputId, newValue);
+        },
+        [inputId, setInputValue]
+    );
+    const resetValue = useCallback(() => {
+        setInputValue(inputId, undefined);
+    }, [inputId, setInputValue]);
+
+    const size = inputSize?.[inputId];
+    const setSize = useCallback(
+        (newSize: Readonly<Size>) => {
+            setInputSize(inputId, newSize);
+        },
+        [inputId, setInputSize]
+    );
+
+    const useInputConnected = useCallback((): boolean => {
+        // TODO: move the function call into the selector
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        return useContextSelector(GlobalVolatileContext, (c) => c.isNodeInputLocked)(
+            nodeId,
+            inputId
         );
-        const definitionType = functionDefinition?.inputDefaults.get(inputId) ?? NeverType.instance;
-        const connectableType =
-            functionDefinition?.inputConvertibleDefaults.get(inputId) ?? NeverType.instance;
+    }, [nodeId, inputId]);
+    const useInputType = useCallback((): Type => {
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        return useContextSelector(GlobalVolatileContext, (c) => {
+            const type = c.typeState.functions.get(nodeId)?.inputs.get(inputId);
+            return type ?? NeverType.instance;
+        });
+    }, [nodeId, inputId]);
 
-        const value = getInputValue(inputId, inputData);
-        const setValue = useCallback(
-            (newValue: NonNullable<InputValue>) => {
-                setInputValue(inputId, newValue);
-            },
-            [inputId, setInputValue]
-        );
-        const resetValue = useCallback(() => {
-            setInputValue(inputId, undefined);
-        }, [inputId, setInputValue]);
+    const InputType = InputComponents[kind];
+    let inputElement = (
+        <InputType
+            definitionType={definitionType}
+            input={input as never}
+            inputKey={`${schemaId}-${inputId}`}
+            isLocked={isLocked}
+            nodeId={nodeId}
+            nodeSchemaId={schemaId}
+            resetValue={resetValue}
+            setSize={setSize}
+            setValue={setValue}
+            size={size}
+            useInputConnected={useInputConnected}
+            useInputType={useInputType}
+            value={value}
+        />
+    );
 
-        const size = inputSize?.[inputId];
-        const setSize = useCallback(
-            (newSize: Readonly<Size>) => {
-                setInputSize(inputId, newSize);
-            },
-            [inputId, setInputSize]
-        );
-
-        const useInputConnected = useCallback((): boolean => {
-            // TODO: move the function call into the selector
-            // eslint-disable-next-line react-hooks/rules-of-hooks
-            return useContextSelector(GlobalVolatileContext, (c) => c.isNodeInputLocked)(
-                nodeId,
-                inputId
-            );
-        }, [nodeId, inputId]);
-        const useInputType = useCallback((): Type => {
-            // eslint-disable-next-line react-hooks/rules-of-hooks
-            return useContextSelector(GlobalVolatileContext, (c) => {
-                const type = c.typeState.functions.get(nodeId)?.inputs.get(inputId);
-                return type ?? NeverType.instance;
-            });
-        }, [nodeId, inputId]);
-
-        const InputType = InputComponents[kind];
-        let inputElement = (
-            <InputType
-                definitionType={definitionType}
-                input={input as never}
-                inputKey={`${schemaId}-${inputId}`}
-                isLocked={isLocked}
-                nodeId={nodeId}
-                nodeSchemaId={schemaId}
-                resetValue={resetValue}
-                setSize={setSize}
-                setValue={setValue}
-                size={size}
-                useInputConnected={useInputConnected}
-                useInputType={useInputType}
-                value={value}
-            />
-        );
-
-        if (afterInput) {
-            inputElement = (
-                <HStack w="full">
-                    {inputElement}
-                    {afterInput}
-                </HStack>
-            );
-        }
-
-        if (kind !== 'generic' && kind !== 'slider' && kind !== 'dropdown' && kind !== 'color') {
-            inputElement = <WithLabel input={input}>{inputElement}</WithLabel>;
-        }
-
-        return (
-            <InputContainer>
-                {hasHandle ? (
-                    <HandleWrapper
-                        connectableType={connectableType}
-                        id={nodeId}
-                        inputId={inputId}
-                    >
-                        {inputElement}
-                    </HandleWrapper>
-                ) : (
-                    inputElement
-                )}
-            </InputContainer>
+    if (afterInput) {
+        inputElement = (
+            <HStack w="full">
+                {inputElement}
+                {afterInput}
+            </HStack>
         );
     }
-);
+
+    if (kind !== 'generic' && kind !== 'slider' && kind !== 'dropdown' && kind !== 'color') {
+        inputElement = <WithLabel input={input}>{inputElement}</WithLabel>;
+    }
+
+    return (
+        <InputContainer>
+            {hasHandle ? (
+                <HandleWrapper
+                    connectableType={connectableType}
+                    id={nodeId}
+                    inputId={inputId}
+                >
+                    {inputElement}
+                </HandleWrapper>
+            ) : (
+                inputElement
+            )}
+        </InputContainer>
+    );
+});

--- a/src/renderer/components/inputs/TextInput.tsx
+++ b/src/renderer/components/inputs/TextInput.tsx
@@ -25,7 +25,8 @@ export const TextInput = memo(
         isLocked,
         useInputConnected,
         useInputType,
-        useInputSize,
+        size,
+        setSize,
         nodeId,
     }: InputProps<'text', string>) => {
         const { label, multiline, minLength, maxLength, def, placeholder } = input;
@@ -112,7 +113,6 @@ export const TextInput = memo(
         ));
 
         // size
-        const [size, setSize] = useInputSize();
         useEffect(() => {
             if (!size) {
                 setSize(DEFAULT_SIZE);

--- a/src/renderer/components/inputs/props.ts
+++ b/src/renderer/components/inputs/props.ts
@@ -11,12 +11,10 @@ export interface InputProps<Kind extends InputKind, Value extends string | numbe
     readonly definitionType: Type;
     readonly isLocked: boolean;
     readonly inputKey: string;
+    readonly size: Readonly<Size> | undefined;
+    readonly setSize: (size: Readonly<Size>) => void;
     readonly useInputConnected: () => boolean;
     readonly useInputType: () => Type;
-    readonly useInputSize: () => readonly [
-        Readonly<Size> | undefined,
-        (size: Readonly<Size>) => void
-    ];
     readonly nodeId?: string;
     readonly nodeSchemaId?: SchemaId;
 }

--- a/src/renderer/components/node/IteratorHelperNode.tsx
+++ b/src/renderer/components/node/IteratorHelperNode.tsx
@@ -23,13 +23,15 @@ export const IteratorHelperNode = memo(({ data, selected }: IteratorHelperNodePr
         GlobalVolatileContext,
         (c) => c.effectivelyDisabledNodes
     );
-    const { updateIteratorBounds, setHoveredNode, setNodeInputValue } = useContext(GlobalContext);
+    const { updateIteratorBounds, setHoveredNode, setNodeInputValue, setNodeInputSize } =
+        useContext(GlobalContext);
     const { schemata, categories } = useContext(BackendContext);
 
-    const { id, inputData, isLocked, parentNode, schemaId } = data;
+    const { id, inputData, inputSize, isLocked, parentNode, schemaId } = data;
     const animated = useContextSelector(GlobalVolatileContext, (c) => c.isAnimated(id));
 
     const setInputValue = useMemo(() => setNodeInputValue.bind(null, id), [id, setNodeInputValue]);
+    const setInputSize = useMemo(() => setNodeInputSize.bind(null, id), [id, setNodeInputSize]);
 
     // We get inputs and outputs this way in case something changes with them in the future
     // This way, we have to do less in the migration file
@@ -104,8 +106,10 @@ export const IteratorHelperNode = memo(({ data, selected }: IteratorHelperNodePr
                     <NodeBody
                         id={id}
                         inputData={inputData}
+                        inputSize={inputSize}
                         isLocked={isLocked}
                         schema={schema}
+                        setInputSize={setInputSize}
                         setInputValue={setInputValue}
                     />
                 </VStack>

--- a/src/renderer/components/node/IteratorNode.tsx
+++ b/src/renderer/components/node/IteratorNode.tsx
@@ -3,6 +3,7 @@ import { memo, useMemo, useRef } from 'react';
 import { useContext, useContextSelector } from 'use-context-selector';
 import { NodeData } from '../../../common/common-types';
 import { DisabledStatus } from '../../../common/nodes/disabled';
+import { EMPTY_OBJECT, noop } from '../../../common/util';
 import { BackendContext } from '../../contexts/BackendContext';
 import { ExecutionContext } from '../../contexts/ExecutionContext';
 import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
@@ -98,8 +99,10 @@ const IteratorNodeInner = memo(({ data, selected }: IteratorNodeProps) => {
                         <NodeInputs
                             id={id}
                             inputData={inputData}
+                            inputSize={EMPTY_OBJECT}
                             isLocked={isLocked}
                             schema={schema}
+                            setInputSize={noop}
                             setInputValue={setInputValue}
                         />
                     </Box>

--- a/src/renderer/components/node/IteratorNode.tsx
+++ b/src/renderer/components/node/IteratorNode.tsx
@@ -3,12 +3,12 @@ import { memo, useMemo, useRef } from 'react';
 import { useContext, useContextSelector } from 'use-context-selector';
 import { NodeData } from '../../../common/common-types';
 import { DisabledStatus } from '../../../common/nodes/disabled';
-import { EMPTY_OBJECT, noop } from '../../../common/util';
 import { BackendContext } from '../../contexts/BackendContext';
 import { ExecutionContext } from '../../contexts/ExecutionContext';
-import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
+import { GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { getCategoryAccentColor } from '../../helpers/accentColors';
 import { shadeColor } from '../../helpers/colorTools';
+import { useNodeStateFromData } from '../../helpers/nodeState';
 import { useDisabled } from '../../hooks/useDisabled';
 import { useNodeMenu } from '../../hooks/useNodeMenu';
 import { useValidity } from '../../hooks/useValidity';
@@ -32,13 +32,13 @@ export const IteratorNode = memo(({ data, selected }: IteratorNodeProps) => (
 ));
 
 const IteratorNodeInner = memo(({ data, selected }: IteratorNodeProps) => {
-    const { schemata, categories } = useContext(BackendContext);
+    const nodeState = useNodeStateFromData(data);
+    const { schema } = nodeState;
+
+    const { categories } = useContext(BackendContext);
     const { getIteratorProgress } = useContext(ExecutionContext);
-    const { setNodeInputValue } = useContext(GlobalContext);
 
-    const { id, inputData, isLocked, schemaId, iteratorSize, minWidth, minHeight } = data;
-
-    const setInputValue = useMemo(() => setNodeInputValue.bind(null, id), [id, setNodeInputValue]);
+    const { id, inputData, iteratorSize, minWidth, minHeight } = data;
 
     const iteratorProgress = getIteratorProgress(id);
 
@@ -46,11 +46,10 @@ const IteratorNodeInner = memo(({ data, selected }: IteratorNodeProps) => {
 
     // We get inputs and outputs this way in case something changes with them in the future
     // This way, we have to do less in the migration file
-    const schema = schemata.get(schemaId);
-    const { inputs, outputs, icon, category, name } = schema;
+    const { inputs, outputs } = schema;
 
     const regularBorderColor = 'var(--node-border-color)';
-    const accentColor = getCategoryAccentColor(categories, category);
+    const accentColor = getCategoryAccentColor(categories, schema.category);
     const borderColor = useMemo(
         () => (selected ? shadeColor(accentColor, 0) : regularBorderColor),
         [selected, accentColor, regularBorderColor]
@@ -86,9 +85,9 @@ const IteratorNodeInner = memo(({ data, selected }: IteratorNodeProps) => {
                     <IteratorNodeHeader
                         accentColor={accentColor}
                         disabledStatus={disabled.status}
-                        icon={icon}
+                        icon={schema.icon}
                         iteratorProgress={iteratorProgress}
-                        name={name}
+                        name={schema.name}
                         selected={selected}
                     />
                     {inputs.length > 0 && <Box py={1} />}
@@ -96,15 +95,7 @@ const IteratorNodeInner = memo(({ data, selected }: IteratorNodeProps) => {
                         bgColor="var(--bg-700)"
                         w="full"
                     >
-                        <NodeInputs
-                            id={id}
-                            inputData={inputData}
-                            inputSize={EMPTY_OBJECT}
-                            isLocked={isLocked}
-                            schema={schema}
-                            setInputSize={noop}
-                            setInputValue={setInputValue}
-                        />
+                        <NodeInputs nodeState={nodeState} />
                     </Box>
                     <Center>
                         <Text
@@ -138,7 +129,7 @@ const IteratorNodeInner = memo(({ data, selected }: IteratorNodeProps) => {
                         <NodeOutputs
                             id={id}
                             outputs={outputs}
-                            schemaId={schemaId}
+                            schemaId={nodeState.schemaId}
                         />
                     </Box>
                 </VStack>

--- a/src/renderer/components/node/Node.tsx
+++ b/src/renderer/components/node/Node.tsx
@@ -17,6 +17,7 @@ import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeS
 import { getCategoryAccentColor, getTypeAccentColors } from '../../helpers/accentColors';
 import { shadeColor } from '../../helpers/colorTools';
 import { getSingleFileWithExtension } from '../../helpers/dataTransfer';
+import { useNodeStateFromData } from '../../helpers/nodeState';
 import { useDisabled } from '../../hooks/useDisabled';
 import { useNodeMenu } from '../../hooks/useNodeMenu';
 import { useRunNode } from '../../hooks/useRunNode';
@@ -56,23 +57,21 @@ export interface NodeProps {
 }
 
 const NodeInner = memo(({ data, selected }: NodeProps) => {
+    const nodeState = useNodeStateFromData(data);
+    const { schema, setInputValue } = nodeState;
+
     const { sendToast } = useContext(AlertBoxContext);
-    const { updateIteratorBounds, setHoveredNode, setNodeInputValue, setNodeInputSize } =
-        useContext(GlobalContext);
-    const { schemata, categories } = useContext(BackendContext);
+    const { updateIteratorBounds, setHoveredNode } = useContext(GlobalContext);
+    const { categories } = useContext(BackendContext);
 
-    const { id, inputData, inputSize, isLocked, parentNode, schemaId } = data;
+    const { id, inputData, parentNode } = data;
     const animated = useContextSelector(GlobalVolatileContext, (c) => c.isAnimated(id));
-
-    const setInputValue = useMemo(() => setNodeInputValue.bind(null, id), [id, setNodeInputValue]);
-    const setInputSize = useMemo(() => setNodeInputSize.bind(null, id), [id, setNodeInputSize]);
 
     const { getEdge } = useReactFlow();
 
     // We get inputs and outputs this way in case something changes with them in the future
     // This way, we have to do less in the migration file
-    const schema = schemata.get(schemaId);
-    const { inputs, icon, category, name } = schema;
+    const { inputs, category } = schema;
 
     const { validity } = useValidity(id, schema, inputData);
 
@@ -135,7 +134,7 @@ const NodeInner = memo(({ data, selected }: NodeProps) => {
 
             const p = getSingleFileWithExtension(event.dataTransfer, fileInput.filetypes);
             if (p) {
-                setNodeInputValue<string>(id, fileInput.id, p);
+                setInputValue(fileInput.id, p);
                 return;
             }
 
@@ -210,20 +209,14 @@ const NodeInner = memo(({ data, selected }: NodeProps) => {
                     <NodeHeader
                         accentColor={accentColor}
                         disabledStatus={disabled.status}
-                        icon={icon}
-                        name={name}
+                        icon={schema.icon}
+                        name={schema.name}
                         parentNode={parentNode}
                         selected={selected}
                     />
                     <NodeBody
                         animated={animated}
-                        id={id}
-                        inputData={inputData}
-                        inputSize={inputSize}
-                        isLocked={isLocked}
-                        schema={schema}
-                        setInputSize={setInputSize}
-                        setInputValue={setInputValue}
+                        nodeState={nodeState}
                     />
                 </VStack>
                 <NodeFooter

--- a/src/renderer/components/node/Node.tsx
+++ b/src/renderer/components/node/Node.tsx
@@ -57,13 +57,15 @@ export interface NodeProps {
 
 const NodeInner = memo(({ data, selected }: NodeProps) => {
     const { sendToast } = useContext(AlertBoxContext);
-    const { updateIteratorBounds, setHoveredNode, setNodeInputValue } = useContext(GlobalContext);
+    const { updateIteratorBounds, setHoveredNode, setNodeInputValue, setNodeInputSize } =
+        useContext(GlobalContext);
     const { schemata, categories } = useContext(BackendContext);
 
     const { id, inputData, inputSize, isLocked, parentNode, schemaId } = data;
     const animated = useContextSelector(GlobalVolatileContext, (c) => c.isAnimated(id));
 
     const setInputValue = useMemo(() => setNodeInputValue.bind(null, id), [id, setNodeInputValue]);
+    const setInputSize = useMemo(() => setNodeInputSize.bind(null, id), [id, setNodeInputSize]);
 
     const { getEdge } = useReactFlow();
 
@@ -220,6 +222,7 @@ const NodeInner = memo(({ data, selected }: NodeProps) => {
                         inputSize={inputSize}
                         isLocked={isLocked}
                         schema={schema}
+                        setInputSize={setInputSize}
                         setInputValue={setInputValue}
                     />
                 </VStack>

--- a/src/renderer/components/node/NodeBody.tsx
+++ b/src/renderer/components/node/NodeBody.tsx
@@ -1,76 +1,45 @@
 import { Box } from '@chakra-ui/react';
 import { memo } from 'react';
-import {
-    InputData,
-    InputId,
-    InputSize,
-    InputValue,
-    NodeSchema,
-    Size,
-} from '../../../common/common-types';
+
 import { isAutoInput } from '../../../common/util';
+import { NodeState } from '../../helpers/nodeState';
 import { NodeInputs } from './NodeInputs';
 import { NodeOutputs } from './NodeOutputs';
 
 interface NodeBodyProps {
-    id: string;
-    inputData: InputData;
-    setInputValue: (inputId: InputId, value: InputValue) => void;
-    inputSize: InputSize | undefined;
-    setInputSize: (inputId: InputId, size: Readonly<Size>) => void;
-    isLocked?: boolean;
-    schema: NodeSchema;
+    nodeState: NodeState;
     animated?: boolean;
 }
 
-export const NodeBody = memo(
-    ({
-        schema,
-        id,
-        inputData,
-        setInputValue,
-        inputSize,
-        setInputSize,
-        isLocked,
-        animated = false,
-    }: NodeBodyProps) => {
-        const { inputs, outputs, schemaId } = schema;
+export const NodeBody = memo(({ nodeState, animated = false }: NodeBodyProps) => {
+    const { inputs, outputs } = nodeState.schema;
 
-        const autoInput = inputs.length === 1 && isAutoInput(inputs[0]);
+    const autoInput = inputs.length === 1 && isAutoInput(inputs[0]);
 
-        return (
-            <>
-                {!autoInput && inputs.length > 0 && <Box py={1} />}
-                {!autoInput && (
-                    <Box
-                        bg="var(--bg-700)"
-                        w="full"
-                    >
-                        <NodeInputs
-                            id={id}
-                            inputData={inputData}
-                            inputSize={inputSize}
-                            isLocked={isLocked}
-                            schema={schema}
-                            setInputSize={setInputSize}
-                            setInputValue={setInputValue}
-                        />
-                    </Box>
-                )}
-
-                {outputs.length > 0 && <Box py={1} />}
+    return (
+        <>
+            {!autoInput && inputs.length > 0 && <Box py={1} />}
+            {!autoInput && (
                 <Box
                     bg="var(--bg-700)"
                     w="full"
                 >
-                    <NodeOutputs
-                        animated={animated}
-                        id={id}
-                        outputs={outputs}
-                        schemaId={schemaId}
-                    />
+                    <NodeInputs nodeState={nodeState} />
                 </Box>
-            </>
-        );
-    }
-);
+            )}
+
+            {outputs.length > 0 && <Box py={1} />}
+            <Box
+                bg="var(--bg-700)"
+                w="full"
+            >
+                <NodeOutputs
+                    animated={animated}
+                    id={nodeState.id}
+                    outputs={outputs}
+                    schemaId={nodeState.schemaId}
+                />
+            </Box>
+        </>
+    );
+});

--- a/src/renderer/components/node/NodeBody.tsx
+++ b/src/renderer/components/node/NodeBody.tsx
@@ -6,6 +6,7 @@ import {
     InputSize,
     InputValue,
     NodeSchema,
+    Size,
 } from '../../../common/common-types';
 import { isAutoInput } from '../../../common/util';
 import { NodeInputs } from './NodeInputs';
@@ -14,8 +15,9 @@ import { NodeOutputs } from './NodeOutputs';
 interface NodeBodyProps {
     id: string;
     inputData: InputData;
-    inputSize?: InputSize;
     setInputValue: (inputId: InputId, value: InputValue) => void;
+    inputSize: InputSize | undefined;
+    setInputSize: (inputId: InputId, size: Readonly<Size>) => void;
     isLocked?: boolean;
     schema: NodeSchema;
     animated?: boolean;
@@ -28,6 +30,7 @@ export const NodeBody = memo(
         inputData,
         setInputValue,
         inputSize,
+        setInputSize,
         isLocked,
         animated = false,
     }: NodeBodyProps) => {
@@ -49,6 +52,7 @@ export const NodeBody = memo(
                             inputSize={inputSize}
                             isLocked={isLocked}
                             schema={schema}
+                            setInputSize={setInputSize}
                             setInputValue={setInputValue}
                         />
                     </Box>

--- a/src/renderer/components/node/NodeInputs.tsx
+++ b/src/renderer/components/node/NodeInputs.tsx
@@ -7,6 +7,7 @@ import {
     InputSize,
     InputValue,
     NodeSchema,
+    Size,
 } from '../../../common/common-types';
 import { getUniqueKey } from '../../../common/group-inputs';
 import { BackendContext } from '../../contexts/BackendContext';
@@ -19,12 +20,13 @@ interface NodeInputsProps {
     id: string;
     inputData: InputData;
     setInputValue: (inputId: InputId, value: InputValue) => void;
-    inputSize?: InputSize;
+    inputSize: InputSize | undefined;
+    setInputSize: (inputId: InputId, size: Readonly<Size>) => void;
     isLocked?: boolean;
 }
 
 const ItemRenderer: InputItemRenderer = memo(
-    ({ item, inputData, setInputValue, inputSize, isLocked, nodeId, schemaId }) => {
+    ({ item, inputData, setInputValue, inputSize, setInputSize, isLocked, nodeId, schemaId }) => {
         if (item.kind === 'group') {
             const { group } = item;
             return (
@@ -37,6 +39,7 @@ const ItemRenderer: InputItemRenderer = memo(
                     isLocked={isLocked}
                     nodeId={nodeId}
                     schemaId={schemaId}
+                    setInputSize={setInputSize}
                     setInputValue={setInputValue}
                 />
             );
@@ -50,6 +53,7 @@ const ItemRenderer: InputItemRenderer = memo(
                 isLocked={isLocked}
                 nodeId={nodeId}
                 schemaId={schemaId}
+                setInputSize={setInputSize}
                 setInputValue={setInputValue}
             />
         );
@@ -57,7 +61,15 @@ const ItemRenderer: InputItemRenderer = memo(
 );
 
 export const NodeInputs = memo(
-    ({ schema, id, inputData, setInputValue, inputSize, isLocked = false }: NodeInputsProps) => {
+    ({
+        schema,
+        id,
+        inputData,
+        setInputValue,
+        inputSize,
+        setInputSize,
+        isLocked = false,
+    }: NodeInputsProps) => {
         const { schemaInputs } = useContext(BackendContext);
 
         const { schemaId } = schema;
@@ -75,6 +87,7 @@ export const NodeInputs = memo(
                         key={getUniqueKey(item)}
                         nodeId={id}
                         schemaId={schemaId}
+                        setInputSize={setInputSize}
                         setInputValue={setInputValue}
                     />
                 ))}

--- a/src/renderer/components/node/NodeInputs.tsx
+++ b/src/renderer/components/node/NodeInputs.tsx
@@ -1,97 +1,52 @@
 /* eslint-disable react/prop-types */
 import { memo } from 'react';
 import { useContext } from 'use-context-selector';
-import {
-    InputData,
-    InputId,
-    InputSize,
-    InputValue,
-    NodeSchema,
-    Size,
-} from '../../../common/common-types';
 import { getUniqueKey } from '../../../common/group-inputs';
 import { BackendContext } from '../../contexts/BackendContext';
+import { NodeState } from '../../helpers/nodeState';
 import { GroupElement } from '../groups/Group';
 import { InputItemRenderer } from '../groups/props';
 import { SchemaInput } from '../inputs/SchemaInput';
 
-interface NodeInputsProps {
-    schema: NodeSchema;
-    id: string;
-    inputData: InputData;
-    setInputValue: (inputId: InputId, value: InputValue) => void;
-    inputSize: InputSize | undefined;
-    setInputSize: (inputId: InputId, size: Readonly<Size>) => void;
-    isLocked?: boolean;
-}
-
-const ItemRenderer: InputItemRenderer = memo(
-    ({ item, inputData, setInputValue, inputSize, setInputSize, isLocked, nodeId, schemaId }) => {
-        if (item.kind === 'group') {
-            const { group } = item;
-            return (
-                <GroupElement
-                    ItemRenderer={ItemRenderer}
-                    group={group}
-                    inputData={inputData}
-                    inputSize={inputSize}
-                    inputs={item.inputs}
-                    isLocked={isLocked}
-                    nodeId={nodeId}
-                    schemaId={schemaId}
-                    setInputSize={setInputSize}
-                    setInputValue={setInputValue}
-                />
-            );
-        }
-
+const ItemRenderer: InputItemRenderer = memo(({ item, nodeState }) => {
+    if (item.kind === 'group') {
+        const { group } = item;
         return (
-            <SchemaInput
-                input={item}
-                inputData={inputData}
-                inputSize={inputSize}
-                isLocked={isLocked}
-                nodeId={nodeId}
-                schemaId={schemaId}
-                setInputSize={setInputSize}
-                setInputValue={setInputValue}
+            <GroupElement
+                ItemRenderer={ItemRenderer}
+                group={group}
+                inputs={item.inputs}
+                nodeState={nodeState}
             />
         );
     }
-);
 
-export const NodeInputs = memo(
-    ({
-        schema,
-        id,
-        inputData,
-        setInputValue,
-        inputSize,
-        setInputSize,
-        isLocked = false,
-    }: NodeInputsProps) => {
-        const { schemaInputs } = useContext(BackendContext);
+    return (
+        <SchemaInput
+            input={item}
+            nodeState={nodeState}
+        />
+    );
+});
 
-        const { schemaId } = schema;
+interface NodeInputsProps {
+    nodeState: NodeState;
+}
 
-        const inputs = schemaInputs.get(schemaId);
+export const NodeInputs = memo(({ nodeState }: NodeInputsProps) => {
+    const { schemaInputs } = useContext(BackendContext);
 
-        return (
-            <>
-                {inputs.map((item) => (
-                    <ItemRenderer
-                        inputData={inputData}
-                        inputSize={inputSize}
-                        isLocked={isLocked}
-                        item={item}
-                        key={getUniqueKey(item)}
-                        nodeId={id}
-                        schemaId={schemaId}
-                        setInputSize={setInputSize}
-                        setInputValue={setInputValue}
-                    />
-                ))}
-            </>
-        );
-    }
-);
+    const inputs = schemaInputs.get(nodeState.schemaId);
+
+    return (
+        <>
+            {inputs.map((item) => (
+                <ItemRenderer
+                    item={item}
+                    key={getUniqueKey(item)}
+                    nodeState={nodeState}
+                />
+            ))}
+        </>
+    );
+});

--- a/src/renderer/helpers/nodeState.ts
+++ b/src/renderer/helpers/nodeState.ts
@@ -1,0 +1,49 @@
+import { useMemo } from 'react';
+import { useContext } from 'use-context-selector';
+import {
+    InputData,
+    InputId,
+    InputSize,
+    InputValue,
+    NodeData,
+    NodeSchema,
+    SchemaId,
+    Size,
+} from '../../common/common-types';
+import { BackendContext } from '../contexts/BackendContext';
+import { GlobalContext } from '../contexts/GlobalNodeState';
+import { useMemoObject } from '../hooks/useMemo';
+
+export interface NodeState {
+    readonly id: string;
+    readonly schemaId: SchemaId;
+    readonly schema: NodeSchema;
+    readonly inputData: InputData;
+    readonly setInputValue: (inputId: InputId, value: InputValue) => void;
+    readonly inputSize: InputSize | undefined;
+    readonly setInputSize: (inputId: InputId, size: Readonly<Size>) => void;
+    readonly isLocked: boolean;
+}
+
+export const useNodeStateFromData = (data: NodeData): NodeState => {
+    const { setNodeInputValue, setNodeInputSize } = useContext(GlobalContext);
+
+    const { id, inputData, inputSize, isLocked, schemaId } = data;
+
+    const setInputValue = useMemo(() => setNodeInputValue.bind(null, id), [id, setNodeInputValue]);
+    const setInputSize = useMemo(() => setNodeInputSize.bind(null, id), [id, setNodeInputSize]);
+
+    const { schemata } = useContext(BackendContext);
+    const schema = schemata.get(schemaId);
+
+    return useMemoObject({
+        id,
+        schemaId,
+        schema,
+        inputData,
+        setInputValue,
+        inputSize,
+        setInputSize,
+        isLocked: isLocked ?? false,
+    });
+};


### PR DESCRIPTION
This PR has 2 main changes:

1. I added `setInputSize` to the props we pass around. This means that inputs no longer need to access global state directly when setting their size.
2. I wrapped all common state we pass around between nodes, groups, and inputs into an interface called `NodeState`. This simplifies a lot of code and significantly cuts down on the number of props we have to pass. This not only simplifies existing code, it will also make it easy to add more node state/functionality later on.

Other changes:
- Moved node example component into its own file.
- Added `useNodeStatefromData` to derive `NodeState` from `NodeData`. This means that we won't even have to update the nodes anymore when NodeState changes.