### PR TITLE
Add handle colors to input/output docs

### DIFF
--- a/src/renderer/components/NodeDocumentation/NodeDocs.tsx
+++ b/src/renderer/components/NodeDocumentation/NodeDocs.tsx
@@ -71,6 +71,7 @@ const InputOutputItem = memo(
                                 bgColor={color}
                                 borderRadius="100%"
                                 h="0.5rem"
+                                key={color}
                                 w="0.5rem"
                             />
                         ))}

--- a/src/renderer/components/NodeDocumentation/NodeDocs.tsx
+++ b/src/renderer/components/NodeDocumentation/NodeDocs.tsx
@@ -22,7 +22,7 @@ import { withoutNull } from '../../../common/types/util';
 import { isAutoInput } from '../../../common/util';
 import { BackendContext } from '../../contexts/BackendContext';
 import { NodeDocumentationContext } from '../../contexts/NodeDocumentationContext';
-import { getCategoryAccentColor } from '../../helpers/accentColors';
+import { getCategoryAccentColor, getTypeAccentColors } from '../../helpers/accentColors';
 import { IconFactory } from '../CustomIcons';
 import { TypeTag } from '../TypeTag';
 import { docsMarkdown } from './docsMarkdown';
@@ -41,13 +41,17 @@ const InputOutputItem = memo(({ label, description, type, optional }: InputOutpu
         type = withoutNull(type);
     }
 
+    const handleColors = getTypeAccentColors(type);
+
     return (
         <ListItem my={2}>
-            <Text
-                fontWeight="bold"
-                userSelect="text"
-            >
-                {label}
+            <HStack>
+                <Text
+                    fontWeight="bold"
+                    userSelect="text"
+                >
+                    {label}
+                </Text>
                 {optional && (
                     <TypeTag
                         isOptional
@@ -59,7 +63,16 @@ const InputOutputItem = memo(({ label, description, type, optional }: InputOutpu
                         optional
                     </TypeTag>
                 )}
-            </Text>
+                {handleColors.map((color) => (
+                    <Box
+                        bgColor={color}
+                        borderRadius="100%"
+                        h="0.5rem"
+                        w="0.5rem"
+                    />
+                ))}
+            </HStack>
+
             {description && <ReactMarkdown components={docsMarkdown}>{description}</ReactMarkdown>}
             <Code userSelect="text">{prettyPrintType(type)}</Code>
         </ListItem>

--- a/src/renderer/components/NodeDocumentation/NodeDocs.tsx
+++ b/src/renderer/components/NodeDocumentation/NodeDocs.tsx
@@ -34,50 +34,56 @@ interface InputOutputItemProps {
     description?: string | null;
     type: Type;
     optional: boolean;
+    hasHandle?: boolean;
 }
-const InputOutputItem = memo(({ label, description, type, optional }: InputOutputItemProps) => {
-    if (optional) {
-        // eslint-disable-next-line no-param-reassign
-        type = withoutNull(type);
-    }
+const InputOutputItem = memo(
+    ({ label, description, type, optional, hasHandle = true }: InputOutputItemProps) => {
+        if (optional) {
+            // eslint-disable-next-line no-param-reassign
+            type = withoutNull(type);
+        }
 
-    const handleColors = getTypeAccentColors(type);
+        const handleColors = getTypeAccentColors(type);
 
-    return (
-        <ListItem my={2}>
-            <HStack>
-                <Text
-                    fontWeight="bold"
-                    userSelect="text"
-                >
-                    {label}
-                </Text>
-                {optional && (
-                    <TypeTag
-                        isOptional
-                        fontSize="small"
-                        height="auto"
-                        mt="-0.2rem"
-                        verticalAlign="middle"
+        return (
+            <ListItem my={2}>
+                <HStack>
+                    <Text
+                        fontWeight="bold"
+                        userSelect="text"
                     >
-                        optional
-                    </TypeTag>
-                )}
-                {handleColors.map((color) => (
-                    <Box
-                        bgColor={color}
-                        borderRadius="100%"
-                        h="0.5rem"
-                        w="0.5rem"
-                    />
-                ))}
-            </HStack>
+                        {label}
+                    </Text>
+                    {optional && (
+                        <TypeTag
+                            isOptional
+                            fontSize="small"
+                            height="auto"
+                            mt="-0.2rem"
+                            verticalAlign="middle"
+                        >
+                            optional
+                        </TypeTag>
+                    )}
+                    {hasHandle &&
+                        handleColors.map((color) => (
+                            <Box
+                                bgColor={color}
+                                borderRadius="100%"
+                                h="0.5rem"
+                                w="0.5rem"
+                            />
+                        ))}
+                </HStack>
 
-            {description && <ReactMarkdown components={docsMarkdown}>{description}</ReactMarkdown>}
-            <Code userSelect="text">{prettyPrintType(type)}</Code>
-        </ListItem>
-    );
-});
+                {description && (
+                    <ReactMarkdown components={docsMarkdown}>{description}</ReactMarkdown>
+                )}
+                <Code userSelect="text">{prettyPrintType(type)}</Code>
+            </ListItem>
+        );
+    }
+);
 
 interface NodeInfoProps {
     schema: NodeSchema;
@@ -142,6 +148,7 @@ const SingleNodeInfo = memo(({ schema, accentColor, functionDefinition }: NodeIn
                             return (
                                 <InputOutputItem
                                     description={input.description}
+                                    hasHandle={input.hasHandle}
                                     key={input.id}
                                     label={input.label}
                                     optional={input.optional}


### PR DESCRIPTION
For some reason, I couldn't get linear gradients to work, assumedly because this is inside a bulleted list? I'm not really sure, but this is the solution I ended up with.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/34788790/9b08fa7c-3764-4a1f-ae5a-407614ae6171)

Multiple:

![image](https://github.com/chaiNNer-org/chaiNNer/assets/34788790/01dd6ad2-f89d-45c0-9854-9d76e27cb69b)

With optional tag:

![image](https://github.com/chaiNNer-org/chaiNNer/assets/34788790/c609b883-ceef-4949-b730-67c43d19c62f)


