### PR TITLE
Better types in docs

### DIFF
--- a/src/common/types/explain.ts
+++ b/src/common/types/explain.ts
@@ -1,0 +1,169 @@
+import {
+    IntIntervalType,
+    NumberPrimitive,
+    NumericLiteralType,
+    StringPrimitive,
+    StructType,
+    Type,
+    UnionType,
+    ValueType,
+} from '@chainner/navi';
+import { joinEnglish } from '../util';
+import { IntNumberType, isColor, isDirectory, isImage } from './util';
+
+const isInt = (n: Type, min = -Infinity, max = Infinity): n is IntIntervalType => {
+    return n.underlying === 'number' && n.type === 'int-interval' && n.min === min && n.max === max;
+};
+
+const getAcceptedNumbers = (number: IntNumberType): Set<number> | undefined => {
+    const numbers = new Set<number>();
+    let infinite = false;
+
+    const add = (n: NumericLiteralType | IntIntervalType): void => {
+        if (n.type === 'literal') {
+            numbers.add(n.value);
+        } else if (n.max - n.min < 10) {
+            for (let i = n.min; i <= n.max; i += 1) {
+                numbers.add(i);
+            }
+        } else {
+            infinite = true;
+        }
+    };
+
+    if (number.type === 'union') {
+        number.items.forEach(add);
+    } else {
+        add(number);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    return infinite ? undefined : numbers;
+};
+export const formatChannelNumber = (n: IntNumberType, subject: string): string | undefined => {
+    const numbers = getAcceptedNumbers(n);
+    if (!numbers) return undefined;
+
+    const known: string[] = [];
+    if (numbers.has(1)) known.push('grayscale');
+    if (numbers.has(3)) known.push('RGB');
+    if (numbers.has(4)) known.push('RGBA');
+
+    if (known.length === numbers.size) {
+        const article = known[0] === 'grayscale' ? 'a' : 'an';
+        if (known.length === 1) return `${article} ${known[0]} ${subject}`;
+        if (known.length === 2) return `${article} ${known[0]} or ${known[1]} ${subject}`;
+        if (known.length === 3)
+            return `${article} ${known[0]}, ${known[1]} or ${known[2]} ${subject}`;
+    }
+
+    return undefined;
+};
+
+const explainNumber = (n: NumberPrimitive): string | undefined => {
+    if (n.type === 'number') return 'a number';
+    if (n.type === 'literal') return `the number ${n.value}`;
+
+    const kind = n.type === 'int-interval' ? 'an integer' : 'a number';
+    if (n.min === -Infinity && n.max === Infinity) return kind;
+    if (n.min === -Infinity) return `${kind} that is at most ${n.max}`;
+    if (n.max === Infinity) return `${kind} that is at least ${n.min}`;
+    return `${kind} between ${n.min} and ${n.max}`;
+};
+
+const explainString = (s: StringPrimitive): string | undefined => {
+    if (s.type === 'string') return 'a string';
+    if (s.type === 'literal') return `the string ${JSON.stringify(s.value)}`;
+    if (s.excluded.size === 1 && s.excluded.has('')) return 'a non-empty string';
+};
+
+const explainStruct = (s: StructType, options: ExplainOptions): string | undefined => {
+    const detailed = (base: string | undefined, detail: string): string | undefined => {
+        if (options.detailed && base) return `${base} ${detail}`;
+        return base;
+    };
+
+    if (isImage(s)) {
+        const width = s.fields[0].type;
+        const height = s.fields[1].type;
+        const channels = s.fields[2].type;
+
+        if (isInt(width, 0) && isInt(height, 0)) {
+            if (isInt(channels, 1)) return detailed('an image', 'of any size and any colorspace');
+            return detailed(formatChannelNumber(channels, 'image'), 'of any size');
+        }
+        if (isInt(width, 1) && isInt(height, 1)) {
+            if (isInt(channels, 1)) return detailed('an non-empty image', 'of any colorspace');
+            const formatted = formatChannelNumber(channels, 'image');
+            if (formatted) return `${formatted} that isn't empty`;
+        }
+    }
+
+    if (isColor(s)) {
+        const channels = s.fields[0].type;
+
+        if (isInt(channels, 1)) return detailed('a color', 'of any colorspace');
+        return formatChannelNumber(channels, 'color');
+    }
+
+    if (isDirectory(s)) {
+        const path = s.fields[0].type;
+        if (path.type === 'string') return 'a directory path';
+    }
+
+    if (s.name === 'Seed') {
+        return 'a seed (for randomness)';
+    }
+};
+
+const explainValue = (type: ValueType, options: ExplainOptions): string | undefined => {
+    if (type.underlying === 'number') return explainNumber(type);
+    if (type.underlying === 'string') return explainString(type);
+    return explainStruct(type, options);
+};
+
+const explainUnion = (u: UnionType, options: ExplainOptions): string | undefined => {
+    let hasUnknown = false;
+    const known: string[] = [];
+    for (const item of u.items) {
+        const explanation = explainValue(item, options);
+        if (explanation) {
+            known.push(explanation);
+        } else {
+            if (options.strictUnion) return undefined;
+            hasUnknown = true;
+        }
+    }
+
+    if (known.length === 0) return undefined;
+    if (hasUnknown) {
+        known.push('some other value');
+    }
+
+    return joinEnglish(known, 'or');
+};
+
+export interface ExplainOptions {
+    /**
+     * If `true`, unions will only be explained if all of their items can be explained.
+     *
+     * @default false
+     */
+    readonly strictUnion?: boolean;
+    /**
+     * If `true`, types will be explained in more detail. E.g. with examples.
+     *
+     * @default false
+     */
+    readonly detailed?: boolean;
+}
+
+/**
+ * Tries to explain the type in plain English.
+ */
+export const explain = (type: Type, options: ExplainOptions): string | undefined => {
+    if (type.underlying === 'any') return 'any value';
+    if (type.underlying === 'never') return 'no value';
+    if (type.underlying === 'union') return explainUnion(type, options);
+    return explainValue(type, options);
+};

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -252,6 +252,9 @@ export const joinEnglish = (list: readonly string[], conj: 'and' | 'or' = 'and')
     return `${list.slice(0, -1).join(', ')}, ${conj} ${list[list.length - 1]}`;
 };
 
+export const capitalize = (string: string): string =>
+    string.charAt(0).toUpperCase() + string.slice(1);
+
 export const fixRoundingError = (n: number): number => {
     if (!Number.isFinite(n)) return n;
 


### PR DESCRIPTION
Changes:
- Don't show type for dropdowns. Showing all options is sufficient. We don't allow connections to dropdowns anyway.
- Added "Type:" before the type.
- Made "Options:" italic.
- Improved type tooltips. They are now derived from the type and use the same underlying explaining logic as type errors. So any improvement we make towards explaining doc types will as improve error messages. In fact, I had to improve the explaining and type error messages now use natural language more often.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/5f07c053-d55c-4b02-a641-943cfd969aa1)

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/27d9a57c-5625-4ac7-911c-00640bddadb4)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/11ab9d0c-be18-4814-939a-1e27cc101a38)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/81bae2f5-1088-45e4-9696-8934a7caf0ed)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/0894aceb-f9d9-428e-8b0f-c518a1ea8025)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/1c9755c0-cd10-4d76-8da1-8037973ff654)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/a9ff70ef-fee8-411c-a9c5-114d1ed283c5)
