### PR TITLE
Improved Upscaling Node Docs + Input Hints

### DIFF
--- a/backend/src/nodes/base_input.py
+++ b/backend/src/nodes/base_input.py
@@ -89,6 +89,7 @@ class BaseInput:
 
         # Optional documentation
         self.description: str | None = None
+        self.hint: bool = False
 
     # This is the method that should be created by each input
     def enforce(self, value: object):
@@ -136,14 +137,16 @@ class BaseInput:
             "optional": self.optional,
             "hasHandle": self.has_handle,
             "description": self.description,
+            "hint": self.hint,
         }
 
     def with_id(self, input_id: InputId | int):
         self.id = InputId(input_id)
         return self
 
-    def with_docs(self, *description: str):
+    def with_docs(self, *description: str, hint=False):
         self.description = "\n\n".join(description)
+        self.hint = hint
         return self
 
     def make_optional(self):

--- a/backend/src/packages/chaiNNer_ncnn/ncnn/processing/upscale_image.py
+++ b/backend/src/packages/chaiNNer_ncnn/ncnn/processing/upscale_image.py
@@ -125,7 +125,14 @@ def upscale_impl(
     inputs=[
         ImageInput().with_id(1),
         NcnnModelInput().with_id(0),
-        TileSizeDropdown().with_id(2),
+        TileSizeDropdown()
+        .with_id(2)
+        .with_docs(
+            "Tiled upscaling is used to allow large images to be upscaled without hitting memory limits.",
+            "This works by splitting the image into tiles (with overlap), upscaling each tile individually, and seamlessly recombining them.",
+            "Generally it's recommended to use the largest tile size possible for best performance (with the ideal scenario being no tiling at all), but depending on the model and image size, this may not be possible.",
+            "If you are having issues with the automatic mode, you can manually select a tile size. On certain machines, a very small tile size such as 256 or 128 might be required for it to work at all.",
+        ),
     ],
     outputs=[
         ImageOutput(image_type="""convenientUpscale(Input0, Input1)"""),

--- a/backend/src/packages/chaiNNer_onnx/onnx/processing/upscale_image.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/processing/upscale_image.py
@@ -50,7 +50,14 @@ def upscale(
     inputs=[
         ImageInput().with_id(1),
         OnnxGenericModelInput().with_id(0),
-        TileSizeDropdown(estimate=False).with_id(2),
+        TileSizeDropdown(estimate=False)
+        .with_id(2)
+        .with_docs(
+            "Tiled upscaling is used to allow large images to be upscaled without hitting memory limits.",
+            "This works by splitting the image into tiles (with overlap), upscaling each tile individually, and seamlessly recombining them.",
+            "Generally it's recommended to use the largest tile size possible for best performance, but depending on the model and image size, this may not be possible.",
+            "ONNX upscaling does not support an automatic mode, meaning you may need to manually select a tile size for it to work.",
+        ),
     ],
     outputs=[ImageOutput("Upscaled Image")],
     name="Upscale Image",

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/io/load_model.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/io/load_model.py
@@ -21,12 +21,11 @@ from .. import io_group
 @io_group.register(
     schema_id="chainner:pytorch:load_model",
     name="Load Model",
-    description="""Load PyTorch state dict (.pth) or TorchScript (.pt) file
-            into an auto-detected supported model architecture.
-            Supports most variations of the RRDB architecture
-            (ESRGAN, Real-ESRGAN, RealSR, BSRGAN, SPSR),
-            Real-ESRGAN's SRVGG architecture, Swift-SRGAN, SwinIR, Swin2SR, HAT, and Omni-SR.
-            Links to the models can be found in chaiNNer's README.""",
+    description=[
+        "Load PyTorch state dict (.pth) or TorchScript (.pt) file into an auto-detected supported model architecture.",
+        "Supports most variations of the RRDB architecture (ESRGAN, Real-ESRGAN, RealSR, BSRGAN, SPSR), Real-ESRGAN's SRVGG architecture, Swift-SRGAN, SwinIR, Swin2SR, HAT, and Omni-SR.",
+        "Links to the official models can be found in chaiNNer's README, and also alongside community-trained models on [OpenModelDB](https://openmodeldb.info/).",
+    ],
     icon="PyTorch",
     inputs=[PthFileInput(primary_input=True)],
     outputs=[

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
@@ -77,7 +77,14 @@ def upscale(
     inputs=[
         ImageInput().with_id(1),
         SrModelInput().with_id(0),
-        TileSizeDropdown().with_id(2),
+        TileSizeDropdown()
+        .with_id(2)
+        .with_docs(
+            "Tiled upscaling is used to allow large images to be upscaled without hitting memory limits.",
+            "This works by splitting the image into tiles (with overlap), upscaling each tile individually, and seamlessly recombining them.",
+            "Generally it's recommended to use the largest tile size possible for best performance (with the ideal scenario being no tiling at all), but depending on the model and image size, this may not be possible.",
+            "If you are having issues with the automatic mode, you can manually select a tile size. Sometimes, a manually selected tile size may be faster than what the automatic mode picks.",
+        ),
     ],
     outputs=[
         ImageOutput(

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
@@ -84,6 +84,7 @@ def upscale(
             "This works by splitting the image into tiles (with overlap), upscaling each tile individually, and seamlessly recombining them.",
             "Generally it's recommended to use the largest tile size possible for best performance (with the ideal scenario being no tiling at all), but depending on the model and image size, this may not be possible.",
             "If you are having issues with the automatic mode, you can manually select a tile size. Sometimes, a manually selected tile size may be faster than what the automatic mode picks.",
+            hint=True,
         ),
     ],
     outputs=[

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -53,6 +53,7 @@ interface InputBase {
     readonly optional: boolean;
     readonly hasHandle: boolean;
     readonly description?: string;
+    readonly hint: boolean;
 }
 export interface InputOption {
     option: string;

--- a/src/renderer/components/inputs/GenericInput.tsx
+++ b/src/renderer/components/inputs/GenericInput.tsx
@@ -1,6 +1,8 @@
-import { InfoIcon } from '@chakra-ui/icons';
-import { Box, Center, HStack, Text, Tooltip } from '@chakra-ui/react';
+import { Box, Center, HStack, Icon, Text, Tooltip } from '@chakra-ui/react';
 import { memo } from 'react';
+import { BsQuestionCircle } from 'react-icons/bs';
+import ReactMarkdown from 'react-markdown';
+import { tooltipDocsMarkdown } from '../NodeDocumentation/docsMarkdown';
 import { TypeTags } from '../TypeTag';
 import { WithoutLabel } from './InputContainer';
 import { InputProps } from './props';
@@ -15,8 +17,16 @@ export const GenericInput = memo(({ input, definitionType }: InputProps<'generic
                 flexDirection="row"
             >
                 <Tooltip
+                    hasArrow
                     borderRadius={8}
-                    label={hint ? description : undefined}
+                    label={
+                        hint ? (
+                            <ReactMarkdown components={tooltipDocsMarkdown}>
+                                {description ?? ''}
+                            </ReactMarkdown>
+                        ) : undefined
+                    }
+                    openDelay={500}
                     px={2}
                     py={1}
                 >
@@ -32,7 +42,8 @@ export const GenericInput = memo(({ input, definitionType }: InputProps<'generic
                                 m={0}
                                 p={0}
                             >
-                                <InfoIcon
+                                <Icon
+                                    as={BsQuestionCircle}
                                     boxSize={3}
                                     ml={1}
                                 />

--- a/src/renderer/components/inputs/GenericInput.tsx
+++ b/src/renderer/components/inputs/GenericInput.tsx
@@ -1,11 +1,12 @@
-import { Box, Center, Text } from '@chakra-ui/react';
+import { InfoIcon } from '@chakra-ui/icons';
+import { Box, Center, HStack, Text, Tooltip } from '@chakra-ui/react';
 import { memo } from 'react';
 import { TypeTags } from '../TypeTag';
 import { WithoutLabel } from './InputContainer';
 import { InputProps } from './props';
 
 export const GenericInput = memo(({ input, definitionType }: InputProps<'generic'>) => {
-    const { label, optional } = input;
+    const { label, optional, hint, description } = input;
 
     return (
         <WithoutLabel>
@@ -13,13 +14,38 @@ export const GenericInput = memo(({ input, definitionType }: InputProps<'generic
                 display="flex"
                 flexDirection="row"
             >
-                <Text>{label}</Text>
-                <Center>
-                    <TypeTags
-                        isOptional={optional}
-                        type={definitionType}
-                    />
-                </Center>
+                <Tooltip
+                    borderRadius={8}
+                    label={hint ? description : undefined}
+                    px={2}
+                    py={1}
+                >
+                    <HStack
+                        m={0}
+                        p={0}
+                        spacing={0}
+                    >
+                        <Text>{label}</Text>
+                        {hint && (
+                            <Center
+                                h="auto"
+                                m={0}
+                                p={0}
+                            >
+                                <InfoIcon
+                                    boxSize={3}
+                                    ml={1}
+                                />
+                            </Center>
+                        )}
+                        <Center>
+                            <TypeTags
+                                isOptional={optional}
+                                type={definitionType}
+                            />
+                        </Center>
+                    </HStack>
+                </Tooltip>
             </Box>
         </WithoutLabel>
     );

--- a/src/renderer/components/inputs/GenericInput.tsx
+++ b/src/renderer/components/inputs/GenericInput.tsx
@@ -1,6 +1,6 @@
-import { Box, Center, HStack, Icon, Text, Tooltip } from '@chakra-ui/react';
+import { QuestionIcon } from '@chakra-ui/icons';
+import { Box, Center, HStack, Text, Tooltip } from '@chakra-ui/react';
 import { memo } from 'react';
-import { BsQuestionCircle } from 'react-icons/bs';
 import ReactMarkdown from 'react-markdown';
 import { tooltipDocsMarkdown } from '../NodeDocumentation/docsMarkdown';
 import { TypeTags } from '../TypeTag';
@@ -42,8 +42,7 @@ export const GenericInput = memo(({ input, definitionType }: InputProps<'generic
                                 m={0}
                                 p={0}
                             >
-                                <Icon
-                                    as={BsQuestionCircle}
+                                <QuestionIcon
                                     boxSize={3}
                                     ml={1}
                                 />

--- a/src/renderer/components/inputs/InputContainer.tsx
+++ b/src/renderer/components/inputs/InputContainer.tsx
@@ -174,7 +174,7 @@ export const WithLabel = memo(
                         <HStack
                             m={0}
                             p={0}
-                            spacing={1}
+                            spacing={0}
                         >
                             <Text
                                 fontSize="xs"
@@ -192,10 +192,16 @@ export const WithLabel = memo(
                                 </Center>
                             )}
                             {hint && (
-                                <InfoIcon
-                                    boxSize={2}
-                                    // ml={1}
-                                />
+                                <Center
+                                    h="auto"
+                                    m={0}
+                                    p={0}
+                                >
+                                    <InfoIcon
+                                        boxSize={2}
+                                        ml={1}
+                                    />
+                                </Center>
                             )}
                         </HStack>
                     </Tooltip>

--- a/src/renderer/components/inputs/InputContainer.tsx
+++ b/src/renderer/components/inputs/InputContainer.tsx
@@ -144,8 +144,8 @@ interface WithLabelProps {
     input: {
         readonly label: string;
         readonly optional: boolean;
-        readonly hint: boolean;
-        readonly description: string;
+        readonly hint?: boolean;
+        readonly description?: string;
     };
 }
 

--- a/src/renderer/components/inputs/InputContainer.tsx
+++ b/src/renderer/components/inputs/InputContainer.tsx
@@ -1,5 +1,5 @@
 import { Type } from '@chainner/navi';
-import { Box, Center, HStack, Text, Tooltip, Icon } from '@chakra-ui/react';
+import { Box, Center, HStack, Icon, Text, Tooltip } from '@chakra-ui/react';
 import React, { memo, useCallback, useMemo } from 'react';
 import { BsQuestionCircle } from 'react-icons/bs';
 import ReactMarkdown from 'react-markdown';

--- a/src/renderer/components/inputs/InputContainer.tsx
+++ b/src/renderer/components/inputs/InputContainer.tsx
@@ -1,7 +1,8 @@
 import { Type } from '@chainner/navi';
-import { InfoIcon } from '@chakra-ui/icons';
-import { Box, Center, HStack, Text, Tooltip } from '@chakra-ui/react';
+import { Box, Center, HStack, Text, Tooltip, Icon } from '@chakra-ui/react';
 import React, { memo, useCallback, useMemo } from 'react';
+import { BsQuestionCircle } from 'react-icons/bs';
+import ReactMarkdown from 'react-markdown';
 import { Connection, Node, useReactFlow } from 'reactflow';
 import { useContext } from 'use-context-selector';
 import { InputId, NodeData } from '../../../common/common-types';
@@ -11,6 +12,7 @@ import { BackendContext } from '../../contexts/BackendContext';
 import { GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { defaultColor, getTypeAccentColors } from '../../helpers/accentColors';
 import { Handle } from '../Handle';
+import { tooltipDocsMarkdown } from '../NodeDocumentation/docsMarkdown';
 import { TypeTag } from '../TypeTag';
 
 export interface HandleWrapperProps {
@@ -166,8 +168,16 @@ export const WithLabel = memo(
                     verticalAlign="middle"
                 >
                     <Tooltip
+                        hasArrow
                         borderRadius={8}
-                        label={hint ? description : undefined}
+                        label={
+                            hint ? (
+                                <ReactMarkdown components={tooltipDocsMarkdown}>
+                                    {description ?? ''}
+                                </ReactMarkdown>
+                            ) : undefined
+                        }
+                        openDelay={500}
                         px={2}
                         py={1}
                     >
@@ -189,7 +199,8 @@ export const WithLabel = memo(
                                     m={0}
                                     p={0}
                                 >
-                                    <InfoIcon
+                                    <Icon
+                                        as={BsQuestionCircle}
                                         boxSize={2}
                                         ml={1}
                                     />

--- a/src/renderer/components/inputs/InputContainer.tsx
+++ b/src/renderer/components/inputs/InputContainer.tsx
@@ -1,7 +1,7 @@
 import { Type } from '@chainner/navi';
-import { Box, Center, HStack, Icon, Text, Tooltip } from '@chakra-ui/react';
+import { QuestionIcon } from '@chakra-ui/icons';
+import { Box, Center, HStack, Text, Tooltip } from '@chakra-ui/react';
 import React, { memo, useCallback, useMemo } from 'react';
-import { BsQuestionCircle } from 'react-icons/bs';
 import ReactMarkdown from 'react-markdown';
 import { Connection, Node, useReactFlow } from 'reactflow';
 import { useContext } from 'use-context-selector';
@@ -199,9 +199,8 @@ export const WithLabel = memo(
                                     m={0}
                                     p={0}
                                 >
-                                    <Icon
-                                        as={BsQuestionCircle}
-                                        boxSize={2}
+                                    <QuestionIcon
+                                        boxSize={3}
                                         ml={1}
                                     />
                                 </Center>

--- a/src/renderer/components/inputs/InputContainer.tsx
+++ b/src/renderer/components/inputs/InputContainer.tsx
@@ -183,14 +183,6 @@ export const WithLabel = memo(
                             >
                                 {label}
                             </Text>
-                            {optional && (
-                                <Center
-                                    h="1rem"
-                                    verticalAlign="middle"
-                                >
-                                    <TypeTag isOptional>optional</TypeTag>
-                                </Center>
-                            )}
                             {hint && (
                                 <Center
                                     h="auto"
@@ -201,6 +193,14 @@ export const WithLabel = memo(
                                         boxSize={2}
                                         ml={1}
                                     />
+                                </Center>
+                            )}
+                            {optional && (
+                                <Center
+                                    h="1rem"
+                                    verticalAlign="middle"
+                                >
+                                    <TypeTag isOptional>optional</TypeTag>
                                 </Center>
                             )}
                         </HStack>

--- a/src/renderer/components/inputs/InputContainer.tsx
+++ b/src/renderer/components/inputs/InputContainer.tsx
@@ -1,5 +1,6 @@
 import { Type } from '@chainner/navi';
-import { Box, Center, HStack, Text } from '@chakra-ui/react';
+import { InfoIcon } from '@chakra-ui/icons';
+import { Box, Center, HStack, Text, Tooltip } from '@chakra-ui/react';
 import React, { memo, useCallback, useMemo } from 'react';
 import { Connection, Node, useReactFlow } from 'reactflow';
 import { useContext } from 'use-context-selector';
@@ -143,11 +144,16 @@ interface WithLabelProps {
     input: {
         readonly label: string;
         readonly optional: boolean;
+        readonly hint: boolean;
+        readonly description: string;
     };
 }
 
 export const WithLabel = memo(
-    ({ input: { label, optional }, children }: React.PropsWithChildren<WithLabelProps>) => {
+    ({
+        input: { label, optional, hint, description },
+        children,
+    }: React.PropsWithChildren<WithLabelProps>) => {
         return (
             <Box
                 className="with-label"
@@ -159,21 +165,40 @@ export const WithLabel = memo(
                     py={0.5}
                     verticalAlign="middle"
                 >
-                    <Text
-                        fontSize="xs"
-                        lineHeight="0.9rem"
-                        textAlign="center"
+                    <Tooltip
+                        borderRadius={8}
+                        label={hint ? description : undefined}
+                        px={2}
+                        py={1}
                     >
-                        {label}
-                    </Text>
-                    {optional && (
-                        <Center
-                            h="1rem"
-                            verticalAlign="middle"
+                        <HStack
+                            m={0}
+                            p={0}
+                            spacing={1}
                         >
-                            <TypeTag isOptional>optional</TypeTag>
-                        </Center>
-                    )}
+                            <Text
+                                fontSize="xs"
+                                lineHeight="0.9rem"
+                                textAlign="center"
+                            >
+                                {label}
+                            </Text>
+                            {optional && (
+                                <Center
+                                    h="1rem"
+                                    verticalAlign="middle"
+                                >
+                                    <TypeTag isOptional>optional</TypeTag>
+                                </Center>
+                            )}
+                            {hint && (
+                                <InfoIcon
+                                    boxSize={2}
+                                    // ml={1}
+                                />
+                            )}
+                        </HStack>
+                    </Tooltip>
                 </Center>
                 <Box pb={1}>{children}</Box>
             </Box>


### PR DESCRIPTION
- Upscaling node doc improvements
- The hint feature discussed on discord. It applies to both labeled and generic inputs, though I really only ever see it being useful for labeled ones, particularly dropdowns,

![image](https://github.com/chaiNNer-org/chaiNNer/assets/34788790/651fb4e4-cc26-4f88-ae60-e9bb301c576c)

![image](https://github.com/chaiNNer-org/chaiNNer/assets/34788790/baf47153-c76e-4539-b644-0289cea285fa)
