### PR TITLE
Update splash.ts -disable alwaysOnTop

### DIFF
--- a/src/main/gui/splash.ts
+++ b/src/main/gui/splash.ts
@@ -21,7 +21,7 @@ export const addSplashScreen = (monitor: ProgressMonitor) => {
         minimizable: true,
         maximizable: false,
         closable: false,
-        alwaysOnTop: true,
+        alwaysOnTop: false,
         titleBarStyle: 'hidden',
         transparent: true,
         roundedCorners: true,


### PR DESCRIPTION
Disable splash screen's alwaysOnTop property. 
Splash screen blocks user from doing anything else while starting up.  
Lasts up to 40 seconds on HDD.