### PR TITLE
Diff function instances in type state

### DIFF
--- a/src/common/nodes/EdgeState.ts
+++ b/src/common/nodes/EdgeState.ts
@@ -1,0 +1,69 @@
+import { EdgeData, InputId, OutputId } from '../common-types';
+import { EMPTY_MAP, parseSourceHandle, parseTargetHandle, stringifyTargetHandle } from '../util';
+import type { Edge } from 'reactflow';
+
+export interface EdgeStateConnection {
+    readonly source: string;
+    readonly sourceHandle: string;
+    readonly target: string;
+    readonly targetHandle: string;
+    readonly outputId: OutputId;
+    readonly inputId: InputId;
+}
+
+export class EdgeState {
+    readonly byTargetHandle: ReadonlyMap<string, EdgeStateConnection>;
+
+    readonly byTarget: ReadonlyMap<string, readonly EdgeStateConnection[]>;
+
+    private constructor(
+        byTargetHandle: EdgeState['byTargetHandle'],
+        byTarget: EdgeState['byTarget']
+    ) {
+        this.byTargetHandle = byTargetHandle;
+        this.byTarget = byTarget;
+    }
+
+    get(nodeId: string, inputId: InputId): EdgeStateConnection | undefined {
+        return this.byTargetHandle.get(stringifyTargetHandle({ nodeId, inputId }));
+    }
+
+    isInputConnected(nodeId: string, inputId: InputId): boolean {
+        return this.byTargetHandle.has(stringifyTargetHandle({ nodeId, inputId }));
+    }
+
+    static readonly empty = new EdgeState(EMPTY_MAP, EMPTY_MAP);
+
+    static create(edges: readonly Edge<EdgeData>[]): EdgeState {
+        const byTargetHandle = new Map<string, EdgeStateConnection>();
+        const byTarget = new Map<string, EdgeStateConnection[]>();
+
+        for (const edge of edges) {
+            if (!edge.sourceHandle || !edge.targetHandle) {
+                // eslint-disable-next-line no-continue
+                continue;
+            }
+
+            const { outputId } = parseSourceHandle(edge.sourceHandle);
+            const { inputId } = parseTargetHandle(edge.targetHandle);
+            const connection: EdgeStateConnection = {
+                source: edge.source,
+                sourceHandle: edge.sourceHandle,
+                target: edge.target,
+                targetHandle: edge.targetHandle,
+                outputId,
+                inputId,
+            };
+
+            byTargetHandle.set(connection.targetHandle, connection);
+            let list = byTarget.get(connection.target);
+            if (!list) {
+                list = [];
+                byTarget.set(connection.target, list);
+            }
+            list.push(connection);
+        }
+
+        return new EdgeState(byTargetHandle, byTarget);
+    }
+}

--- a/src/common/nodes/condition.ts
+++ b/src/common/nodes/condition.ts
@@ -81,6 +81,6 @@ export const testInputConditionTypeState = (
         condition,
         inputData,
         (id) => typeState.functions.get(nodeId)?.inputs.get(id),
-        (id) => typeState.isInputConnected(nodeId, id)
+        (id) => typeState.edges.isInputConnected(nodeId, id)
     );
 };

--- a/src/common/types/function.ts
+++ b/src/common/types/function.ts
@@ -497,18 +497,9 @@ export class FunctionInstance {
 
     static fromPartialInputs(
         definition: FunctionDefinition,
-        partialInputs:
-            | ReadonlyMap<InputId, NonNeverType>
-            | ((inputId: InputId) => NonNeverType | undefined),
+        partialInputs: (inputId: InputId) => NonNeverType | undefined,
         outputNarrowing: ReadonlyMap<OutputId, Type> = EMPTY_MAP
     ): FunctionInstance {
-        if (typeof partialInputs === 'object') {
-            if (partialInputs.size === 0) return definition.defaultInstance;
-            const map = partialInputs;
-            // eslint-disable-next-line no-param-reassign
-            partialInputs = (id) => map.get(id);
-        }
-
         const inputErrors: FunctionInputAssignmentError[] = [];
         const outputErrors: FunctionOutputError[] = [];
 

--- a/src/renderer/contexts/GlobalNodeState.tsx
+++ b/src/renderer/contexts/GlobalNodeState.tsx
@@ -255,7 +255,8 @@ export const GlobalProvider = memo(
                     nodeMap,
                     getEdges(),
                     manualOutputTypes.map,
-                    functionDefinitions
+                    functionDefinitions,
+                    typeStateRef.current
                 );
                 setTypeState(types);
                 typeStateRef.current = types;


### PR DESCRIPTION
The main change is that I added diffing to function instances in type state. This means that TypeState will now reuse old function instances if possible. This should allow for a lot more memo-ing, since the function instance and its types will all be the same object.

I also did some other minor changes:
- Added an `EdgeState` class to represent the state of edges of the current type state.
- Removed the map interface for `fromPartialInputs`' `partialInputs` parameter.