### PR TITLE
Improve Doc Node Example Layout

### DIFF
--- a/src/renderer/components/NodeDocumentation/NodeDocs.tsx
+++ b/src/renderer/components/NodeDocumentation/NodeDocs.tsx
@@ -1,6 +1,7 @@
 import { NeverType, Type } from '@chainner/navi';
 import {
     Box,
+    Center,
     Code,
     Divider,
     Flex,
@@ -331,15 +332,15 @@ export const NodeDocs = memo(() => {
 
     const schema = schemata.schemata;
     const selectedSchema = schemata.get(selectedSchemaId ?? schema[0].schemaId);
-    const selectedFunctionDefinition = functionDefinitions.get(
-        selectedSchemaId ?? schema[0].schemaId
-    );
+
     const selectedAccentColor = getCategoryAccentColor(categories, selectedSchema.category);
 
     const [isLargerThan1200] = useMediaQuery('(min-width: 1200px)');
 
-    const hasIteratorHelperNodes =
-        selectedSchema.defaultNodes && selectedSchema.defaultNodes.length > 0;
+    const nodeDocsToShow = [
+        selectedSchema,
+        ...(selectedSchema.defaultNodes?.map((n) => schemata.get(n.schemaId)) ?? []),
+    ];
 
     return (
         <Box
@@ -348,9 +349,7 @@ export const NodeDocs = memo(() => {
             w="full"
         >
             <Box w="full">
-                <Flex
-                    direction={isLargerThan1200 ? 'row' : 'column'}
-                    gap={4}
+                <Box
                     left={0}
                     maxH="full"
                     overflowY="scroll"
@@ -368,91 +367,44 @@ export const NodeDocs = memo(() => {
                         textAlign="left"
                         w="full"
                     >
-                        <HStack>
-                            <SingleNodeInfo
-                                accentColor={selectedAccentColor}
-                                functionDefinition={selectedFunctionDefinition}
-                                schema={selectedSchema}
-                            />
-                            <Box
-                                h="full"
-                                position="relative"
-                            >
-                                <Box
-                                    h="full"
-                                    mr={6}
-                                    position="relative"
-                                    verticalAlign="top"
+                        {nodeDocsToShow.map((nodeSchema) => {
+                            const nodeFunctionDefinition = functionDefinitions.get(
+                                nodeSchema.schemaId
+                            );
+                            return (
+                                <Flex
+                                    direction={isLargerThan1200 ? 'row' : 'column'}
+                                    gap={4}
                                 >
-                                    <NodeExample
+                                    <SingleNodeInfo
                                         accentColor={selectedAccentColor}
-                                        selectedSchema={selectedSchema}
+                                        functionDefinition={nodeFunctionDefinition}
+                                        key={nodeSchema.schemaId}
+                                        schema={nodeSchema}
                                     />
-                                </Box>
-                            </Box>
-                        </HStack>
-                        {hasIteratorHelperNodes &&
-                            selectedSchema.defaultNodes.map((defaultNode) => {
-                                const nodeSchema = schemata.get(defaultNode.schemaId);
-                                const nodeFunctionDefinition = functionDefinitions.get(
-                                    defaultNode.schemaId
-                                );
-                                return (
-                                    <HStack>
-                                        <SingleNodeInfo
-                                            accentColor={selectedAccentColor}
-                                            functionDefinition={nodeFunctionDefinition}
-                                            key={defaultNode.schemaId}
-                                            schema={nodeSchema}
-                                        />
+                                    <Center
+                                        h="full"
+                                        position="relative"
+                                        verticalAlign="top"
+                                    >
                                         <Box
-                                            h="full"
+                                            maxW="fit-content"
+                                            mr={6}
                                             position="relative"
+                                            w="auto"
                                         >
-                                            <Box
-                                                h="full"
-                                                mr={6}
-                                                position="relative"
-                                                verticalAlign="top"
-                                            >
-                                                <NodeExample
-                                                    accentColor={selectedAccentColor}
-                                                    key={defaultNode.schemaId}
-                                                    selectedSchema={nodeSchema}
-                                                />
-                                            </Box>
+                                            <NodeExample
+                                                accentColor={selectedAccentColor}
+                                                key={nodeSchema.schemaId}
+                                                selectedSchema={nodeSchema}
+                                            />
                                         </Box>
-                                    </HStack>
-                                );
-                            })}
+                                    </Center>
+                                </Flex>
+                            );
+                        })}
                     </VStack>
-                    {/* <Box
-                        h="full"
-                        position="relative"
-                    >
-                        <VStack
-                            alignItems="left"
-                            mr={6}
-                            position="relative"
-                        >
-                            <NodeExample
-                                accentColor={selectedAccentColor}
-                                selectedSchema={selectedSchema}
-                            />
-                            {hasIteratorHelperNodes &&
-                                selectedSchema.defaultNodes.map((defaultNode) => {
-                                    const nodeSchema = schemata.get(defaultNode.schemaId);
-                                    return (
-                                        <NodeExample
-                                            accentColor={selectedAccentColor}
-                                            key={defaultNode.schemaId}
-                                            selectedSchema={nodeSchema}
-                                        />
-                                    );
-                                })}
-                        </VStack>
-                    </Box> */}
-                </Flex>
+                </Box>
             </Box>
         </Box>
     );

--- a/src/renderer/components/NodeDocumentation/NodeDocs.tsx
+++ b/src/renderer/components/NodeDocumentation/NodeDocs.tsx
@@ -368,11 +368,29 @@ export const NodeDocs = memo(() => {
                         textAlign="left"
                         w="full"
                     >
-                        <SingleNodeInfo
-                            accentColor={selectedAccentColor}
-                            functionDefinition={selectedFunctionDefinition}
-                            schema={selectedSchema}
-                        />
+                        <HStack>
+                            <SingleNodeInfo
+                                accentColor={selectedAccentColor}
+                                functionDefinition={selectedFunctionDefinition}
+                                schema={selectedSchema}
+                            />
+                            <Box
+                                h="full"
+                                position="relative"
+                            >
+                                <Box
+                                    h="full"
+                                    mr={6}
+                                    position="relative"
+                                    verticalAlign="top"
+                                >
+                                    <NodeExample
+                                        accentColor={selectedAccentColor}
+                                        selectedSchema={selectedSchema}
+                                    />
+                                </Box>
+                            </Box>
+                        </HStack>
                         {hasIteratorHelperNodes &&
                             selectedSchema.defaultNodes.map((defaultNode) => {
                                 const nodeSchema = schemata.get(defaultNode.schemaId);
@@ -380,16 +398,35 @@ export const NodeDocs = memo(() => {
                                     defaultNode.schemaId
                                 );
                                 return (
-                                    <SingleNodeInfo
-                                        accentColor={selectedAccentColor}
-                                        functionDefinition={nodeFunctionDefinition}
-                                        key={defaultNode.schemaId}
-                                        schema={nodeSchema}
-                                    />
+                                    <HStack>
+                                        <SingleNodeInfo
+                                            accentColor={selectedAccentColor}
+                                            functionDefinition={nodeFunctionDefinition}
+                                            key={defaultNode.schemaId}
+                                            schema={nodeSchema}
+                                        />
+                                        <Box
+                                            h="full"
+                                            position="relative"
+                                        >
+                                            <Box
+                                                h="full"
+                                                mr={6}
+                                                position="relative"
+                                                verticalAlign="top"
+                                            >
+                                                <NodeExample
+                                                    accentColor={selectedAccentColor}
+                                                    key={defaultNode.schemaId}
+                                                    selectedSchema={nodeSchema}
+                                                />
+                                            </Box>
+                                        </Box>
+                                    </HStack>
                                 );
                             })}
                     </VStack>
-                    <Box
+                    {/* <Box
                         h="full"
                         position="relative"
                     >
@@ -414,7 +451,7 @@ export const NodeDocs = memo(() => {
                                     );
                                 })}
                         </VStack>
-                    </Box>
+                    </Box> */}
                 </Flex>
             </Box>
         </Box>

--- a/src/renderer/components/NodeDocumentation/NodeExample.tsx
+++ b/src/renderer/components/NodeDocumentation/NodeExample.tsx
@@ -104,7 +104,6 @@ export const NodeExample = memo(({ accentColor, selectedSchema }: NodeExamplePro
         <Center
             key={selectedSchema.schemaId}
             pointerEvents="none"
-            w="auto"
         >
             <Center
                 bg="var(--node-bg-color)"
@@ -115,7 +114,6 @@ export const NodeExample = memo(({ accentColor, selectedSchema }: NodeExamplePro
                 minWidth="240px"
                 overflow="hidden"
                 transition="0.15s ease-in-out"
-                w="full"
             >
                 <VStack
                     spacing={0}


### PR DESCRIPTION
- Fixes the node width issue mentioned on discord
- Aligns node examples with their docs
- Cleaner code for the iterator helper node doc stuff

![image](https://github.com/chaiNNer-org/chaiNNer/assets/34788790/b58922d6-0ddb-42ea-944b-07f58a2e56b2)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/34788790/1706aa19-c6d5-48bd-8f98-b0a5270ad293)
