### PR TITLE
Changed Surface blur diameter to radius

### DIFF
--- a/backend/src/nodes/properties/inputs/numeric_inputs.py
+++ b/backend/src/nodes/properties/inputs/numeric_inputs.py
@@ -119,7 +119,7 @@ class SliderInput(NumberInput):
         ends: Tuple[Union[str, None], Union[str, None]] = (None, None),
         hide_trailing_zeros: bool = False,
         gradient: Union[List[str], None] = None,
-        scale: Literal["linear", "log", "log-offset"] = "linear",
+        scale: Literal["linear", "log", "log-offset", "sqrt"] = "linear",
     ):
         super().__init__(
             label,

--- a/backend/src/packages/chaiNNer_standard/image_filter/blur/surface_blur.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/blur/surface_blur.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import cv2
 import numpy as np
 
-from nodes.properties.inputs import ImageInput, NumberInput, SliderInput
+from nodes.properties.inputs import ImageInput, SliderInput
 from nodes.properties.outputs import ImageOutput
 from nodes.utils.utils import get_h_w_c
 
@@ -17,7 +17,14 @@ from .. import blur_group
     icon="MdBlurOn",
     inputs=[
         ImageInput(),
-        NumberInput("Diameter", controls_step=1, default=12),
+        SliderInput(
+            "Radius",
+            minimum=0,
+            maximum=100,
+            default=4,
+            controls_step=1,
+            scale="sqrt",
+        ),
         SliderInput(
             "Color Sigma",
             controls_step=1,
@@ -39,14 +46,15 @@ from .. import blur_group
 )
 def surface_blur_node(
     img: np.ndarray,
-    diameter: int,
+    radius: int,
     sigma_color: int,
     sigma_space: int,
 ) -> np.ndarray:
-    if diameter == 0 or sigma_color == 0 or sigma_space == 0:
+    if radius == 0 or sigma_color == 0 or sigma_space == 0:
         return img
 
     sigma_color_adjusted = sigma_color / 255
+    diameter = radius * 2 + 1
 
     _, _, c = get_h_w_c(img)
     if c == 4:

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -117,7 +117,7 @@ export interface SliderInput extends InputBase {
     readonly ends: readonly [string | null, string | null];
     readonly sliderStep: number;
     readonly gradient?: readonly string[] | null;
-    readonly scale: 'linear' | 'log' | 'log-offset';
+    readonly scale: 'linear' | 'log' | 'log-offset' | 'sqrt';
 }
 export interface ColorInput extends InputBase {
     readonly kind: 'color';

--- a/src/common/migrations.ts
+++ b/src/common/migrations.ts
@@ -1181,6 +1181,28 @@ const emptyStringInput: ModernMigration = (data) => {
     return data;
 };
 
+const surfaceBlurRadius: ModernMigration = (data) => {
+    const toRadius = (diameter: number): number => {
+        diameter = Math.round(diameter);
+        if (diameter <= 0) return 0;
+        if (diameter <= 3) return 1;
+        // d = 2r+1
+        const r = Math.ceil((diameter - 1) / 2);
+        return Math.min(r, 100);
+    };
+
+    data.nodes.forEach((node) => {
+        if (node.data.schemaId === 'chainner:image:bilateral_blur') {
+            const diameter = node.data.inputData[1];
+            if (typeof diameter === 'number') {
+                node.data.inputData[1] = toRadius(diameter);
+            }
+        }
+    });
+
+    return data;
+};
+
 // ==============
 
 const versionToMigration = (version: string) => {
@@ -1228,6 +1250,7 @@ const migrations = [
     seedInput,
     createColor,
     emptyStringInput,
+    surfaceBlurRadius,
 ];
 
 export const currentMigration = migrations.length;

--- a/src/renderer/components/inputs/SliderInput.tsx
+++ b/src/renderer/components/inputs/SliderInput.tsx
@@ -11,7 +11,14 @@ import { BackendContext } from '../../contexts/BackendContext';
 import { useContextMenu } from '../../hooks/useContextMenu';
 import { AdvancedNumberInput } from './elements/AdvanceNumberInput';
 import { CopyOverrideIdSection } from './elements/CopyOverrideIdSection';
-import { LINEAR_SCALE, LogScale, Scale, SliderStyle, StyledSlider } from './elements/StyledSlider';
+import {
+    LINEAR_SCALE,
+    LogScale,
+    PowerScale,
+    Scale,
+    SliderStyle,
+    StyledSlider,
+} from './elements/StyledSlider';
 import { WithLabel, WithoutLabel } from './InputContainer';
 import { InputProps } from './props';
 
@@ -25,6 +32,8 @@ const parseScale = (
             return new LogScale(input.min, input.precision);
         case 'log-offset':
             return new LogScale(input.min + 0.66, input.precision);
+        case 'sqrt':
+            return new PowerScale(0.5, input.min, input.precision);
         default:
             return assertNever(input.scale);
     }

--- a/src/renderer/components/inputs/elements/StyledSlider.tsx
+++ b/src/renderer/components/inputs/elements/StyledSlider.tsx
@@ -36,6 +36,28 @@ export class LogScale implements Scale {
         return Number(value.toFixed(this.precision));
     }
 }
+export class PowerScale implements Scale {
+    public readonly power: number;
+
+    public readonly min: number;
+
+    public readonly precision: number;
+
+    constructor(power: number, min: number, precision: number) {
+        this.power = power;
+        this.min = min;
+        this.precision = precision;
+    }
+
+    toScale(value: number): number {
+        return (value - this.min) ** this.power;
+    }
+
+    fromScale(scaledValue: number): number {
+        const value = scaledValue ** (1 / this.power) + this.min;
+        return Number(value.toFixed(this.precision));
+    }
+}
 
 interface OldLabelStyle {
     readonly type: 'old-label';


### PR DESCRIPTION
I noticed that the Diameter input of the Surface Blur node (#1292) behaved weirdly. In my testing, I set both sigmas to 1000 (max), which makes the node behave like a simple Gaussian blur. This makes it easy to see the effects of the diameter. I saw that D=1,2,3 produced the same image. Same with D=4,5 and D=6,7 etc. In general, only odd numbers >=3 were actually used by OpenCV's `bilateralFilter`.

To fix this, I switched to radius instead. The diameter is then calculated as 2r+1. This makes the node behave as expected and is consistent with all other blur nodes. I also set 100 as the max radius, because Surface blur is extremely slow for large radii (anything R>30 takes multiple seconds at 100% CPU on all cores).

Since both linear and log scale didn't feel right for the radius slider, I added a new sqrt scale. We can use this scale for other stuff in the future, but it's only used here right now.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/fdd5ef6a-8288-41be-af32-327031786052)

Migration: Since this change is breaking, I added a migration. Migrating input values is easy, but connections are hard. 

In fact, 3 nodes necessary to approximately convert from diameter to radius (D=1 is incorrectly mapped to R=0):
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/330f36b4-0cef-45b0-83fa-db93ab54c057)

And it takes 6 nodes for a correct conversion:
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/adf334dd-adab-4e6d-a8e1-dbff4c7392f1)

Do I have to code up a migration for connections, or can we just list this under "breaking changes" in the next release?