### PR TITLE
File input docs improvements

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image/io/load_image.py
+++ b/backend/src/packages/chaiNNer_standard/image/io/load_image.py
@@ -120,8 +120,7 @@ valid_formats = get_available_image_formats()
     icon="BsFillImageFill",
     inputs=[
         ImageFileInput(primary_input=True).with_docs(
-            "Select the path of an image file.",
-            f"Supports the following image formats: {', '.join(valid_formats)}",
+            "Select the path of an image file."
         )
     ],
     outputs=[

--- a/src/renderer/components/NodeDocumentation/NodeDocs.tsx
+++ b/src/renderer/components/NodeDocumentation/NodeDocs.tsx
@@ -49,7 +49,7 @@ const InputOutputItem = memo(({ type, item }: InputOutputItemProps) => {
 
     return (
         <ListItem my={2}>
-            <HStack>
+            <HStack mb={1}>
                 <Text
                     fontWeight="bold"
                     userSelect="text"
@@ -85,7 +85,7 @@ const InputOutputItem = memo(({ type, item }: InputOutputItemProps) => {
 
             <VStack
                 alignItems="start"
-                mb={2}
+                mb={1}
                 w="full"
             >
                 {isFileInput && supportedFileTypes.length > 0 && (

--- a/src/renderer/components/NodeDocumentation/NodeDocs.tsx
+++ b/src/renderer/components/NodeDocumentation/NodeDocs.tsx
@@ -35,7 +35,8 @@ interface InputOutputItemProps {
 }
 
 const InputOutputItem = memo(({ type, item }: InputOutputItemProps) => {
-    if ('optional' in item && item.optional) {
+    const isOptional = 'optional' in item && item.optional;
+    if (isOptional) {
         // eslint-disable-next-line no-param-reassign
         type = withoutNull(type);
     }
@@ -55,7 +56,7 @@ const InputOutputItem = memo(({ type, item }: InputOutputItemProps) => {
                 >
                     {item.label}
                 </Text>
-                {'optional' in item && item.optional && (
+                {isOptional && (
                     <TypeTag
                         isOptional
                         fontSize="small"

--- a/src/renderer/components/NodeDocumentation/NodeDocs.tsx
+++ b/src/renderer/components/NodeDocumentation/NodeDocs.tsx
@@ -43,9 +43,9 @@ const InputOutputItem = memo(({ type, item }: InputOutputItemProps) => {
 
     const handleColors = getTypeAccentColors(type);
 
-    const isFileInput = 'kind' in item && item.kind === 'file';
+    const isFileInput = item.kind === 'file';
     const supportedFileTypes = isFileInput ? item.filetypes : [];
-    const isPrimaryInput = isFileInput && 'primaryInput' in item && item.primaryInput;
+    const isPrimaryInput = isFileInput && item.primaryInput;
 
     return (
         <ListItem my={2}>
@@ -79,15 +79,15 @@ const InputOutputItem = memo(({ type, item }: InputOutputItemProps) => {
                     ))}
             </HStack>
 
+            {item.description && (
+                <ReactMarkdown components={docsMarkdown}>{item.description}</ReactMarkdown>
+            )}
+
             <VStack
                 alignItems="start"
-                my={2}
+                mb={2}
                 w="full"
             >
-                {item.description && (
-                    <ReactMarkdown components={docsMarkdown}>{item.description}</ReactMarkdown>
-                )}
-
                 {isFileInput && supportedFileTypes.length > 0 && (
                     <Text
                         fontSize="md"

--- a/src/renderer/components/NodeDocumentation/NodeDocs.tsx
+++ b/src/renderer/components/NodeDocumentation/NodeDocs.tsx
@@ -15,7 +15,7 @@ import {
 import { memo } from 'react';
 import { ReactMarkdown } from 'react-markdown/lib/react-markdown';
 import { useContext } from 'use-context-selector';
-import { NodeSchema } from '../../../common/common-types';
+import { Input, NodeSchema, Output } from '../../../common/common-types';
 import { FunctionDefinition } from '../../../common/types/function';
 import { prettyPrintType } from '../../../common/types/pretty';
 import { withoutNull } from '../../../common/types/util';
@@ -30,61 +30,98 @@ import { NodeExample } from './NodeExample';
 import { SchemaLink } from './SchemaLink';
 
 interface InputOutputItemProps {
-    label: string;
-    description?: string | null;
+    item: Input | Output;
     type: Type;
-    optional: boolean;
-    hasHandle?: boolean;
 }
-const InputOutputItem = memo(
-    ({ label, description, type, optional, hasHandle = true }: InputOutputItemProps) => {
-        if (optional) {
-            // eslint-disable-next-line no-param-reassign
-            type = withoutNull(type);
-        }
 
-        const handleColors = getTypeAccentColors(type);
+const InputOutputItem = memo(({ type, item }: InputOutputItemProps) => {
+    if ('optional' in item && item.optional) {
+        // eslint-disable-next-line no-param-reassign
+        type = withoutNull(type);
+    }
 
-        return (
-            <ListItem my={2}>
-                <HStack>
+    const handleColors = getTypeAccentColors(type);
+
+    const isFileInput = 'kind' in item && item.kind === 'file';
+    const supportedFileTypes = isFileInput ? item.filetypes : [];
+    const isPrimaryInput = isFileInput && 'primaryInput' in item && item.primaryInput;
+
+    return (
+        <ListItem my={2}>
+            <HStack>
+                <Text
+                    fontWeight="bold"
+                    userSelect="text"
+                >
+                    {item.label}
+                </Text>
+                {'optional' in item && item.optional && (
+                    <TypeTag
+                        isOptional
+                        fontSize="small"
+                        height="auto"
+                        mt="-0.2rem"
+                        verticalAlign="middle"
+                    >
+                        optional
+                    </TypeTag>
+                )}
+                {item.hasHandle &&
+                    handleColors.map((color) => (
+                        <Box
+                            bgColor={color}
+                            borderRadius="100%"
+                            h="0.5rem"
+                            key={color}
+                            w="0.5rem"
+                        />
+                    ))}
+            </HStack>
+
+            <VStack
+                alignItems="start"
+                my={2}
+                w="full"
+            >
+                {item.description && (
+                    <ReactMarkdown components={docsMarkdown}>{item.description}</ReactMarkdown>
+                )}
+
+                {isFileInput && supportedFileTypes.length > 0 && (
                     <Text
-                        fontWeight="bold"
+                        fontSize="md"
                         userSelect="text"
                     >
-                        {label}
-                    </Text>
-                    {optional && (
-                        <TypeTag
-                            isOptional
-                            fontSize="small"
-                            height="auto"
-                            mt="-0.2rem"
-                            verticalAlign="middle"
-                        >
-                            optional
-                        </TypeTag>
-                    )}
-                    {hasHandle &&
-                        handleColors.map((color) => (
-                            <Box
-                                bgColor={color}
-                                borderRadius="100%"
-                                h="0.5rem"
-                                key={color}
-                                w="0.5rem"
-                            />
+                        Supported file types:
+                        {supportedFileTypes.map((fileType) => (
+                            <TypeTag
+                                fontSize="small"
+                                height="auto"
+                                mt="-0.2rem"
+                                verticalAlign="middle"
+                            >
+                                {fileType}
+                            </TypeTag>
                         ))}
-                </HStack>
-
-                {description && (
-                    <ReactMarkdown components={docsMarkdown}>{description}</ReactMarkdown>
+                    </Text>
                 )}
+
+                {isFileInput && isPrimaryInput && (
+                    <Text
+                        fontSize="md"
+                        userSelect="text"
+                    >
+                        This input is the primary input for its supported file types. This means
+                        that you can drag and drop supported files into chaiNNer, and it will create
+                        a node with this input filled in automatically.
+                    </Text>
+                )}
+
                 <Code userSelect="text">{prettyPrintType(type)}</Code>
-            </ListItem>
-        );
-    }
-);
+            </VStack>
+        </ListItem>
+    );
+});
 
 interface NodeInfoProps {
     schema: NodeSchema;
@@ -148,11 +185,8 @@ const SingleNodeInfo = memo(({ schema, accentColor, functionDefinition }: NodeIn
                         {inputs.map((input) => {
                             return (
                                 <InputOutputItem
-                                    description={input.description}
-                                    hasHandle={input.hasHandle}
+                                    item={input}
                                     key={input.id}
-                                    label={input.label}
-                                    optional={input.optional}
                                     type={
                                         functionDefinition?.inputDefaults.get(input.id) ??
                                         NeverType.instance
@@ -184,10 +218,8 @@ const SingleNodeInfo = memo(({ schema, accentColor, functionDefinition }: NodeIn
                         {outputs.map((output) => {
                             return (
                                 <InputOutputItem
-                                    description={output.description}
+                                    item={output}
                                     key={output.id}
-                                    label={output.label}
-                                    optional={false}
                                     type={
                                         functionDefinition?.outputDefaults.get(output.id) ??
                                         NeverType.instance

--- a/src/renderer/components/NodeDocumentation/docsMarkdown.tsx
+++ b/src/renderer/components/NodeDocumentation/docsMarkdown.tsx
@@ -12,7 +12,7 @@ const getDocsMarkdownComponents = (interactive: boolean): Components => {
         p: ({ children }) => {
             return (
                 <Text
-                    my={2}
+                    mb={1}
                     userSelect="text"
                 >
                     {children}

--- a/src/renderer/components/NodeDocumentation/docsMarkdown.tsx
+++ b/src/renderer/components/NodeDocumentation/docsMarkdown.tsx
@@ -10,14 +10,7 @@ import { SchemaLink } from './SchemaLink';
 const getDocsMarkdownComponents = (interactive: boolean): Components => {
     return {
         p: ({ children }) => {
-            return (
-                <Text
-                    // my={2}
-                    userSelect="text"
-                >
-                    {children}
-                </Text>
-            );
+            return <Text userSelect="text">{children}</Text>;
         },
         // eslint-disable-next-line react/prop-types
         code: memo(({ inline, className, children, ...props }) => {

--- a/src/renderer/components/NodeDocumentation/docsMarkdown.tsx
+++ b/src/renderer/components/NodeDocumentation/docsMarkdown.tsx
@@ -12,7 +12,7 @@ const getDocsMarkdownComponents = (interactive: boolean): Components => {
         p: ({ children }) => {
             return (
                 <Text
-                    my={2}
+                    // my={2}
                     userSelect="text"
                 >
                     {children}

--- a/src/renderer/components/NodeDocumentation/docsMarkdown.tsx
+++ b/src/renderer/components/NodeDocumentation/docsMarkdown.tsx
@@ -10,7 +10,14 @@ import { SchemaLink } from './SchemaLink';
 const getDocsMarkdownComponents = (interactive: boolean): Components => {
     return {
         p: ({ children }) => {
-            return <Text userSelect="text">{children}</Text>;
+            return (
+                <Text
+                    my={2}
+                    userSelect="text"
+                >
+                    {children}
+                </Text>
+            );
         },
         // eslint-disable-next-line react/prop-types
         code: memo(({ inline, className, children, ...props }) => {


### PR DESCRIPTION
- Displays supported filetypes using type tags instead of in the description. Also applies automatically now instead of needing to be done via the backend
- Indicates if an input is the primary input for its type, and lets the user know what that means.

I don't necessarily like having all those booleans in InputOutputItem, but we can maybe have some kind of doc component selector thing in the future if we need to add more of those for different input types.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/34788790/90acf3f4-7b87-4b72-aba8-78ca2bb43d33)
