### PR TITLE
Fixed ICP

### DIFF
--- a/src/common/safeIpc.ts
+++ b/src/common/safeIpc.ts
@@ -8,7 +8,6 @@ import {
     ipcMain as unsafeIpcMain,
     ipcRenderer as unsafeIpcRenderer,
 } from 'electron';
-import { Systeminformation } from 'systeminformation';
 import { FileOpenResult, FileSaveResult, PythonInfo, Version } from './common-types';
 import { ParsedSaveData, SaveData } from './SaveFile';
 import { Progress } from './ui/progress';
@@ -20,9 +19,6 @@ interface ChannelInfo<ReturnType, Args extends unknown[] = []> {
 type SendChannelInfo<Args extends unknown[] = []> = ChannelInfo<void, Args>;
 
 export interface InvokeChannels {
-    'get-nvidia-gpu-name': ChannelInfo<string | null>;
-    'get-nvidia-gpus': ChannelInfo<string[] | null>;
-    'get-gpu-info': ChannelInfo<Systeminformation.GraphicsData>;
     'get-python': ChannelInfo<PythonInfo>;
     'get-port': ChannelInfo<number>;
     'get-localstorage-location': ChannelInfo<string>;

--- a/src/main/gui/main-window.ts
+++ b/src/main/gui/main-window.ts
@@ -13,7 +13,6 @@ import { BackendProcess } from '../backend/process';
 import { setupBackend } from '../backend/setup';
 import { getRootDirSync } from '../platform';
 import { settingStorage, settingStorageLocation } from '../setting-storage';
-import { getGpuInfo } from '../systemInfo';
 import { MenuData, setMainMenu } from './menu';
 import { addSplashScreen } from './splash';
 
@@ -25,7 +24,6 @@ const registerEventHandlerPreSetup = (
 ) => {
     ipcMain.handle('get-app-version', () => version);
     ipcMain.handle('get-appdata', () => getRootDirSync());
-    ipcMain.handle('get-gpu-info', getGpuInfo);
     ipcMain.handle('get-localstorage-location', () => settingStorageLocation);
     ipcMain.handle('refresh-nodes', () => args.refresh);
 

--- a/src/renderer/contexts/DependencyContext.tsx
+++ b/src/renderer/contexts/DependencyContext.tsx
@@ -38,7 +38,6 @@ import { Package, PyPiPackage } from '../../common/dependencies';
 import { Integration, externalIntegrations } from '../../common/externalIntegrations';
 import { log } from '../../common/log';
 import { OnStdio, PipList, runPipInstall, runPipList, runPipUninstall } from '../../common/pip';
-import { ipcRenderer } from '../../common/safeIpc';
 import { noop } from '../../common/util';
 import { versionGt } from '../../common/version';
 import { useAsyncEffect } from '../hooks/useAsyncEffect';
@@ -297,10 +296,10 @@ export const DependencyProvider = memo(({ children }: React.PropsWithChildren<un
     const [hasNvidia, setHasNvidia] = useState(false);
     useAsyncEffect(
         () => ({
-            supplier: async () => !!(await ipcRenderer.invoke('get-nvidia-gpu-name')),
+            supplier: async () => (await backend.listNvidiaGpus()).length > 0,
             successEffect: setHasNvidia,
         }),
-        []
+        [backend]
     );
 
     const [availableDeps, setAvailableDeps] = useState<Package[]>([]);


### PR DESCRIPTION
This is part of my review for #1948.

Changes:
- Removed "get-nvidia-gpu-name" and "get-nvidia-gpus" channels from ICP since their handlers were removed in #1948.
- Query backend directly in DependencyContext instead of using the removed ICP channel.
- Removed "get-gpu-info" channel because it was unused, and client-side GPU info is useless now anyway.