### PR TITLE
Fixed initial input string for slider inputs

### DIFF
--- a/src/renderer/components/inputs/SliderInput.tsx
+++ b/src/renderer/components/inputs/SliderInput.tsx
@@ -76,7 +76,7 @@ export const SliderInput = memo(
             ends,
         } = input;
 
-        const [inputString, setInputString] = useState(String(value));
+        const [inputString, setInputString] = useState(String(value ?? def));
         const [sliderValue, setSliderValue] = useState(value ?? def);
 
         const precisionOutput = useCallback(


### PR DESCRIPTION
I noticed a minor visual bug slider inputs had. A slider input would show "undefined" in its number input for one frame before showing the correct value. This was especially noticeable in doc pages when switching between nodes.