### PR TITLE
Require RGB in Write Output Frame

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/video_frame_iterator.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/video_frame_iterator.py
@@ -84,7 +84,7 @@ def VideoFrameIteratorFrameLoaderNode(
     icon="MdVideoCameraBack",
     node_type="iteratorHelper",
     inputs=[
-        ImageInput("Frame"),
+        ImageInput("Frame", channels=3),
         DirectoryInput("Output Video Directory", has_handle=True),
         TextInput("Output Video Name"),
         VideoTypeDropdown(),


### PR DESCRIPTION
Based on our discussion on Discord, it seems like the Video Frame iterator only supports writing RGB output frames. This PR enforces this requirement by adding it to the `ImageInput` of the node.