### PR TITLE
Better computed alpha

### DIFF
--- a/backend/src/nodes/impl/upscale/convenient_upscale.py
+++ b/backend/src/nodes/impl/upscale/convenient_upscale.py
@@ -65,7 +65,13 @@ def convenient_upscale(
             upscale(as_target_channels(white, model_in_nc, True)), 3, True
         )
 
-        alpha = 1 - np.mean(white_up - black_up, axis=2)  # type: ignore
+        # Interpolate between the alpha values to get a less noisy alpha
+        alpha_candidates = 1 - (white_up - black_up)
+        alpha_min = np.min(alpha_candidates, axis=2)
+        alpha_max = np.max(alpha_candidates, axis=2)
+        alpha_mean = np.mean(alpha_candidates, axis=2)
+        alpha = alpha_max * alpha_mean + alpha_min * (1 - alpha_mean)
+
         return np.dstack((black_up, alpha))
 
     return as_target_channels(

--- a/backend/src/nodes/impl/upscale/convenient_upscale.py
+++ b/backend/src/nodes/impl/upscale/convenient_upscale.py
@@ -66,7 +66,7 @@ def convenient_upscale(
         )
 
         # Interpolate between the alpha values to get a less noisy alpha
-        alpha_candidates = 1 - (white_up - black_up)
+        alpha_candidates = 1 - (white_up - black_up)  #  type: ignore
         alpha_min = np.min(alpha_candidates, axis=2)
         alpha_max = np.max(alpha_candidates, axis=2)
         alpha_mean = np.mean(alpha_candidates, axis=2)

--- a/backend/src/nodes/impl/upscale/convenient_upscale.py
+++ b/backend/src/nodes/impl/upscale/convenient_upscale.py
@@ -65,7 +65,7 @@ def convenient_upscale(
             upscale(as_target_channels(white, model_in_nc, True)), 3, True
         )
 
-        # Interpolate between the alpha values to get a less noisy alpha
+        # Interpolate between the alpha values to get a more defined alpha
         alpha_candidates = 1 - (white_up - black_up)  #  type: ignore
         alpha_min = np.min(alpha_candidates, axis=2)
         alpha_max = np.max(alpha_candidates, axis=2)


### PR DESCRIPTION
This PR makes a minor improvement to `convenient_upscale` (and therefor all upscaling nodes).

When computing alpha using the black and white image upscales, we get 3 channels that all represent the computed alpha. We previously simply took the mean of those 3 and called it a day, but we can do better. By using the mean to interpolate between the min and max of those 3 channels, we get a lot better results near 0 and 1.

Why? If we model AI upscaling as simply adding noise to the true high-res alpha, then it makes sense that the mean of 3 noisy versions of the same image will never give us true 0 or 1. The mean will always be slightly above 0 and slightly below 1. By using the mean to interpolate between the min and max, we can get much closer to true 0 and 1.
However, the tradeoff is that we also get more noise. Since fluctuations in min and max will now affect the output a lot, we will get more noise in the final alpha. This noise is of course bounded by the amount of noise the upscaler produces, so it's not too bad in practice.

### Examples

Here are some non-cherry-picked examples. The images were DDS compressed and contained either binary alpha or full alpha with clearly defined edges. They were upscaled 4x using either UltraSharp or AnimeSharp. The output alpha has been multiplied by 16x to make the noise more visible. I also zoomed in 2x.

(Open the images in a new tab and switch between them to see the differences.)

| Old (np.mean) | New |
| --- | --- |
| ![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/1b941bd2-f56d-4413-a5f7-f85dd6c80f59) | ![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/55e00a37-b4a1-43cf-a1c0-21b93a5484f5) |
| ![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/f6feb5d9-7250-4a6d-b35b-1fd80e16febe) | ![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/d8340043-9f44-4ac5-81ef-e0c31d0df6e0) |
| ![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/f8d748ce-6966-4a92-9c00-645a16e96d8e) | ![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/43ed7916-3079-4206-ade2-2398ffe6591f) |

As we can see, the new method produces generally sharper results with a lot less haloing around edges.