### PR TITLE
Fixed wide dropdowns

### DIFF
--- a/src/renderer/components/inputs/elements/Dropdown.tsx
+++ b/src/renderer/components/inputs/elements/Dropdown.tsx
@@ -38,6 +38,7 @@ export const DropDown = memo(({ value, onChange, reset, isDisabled, options }: D
             disabled={isDisabled}
             draggable={false}
             size="sm"
+            style={{ contain: 'size' }}
             value={selection}
             onChange={handleChange}
         >


### PR DESCRIPTION
This fixes wide dropdowns. Dropdowns will now always have their size determined by their container. Long options no longer cause them to expand.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/2c2dc7d8-6398-4336-91e6-9746564677b3)
