### PR TITLE
Fixed `round_half_up` for negative integers

### DIFF
--- a/backend/src/nodes/utils/utils.py
+++ b/backend/src/nodes/utils/utils.py
@@ -1,6 +1,7 @@
 # From https://github.com/victorca25/iNNfer/blob/main/utils/utils.py
 from __future__ import annotations
 
+import math
 import os
 import re
 from dataclasses import dataclass
@@ -28,7 +29,7 @@ def round_half_up(number: Union[float, int]) -> int:
 
     https://en.wikipedia.org/wiki/Rounding#Rounding_to_the_nearest_integer
     """
-    return int(number + 0.5)
+    return math.floor(number + 0.5)
 
 
 def get_h_w_c(image: np.ndarray) -> Tuple[int, int, int]:


### PR DESCRIPTION
Due to `int(x)` *truncating* the input number, `round_half_up` produced incorrect results for negative integers. E.g.
```py
>>> round_half_up(2)
2
>>> round_half_up(1)
1
>>> round_half_up(0)
0
>>> round_half_up(-1)
0
>>> round_half_up(-2)
-1
```

The fix is to use `math.floor`, which actually floors the input number.

---

This fixes the Shift node not working for amount=-1.