### PR TITLE
Shorter label for contrast bias in HBF

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image_filter/sharpen/high_boost_filter.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/sharpen/high_boost_filter.py
@@ -44,7 +44,7 @@ class KernelType(Enum):
         ),
         if_enum_group(3, 1)(
             SliderInput(
-                "Contrast Adaptive Bias",
+                "Contrast Bias",
                 minimum=1,
                 maximum=3,
                 default=2,


### PR DESCRIPTION
As can be seen in #1975, the label "Contrast Adaptive Bias" is too long. So I shortened it to "Contrast Bias".