### PR TITLE
Shorter names for channel inputs/outputs in Split/Merge Transparency

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image_channel/transparency/transparency_merge.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/transparency/transparency_merge.py
@@ -16,8 +16,8 @@ from . import node_group
     description="Merge RGB and Alpha (transparency) image channels into 4-channel RGBA channels.",
     icon="MdCallMerge",
     inputs=[
-        ImageInput("RGB Channels", allow_colors=True),
-        ImageInput("Alpha Channel", allow_colors=True, channels=1),
+        ImageInput("RGB", allow_colors=True),
+        ImageInput("Alpha", allow_colors=True, channels=1),
     ],
     outputs=[
         ImageOutput(

--- a/backend/src/packages/chaiNNer_standard/image_channel/transparency/transparency_split.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/transparency/transparency_split.py
@@ -20,13 +20,13 @@ from . import node_group
     inputs=[ImageInput(channels=[1, 3, 4])],
     outputs=[
         ImageOutput(
-            "RGB Channels",
+            "RGB",
             image_type=navi.Image(size_as="Input0"),
             channels=3,
             assume_normalized=True,
         ),
         ImageOutput(
-            "Alpha Channel",
+            "Alpha",
             image_type=navi.Image(size_as="Input0"),
             channels=1,
             assume_normalized=True,


### PR DESCRIPTION
This fixes something very minor. The names "RGB channels" and "Alpha channel" in Split Transparency were so long that type tags frequently causes the width of the node to expand. So I choose shorter names to prevent this. For