### PR TITLE
Consistently use sliders for blur radius-like number inputs

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image_filter/blur/box_blur.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/blur/box_blur.py
@@ -5,7 +5,7 @@ from math import ceil
 import cv2
 import numpy as np
 
-from nodes.properties.inputs import ImageInput, NumberInput
+from nodes.properties.inputs import ImageInput, SliderInput
 from nodes.properties.outputs import ImageOutput
 
 from .. import blur_group
@@ -18,8 +18,26 @@ from .. import blur_group
     icon="MdBlurOn",
     inputs=[
         ImageInput(),
-        NumberInput("Radius X", precision=1, controls_step=1),
-        NumberInput("Radius Y", precision=1, controls_step=1),
+        SliderInput(
+            "Radius X",
+            minimum=0,
+            maximum=1000,
+            default=1,
+            precision=1,
+            controls_step=1,
+            slider_step=0.1,
+            scale="log",
+        ),
+        SliderInput(
+            "Radius Y",
+            minimum=0,
+            maximum=1000,
+            default=1,
+            precision=1,
+            controls_step=1,
+            slider_step=0.1,
+            scale="log",
+        ),
     ],
     outputs=[ImageOutput(image_type="Input0")],
 )

--- a/backend/src/packages/chaiNNer_standard/image_filter/blur/gaussian_blur.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/blur/gaussian_blur.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import cv2
 import numpy as np
 
-from nodes.properties.inputs import ImageInput, NumberInput
+from nodes.properties.inputs import ImageInput, SliderInput
 from nodes.properties.outputs import ImageOutput
 
 from .. import blur_group
@@ -16,8 +16,26 @@ from .. import blur_group
     icon="MdBlurOn",
     inputs=[
         ImageInput(),
-        NumberInput("Radius X", precision=1, controls_step=1),
-        NumberInput("Radius Y", precision=1, controls_step=1),
+        SliderInput(
+            "Radius X",
+            minimum=0,
+            maximum=1000,
+            default=1,
+            precision=1,
+            controls_step=1,
+            slider_step=0.1,
+            scale="log",
+        ),
+        SliderInput(
+            "Radius Y",
+            minimum=0,
+            maximum=1000,
+            default=1,
+            precision=1,
+            controls_step=1,
+            slider_step=0.1,
+            scale="log",
+        ),
     ],
     outputs=[ImageOutput(image_type="Input0")],
 )

--- a/backend/src/packages/chaiNNer_standard/image_filter/blur/lens_blur.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/blur/lens_blur.py
@@ -8,7 +8,7 @@ import cv2
 import numpy as np
 
 from nodes.impl.image_utils import as_3d
-from nodes.properties.inputs import ImageInput, NumberInput, SliderInput
+from nodes.properties.inputs import ImageInput, SliderInput
 from nodes.properties.outputs import ImageOutput
 
 from .. import blur_group
@@ -141,11 +141,14 @@ def lens_blur(
     icon="MdBlurOn",
     inputs=[
         ImageInput(),
-        NumberInput(
+        SliderInput(
             "Radius",
             minimum=0,
+            maximum=1000,
             default=3,
+            precision=0,
             controls_step=1,
+            scale="log",
         ),
         SliderInput(
             "Components",

--- a/backend/src/packages/chaiNNer_standard/image_filter/blur/median_blur.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/blur/median_blur.py
@@ -4,7 +4,7 @@ import cv2
 import numpy as np
 
 from nodes.impl.image_utils import to_uint8
-from nodes.properties.inputs import ImageInput, NumberInput
+from nodes.properties.inputs import ImageInput, SliderInput
 from nodes.properties.outputs import ImageOutput
 
 from .. import blur_group
@@ -17,7 +17,7 @@ from .. import blur_group
     icon="MdBlurOn",
     inputs=[
         ImageInput(),
-        NumberInput("Radius"),
+        SliderInput("Radius", minimum=0, maximum=1000, default=1, scale="log"),
     ],
     outputs=[ImageOutput(image_type="Input0")],
 )
@@ -28,7 +28,8 @@ def median_blur_node(
     if radius == 0:
         return img
     else:
-        if radius < 3:
-            return cv2.medianBlur(img, 2 * radius + 1)
-        else:  # cv2 requires uint8 for kernel size (2r+1) > 5
-            return cv2.medianBlur(to_uint8(img, normalized=True), 2 * radius + 1)
+        size = 2 * radius + 1
+        if size <= 5:
+            return cv2.medianBlur(img, size)
+        else:  # cv2 requires uint8 for kernel size > 5
+            return cv2.medianBlur(to_uint8(img, normalized=True), size)

--- a/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/dilate.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/dilate.py
@@ -5,7 +5,7 @@ from enum import Enum
 import cv2
 import numpy as np
 
-from nodes.properties.inputs import EnumInput, ImageInput, NumberInput
+from nodes.properties.inputs import EnumInput, ImageInput, SliderInput
 from nodes.properties.outputs import ImageOutput
 
 from .. import miscellaneous_group
@@ -32,17 +32,21 @@ class MorphShape(Enum):
                 MorphShape.CROSS: "Cross",
             },
         ),
-        NumberInput(
+        SliderInput(
             "Radius",
             minimum=0,
+            maximum=1000,
             default=1,
             controls_step=1,
+            scale="log",
         ),
-        NumberInput(
+        SliderInput(
             "Iterations",
             minimum=0,
+            maximum=1000,
             default=1,
             controls_step=1,
+            scale="log",
         ),
     ],
     outputs=[ImageOutput(image_type="Input0")],

--- a/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/erode.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/erode.py
@@ -5,7 +5,7 @@ from enum import Enum
 import cv2
 import numpy as np
 
-from nodes.properties.inputs import EnumInput, ImageInput, NumberInput
+from nodes.properties.inputs import EnumInput, ImageInput, SliderInput
 from nodes.properties.outputs import ImageOutput
 
 from .. import miscellaneous_group
@@ -32,17 +32,21 @@ class MorphShape(Enum):
                 MorphShape.CROSS: "Cross",
             },
         ),
-        NumberInput(
+        SliderInput(
             "Radius",
             minimum=0,
+            maximum=1000,
             default=1,
             controls_step=1,
+            scale="log",
         ),
-        NumberInput(
+        SliderInput(
             "Iterations",
             minimum=0,
+            maximum=1000,
             default=1,
             controls_step=1,
+            scale="log",
         ),
     ],
     outputs=[ImageOutput(image_type="Input0")],

--- a/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/high_pass.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/high_pass.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import cv2
 import numpy as np
 
-from nodes.properties.inputs import ImageInput, NumberInput, SliderInput
+from nodes.properties.inputs import ImageInput, SliderInput
 from nodes.properties.outputs import ImageOutput
 
 from .. import miscellaneous_group
@@ -20,7 +20,16 @@ from .. import miscellaneous_group
     icon="MdOutlineAutoFixHigh",
     inputs=[
         ImageInput(channels=[1, 3, 4]),
-        NumberInput("Radius", minimum=0, default=3, precision=2, controls_step=1),
+        SliderInput(
+            "Radius",
+            minimum=0,
+            maximum=1000,
+            default=3,
+            precision=1,
+            controls_step=1,
+            slider_step=0.1,
+            scale="log",
+        ),
         SliderInput(
             "Contrast",
             minimum=0,

--- a/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/pixelate.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/pixelate.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import cv2
 import numpy as np
 
-from nodes.properties.inputs import ImageInput, NumberInput
+from nodes.properties.inputs import ImageInput, SliderInput
 from nodes.properties.outputs import ImageOutput
 
 from .. import miscellaneous_group
@@ -16,8 +16,8 @@ from .. import miscellaneous_group
     icon="MdOutlineAutoFixHigh",
     inputs=[
         ImageInput(),
-        NumberInput("Size X", default=10, precision=0, minimum=1, controls_step=1),
-        NumberInput("Size Y", default=10, precision=0, minimum=1, controls_step=1),
+        SliderInput("Size X", minimum=1, maximum=1024, default=10, scale="log"),
+        SliderInput("Size Y", minimum=1, maximum=1024, default=10, scale="log"),
     ],
     outputs=[ImageOutput(image_type="Input0")],
 )

--- a/backend/src/packages/chaiNNer_standard/image_filter/sharpen/unsharp_mask.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/sharpen/unsharp_mask.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import cv2
 import numpy as np
 
-from nodes.properties.inputs import ImageInput, NumberInput, SliderInput
+from nodes.properties.inputs import ImageInput, SliderInput
 from nodes.properties.outputs import ImageOutput
 
 from .. import sharpen_group
@@ -17,7 +17,16 @@ from .. import sharpen_group
     icon="MdBlurOff",
     inputs=[
         ImageInput(),
-        NumberInput("Radius", minimum=0, default=3, precision=1, controls_step=1),
+        SliderInput(
+            "Radius",
+            minimum=0,
+            maximum=1000,
+            default=3,
+            precision=1,
+            controls_step=1,
+            slider_step=0.1,
+            scale="log",
+        ),
         SliderInput(
             "Amount",
             minimum=0,


### PR DESCRIPTION
Sliders generally offer a better user experience, so I converted the radius number inputs of all blur operations to sliders. Since sliders need a maximum, I used 1000 everywhere. A blur radius >1000 would just average the image anyway (assuming "normal" images size ≤2k). The new sliders use a log scale, so it's easy to input small and large values.

In the future, we may want to allow values >1000 again, but that can be done via a separate slider maximum that is disconnected from the real maximum (if any) of the input.

Before:
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/d664cafe-2cd7-4792-9ee1-7a1566b849e7)

After:
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/38d1d8fe-1bd8-4956-ac88-3df0c40f04d1)
