### PR TITLE
Remove upscale wiki menu link

### DIFF
--- a/src/main/gui/menu.ts
+++ b/src/main/gui/menu.ts
@@ -236,12 +236,6 @@ export const setMainMenu = ({ mainWindow, menuData, enabled = false }: MainMenuA
                         await shell.openPath(getLogsFolder());
                     },
                 },
-                {
-                    label: 'Get Models (Upscale Wiki)',
-                    click: async () => {
-                        await shell.openExternal('https://upscale.wiki/wiki/Model_Database');
-                    },
-                },
                 { type: 'separator' },
                 {
                     label: 'About chaiNNer',


### PR DESCRIPTION
I don't think this is needed anymore, since with #1937 it is linked in the upscale node documentation along with OMDB