### PR TITLE
Fixed slider text overflow

### DIFF
--- a/src/renderer/components/inputs/elements/StyledSlider.tsx
+++ b/src/renderer/components/inputs/elements/StyledSlider.tsx
@@ -145,6 +145,7 @@ export const StyledSlider = memo(
                                 cursor="pointer"
                                 display="flex"
                                 h="full"
+                                p="1px"
                                 position="absolute"
                                 userSelect="none"
                                 w="full"
@@ -156,8 +157,11 @@ export const StyledSlider = memo(
                                     cursor="pointer"
                                     fontSize="14px"
                                     lineHeight="1.4em"
+                                    overflow="hidden"
                                     pl={2}
+                                    textOverflow="ellipsis"
                                     userSelect="none"
+                                    w="full"
                                     whiteSpace="nowrap"
                                 >
                                     {style.label}


### PR DESCRIPTION
I noticed that the new sliders didn't deal well with long labels, so I fixed with using an ellipsis. Users can still read the full label in the docs, so I think hiding a little of it is fine.

Before:
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/c175a77e-ad0a-45e8-a520-f0a169f06121)

After:
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/5659d230-e06d-4a15-a9b9-197704eac2c4)
