### PR TITLE
Add trigger for site build to release workflow

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -1,0 +1,21 @@
+name: Build chaiNNer.app
+
+on:
+    release:
+        types:
+            - published
+            - edited
+
+    workflow_dispatch:
+
+jobs:
+    build-site:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Trigger chaiNNer.app build + deploy
+              uses: fjogeleit/http-request-action@v1
+              with:
+                  url: 'https://api.github.com/repos/chaiNNer-org/chaiNNer-org.github.io/dispatches'
+                  method: 'POST'
+                  customHeaders: '{"Accept": "application/vnd.github+json", "Authorization": "token ${{ secrets.GITHUB_TOKEN }}"}'
+                  data: '{"event_type": "webhook"}'

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -21,5 +21,5 @@ jobs:
                   url: 'https://api.github.com/repos/chaiNNer-org/chaiNNer-org.github.io/dispatches'
                   method: 'POST'
                   customHeaders: '{"Accept": "application/vnd.github+json"}'
-                  bearerToken: ${{ secrets.GITHUB_TOKEN }}
+                  bearerToken: ${{ secrets.GH_TEST_TOKEN }}
                   data: '{"event_type": "webhook"}'

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -5,9 +5,6 @@ on:
         types:
             - published
             - edited
-    push:
-        branches:
-            - site-webhook
 
     workflow_dispatch:
 

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -5,6 +5,9 @@ on:
         types:
             - published
             - edited
+    push:
+        branches:
+            - site-webhook
 
     workflow_dispatch:
 

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -20,5 +20,6 @@ jobs:
               with:
                   url: 'https://api.github.com/repos/chaiNNer-org/chaiNNer-org.github.io/dispatches'
                   method: 'POST'
-                  customHeaders: '{"Accept": "application/vnd.github+json", "Authorization": "token ${{ secrets.GITHUB_TOKEN }}"}'
+                  customHeaders: '{"Accept": "application/vnd.github+json"}'
+                  bearerToken: ${{ secrets.GITHUB_TOKEN }}
                   data: '{"event_type": "webhook"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,3 +37,15 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: npm run publish
+    # Trigger POST request to build site
+    build-site:
+        needs: release
+        runs-on: ubuntu-latest
+        steps:
+            - name: Trigger chaiNNer.app build + deploy
+              uses: fjogeleit/http-request-action@v1
+              with:
+                  url: 'https://api.github.com/repos/chaiNNer-org/chaiNNer-org.github.io/dispatches'
+                  method: 'POST'
+                  customHeaders: '{"Accept": "application/vnd.github+json", "Authorization": "token ${{ secrets.GITHUB_TOKEN }}"}'
+                  data: '{"event_type": "webhook"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,15 +37,3 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: npm run publish
-    # Trigger POST request to build site
-    build-site:
-        needs: release
-        runs-on: ubuntu-latest
-        steps:
-            - name: Trigger chaiNNer.app build + deploy
-              uses: fjogeleit/http-request-action@v1
-              with:
-                  url: 'https://api.github.com/repos/chaiNNer-org/chaiNNer-org.github.io/dispatches'
-                  method: 'POST'
-                  customHeaders: '{"Accept": "application/vnd.github+json", "Authorization": "token ${{ secrets.GITHUB_TOKEN }}"}'
-                  data: '{"event_type": "webhook"}'


### PR DESCRIPTION
This for sure works. The issue is I had to use a personal token secret rather than the default GH token since that one is repo-scoped. Should be fine though.