### PR TITLE
Moved type info and output info into NodeState

### DIFF
--- a/src/common/IdSet.ts
+++ b/src/common/IdSet.ts
@@ -34,6 +34,8 @@ export namespace IdSet {
         let s = '';
         let last = -1;
         for (const id of sorted) {
+            if (id < 0 || id > 65535 || !Number.isInteger(id)) throw new Error(`Invalid id: ${id}`);
+
             if (id !== last) {
                 last = id;
                 s += String.fromCharCode(id);
@@ -46,13 +48,3 @@ export namespace IdSet {
         return fromSorted(sorted);
     };
 }
-
-export const toIdSetMap = <K, V extends number>(
-    map: ReadonlyMap<K, Iterable<V>>
-): Map<K, IdSet<V>> => {
-    const result = new Map<K, IdSet<V>>();
-    for (const [k, iter] of map) {
-        result.set(k, IdSet.from(iter));
-    }
-    return result;
-};

--- a/src/common/IdSet.ts
+++ b/src/common/IdSet.ts
@@ -1,0 +1,58 @@
+/**
+ * A value-type representation of a set of numeric ids. The main purpose of this type is to
+ * provide a representation of sets that can be memoized by React.
+ *
+ * This type makes the following assumptions about ids:
+ * 1. They are non-negative integers.
+ * 2. They are reasonably small integers. They should ideally be below 128 and must be below 65536.
+ *
+ * {@link IdSet.Builder} makes the same assumptions.
+ */
+export type IdSet<T extends number> = string & { __inputIdSet: never; __type: T };
+
+// eslint-disable-next-line @typescript-eslint/no-namespace, @typescript-eslint/no-redeclare
+export namespace IdSet {
+    export const empty: IdSet<never> = '' as IdSet<never>;
+
+    export const isEmpty = <T extends number>(idSet: IdSet<T>): boolean => {
+        return idSet.length === 0;
+    };
+
+    export const has = <T extends number>(idSet: IdSet<T>, id: T): boolean => {
+        const char = String.fromCharCode(id);
+        return idSet.includes(char);
+    };
+    export const toSet = <T extends number>(idSet: IdSet<T>): Set<T> => {
+        const set = new Set<T>();
+        for (let i = 0; i < idSet.length; i += 1) {
+            set.add(idSet.charCodeAt(i) as T);
+        }
+        return set;
+    };
+
+    const fromSorted = <T extends number>(sorted: readonly T[]): IdSet<T> => {
+        let s = '';
+        let last = -1;
+        for (const id of sorted) {
+            if (id !== last) {
+                last = id;
+                s += String.fromCharCode(id);
+            }
+        }
+        return s as IdSet<T>;
+    };
+    export const from = <T extends number>(iter: Iterable<T>): IdSet<T> => {
+        const sorted = Array.from(iter).sort((a, b) => a - b);
+        return fromSorted(sorted);
+    };
+}
+
+export const toIdSetMap = <K, V extends number>(
+    map: ReadonlyMap<K, Iterable<V>>
+): Map<K, IdSet<V>> => {
+    const result = new Map<K, IdSet<V>>();
+    for (const [k, iter] of map) {
+        result.set(k, IdSet.from(iter));
+    }
+    return result;
+};

--- a/src/renderer/components/NodeDocumentation/NodeExample.tsx
+++ b/src/renderer/components/NodeDocumentation/NodeExample.tsx
@@ -69,8 +69,13 @@ export const NodeExample = memo(({ accentColor, selectedSchema }: NodeExamplePro
         [setInputSize]
     );
 
+    const nodeIdPrefix = 'FakeId ';
+    const suffixLength = 36 - nodeIdPrefix.length;
+    const nodeId =
+        nodeIdPrefix + selectedSchema.schemaId.slice(-suffixLength).padStart(suffixLength, ' ');
+    if (nodeId.length !== 36) throw new Error('Fake node ID must have the length of a real one.');
+
     const { functionDefinitions } = useContext(BackendContext);
-    const nodeId = '<fake node id>';
 
     const typeState = useMemo(() => {
         const node: Node<NodeData> = {

--- a/src/renderer/components/NodeDocumentation/NodeExample.tsx
+++ b/src/renderer/components/NodeDocumentation/NodeExample.tsx
@@ -1,15 +1,22 @@
 import { Center, VStack } from '@chakra-ui/react';
-import { memo, useCallback, useState } from 'react';
+import { memo, useCallback, useMemo, useState } from 'react';
+import { Node } from 'reactflow';
+import { useContext } from 'use-context-selector';
 import {
+    Condition,
     InputData,
     InputId,
     InputSize,
     InputValue,
+    NodeData,
     NodeSchema,
     Size,
 } from '../../../common/common-types';
 import { DisabledStatus } from '../../../common/nodes/disabled';
-import { EMPTY_OBJECT, EMPTY_SET } from '../../../common/util';
+import { TypeState } from '../../../common/nodes/TypeState';
+import { EMPTY_ARRAY, EMPTY_MAP, EMPTY_OBJECT, EMPTY_SET } from '../../../common/util';
+import { BackendContext } from '../../contexts/BackendContext';
+import { TypeInfo, testInputConditionTypeInfo } from '../../helpers/nodeState';
 import { NodeBody } from '../node/NodeBody';
 import { NodeFooter } from '../node/NodeFooter/NodeFooter';
 import { NodeHeader } from '../node/NodeHeader';
@@ -62,6 +69,32 @@ export const NodeExample = memo(({ accentColor, selectedSchema }: NodeExamplePro
         [setInputSize]
     );
 
+    const { functionDefinitions } = useContext(BackendContext);
+    const nodeId = '<fake node id>';
+
+    const typeState = useMemo(() => {
+        const node: Node<NodeData> = {
+            id: nodeId,
+            position: { x: 0, y: 0 },
+            data: {
+                id: nodeId,
+                schemaId: selectedSchema.schemaId,
+                inputData,
+            },
+        };
+        return TypeState.create(
+            new Map([[nodeId, node]]),
+            EMPTY_ARRAY,
+            EMPTY_MAP,
+            functionDefinitions
+        );
+    }, [nodeId, selectedSchema, inputData, functionDefinitions]);
+
+    const typeInfo: TypeInfo = {
+        instance: typeState.functions.get(nodeId),
+        connectedInputs: EMPTY_SET,
+    };
+
     return (
         <Center
             key={selectedSchema.schemaId}
@@ -97,7 +130,7 @@ export const NodeExample = memo(({ accentColor, selectedSchema }: NodeExamplePro
                         <NodeBody
                             animated={false}
                             nodeState={{
-                                id: '<fake node id>',
+                                id: nodeId,
                                 schemaId: selectedSchema.schemaId,
                                 schema: selectedSchema,
                                 inputData,
@@ -106,12 +139,16 @@ export const NodeExample = memo(({ accentColor, selectedSchema }: NodeExamplePro
                                 setInputSize: setSingleInputSize,
                                 isLocked: false,
                                 connectedInputs: EMPTY_SET,
+                                connectedOutputs: EMPTY_SET,
+                                type: typeInfo,
+                                testCondition: (condition: Condition): boolean =>
+                                    testInputConditionTypeInfo(condition, inputData, typeInfo),
                             }}
                         />
                     </VStack>
                     <NodeFooter
                         animated={false}
-                        id="<fake node id>"
+                        id={nodeId}
                         validity={{ isValid: true }}
                     />
                 </VStack>

--- a/src/renderer/components/groups/ConditionalGroup.tsx
+++ b/src/renderer/components/groups/ConditionalGroup.tsx
@@ -1,22 +1,14 @@
 import { memo, useMemo } from 'react';
-import { useContextSelector } from 'use-context-selector';
 import { InputItem, getUniqueKey } from '../../../common/group-inputs';
-import { testInputConditionTypeState } from '../../../common/nodes/condition';
-import { GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { GroupProps } from './props';
 import { someInput } from './util';
 
 export const ConditionalGroup = memo(
     ({ inputs, nodeState, group, ItemRenderer }: GroupProps<'conditional'>) => {
-        const { id: nodeId, inputData } = nodeState;
+        const { testCondition } = nodeState;
         const { condition } = group.options;
 
-        const typeState = useContextSelector(GlobalVolatileContext, (c) => c.typeState);
-
-        const isEnabled = useMemo(
-            () => testInputConditionTypeState(condition, inputData, nodeId, typeState),
-            [condition, nodeId, inputData, typeState]
-        );
+        const isEnabled = useMemo(() => testCondition(condition), [condition, testCondition]);
 
         const showInput = (input: InputItem): boolean => {
             if (isEnabled) return true;

--- a/src/renderer/components/groups/RequiredGroup.tsx
+++ b/src/renderer/components/groups/RequiredGroup.tsx
@@ -1,23 +1,15 @@
 import { memo, useMemo } from 'react';
-import { useContextSelector } from 'use-context-selector';
 import { GenericInput } from '../../../common/common-types';
 import { getUniqueKey } from '../../../common/group-inputs';
-import { testInputConditionTypeState } from '../../../common/nodes/condition';
 import { getRequireCondition } from '../../../common/nodes/required';
-import { GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { GroupProps } from './props';
 
 export const RequiredGroup = memo(
     ({ inputs, nodeState, group, ItemRenderer }: GroupProps<'required'>) => {
-        const { id: nodeId, inputData, schema } = nodeState;
-
-        const typeState = useContextSelector(GlobalVolatileContext, (c) => c.typeState);
+        const { schema, testCondition } = nodeState;
 
         const condition = getRequireCondition(schema, group);
-        const isRequired = useMemo(
-            () => testInputConditionTypeState(condition, inputData, nodeId, typeState),
-            [condition, nodeId, inputData, typeState]
-        );
+        const isRequired = useMemo(() => testCondition(condition), [condition, testCondition]);
 
         const requiredInputs: GenericInput[] = useMemo(() => {
             return inputs.map((i) => ({ ...i, optional: false }));

--- a/src/renderer/components/inputs/DirectoryInput.tsx
+++ b/src/renderer/components/inputs/DirectoryInput.tsx
@@ -43,7 +43,7 @@ export const DirectoryInput = memo(
         input,
         inputKey,
         isConnected,
-        useInputType,
+        inputType,
         nodeId,
     }: InputProps<'directory', string>) => {
         const { t } = useTranslation();
@@ -62,7 +62,6 @@ export const DirectoryInput = memo(
             }
         };
 
-        const inputType = useInputType();
         const displayDirectory = isConnected ? getDirectoryPath(inputType) : value;
 
         const menu = useContextMenu(() => (

--- a/src/renderer/components/inputs/NumberInput.tsx
+++ b/src/renderer/components/inputs/NumberInput.tsx
@@ -17,7 +17,7 @@ export const NumberInput = memo(
         input,
         isConnected,
         isLocked,
-        useInputType,
+        inputType,
         nodeId,
     }: InputProps<'number', number>) => {
         const { def, min, max, unit, precision, controlsStep, hideTrailingZeros } = input;
@@ -45,7 +45,6 @@ export const NumberInput = memo(
             }
         }, [value, def, setValue]);
 
-        const inputType = useInputType();
         const typeNumberString = isNumericLiteral(inputType) ? inputType.toString() : '';
         const displayString = isConnected ? typeNumberString : inputString;
 

--- a/src/renderer/components/inputs/SchemaInput.tsx
+++ b/src/renderer/components/inputs/SchemaInput.tsx
@@ -1,11 +1,10 @@
-import { NeverType, Type } from '@chainner/navi';
+import { NeverType } from '@chainner/navi';
 import { HStack } from '@chakra-ui/react';
 import { memo, useCallback } from 'react';
 import { useContextSelector } from 'use-context-selector';
 import { Input, InputKind, InputValue, Size } from '../../../common/common-types';
 import { getInputValue } from '../../../common/util';
 import { BackendContext } from '../../contexts/BackendContext';
-import { GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { NodeState } from '../../helpers/nodeState';
 import { ColorInput } from './ColorInput';
 import { DirectoryInput } from './DirectoryInput';
@@ -53,6 +52,7 @@ export const SchemaInput = memo(({ input, nodeState, afterInput }: SingleInputPr
         setInputSize,
         isLocked,
         connectedInputs,
+        type,
     } = nodeState;
 
     const functionDefinition = useContextSelector(BackendContext, (c) =>
@@ -81,13 +81,7 @@ export const SchemaInput = memo(({ input, nodeState, afterInput }: SingleInputPr
         [inputId, setInputSize]
     );
 
-    const useInputType = useCallback((): Type => {
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        return useContextSelector(GlobalVolatileContext, (c) => {
-            const type = c.typeState.functions.get(nodeId)?.inputs.get(inputId);
-            return type ?? NeverType.instance;
-        });
-    }, [nodeId, inputId]);
+    const inputType = type.instance?.inputs.get(inputId) ?? NeverType.instance;
 
     const InputType = InputComponents[kind];
     let inputElement = (
@@ -95,6 +89,7 @@ export const SchemaInput = memo(({ input, nodeState, afterInput }: SingleInputPr
             definitionType={definitionType}
             input={input as never}
             inputKey={`${schemaId}-${inputId}`}
+            inputType={inputType}
             isConnected={connectedInputs.has(inputId)}
             isLocked={isLocked}
             nodeId={nodeId}
@@ -103,7 +98,6 @@ export const SchemaInput = memo(({ input, nodeState, afterInput }: SingleInputPr
             setSize={setSize}
             setValue={setValue}
             size={size}
-            useInputType={useInputType}
             value={value}
         />
     );

--- a/src/renderer/components/inputs/SliderInput.tsx
+++ b/src/renderer/components/inputs/SliderInput.tsx
@@ -59,7 +59,7 @@ export const SliderInput = memo(
         input,
         isConnected,
         isLocked,
-        useInputType,
+        inputType,
         nodeId,
         nodeSchemaId,
     }: InputProps<'slider', number>) => {
@@ -121,7 +121,6 @@ export const SliderInput = memo(
             );
         }, [input, schema]);
 
-        const inputType = useInputType();
         const typeNumber = isNumericLiteral(inputType) ? inputType.value : undefined;
         const typeNumberString = typeNumber !== undefined ? precisionOutput(typeNumber) : '';
 

--- a/src/renderer/components/inputs/TextInput.tsx
+++ b/src/renderer/components/inputs/TextInput.tsx
@@ -24,7 +24,7 @@ export const TextInput = memo(
         input,
         isConnected,
         isLocked,
-        useInputType,
+        inputType,
         size,
         setSize,
         nodeId,
@@ -62,7 +62,6 @@ export const TextInput = memo(
             500
         );
 
-        const inputType = useInputType();
         const strType = inputType.underlying === 'number' ? typeToString(inputType) : inputType;
         const typeText =
             strType.underlying === 'string' && strType.type === 'literal'

--- a/src/renderer/components/inputs/props.ts
+++ b/src/renderer/components/inputs/props.ts
@@ -14,7 +14,7 @@ export interface InputProps<Kind extends InputKind, Value extends string | numbe
     readonly inputKey: string;
     readonly size: Readonly<Size> | undefined;
     readonly setSize: (size: Readonly<Size>) => void;
-    readonly useInputType: () => Type;
+    readonly inputType: Type;
     readonly nodeId?: string;
     readonly nodeSchemaId?: SchemaId;
 }

--- a/src/renderer/components/node/IteratorNode.tsx
+++ b/src/renderer/components/node/IteratorNode.tsx
@@ -127,9 +127,8 @@ const IteratorNodeInner = memo(({ data, selected }: IteratorNodeProps) => {
                         w="full"
                     >
                         <NodeOutputs
-                            id={id}
-                            outputs={outputs}
-                            schemaId={nodeState.schemaId}
+                            animated={false}
+                            nodeState={nodeState}
                         />
                     </Box>
                 </VStack>

--- a/src/renderer/components/node/NodeBody.tsx
+++ b/src/renderer/components/node/NodeBody.tsx
@@ -35,9 +35,7 @@ export const NodeBody = memo(({ nodeState, animated = false }: NodeBodyProps) =>
             >
                 <NodeOutputs
                     animated={animated}
-                    id={nodeState.id}
-                    outputs={outputs}
-                    schemaId={nodeState.schemaId}
+                    nodeState={nodeState}
                 />
             </Box>
         </>

--- a/src/renderer/components/outputs/GenericOutput.tsx
+++ b/src/renderer/components/outputs/GenericOutput.tsx
@@ -1,15 +1,9 @@
 import { Center, Flex, Spacer, Text } from '@chakra-ui/react';
 import { memo } from 'react';
-import { useContextSelector } from 'use-context-selector';
-import { GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { TypeTags } from '../TypeTag';
 import { OutputProps } from './props';
 
-export const GenericOutput = memo(({ label, id, outputId }: OutputProps) => {
-    const type = useContextSelector(GlobalVolatileContext, (c) =>
-        c.typeState.functions.get(id)?.outputs.get(outputId)
-    );
-
+export const GenericOutput = memo(({ output, type }: OutputProps) => {
     return (
         <Flex
             h="full"
@@ -18,17 +12,15 @@ export const GenericOutput = memo(({ label, id, outputId }: OutputProps) => {
             w="full"
         >
             <Spacer />
-            {type && (
-                <Center
-                    h="2rem"
-                    verticalAlign="middle"
-                >
-                    <TypeTags
-                        isOptional={false}
-                        type={type}
-                    />
-                </Center>
-            )}
+            <Center
+                h="2rem"
+                verticalAlign="middle"
+            >
+                <TypeTags
+                    isOptional={false}
+                    type={type}
+                />
+            </Center>
             <Text
                 h="full"
                 lineHeight="2rem"
@@ -36,7 +28,7 @@ export const GenericOutput = memo(({ label, id, outputId }: OutputProps) => {
                 ml={1}
                 textAlign="right"
             >
-                {label}
+                {output.label}
             </Text>
         </Flex>
     );

--- a/src/renderer/components/outputs/LargeImageOutput.tsx
+++ b/src/renderer/components/outputs/LargeImageOutput.tsx
@@ -30,14 +30,14 @@ const pickImage = (previews: PreviewImage[], realSize: number) => {
     return found ?? previews[previews.length - 1];
 };
 
-export const LargeImageOutput = memo(({ outputId, useOutputData, animated }: OutputProps) => {
+export const LargeImageOutput = memo(({ output, useOutputData, animated }: OutputProps) => {
     const { t } = useTranslation();
 
     const dpr = useDevicePixelRatio();
     const zoom = useContextSelector(GlobalVolatileContext, (c) => c.zoom);
     const realSize = IMAGE_PREVIEW_SIZE * zoom * dpr;
 
-    const { last, stale } = useOutputData<LargeImageBroadcastData>(outputId);
+    const { last, stale } = useOutputData<LargeImageBroadcastData>(output.id);
 
     const imgBgColor = 'var(--node-image-preview-bg)';
     const fontColor = 'var(--node-image-preview-color)';

--- a/src/renderer/components/outputs/TaggedOutput.tsx
+++ b/src/renderer/components/outputs/TaggedOutput.tsx
@@ -6,8 +6,8 @@ interface TagData {
     tags?: readonly string[] | null;
 }
 
-export const TaggedOutput = memo(({ outputId, useOutputData, animated }: OutputProps) => {
-    const { current } = useOutputData<TagData>(outputId);
+export const TaggedOutput = memo(({ output, useOutputData, animated }: OutputProps) => {
+    const { current } = useOutputData<TagData>(output.id);
 
     return (
         <ModelDataTags

--- a/src/renderer/components/outputs/props.ts
+++ b/src/renderer/components/outputs/props.ts
@@ -1,5 +1,5 @@
 import { Type } from '@chainner/navi';
-import { OutputId, OutputKind, SchemaId } from '../../../common/common-types';
+import { NodeSchema, Output, OutputId } from '../../../common/common-types';
 
 export interface UseOutputData<T> {
     /** The current output data. Current here means most recent + up to date (= same input hash). */
@@ -11,13 +11,11 @@ export interface UseOutputData<T> {
 }
 
 export interface OutputProps {
+    readonly output: Output;
     readonly id: string;
-    readonly outputId: OutputId;
-    readonly label: string;
-    readonly schemaId: SchemaId;
+    readonly schema: NodeSchema;
     readonly definitionType: Type;
-    readonly hasHandle: boolean;
+    readonly type: Type;
     readonly useOutputData: <T>(outputId: OutputId) => UseOutputData<T>;
     readonly animated: boolean;
-    readonly kind: OutputKind;
 }

--- a/src/renderer/contexts/GlobalNodeState.tsx
+++ b/src/renderer/contexts/GlobalNodeState.tsx
@@ -24,6 +24,7 @@ import {
     OutputId,
     Size,
 } from '../../common/common-types';
+import { IdSet, toIdSetMap } from '../../common/IdSet';
 import { log } from '../../common/log';
 import { getEffectivelyDisabledNodes } from '../../common/nodes/disabled';
 import { TypeState } from '../../common/nodes/TypeState';
@@ -36,7 +37,6 @@ import {
 } from '../../common/types/mismatch';
 import { withoutNull } from '../../common/types/util';
 import {
-    EMPTY_ARRAY,
     EMPTY_SET,
     createUniqueId,
     deepCopy,
@@ -95,7 +95,7 @@ interface GlobalVolatile {
     nodeChanges: ChangeCounter;
     edgeChanges: ChangeCounter;
     typeState: TypeState;
-    getConnectedInputs: (id: string) => readonly InputId[];
+    getConnectedInputs: (id: string) => IdSet<InputId>;
     isValidConnection: (connection: Readonly<Connection>) => Validity;
     effectivelyDisabledNodes: ReadonlySet<string>;
     zoom: number;
@@ -1036,14 +1036,14 @@ export const GlobalProvider = memo(
                             inputs.push(parseTargetHandle(e.targetHandle).inputId);
                         }
                     }
-                    return map;
+                    return toIdSetMap(map);
                 });
             },
             // eslint-disable-next-line react-hooks/exhaustive-deps
             [edgeChanges, getEdges]
         );
         const getConnectedInputs = useCallback(
-            (id: string): readonly InputId[] => connectedInputsMap().get(id) ?? EMPTY_ARRAY,
+            (id: string): IdSet<InputId> => connectedInputsMap().get(id) ?? IdSet.empty,
             [connectedInputsMap]
         );
 


### PR DESCRIPTION
This PR has 2 main changes:

1. I moved type information into `NodeState`. Groups, inputs, and outputs can now access their current type without needing to context-select `typeState` directly. This only makes the implementation of groups, inputs, and outputs simpler, it's also more efficient because we only need one `useContextSelector` per node to get type information (not counting handles).
2. I also changed outputs to use `NodeState`. This means that inputs and outputs are guaranteed to be consistent now by virtue of being fed the same data. 

Because of this, node examples now have output types.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/8f387549-3a7e-43b1-9db0-e7092b3e9610)


Other changes:
- Added `IdSet`. This is a value-type representation of a set of integers (typically `InputId`s or `OutputId`s). Basically, I needed a way to memoize based on a set of input ids, because I used one in the deps array of `useMemo`. Since I recreated that set quite often, I would frequently get new set instances even though their value (=the contained ids) was the same. To work around this, I convert the set into a string representation, so react compares string values instead of set instances. `IdSet` is that string representation. \
    It's not important how `IdSet` represents ids as a string. I wanted to use a bitset initially, but that would limit us to having at most 32 inputs/outputs. Since nodes like Save Image may hit that limit some day, I went with a string representation instead. The current representation supports 65536 ids.