### PR TITLE
Added naming convention check

### DIFF
--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -46,6 +46,17 @@ jobs:
               env:
                   TYPE_CHECK_LEVEL: 'error'
 
+    backend-name-check-test:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-python@v4
+              with:
+                  python-version: '3.9'
+            - run: python ./backend/src/run.py --close-after-start
+              env:
+                  NAME_CHECK_LEVEL: 'error'
+
     backend-bootstrap:
         runs-on: ubuntu-latest
         strategy:

--- a/backend/src/packages/chaiNNer_standard/image_utility/modification/shift.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/modification/shift.py
@@ -32,7 +32,7 @@ from .. import modification_group
         )
     ],
 )
-def shift_node(
+def shift_amount_node(
     img: np.ndarray,
     amount_x: int,
     amount_y: int,

--- a/backend/src/packages/chaiNNer_standard/image_utility/modification/shift.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/modification/shift.py
@@ -32,7 +32,7 @@ from .. import modification_group
         )
     ],
 )
-def shift_amount_node(
+def shift_node(
     img: np.ndarray,
     amount_x: int,
     amount_y: int,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "electron-forge start -- --devtools",
     "frontend": "electron-forge start -- --remote-backend=http://127.0.0.1:8000 --devtools",
-    "dev": "concurrently \"cd backend/src && cross-env TYPE_CHECK_LEVEL=warn nodemon ./run.py 8000\" \"electron-forge start -- --remote-backend=http://127.0.0.1:8000 --refresh --devtools\"",
+    "dev": "concurrently \"cd backend/src && cross-env CHECK_LEVEL=fix nodemon ./run.py 8000\" \"electron-forge start -- --remote-backend=http://127.0.0.1:8000 --refresh --devtools\"",
     "debug": "concurrently \"npm run debug:py\" \"electron-forge start -- --remote-backend=http://127.0.0.1:8000 --refresh --devtools\"",
     "debug:py": "cd backend/src && nodemon --exec \"python -m debugpy --listen 5678\" ./run.py 8000",
     "package": "cross-env NODE_ENV=production electron-forge package",


### PR DESCRIPTION
Follow up to #1968. This PR adds the actual naming convention check as well as a mode for automatically fixing improperly named functions and files.

The naming convention check + fix itself is rather simple. It's just a small function. The interesting bit is the stuff around it. 
I generalized the `TYPE_CHECK_LEVEL` logic to (1) include a `FIX` check level, and (2) added a `NAME_CHECK_LEVEL`. So name check is controlled via env vars just like the type check. There is now also a `CHECK_LEVEL` env var to control both at once. `CHECK_LEVEL` will be very useful if we add more checks in the future.

I also changed the check level from `WARN` to `FIX` for `npm run dev`. This has the interesting effect that the server will automatically rename functions and files when you change the name of a node.