### PR TITLE
Highlight node documentation search query terms

### DIFF
--- a/src/renderer/components/NodeDocumentation/Highlighter.tsx
+++ b/src/renderer/components/NodeDocumentation/Highlighter.tsx
@@ -1,0 +1,39 @@
+import { Highlight } from '@chakra-ui/react';
+import { Fragment, PropsWithChildren, memo } from 'react';
+
+interface HighlighterProps {
+    searchTerms: readonly string[];
+}
+
+const recursivelyMarkChildren = (
+    children: React.ReactNode | string[],
+    searchTerms: readonly string[]
+): React.ReactNode | string[] => {
+    if (Array.isArray(children)) {
+        return children.map((child, i) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <Fragment key={i}>{recursivelyMarkChildren(child, searchTerms)}</Fragment>
+        ));
+    }
+
+    if (typeof children === 'string') {
+        return (
+            <Highlight
+                query={[...searchTerms]}
+                styles={{
+                    backgroundColor: 'yellow.300',
+                }}
+            >
+                {children}
+            </Highlight>
+        );
+    }
+
+    return children;
+};
+
+export const Highlighter = memo(
+    ({ children, searchTerms }: PropsWithChildren<HighlighterProps>) => {
+        return <>{recursivelyMarkChildren(children, searchTerms)}</>;
+    }
+);

--- a/src/renderer/components/NodeDocumentation/NodeDocs.tsx
+++ b/src/renderer/components/NodeDocumentation/NodeDocs.tsx
@@ -396,6 +396,7 @@ export const NodeDocs = memo(() => {
                                 <Flex
                                     direction={isLargerThan1200 ? 'row' : 'column'}
                                     gap={4}
+                                    key={nodeSchema.schemaId}
                                 >
                                     <SingleNodeInfo
                                         accentColor={selectedAccentColor}

--- a/src/renderer/components/NodeDocumentation/NodeDocs.tsx
+++ b/src/renderer/components/NodeDocumentation/NodeDocs.tsx
@@ -7,7 +7,6 @@ import {
     Flex,
     HStack,
     Heading,
-    Highlight,
     ListItem,
     Text,
     Tooltip,
@@ -29,6 +28,7 @@ import { getCategoryAccentColor, getTypeAccentColors } from '../../helpers/accen
 import { IconFactory } from '../CustomIcons';
 import { TypeTag } from '../TypeTag';
 import { docsMarkdown } from './docsMarkdown';
+import { Highlighter } from './Highlighter';
 import { NodeExample } from './NodeExample';
 import { SchemaLink } from './SchemaLink';
 
@@ -73,14 +73,7 @@ const InputOutputItem = memo(({ type, item }: InputOutputItemProps) => {
                     fontWeight="bold"
                     userSelect="text"
                 >
-                    <Highlight
-                        query={[...searchTerms]}
-                        styles={{
-                            backgroundColor: 'yellow.300',
-                        }}
-                    >
-                        {item.label}
-                    </Highlight>
+                    <Highlighter searchTerms={searchTerms}>{item.label}</Highlighter>
                 </Text>
                 {isOptional && (
                     <TypeTag
@@ -235,14 +228,7 @@ const SingleNodeInfo = memo(({ schema, accentColor, functionDefinition }: NodeIn
                         size="lg"
                         userSelect="text"
                     >
-                        <Highlight
-                            query={[...searchTerms]}
-                            styles={{
-                                backgroundColor: 'yellow.300',
-                            }}
-                        >
-                            {schema.name}
-                        </Highlight>
+                        <Highlighter searchTerms={searchTerms}>{schema.name}</Highlighter>
                     </Heading>
                 </HStack>
                 <ReactMarkdown components={docsMarkdown}>{schema.description}</ReactMarkdown>

--- a/src/renderer/components/NodeDocumentation/NodeDocs.tsx
+++ b/src/renderer/components/NodeDocumentation/NodeDocs.tsx
@@ -45,8 +45,8 @@ interface InputOutputItemProps {
 }
 
 const InputOutputItem = memo(({ type, item }: InputOutputItemProps) => {
-    const { useNodeDocumentationSearch } = useContext(NodeDocumentationContext);
-    const { searchTerms } = useNodeDocumentationSearch;
+    const { nodeDocsSearchState } = useContext(NodeDocumentationContext);
+    const { searchTerms } = nodeDocsSearchState;
 
     const isOptional = 'optional' in item && item.optional;
     if (isOptional) {
@@ -74,7 +74,7 @@ const InputOutputItem = memo(({ type, item }: InputOutputItemProps) => {
                     userSelect="text"
                 >
                     <Highlight
-                        query={searchTerms}
+                        query={[...searchTerms]}
                         styles={{
                             backgroundColor: 'yellow.300',
                         }}
@@ -201,10 +201,10 @@ interface NodeInfoProps {
     functionDefinition?: FunctionDefinition;
 }
 const SingleNodeInfo = memo(({ schema, accentColor, functionDefinition }: NodeInfoProps) => {
-    const { useNodeDocumentationSearch } = useContext(NodeDocumentationContext);
+    const { nodeDocsSearchState } = useContext(NodeDocumentationContext);
     const { schemata } = useContext(BackendContext);
 
-    const { searchTerms } = useNodeDocumentationSearch;
+    const { searchTerms } = nodeDocsSearchState;
 
     const inputs = schema.inputs.filter((i) => !isAutoInput(i));
     const outputs = schema.outputs.filter((o) => o.hasHandle);
@@ -236,7 +236,7 @@ const SingleNodeInfo = memo(({ schema, accentColor, functionDefinition }: NodeIn
                         userSelect="text"
                     >
                         <Highlight
-                            query={searchTerms}
+                            query={[...searchTerms]}
                             styles={{
                                 backgroundColor: 'yellow.300',
                             }}

--- a/src/renderer/components/NodeDocumentation/NodeDocs.tsx
+++ b/src/renderer/components/NodeDocumentation/NodeDocs.tsx
@@ -44,6 +44,9 @@ interface InputOutputItemProps {
 }
 
 const InputOutputItem = memo(({ type, item }: InputOutputItemProps) => {
+    const { useNodeDocumentationSearch } = useContext(NodeDocumentationContext);
+    const { searchTerms } = useNodeDocumentationSearch;
+
     const isOptional = 'optional' in item && item.optional;
     if (isOptional) {
         // eslint-disable-next-line no-param-reassign
@@ -69,7 +72,14 @@ const InputOutputItem = memo(({ type, item }: InputOutputItemProps) => {
                     fontWeight="bold"
                     userSelect="text"
                 >
-                    {item.label}
+                    <Highlight
+                        query={searchTerms}
+                        styles={{
+                            backgroundColor: 'yellow.300',
+                        }}
+                    >
+                        {item.label}
+                    </Highlight>
                 </Text>
                 {isOptional && (
                     <TypeTag

--- a/src/renderer/components/NodeDocumentation/NodeDocs.tsx
+++ b/src/renderer/components/NodeDocumentation/NodeDocs.tsx
@@ -6,6 +6,7 @@ import {
     Flex,
     HStack,
     Heading,
+    Highlight,
     ListItem,
     Text,
     Tooltip,
@@ -189,7 +190,10 @@ interface NodeInfoProps {
     functionDefinition?: FunctionDefinition;
 }
 const SingleNodeInfo = memo(({ schema, accentColor, functionDefinition }: NodeInfoProps) => {
+    const { useNodeDocumentationSearch } = useContext(NodeDocumentationContext);
     const { schemata } = useContext(BackendContext);
+
+    const { searchTerms } = useNodeDocumentationSearch;
 
     const inputs = schema.inputs.filter((i) => !isAutoInput(i));
     const outputs = schema.outputs.filter((o) => o.hasHandle);
@@ -220,7 +224,14 @@ const SingleNodeInfo = memo(({ schema, accentColor, functionDefinition }: NodeIn
                         size="lg"
                         userSelect="text"
                     >
-                        {schema.name}
+                        <Highlight
+                            query={searchTerms}
+                            styles={{
+                                backgroundColor: 'yellow.300',
+                            }}
+                        >
+                            {schema.name}
+                        </Highlight>
                     </Heading>
                 </HStack>
                 <ReactMarkdown components={docsMarkdown}>{schema.description}</ReactMarkdown>

--- a/src/renderer/components/NodeDocumentation/NodesList.tsx
+++ b/src/renderer/components/NodeDocumentation/NodesList.tsx
@@ -50,6 +50,21 @@ export const NodesList = memo(() => {
         [byCategories, categories, scoreMap, searchQuery]
     );
 
+    const highestNode = useMemo(
+        () =>
+            byCategories
+                .get(categoriesByMaxNodeScore[0].name)
+                ?.sort(
+                    (a, b) => (scoreMap.get(b.schemaId) ?? 0) - (scoreMap.get(a.schemaId) ?? 0)
+                )[0] ?? undefined,
+        [byCategories, categoriesByMaxNodeScore, scoreMap]
+    );
+
+    useEffect(() => {
+        openNodeDocumentation(highestNode?.schemaId);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [highestNode]);
+
     const selectedElement = useRef<HTMLDivElement>(null);
 
     const [selectScrollTrigger, setSelectScrollTrigger] = useState(false);

--- a/src/renderer/components/NodeDocumentation/NodesList.tsx
+++ b/src/renderer/components/NodeDocumentation/NodesList.tsx
@@ -1,8 +1,6 @@
 import { Box, Center, HStack, Text, VStack } from '@chakra-ui/react';
-import MiniSearch from 'minisearch';
 import { memo, useEffect, useMemo, useRef, useState } from 'react';
 import { useContext } from 'use-context-selector';
-import { NodeSchema } from '../../../common/common-types';
 import { BackendContext } from '../../contexts/BackendContext';
 import { NodeDocumentationContext } from '../../contexts/NodeDocumentationContext';
 import { getNodesByCategory } from '../../helpers/nodeSearchFuncs';
@@ -10,40 +8,13 @@ import { IconFactory } from '../CustomIcons';
 import { SearchBar } from '../SearchBar';
 
 export const NodesList = memo(() => {
-    const { selectedSchemaId, isOpen, openNodeDocumentation } =
+    const { selectedSchemaId, isOpen, openNodeDocumentation, useNodeDocumentationSearch } =
         useContext(NodeDocumentationContext);
 
     const { schemata, categories } = useContext(BackendContext);
     const schema = schemata.schemata;
-    const searchableSchema = useMemo(() => {
-        return schema.map((s) => ({
-            ...s,
-            inputs: s.inputs.map((i) => `${i.label} ${i.description ?? ''}`),
-            outputs: s.outputs.map((o) => `${o.label} ${o.description ?? ''}`),
-        }));
-    }, [schema]);
 
-    const [searchQuery, setSearchQuery] = useState('');
-
-    const idField: keyof NodeSchema = 'schemaId';
-    const fields: (keyof NodeSchema)[] = [
-        'category',
-        'description',
-        'name',
-        'subcategory',
-        'inputs',
-        'outputs',
-    ];
-    const miniSearch = new MiniSearch({ idField, fields });
-
-    miniSearch.addAll(searchableSchema);
-
-    const searchResult = miniSearch.search(searchQuery, {
-        boost: { name: 2 },
-        fuzzy: 0.2,
-        prefix: true,
-        combineWith: 'AND',
-    });
+    const { searchQuery, setSearchQuery, searchResult } = useNodeDocumentationSearch;
 
     const scoreMap = useMemo(() => {
         const map = new Map<string, number>();

--- a/src/renderer/components/NodeDocumentation/NodesList.tsx
+++ b/src/renderer/components/NodeDocumentation/NodesList.tsx
@@ -60,10 +60,13 @@ export const NodesList = memo(() => {
         [byCategories, categoriesByMaxNodeScore, scoreMap]
     );
 
+    const prevHighestNode = useRef(highestNode);
     useEffect(() => {
-        openNodeDocumentation(highestNode?.schemaId);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [highestNode]);
+        if (prevHighestNode.current?.schemaId !== highestNode?.schemaId) {
+            openNodeDocumentation(highestNode?.schemaId);
+            prevHighestNode.current = highestNode;
+        }
+    }, [highestNode, openNodeDocumentation]);
 
     const selectedElement = useRef<HTMLDivElement>(null);
 

--- a/src/renderer/components/NodeDocumentation/NodesList.tsx
+++ b/src/renderer/components/NodeDocumentation/NodesList.tsx
@@ -14,17 +14,20 @@ export const NodesList = memo(() => {
     const { schemata, categories } = useContext(BackendContext);
     const schema = schemata.schemata;
 
-    const { searchQuery, setSearchQuery, searchResult } = nodeDocsSearchState;
+    const { searchQuery, setSearchQuery, searchResults } = nodeDocsSearchState;
 
     const scoreMap = useMemo(() => {
         const map = new Map<string, number>();
-        searchResult.forEach((result) => {
+        searchResults.forEach((result) => {
             map.set(String(result.id), result.score);
         });
         return map;
-    }, [searchResult]);
+    }, [searchResults]);
 
-    const matchingSchemaIds = useMemo(() => searchResult.map((s) => String(s.id)), [searchResult]);
+    const matchingSchemaIds = useMemo(
+        () => searchResults.map((s) => String(s.id)),
+        [searchResults]
+    );
     const filteredSchema = useMemo(
         () => schema.filter((s) => !searchQuery || matchingSchemaIds.includes(s.schemaId)),
         [matchingSchemaIds, schema, searchQuery]

--- a/src/renderer/components/NodeDocumentation/NodesList.tsx
+++ b/src/renderer/components/NodeDocumentation/NodesList.tsx
@@ -8,13 +8,13 @@ import { IconFactory } from '../CustomIcons';
 import { SearchBar } from '../SearchBar';
 
 export const NodesList = memo(() => {
-    const { selectedSchemaId, isOpen, openNodeDocumentation, useNodeDocumentationSearch } =
+    const { selectedSchemaId, isOpen, openNodeDocumentation, nodeDocsSearchState } =
         useContext(NodeDocumentationContext);
 
     const { schemata, categories } = useContext(BackendContext);
     const schema = schemata.schemata;
 
-    const { searchQuery, setSearchQuery, searchResult } = useNodeDocumentationSearch;
+    const { searchQuery, setSearchQuery, searchResult } = nodeDocsSearchState;
 
     const scoreMap = useMemo(() => {
         const map = new Map<string, number>();

--- a/src/renderer/components/NodeDocumentation/docsMarkdown.tsx
+++ b/src/renderer/components/NodeDocumentation/docsMarkdown.tsx
@@ -1,25 +1,40 @@
-import { Code, Link, Text } from '@chakra-ui/react';
+import { Code, Highlight, Link, Text } from '@chakra-ui/react';
 import ChakraUIRenderer from 'chakra-ui-markdown-renderer';
-import { memo } from 'react';
+import { PropsWithChildren, memo } from 'react';
 import { Components } from 'react-markdown';
 import { useContext } from 'use-context-selector';
 import { SchemaId } from '../../../common/common-types';
 import { BackendContext } from '../../contexts/BackendContext';
+import { NodeDocumentationContext } from '../../contexts/NodeDocumentationContext';
 import { SchemaLink } from './SchemaLink';
 
 const getDocsMarkdownComponents = (interactive: boolean): Components => {
     return {
-        p: ({ children }) => {
+        p: memo(({ children }: PropsWithChildren<unknown>) => {
+            const { useNodeDocumentationSearch } = useContext(NodeDocumentationContext);
+            const { searchTerms } = useNodeDocumentationSearch;
+
+            const stringChildren = Array.isArray(children)
+                ? (children as string[]).join('')
+                : String(children);
+
             return (
                 <Text
                     fontSize="md"
                     marginTop={1}
                     userSelect="text"
                 >
-                    {children}
+                    <Highlight
+                        query={searchTerms}
+                        styles={{
+                            backgroundColor: 'yellow.300',
+                        }}
+                    >
+                        {stringChildren}
+                    </Highlight>
                 </Text>
             );
-        },
+        }),
         a: ({ children, href }) => {
             return (
                 <Link

--- a/src/renderer/components/NodeDocumentation/docsMarkdown.tsx
+++ b/src/renderer/components/NodeDocumentation/docsMarkdown.tsx
@@ -11,8 +11,8 @@ import { SchemaLink } from './SchemaLink';
 const getDocsMarkdownComponents = (interactive: boolean): Components => {
     return {
         p: memo(({ children }: PropsWithChildren<unknown>) => {
-            const { useNodeDocumentationSearch } = useContext(NodeDocumentationContext);
-            const { searchTerms } = useNodeDocumentationSearch;
+            const { nodeDocsSearchState } = useContext(NodeDocumentationContext);
+            const { searchTerms } = nodeDocsSearchState;
 
             const stringChildren = Array.isArray(children)
                 ? (children as string[]).join('')
@@ -25,7 +25,7 @@ const getDocsMarkdownComponents = (interactive: boolean): Components => {
                     userSelect="text"
                 >
                     <Highlight
-                        query={searchTerms}
+                        query={[...searchTerms]}
                         styles={{
                             backgroundColor: 'yellow.300',
                         }}

--- a/src/renderer/components/NodeDocumentation/docsMarkdown.tsx
+++ b/src/renderer/components/NodeDocumentation/docsMarkdown.tsx
@@ -1,39 +1,13 @@
-import { Code, Highlight, Link, Text } from '@chakra-ui/react';
+import { Code, Link, Text } from '@chakra-ui/react';
 import ChakraUIRenderer from 'chakra-ui-markdown-renderer';
-import { Fragment, PropsWithChildren, memo } from 'react';
+import { PropsWithChildren, memo } from 'react';
 import { Components } from 'react-markdown';
 import { useContext } from 'use-context-selector';
 import { SchemaId } from '../../../common/common-types';
 import { BackendContext } from '../../contexts/BackendContext';
 import { NodeDocumentationContext } from '../../contexts/NodeDocumentationContext';
+import { Highlighter } from './Highlighter';
 import { SchemaLink } from './SchemaLink';
-
-const recursivelyMarkChildren = (
-    children: React.ReactNode | string[],
-    searchTerms: readonly string[]
-): React.ReactNode | string[] => {
-    if (Array.isArray(children)) {
-        return children.map((child, i) => (
-            // eslint-disable-next-line react/no-array-index-key
-            <Fragment key={i}>{recursivelyMarkChildren(child, searchTerms)}</Fragment>
-        ));
-    }
-
-    if (typeof children === 'string') {
-        return (
-            <Highlight
-                query={[...searchTerms]}
-                styles={{
-                    backgroundColor: 'yellow.300',
-                }}
-            >
-                {children}
-            </Highlight>
-        );
-    }
-
-    return children;
-};
 
 const getDocsMarkdownComponents = (interactive: boolean): Components => {
     return {
@@ -47,7 +21,7 @@ const getDocsMarkdownComponents = (interactive: boolean): Components => {
                     marginTop={1}
                     userSelect="text"
                 >
-                    {recursivelyMarkChildren(children, searchTerms)}
+                    <Highlighter searchTerms={searchTerms}>{children}</Highlighter>
                 </Text>
             );
         }),

--- a/src/renderer/contexts/NodeDocumentationContext.tsx
+++ b/src/renderer/contexts/NodeDocumentationContext.tsx
@@ -1,14 +1,22 @@
 import { useDisclosure } from '@chakra-ui/react';
-import React, { memo } from 'react';
-import { createContext } from 'use-context-selector';
-import { SchemaId } from '../../common/common-types';
+import MiniSearch, { SearchResult } from 'minisearch';
+import React, { memo, useMemo, useState } from 'react';
+import { createContext, useContext } from 'use-context-selector';
+import { NodeSchema, SchemaId } from '../../common/common-types';
 import { useMemoObject } from '../hooks/useMemo';
+import { BackendContext } from './BackendContext';
 
 interface NodeDocumentationContextState {
     selectedSchemaId: SchemaId | undefined;
     isOpen: boolean;
     openNodeDocumentation: (schemaId?: SchemaId) => void;
     onClose: () => void;
+    useNodeDocumentationSearch: {
+        searchQuery: string;
+        setSearchQuery: (query: string) => void;
+        searchResult: SearchResult[];
+        searchTerms: string[];
+    };
 }
 
 // TODO: create context requires default values
@@ -25,11 +33,53 @@ export const NodeDocumentationProvider = memo(({ children }: React.PropsWithChil
         onOpen();
     };
 
+    const { schemata } = useContext(BackendContext);
+    const schema = schemata.schemata;
+    const searchableSchema = useMemo(() => {
+        return schema.map((s) => ({
+            ...s,
+            inputs: s.inputs.map((i) => `${i.label} ${i.description ?? ''}`),
+            outputs: s.outputs.map((o) => `${o.label} ${o.description ?? ''}`),
+        }));
+    }, [schema]);
+
+    const [searchQuery, setSearchQuery] = useState('');
+
+    const idField: keyof NodeSchema = 'schemaId';
+    const fields: (keyof NodeSchema)[] = [
+        'category',
+        'description',
+        'name',
+        'subcategory',
+        'inputs',
+        'outputs',
+    ];
+    const miniSearch = new MiniSearch({ idField, fields });
+
+    miniSearch.addAll(searchableSchema);
+
+    const searchResult = miniSearch.search(searchQuery, {
+        boost: { name: 2 },
+        fuzzy: 0.2,
+        prefix: true,
+        combineWith: 'AND',
+    });
+
+    const searchTerms = searchResult.find((s) => s.id === selectedSchemaId)?.terms ?? [];
+
+    const useNodeDocumentationSearch = {
+        searchQuery,
+        setSearchQuery,
+        searchResult,
+        searchTerms,
+    };
+
     const contextValue = useMemoObject({
         selectedSchemaId,
         isOpen,
         openNodeDocumentation,
         onClose,
+        useNodeDocumentationSearch,
     });
 
     return (

--- a/src/renderer/contexts/NodeDocumentationContext.tsx
+++ b/src/renderer/contexts/NodeDocumentationContext.tsx
@@ -65,14 +65,20 @@ export const NodeDocumentationProvider = memo(({ children }: React.PropsWithChil
         combineWith: 'AND',
     });
 
-    const searchTerms = searchResult.find((s) => s.id === selectedSchemaId)?.terms ?? [];
+    const searchTerms = useMemo(
+        () => searchResult.find((s) => s.id === selectedSchemaId)?.terms ?? [],
+        [searchResult, selectedSchemaId]
+    );
 
-    const nodeDocsSearchState = useMemo(() => ({
-        searchQuery,
-        setSearchQuery,
-        searchResult,
-        searchTerms,
-    }), [searchQuery, setSearchQuery, searchResult, searchTerms]);
+    const nodeDocsSearchState = useMemo(
+        () => ({
+            searchQuery,
+            setSearchQuery,
+            searchResult,
+            searchTerms,
+        }),
+        [searchQuery, setSearchQuery, searchResult, searchTerms]
+    );
 
     const contextValue = useMemoObject({
         selectedSchemaId,

--- a/src/renderer/contexts/NodeDocumentationContext.tsx
+++ b/src/renderer/contexts/NodeDocumentationContext.tsx
@@ -11,11 +11,11 @@ interface NodeDocumentationContextState {
     isOpen: boolean;
     openNodeDocumentation: (schemaId?: SchemaId) => void;
     onClose: () => void;
-    useNodeDocumentationSearch: {
+    nodeDocsSearchState: {
         searchQuery: string;
         setSearchQuery: (query: string) => void;
-        searchResult: SearchResult[];
-        searchTerms: string[];
+        searchResult: readonly SearchResult[];
+        searchTerms: readonly string[];
     };
 }
 
@@ -67,7 +67,7 @@ export const NodeDocumentationProvider = memo(({ children }: React.PropsWithChil
 
     const searchTerms = searchResult.find((s) => s.id === selectedSchemaId)?.terms ?? [];
 
-    const useNodeDocumentationSearch = {
+    const nodeDocsSearchState = {
         searchQuery,
         setSearchQuery,
         searchResult,
@@ -79,7 +79,7 @@ export const NodeDocumentationProvider = memo(({ children }: React.PropsWithChil
         isOpen,
         openNodeDocumentation,
         onClose,
-        useNodeDocumentationSearch,
+        nodeDocsSearchState,
     });
 
     return (

--- a/src/renderer/contexts/NodeDocumentationContext.tsx
+++ b/src/renderer/contexts/NodeDocumentationContext.tsx
@@ -67,12 +67,12 @@ export const NodeDocumentationProvider = memo(({ children }: React.PropsWithChil
 
     const searchTerms = searchResult.find((s) => s.id === selectedSchemaId)?.terms ?? [];
 
-    const nodeDocsSearchState = {
+    const nodeDocsSearchState = useMemo(() => ({
         searchQuery,
         setSearchQuery,
         searchResult,
         searchTerms,
-    };
+    }), [searchQuery, setSearchQuery, searchResult, searchTerms]);
 
     const contextValue = useMemoObject({
         selectedSchemaId,

--- a/src/renderer/contexts/NodeDocumentationContext.tsx
+++ b/src/renderer/contexts/NodeDocumentationContext.tsx
@@ -14,7 +14,7 @@ interface NodeDocumentationContextState {
     nodeDocsSearchState: {
         searchQuery: string;
         setSearchQuery: (query: string) => void;
-        searchResult: readonly SearchResult[];
+        searchResults: readonly SearchResult[];
         searchTerms: readonly string[];
     };
 }
@@ -26,7 +26,7 @@ export const NodeDocumentationContext = createContext<NodeDocumentationContextSt
 
 export const NodeDocumentationProvider = memo(({ children }: React.PropsWithChildren<unknown>) => {
     const { isOpen, onOpen, onClose } = useDisclosure();
-    const [selectedSchemaId, setSelectedSchemaId] = React.useState<SchemaId | undefined>(undefined);
+    const [selectedSchemaId, setSelectedSchemaId] = useState<SchemaId | undefined>(undefined);
 
     const openNodeDocumentation = (schemaId?: SchemaId) => {
         setSelectedSchemaId(schemaId);
@@ -34,53 +34,54 @@ export const NodeDocumentationProvider = memo(({ children }: React.PropsWithChil
     };
 
     const { schemata } = useContext(BackendContext);
-    const schema = schemata.schemata;
-    const searchableSchema = useMemo(() => {
-        return schema.map((s) => ({
-            ...s,
-            inputs: s.inputs.map((i) => `${i.label} ${i.description ?? ''}`),
-            outputs: s.outputs.map((o) => `${o.label} ${o.description ?? ''}`),
-        }));
-    }, [schema]);
+    const miniSearch = useMemo(() => {
+        const idField: keyof NodeSchema = 'schemaId';
+        const fields: (keyof NodeSchema)[] = [
+            'category',
+            'description',
+            'name',
+            'subcategory',
+            'inputs',
+            'outputs',
+        ];
+
+        const search = new MiniSearch<NodeSchema>({
+            idField,
+            fields,
+
+            extractField: (document, fieldName): string => {
+                if (fieldName === 'inputs' || fieldName === 'outputs') {
+                    return document[fieldName]
+                        .map((i) => `${i.label} ${i.description ?? ''}`)
+                        .join('\n\n');
+                }
+                return String((document as unknown as Record<string, unknown>)[fieldName]);
+            },
+        });
+        search.addAll(schemata.schemata);
+        return search;
+    }, [schemata]);
 
     const [searchQuery, setSearchQuery] = useState('');
 
-    const idField: keyof NodeSchema = 'schemaId';
-    const fields: (keyof NodeSchema)[] = [
-        'category',
-        'description',
-        'name',
-        'subcategory',
-        'inputs',
-        'outputs',
-    ];
-    const miniSearch = new MiniSearch({ idField, fields });
+    const nodeDocsSearchState =
+        useMemo((): NodeDocumentationContextState['nodeDocsSearchState'] => {
+            const searchResults = miniSearch.search(searchQuery, {
+                boost: { name: 2 },
+                fuzzy: 0.2,
+                prefix: true,
+                combineWith: 'AND',
+            });
 
-    miniSearch.addAll(searchableSchema);
+            return {
+                searchQuery,
+                setSearchQuery,
+                searchResults,
+                searchTerms: searchResults.find((s) => s.id === selectedSchemaId)?.terms ?? [],
+            };
+        }, [searchQuery, setSearchQuery, selectedSchemaId, miniSearch]);
 
-    const searchResult = miniSearch.search(searchQuery, {
-        boost: { name: 2 },
-        fuzzy: 0.2,
-        prefix: true,
-        combineWith: 'AND',
-    });
-
-    const searchTerms = useMemo(
-        () => searchResult.find((s) => s.id === selectedSchemaId)?.terms ?? [],
-        [searchResult, selectedSchemaId]
-    );
-
-    const nodeDocsSearchState = useMemo(
-        () => ({
-            searchQuery,
-            setSearchQuery,
-            searchResult,
-            searchTerms,
-        }),
-        [searchQuery, setSearchQuery, searchResult, searchTerms]
-    );
-
-    const contextValue = useMemoObject({
+    const contextValue = useMemoObject<NodeDocumentationContextState>({
         selectedSchemaId,
         isOpen,
         openNodeDocumentation,


### PR DESCRIPTION
I could see this being a bit annoying, so I almost wonder if it should be a toggleable thing. I'm open to adding that as part of this if you agree. I do think this helps visibly show how a node matches what you've searched for.

Also, part of this PR makes it auto-select the first node in the list when you search.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/34788790/9d03582e-f1dc-41fb-9959-2acd0f0d7982)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/34788790/87740b1e-27ae-462f-99fd-a77bc17fcf77)

Also while doing this I realized we don't show node groups (subcategories) anywhere on here, so I'll address that in a separate PR.
