### PR TITLE
Add some missing `readonly`s

### DIFF
--- a/src/renderer/contexts/BackendContext.tsx
+++ b/src/renderer/contexts/BackendContext.tsx
@@ -23,8 +23,8 @@ interface BackendContextState {
      *
      * Some categories might be empty.
      */
-    categories: Category[];
-    categoriesMissingNodes: string[];
+    categories: readonly Category[];
+    categoriesMissingNodes: readonly string[];
     functionDefinitions: Map<SchemaId, FunctionDefinition>;
     scope: Scope;
     restartingRef: Readonly<React.MutableRefObject<boolean>>;

--- a/src/renderer/hooks/usePaneNodeSearchMenu.tsx
+++ b/src/renderer/hooks/usePaneNodeSearchMenu.tsx
@@ -111,7 +111,7 @@ interface MenuProps {
     targets: ReadonlyMap<NodeSchema, ConnectionTarget>;
     schemata: readonly NodeSchema[];
     favorites: ReadonlySet<SchemaId>;
-    categories: Category[];
+    categories: readonly Category[];
 }
 
 const Menu = memo(({ onSelect, targets, schemata, favorites, categories }: MenuProps) => {


### PR DESCRIPTION
While working on #1930, I accidentally sorted `categories` in-place (which caused a bug), and realized that the type was such that it wasn't considered an error. So, this fixes that.

There's probably more `readonly`s that are missing, but this is a good start.