### PR TITLE
Moved inputConnected into NodeState

### DIFF
--- a/src/renderer/components/NodeDocumentation/NodeExample.tsx
+++ b/src/renderer/components/NodeDocumentation/NodeExample.tsx
@@ -9,7 +9,7 @@ import {
     Size,
 } from '../../../common/common-types';
 import { DisabledStatus } from '../../../common/nodes/disabled';
-import { EMPTY_OBJECT } from '../../../common/util';
+import { EMPTY_OBJECT, EMPTY_SET } from '../../../common/util';
 import { NodeBody } from '../node/NodeBody';
 import { NodeFooter } from '../node/NodeFooter/NodeFooter';
 import { NodeHeader } from '../node/NodeHeader';
@@ -105,6 +105,7 @@ export const NodeExample = memo(({ accentColor, selectedSchema }: NodeExamplePro
                                 inputSize,
                                 setInputSize: setSingleInputSize,
                                 isLocked: false,
+                                connectedInputs: EMPTY_SET,
                             }}
                         />
                     </VStack>

--- a/src/renderer/components/groups/ConditionalGroup.tsx
+++ b/src/renderer/components/groups/ConditionalGroup.tsx
@@ -11,10 +11,6 @@ export const ConditionalGroup = memo(
         const { id: nodeId, inputData } = nodeState;
         const { condition } = group.options;
 
-        const isNodeInputLocked = useContextSelector(
-            GlobalVolatileContext,
-            (c) => c.isNodeInputLocked
-        );
         const typeState = useContextSelector(GlobalVolatileContext, (c) => c.typeState);
 
         const isEnabled = useMemo(
@@ -26,7 +22,7 @@ export const ConditionalGroup = memo(
             if (isEnabled) return true;
 
             // input or some input of the group is connected to another node
-            return someInput(input, ({ id }) => isNodeInputLocked(nodeId, id));
+            return someInput(input, ({ id }) => nodeState.connectedInputs.has(id));
         };
 
         return (

--- a/src/renderer/components/groups/OptionalInputsGroup.tsx
+++ b/src/renderer/components/groups/OptionalInputsGroup.tsx
@@ -1,21 +1,14 @@
 import { Box, Button, Center, Icon } from '@chakra-ui/react';
 import { memo, useEffect, useMemo, useState } from 'react';
 import { IoAddOutline } from 'react-icons/io5';
-import { useContextSelector } from 'use-context-selector';
 import { getUniqueKey } from '../../../common/group-inputs';
 import { findLastIndex, getInputValue } from '../../../common/util';
-import { GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { GroupProps } from './props';
 import { someInput } from './util';
 
 export const OptionalInputsGroup = memo(
     ({ inputs, nodeState, ItemRenderer }: GroupProps<'optional-list'>) => {
-        const { id: nodeId, inputData } = nodeState;
-
-        const isNodeInputLocked = useContextSelector(
-            GlobalVolatileContext,
-            (c) => c.isNodeInputLocked
-        );
+        const { inputData, connectedInputs } = nodeState;
 
         // number of edges that need to be uncovered due to either having a value or an edge
         const uncoveredDueToValue = useMemo(() => {
@@ -23,11 +16,11 @@ export const OptionalInputsGroup = memo(
                 findLastIndex(inputs, (item) => {
                     return someInput(item, (input) => {
                         const value = getInputValue(input.id, inputData);
-                        return value !== undefined || isNodeInputLocked(nodeId, input.id);
+                        return value !== undefined || connectedInputs.has(input.id);
                     });
                 }) + 1
             );
-        }, [inputs, inputData, nodeId, isNodeInputLocked]);
+        }, [inputs, inputData, connectedInputs]);
 
         // number of inputs the user set to be uncovered
         const [userUncovered, setUserUncovered] = useState(0);

--- a/src/renderer/components/groups/SeedGroup.tsx
+++ b/src/renderer/components/groups/SeedGroup.tsx
@@ -1,19 +1,14 @@
 import { IconButton, Tooltip } from '@chakra-ui/react';
 import { memo, useCallback } from 'react';
 import { HiOutlineRefresh } from 'react-icons/hi';
-import { useContextSelector } from 'use-context-selector';
-import { GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { SchemaInput } from '../inputs/SchemaInput';
 import { GroupProps } from './props';
 
 export const SeedGroup = memo(({ inputs, nodeState }: GroupProps<'seed'>) => {
-    const { id: nodeId, setInputValue, isLocked } = nodeState;
-    const [input] = inputs;
+    const { setInputValue, isLocked, connectedInputs } = nodeState;
 
-    const isInputLocked = useContextSelector(GlobalVolatileContext, (c) => c.isNodeInputLocked)(
-        nodeId,
-        input.id
-    );
+    const [input] = inputs;
+    const isInputLocked = connectedInputs.has(input.id);
 
     const setRandom = useCallback(() => {
         const RANDOM_MAX = 1e6;

--- a/src/renderer/components/inputs/ColorInput.tsx
+++ b/src/renderer/components/inputs/ColorInput.tsx
@@ -296,13 +296,7 @@ const ColorPickerPopover = memo(({ color, onChange, kinds }: ColorPickerProps) =
 });
 
 export const ColorInput = memo(
-    ({
-        value,
-        setValue,
-        input,
-        definitionType,
-        useInputConnected,
-    }: InputProps<'color', string>) => {
+    ({ value, setValue, input, definitionType, isConnected }: InputProps<'color', string>) => {
         const { label, optional, def, channels } = input;
 
         const noValue = value === undefined;
@@ -330,7 +324,6 @@ export const ColorInput = memo(
             }
         }, [invalidColor, setValue, def]);
 
-        const connected = useInputConnected();
         const kinds = useMemo(() => {
             if (!channels) {
                 return ALL_KINDS;
@@ -362,7 +355,7 @@ export const ColorInput = memo(
                             type={definitionType}
                         />
                     </Center>
-                    {!connected && color && (
+                    {!isConnected && color && (
                         <>
                             <Spacer />
                             <ColorPickerPopover

--- a/src/renderer/components/inputs/DirectoryInput.tsx
+++ b/src/renderer/components/inputs/DirectoryInput.tsx
@@ -42,7 +42,7 @@ export const DirectoryInput = memo(
         isLocked,
         input,
         inputKey,
-        useInputConnected,
+        isConnected,
         useInputType,
         nodeId,
     }: InputProps<'directory', string>) => {
@@ -62,15 +62,14 @@ export const DirectoryInput = memo(
             }
         };
 
-        const isInputConnected = useInputConnected();
         const inputType = useInputType();
-        const displayDirectory = isInputConnected ? getDirectoryPath(inputType) : value;
+        const displayDirectory = isConnected ? getDirectoryPath(inputType) : value;
 
         const menu = useContextMenu(() => (
             <MenuList className="nodrag">
                 <MenuItem
                     icon={<BsFolderPlus />}
-                    isDisabled={isLocked || isInputConnected}
+                    isDisabled={isLocked || isConnected}
                     // eslint-disable-next-line @typescript-eslint/no-misused-promises
                     onClick={onButtonClick}
                 >
@@ -129,7 +128,7 @@ export const DirectoryInput = memo(
                         isReadOnly
                         borderRadius="lg"
                         cursor="pointer"
-                        disabled={isLocked || isInputConnected}
+                        disabled={isLocked || isConnected}
                         draggable={false}
                         placeholder="Click to select..."
                         size="sm"

--- a/src/renderer/components/inputs/FileInput.tsx
+++ b/src/renderer/components/inputs/FileInput.tsx
@@ -30,7 +30,7 @@ export const FileInput = memo(
         setValue: setFilePath,
         input,
         inputKey,
-        useInputConnected,
+        isConnected,
         isLocked,
         nodeId,
     }: InputProps<'file', string>) => {
@@ -38,7 +38,6 @@ export const FileInput = memo(
 
         const { label, filetypes } = input;
 
-        const isInputConnected = useInputConnected();
         const { sendToast } = useContext(AlertBoxContext);
 
         const { getLastDirectory, setLastDirectory } = useLastDirectory(inputKey);
@@ -106,7 +105,7 @@ export const FileInput = memo(
             <MenuList className="nodrag">
                 <MenuItem
                     icon={<BsFileEarmarkPlus />}
-                    isDisabled={isLocked || isInputConnected}
+                    isDisabled={isLocked || isConnected}
                     // eslint-disable-next-line @typescript-eslint/no-misused-promises
                     onClick={onButtonClick}
                 >
@@ -181,7 +180,7 @@ export const FileInput = memo(
                             alt={filePath}
                             borderRadius="lg"
                             cursor="pointer"
-                            disabled={isLocked || isInputConnected}
+                            disabled={isLocked || isConnected}
                             draggable={false}
                             placeholder="Click to select a file..."
                             size="sm"

--- a/src/renderer/components/inputs/NumberInput.tsx
+++ b/src/renderer/components/inputs/NumberInput.tsx
@@ -15,8 +15,8 @@ export const NumberInput = memo(
         value,
         setValue,
         input,
+        isConnected,
         isLocked,
-        useInputConnected,
         useInputType,
         nodeId,
     }: InputProps<'number', number>) => {
@@ -45,10 +45,9 @@ export const NumberInput = memo(
             }
         }, [value, def, setValue]);
 
-        const isInputConnected = useInputConnected();
         const inputType = useInputType();
         const typeNumberString = isNumericLiteral(inputType) ? inputType.toString() : '';
-        const displayString = isInputConnected ? typeNumberString : inputString;
+        const displayString = isConnected ? typeNumberString : inputString;
 
         const { t } = useTranslation();
 
@@ -92,7 +91,7 @@ export const NumberInput = memo(
                     defaultValue={def}
                     hideTrailingZeros={hideTrailingZeros}
                     inputString={displayString}
-                    isDisabled={isLocked || isInputConnected}
+                    isDisabled={isLocked || isConnected}
                     max={max ?? Infinity}
                     min={min ?? -Infinity}
                     precision={precision}

--- a/src/renderer/components/inputs/SchemaInput.tsx
+++ b/src/renderer/components/inputs/SchemaInput.tsx
@@ -52,6 +52,7 @@ export const SchemaInput = memo(({ input, nodeState, afterInput }: SingleInputPr
         inputSize,
         setInputSize,
         isLocked,
+        connectedInputs,
     } = nodeState;
 
     const functionDefinition = useContextSelector(BackendContext, (c) =>
@@ -80,14 +81,6 @@ export const SchemaInput = memo(({ input, nodeState, afterInput }: SingleInputPr
         [inputId, setInputSize]
     );
 
-    const useInputConnected = useCallback((): boolean => {
-        // TODO: move the function call into the selector
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        return useContextSelector(GlobalVolatileContext, (c) => c.isNodeInputLocked)(
-            nodeId,
-            inputId
-        );
-    }, [nodeId, inputId]);
     const useInputType = useCallback((): Type => {
         // eslint-disable-next-line react-hooks/rules-of-hooks
         return useContextSelector(GlobalVolatileContext, (c) => {
@@ -102,6 +95,7 @@ export const SchemaInput = memo(({ input, nodeState, afterInput }: SingleInputPr
             definitionType={definitionType}
             input={input as never}
             inputKey={`${schemaId}-${inputId}`}
+            isConnected={connectedInputs.has(inputId)}
             isLocked={isLocked}
             nodeId={nodeId}
             nodeSchemaId={schemaId}
@@ -109,7 +103,6 @@ export const SchemaInput = memo(({ input, nodeState, afterInput }: SingleInputPr
             setSize={setSize}
             setValue={setValue}
             size={size}
-            useInputConnected={useInputConnected}
             useInputType={useInputType}
             value={value}
         />

--- a/src/renderer/components/inputs/SliderInput.tsx
+++ b/src/renderer/components/inputs/SliderInput.tsx
@@ -57,8 +57,8 @@ export const SliderInput = memo(
         value,
         setValue,
         input,
+        isConnected,
         isLocked,
-        useInputConnected,
         useInputType,
         nodeId,
         nodeSchemaId,
@@ -121,12 +121,11 @@ export const SliderInput = memo(
             );
         }, [input, schema]);
 
-        const isInputConnected = useInputConnected();
         const inputType = useInputType();
         const typeNumber = isNumericLiteral(inputType) ? inputType.value : undefined;
         const typeNumberString = typeNumber !== undefined ? precisionOutput(typeNumber) : '';
 
-        const displaySliderValue: number = isInputConnected ? typeNumber ?? def : sliderValue;
+        const displaySliderValue: number = isConnected ? typeNumber ?? def : sliderValue;
         const expr = noteExpression
             ? tryEvaluate(noteExpression, {
                   min,
@@ -184,7 +183,7 @@ export const SliderInput = memo(
                     {ends[0] && <Text fontSize="xs">{ends[0]}</Text>}
                     <StyledSlider
                         def={def}
-                        isDisabled={isLocked || isInputConnected}
+                        isDisabled={isLocked || isConnected}
                         max={max}
                         min={min}
                         scale={scale}
@@ -202,9 +201,9 @@ export const SliderInput = memo(
                         controlsStep={controlsStep}
                         defaultValue={def}
                         hideTrailingZeros={hideTrailingZeros}
-                        inputString={isInputConnected ? typeNumberString : inputString}
+                        inputString={isConnected ? typeNumberString : inputString}
                         inputWidth={`${inputWidthRem}rem`}
-                        isDisabled={isLocked || isInputConnected}
+                        isDisabled={isLocked || isConnected}
                         max={max}
                         min={min}
                         precision={precision}

--- a/src/renderer/components/inputs/TextInput.tsx
+++ b/src/renderer/components/inputs/TextInput.tsx
@@ -22,8 +22,8 @@ export const TextInput = memo(
         setValue,
         resetValue,
         input,
+        isConnected,
         isLocked,
-        useInputConnected,
         useInputType,
         size,
         setSize,
@@ -62,14 +62,13 @@ export const TextInput = memo(
             500
         );
 
-        const isInputConnected = useInputConnected();
         const inputType = useInputType();
         const strType = inputType.underlying === 'number' ? typeToString(inputType) : inputType;
         const typeText =
             strType.underlying === 'string' && strType.type === 'literal'
                 ? strType.value
                 : undefined;
-        const displayText = isInputConnected ? typeText : tempText;
+        const displayText = isConnected ? typeText : tempText;
 
         const { t } = useTranslation();
 
@@ -88,7 +87,7 @@ export const TextInput = memo(
                 </MenuItem>
                 <MenuItem
                     icon={<MdContentPaste />}
-                    isDisabled={isInputConnected}
+                    isDisabled={isConnected}
                     onClick={() => {
                         let text = clipboard.readText();
                         // replace new lines
@@ -172,7 +171,7 @@ export const TextInput = memo(
                 >
                     <Textarea
                         className="nodrag"
-                        disabled={isLocked || isInputConnected}
+                        disabled={isLocked || isConnected}
                         draggable={false}
                         h="100%"
                         maxLength={maxLength ?? undefined}
@@ -195,7 +194,7 @@ export const TextInput = memo(
             <Input
                 borderRadius="lg"
                 className="nodrag"
-                disabled={isLocked || isInputConnected}
+                disabled={isLocked || isConnected}
                 draggable={false}
                 maxLength={maxLength ?? undefined}
                 placeholder={placeholder ?? label}

--- a/src/renderer/components/inputs/props.ts
+++ b/src/renderer/components/inputs/props.ts
@@ -10,10 +10,10 @@ export interface InputProps<Kind extends InputKind, Value extends string | numbe
     readonly input: Omit<PartialBy<OfKind<Input, Kind>, 'id'>, 'type' | 'conversion'>;
     readonly definitionType: Type;
     readonly isLocked: boolean;
+    readonly isConnected: boolean;
     readonly inputKey: string;
     readonly size: Readonly<Size> | undefined;
     readonly setSize: (size: Readonly<Size>) => void;
-    readonly useInputConnected: () => boolean;
     readonly useInputType: () => Type;
     readonly nodeId?: string;
     readonly nodeSchemaId?: SchemaId;

--- a/src/renderer/helpers/nodeState.ts
+++ b/src/renderer/helpers/nodeState.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useContext } from 'use-context-selector';
+import { useContext, useContextSelector } from 'use-context-selector';
 import {
     InputData,
     InputId,
@@ -10,8 +10,9 @@ import {
     SchemaId,
     Size,
 } from '../../common/common-types';
+import { EMPTY_SET } from '../../common/util';
 import { BackendContext } from '../contexts/BackendContext';
-import { GlobalContext } from '../contexts/GlobalNodeState';
+import { GlobalContext, GlobalVolatileContext } from '../contexts/GlobalNodeState';
 import { useMemoObject } from '../hooks/useMemo';
 
 export interface NodeState {
@@ -23,6 +24,7 @@ export interface NodeState {
     readonly inputSize: InputSize | undefined;
     readonly setInputSize: (inputId: InputId, size: Readonly<Size>) => void;
     readonly isLocked: boolean;
+    readonly connectedInputs: ReadonlySet<InputId>;
 }
 
 export const useNodeStateFromData = (data: NodeData): NodeState => {
@@ -36,6 +38,20 @@ export const useNodeStateFromData = (data: NodeData): NodeState => {
     const { schemata } = useContext(BackendContext);
     const schema = schemata.get(schemaId);
 
+    const connectedInputsString = useContextSelector(GlobalVolatileContext, (c) =>
+        c.getConnectedInputs(id).join(' ')
+    );
+    const connectedInputs = useMemo(() => {
+        if (!connectedInputsString) return EMPTY_SET;
+
+        const inputs = new Set<InputId>();
+        for (const inputIdString of connectedInputsString.split(' ')) {
+            const inputId = Number(inputIdString) as InputId;
+            inputs.add(inputId);
+        }
+        return inputs;
+    }, [connectedInputsString]);
+
     return useMemoObject({
         id,
         schemaId,
@@ -45,5 +61,6 @@ export const useNodeStateFromData = (data: NodeData): NodeState => {
         inputSize,
         setInputSize,
         isLocked: isLocked ?? false,
+        connectedInputs,
     });
 };


### PR DESCRIPTION
This PR moves information about which inputs are connected into NodeState. 

I did this by changing the API of global volatile. `isNodeInputLocked(id: string, inputId: InputId): bool` is no more, instead I added `getConnectedInputs(id: string): ReadonlySet<InputId>`. This API makes it easier to for groups and likes to check for connected inputs. I also heavily cache and memoize this data, so it should be a lot more efficient now since most inputs use it. While we previously went through all edges for each call of `isNodeInputLocked`, we now compute connected inputs once globally and then reuse it until edges are updated.

While this is more efficient, I don't expect to see performance gains. TypeState also changes on edge changes, and it isn't cached well right now.