### PR TITLE
Use `textTransform` instead of `toUpperCase`

### DIFF
--- a/src/renderer/components/NodeSelectorPanel/RepresentativeNode.tsx
+++ b/src/renderer/components/NodeSelectorPanel/RepresentativeNode.tsx
@@ -124,10 +124,11 @@ export const RepresentativeNode = memo(
                                         size="xs"
                                         textAlign="left"
                                         textOverflow="truncate"
+                                        textTransform="uppercase"
                                         verticalAlign="middle"
                                         whiteSpace="nowrap"
                                     >
-                                        {name.toUpperCase()}
+                                        {name}
                                     </Heading>
                                 </Box>
                                 <Spacer />

--- a/src/renderer/components/node/IteratorNodeHeader.tsx
+++ b/src/renderer/components/node/IteratorNodeHeader.tsx
@@ -74,9 +74,10 @@ export const IteratorNodeHeader = memo(
                                 p={0}
                                 size="sm"
                                 textAlign="center"
+                                textTransform="uppercase"
                                 verticalAlign="middle"
                             >
-                                {name.toUpperCase()}
+                                {name}
                             </Heading>
                         </Center>
                     </HStack>

--- a/src/renderer/components/node/NodeHeader.tsx
+++ b/src/renderer/components/node/NodeHeader.tsx
@@ -62,10 +62,11 @@ export const NodeHeader = memo(
                             p={0}
                             size="sm"
                             textAlign="center"
+                            textTransform="uppercase"
                             verticalAlign="middle"
                             whiteSpace="nowrap"
                         >
-                            {name.toUpperCase()}
+                            {name}
                         </Heading>
                     </Center>
                 </HStack>


### PR DESCRIPTION
Very minor thing. I think we should use CSS text transform instead of JS String `toUpperCase` when changing the case of text for a particular design.