### PR TITLE
Better string character length range descriptions

### DIFF
--- a/src/renderer/components/NodeDocumentation/NodeDocs.tsx
+++ b/src/renderer/components/NodeDocumentation/NodeDocs.tsx
@@ -17,7 +17,7 @@ import {
 import { memo } from 'react';
 import { ReactMarkdown } from 'react-markdown/lib/react-markdown';
 import { useContext } from 'use-context-selector';
-import { Condition, Input, NodeSchema, Output } from '../../../common/common-types';
+import { Condition, Input, NodeSchema, Output, TextInput } from '../../../common/common-types';
 import { isTautology } from '../../../common/nodes/condition';
 import { getInputCondition } from '../../../common/nodes/inputCondition';
 import { explain } from '../../../common/types/explain';
@@ -59,6 +59,26 @@ const TypeView = memo(({ type }: TypeViewProps) => {
         </Tooltip>
     );
 });
+
+const getTextLength = (input: TextInput): string => {
+    const chars = (count: number): string => `${count} ${count === 1 ? 'character' : 'characters'}`;
+
+    const minLength = input.minLength ?? 0;
+    const { maxLength } = input;
+
+    let range;
+    if (maxLength) {
+        if (maxLength === minLength) {
+            range = `exactly ${chars(maxLength)}`;
+        } else {
+            range = `between ${minLength} and ${chars(maxLength)}`;
+        }
+    } else {
+        range = `at least ${chars(minLength)}`;
+    }
+
+    return `A ${input.multiline ? 'multi-line ' : ''}string ${range} long.`;
+};
 
 interface InputOutputItemProps {
     schema: NodeSchema;
@@ -183,21 +203,12 @@ const InputOutputItem = memo(({ type, item, condition, schema }: InputOutputItem
                         </Text>
                     )}
 
-                    {isTextInput && (
+                    {isTextInput && !((item.minLength ?? 0) === 0 && item.maxLength == null) && (
                         <Text
                             fontSize="md"
                             userSelect="text"
                         >
-                            {`A ${item.multiline ? 'multi-line ' : ''}string ${
-                                item.maxLength
-                                    ? `between ${item.minLength ?? 0} and ${item.maxLength}`
-                                    : `at least ${item.minLength ?? 0}`
-                            } character${
-                                (item.maxLength === null || item.maxLength === undefined) &&
-                                item.minLength === 1
-                                    ? ''
-                                    : 's'
-                            } long.`}
+                            {getTextLength(item)}
                         </Text>
                     )}
 


### PR DESCRIPTION
Changes:
- Don't show "A string at least 0 characters long." All strings are at least 0 characters long, so why even show this sentence.
- Added case for exact ranges (min == max).

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/2468c59f-9f58-40d5-9854-10322b344699)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/9212930d-c874-4462-8c2b-7d53162b663a)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/8bacd54d-8445-4394-b525-3c5a16331bcb)
