### PR TITLE
Added linked inputs group

### DIFF
--- a/backend/src/nodes/groups.py
+++ b/backend/src/nodes/groups.py
@@ -202,7 +202,7 @@ def optional_list_group(*inputs: BaseInput | NestedGroup):
     return group("optional-list")(*inputs)
 
 
-def linked_inputs_group(*inputs: BaseInput | NestedGroup):
+def linked_inputs_group(*inputs: BaseInput):
     """
     This group wraps around inputs of the same type. It ensures that all inputs have the same
     value.

--- a/backend/src/nodes/groups.py
+++ b/backend/src/nodes/groups.py
@@ -198,6 +198,17 @@ def optional_list_group(*inputs: BaseInput | NestedGroup):
     can be used to create a similar effect.
 
     See the Text Append node for an example.
-    ```
     """
     return group("optional-list")(*inputs)
+
+
+def linked_inputs_group(*inputs: BaseInput | NestedGroup):
+    """
+    This group wraps around inputs of the same type. It ensures that all inputs have the same
+    value.
+
+    "The same type" here not only refers to the Navi type of those inputs. All possible values
+    from all inputs must also be valid values for all other inputs. This typically necessitates
+    that the inputs are of the same class and use the same parameters.
+    """
+    return group("linked-inputs")(*inputs)

--- a/backend/src/packages/chaiNNer_standard/image_filter/blur/box_blur.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/blur/box_blur.py
@@ -6,6 +6,7 @@ from math import ceil
 import cv2
 import numpy as np
 
+from nodes.groups import linked_inputs_group
 from nodes.properties.inputs import ImageInput, SliderInput
 from nodes.properties.outputs import ImageOutput
 
@@ -52,25 +53,27 @@ def get_kernel_2d(radius_x: float, radius_y) -> np.ndarray:
     icon="MdBlurOn",
     inputs=[
         ImageInput(),
-        SliderInput(
-            "Radius X",
-            minimum=0,
-            maximum=1000,
-            default=1,
-            precision=1,
-            controls_step=1,
-            slider_step=0.1,
-            scale="log",
-        ),
-        SliderInput(
-            "Radius Y",
-            minimum=0,
-            maximum=1000,
-            default=1,
-            precision=1,
-            controls_step=1,
-            slider_step=0.1,
-            scale="log",
+        linked_inputs_group(
+            SliderInput(
+                "Radius X",
+                minimum=0,
+                maximum=1000,
+                default=1,
+                precision=1,
+                controls_step=1,
+                slider_step=0.1,
+                scale="log",
+            ),
+            SliderInput(
+                "Radius Y",
+                minimum=0,
+                maximum=1000,
+                default=1,
+                precision=1,
+                controls_step=1,
+                slider_step=0.1,
+                scale="log",
+            ),
         ),
     ],
     outputs=[ImageOutput(image_type="Input0")],

--- a/backend/src/packages/chaiNNer_standard/image_filter/blur/gaussian_blur.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/blur/gaussian_blur.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 
+from nodes.groups import linked_inputs_group
 from nodes.impl.image_utils import fast_gaussian_blur
 from nodes.properties.inputs import ImageInput, SliderInput
 from nodes.properties.outputs import ImageOutput
@@ -16,25 +17,27 @@ from .. import blur_group
     icon="MdBlurOn",
     inputs=[
         ImageInput(),
-        SliderInput(
-            "Radius X",
-            minimum=0,
-            maximum=1000,
-            default=1,
-            precision=1,
-            controls_step=1,
-            slider_step=0.1,
-            scale="log",
-        ),
-        SliderInput(
-            "Radius Y",
-            minimum=0,
-            maximum=1000,
-            default=1,
-            precision=1,
-            controls_step=1,
-            slider_step=0.1,
-            scale="log",
+        linked_inputs_group(
+            SliderInput(
+                "Radius X",
+                minimum=0,
+                maximum=1000,
+                default=1,
+                precision=1,
+                controls_step=1,
+                slider_step=0.1,
+                scale="log",
+            ),
+            SliderInput(
+                "Radius Y",
+                minimum=0,
+                maximum=1000,
+                default=1,
+                precision=1,
+                controls_step=1,
+                slider_step=0.1,
+                scale="log",
+            ),
         ),
     ],
     outputs=[ImageOutput(image_type="Input0")],

--- a/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/pixelate.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/pixelate.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import cv2
 import numpy as np
 
+from nodes.groups import linked_inputs_group
 from nodes.properties.inputs import ImageInput, SliderInput
 from nodes.properties.outputs import ImageOutput
 
@@ -16,8 +17,10 @@ from .. import miscellaneous_group
     icon="MdOutlineAutoFixHigh",
     inputs=[
         ImageInput(),
-        SliderInput("Size X", minimum=1, maximum=1024, default=10, scale="log"),
-        SliderInput("Size Y", minimum=1, maximum=1024, default=10, scale="log"),
+        linked_inputs_group(
+            SliderInput("Size X", minimum=1, maximum=1024, default=10, scale="log"),
+            SliderInput("Size Y", minimum=1, maximum=1024, default=10, scale="log"),
+        ),
     ],
     outputs=[ImageOutput(image_type="Input0")],
 )

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -212,6 +212,10 @@ interface SeedGroup extends GroupBase {
     readonly kind: 'seed';
     readonly options: Readonly<Record<string, never>>;
 }
+interface LinkedInputsGroup extends GroupBase {
+    readonly kind: 'linked-inputs';
+    readonly options: Readonly<Record<string, never>>;
+}
 export type GroupKind = Group['kind'];
 export type Group =
     | NcnnFileInputGroup
@@ -219,7 +223,8 @@ export type Group =
     | OptionalListGroup
     | ConditionalGroup
     | RequiredGroup
-    | SeedGroup;
+    | SeedGroup
+    | LinkedInputsGroup;
 
 export type OfKind<T extends { readonly kind: string }, Kind extends T['kind']> = T extends {
     readonly kind: Kind;

--- a/src/common/group-inputs.ts
+++ b/src/common/group-inputs.ts
@@ -11,6 +11,7 @@ import {
     NodeSchema,
     NumberInput,
     OfKind,
+    SliderInput,
 } from './common-types';
 import { getChainnerScope } from './types/chainner-scope';
 import { fromJson } from './types/json';
@@ -34,6 +35,7 @@ type DeclaredGroupInputs = InputGuarantees<{
     'ncnn-file-inputs': readonly [FileInput, FileInput];
     'optional-list': readonly [InputItem, ...InputItem[]];
     seed: readonly [NumberInput];
+    'linked-inputs': readonly [SliderInput, SliderInput, ...SliderInput[]];
 }>;
 
 // A bit hacky, but this ensures that GroupInputs covers exactly all group types, no more and no less
@@ -142,6 +144,19 @@ const groupInputsChecks: {
         const [input] = inputs;
 
         if (input.kind !== 'number') return 'Expected the input to be a number input';
+    },
+    'linked-inputs': (inputs) => {
+        if (inputs.length < 2) return 'Expected at least 2 inputs';
+        if (!allInputsOfKind(inputs, 'slider')) return `Expected all inputs to be slider inputs`;
+
+        const [ref] = inputs;
+        for (const i of inputs) {
+            if (i.min !== ref.min) return 'Expected all inputs to have the same min value';
+            if (i.max !== ref.max) return 'Expected all inputs to have the same max value';
+            if (i.precision !== ref.precision)
+                return 'Expected all inputs to have the same precision value';
+            if (i.def !== ref.def) return 'Expected all inputs to have the same default value';
+        }
     },
 };
 

--- a/src/renderer/components/groups/Group.tsx
+++ b/src/renderer/components/groups/Group.tsx
@@ -4,6 +4,7 @@ import { InputItem } from '../../../common/group-inputs';
 import { NodeState } from '../../helpers/nodeState';
 import { ConditionalGroup } from './ConditionalGroup';
 import { FromToDropdownsGroup } from './FromToDropdownsGroup';
+import { LinkedInputsGroup } from './LinkedInputsGroup';
 import { NcnnFileInputsGroup } from './NcnnFileInputsGroup';
 import { OptionalInputsGroup } from './OptionalInputsGroup';
 import { GroupProps, InputItemRenderer } from './props';
@@ -19,6 +20,7 @@ const GroupComponents: {
     'ncnn-file-inputs': NcnnFileInputsGroup,
     'optional-list': OptionalInputsGroup,
     seed: SeedGroup,
+    'linked-inputs': LinkedInputsGroup,
 };
 
 interface GroupElementProps {

--- a/src/renderer/components/groups/LinkedInputsGroup.tsx
+++ b/src/renderer/components/groups/LinkedInputsGroup.tsx
@@ -43,7 +43,7 @@ export const LinkedInputsGroup = memo(
 
         const allConnected = inputs.every((input) => nodeState.connectedInputs.has(input.id));
 
-        const ttLabel = linked
+        const label = linked
             ? `The values of ${joinEnglish(
                   inputs.map((input) => input.label),
                   'and'
@@ -53,8 +53,14 @@ export const LinkedInputsGroup = memo(
                   'and'
               )} to the same value.`;
 
+        const linkButtonWidth = 1.4;
+        const linkButtonHeight = 2;
+
         return (
-            <HStack spacing={0}>
+            <HStack
+                position="relative"
+                spacing={0}
+            >
                 <Box w="full">
                     {inputs.map((item) => (
                         <ItemRenderer
@@ -65,18 +71,42 @@ export const LinkedInputsGroup = memo(
                     ))}
                 </Box>
                 <Box pr={2}>
+                    <Box
+                        borderColor="white"
+                        borderRadius="0 .5rem 0 0"
+                        borderStyle="solid"
+                        borderWidth="1px 2px 0 0"
+                        bottom={`calc(50% + ${linkButtonHeight / 2}rem)`}
+                        opacity={0.5}
+                        position="absolute"
+                        right={`calc(${linkButtonWidth / 2}rem + 0.5rem - 1px)`}
+                        top=".5rem"
+                        w={2}
+                    />
+                    <Box
+                        borderColor="white"
+                        borderRadius="0 0 .5rem 0"
+                        borderStyle="solid"
+                        borderWidth="0 2px 1px 0"
+                        bottom=".5rem"
+                        opacity={0.5}
+                        position="absolute"
+                        right={`calc(${linkButtonWidth / 2}rem + 0.5rem - 1px)`}
+                        top={`calc(50% + ${linkButtonHeight / 2}rem)`}
+                        w={2}
+                    />
                     <Tooltip
                         closeOnClick
                         closeOnPointerDown
                         hasArrow
                         borderRadius={8}
                         isDisabled={isLocked || allConnected}
-                        label={ttLabel}
+                        label={label}
                         openDelay={2000}
                     >
                         <IconButton
-                            aria-label={ttLabel}
-                            h="2rem"
+                            aria-label={label}
+                            h={`${linkButtonHeight}rem`}
                             icon={
                                 linked ? (
                                     <IoMdLink style={{ transform: 'rotate(90deg)' }} />
@@ -88,7 +118,7 @@ export const LinkedInputsGroup = memo(
                             minWidth={0}
                             size="md"
                             variant="outline"
-                            w="1.4rem"
+                            w={`${linkButtonWidth}rem`}
                             onClick={() => {
                                 if (linked) {
                                     // just unlink

--- a/src/renderer/components/groups/LinkedInputsGroup.tsx
+++ b/src/renderer/components/groups/LinkedInputsGroup.tsx
@@ -54,11 +54,12 @@ export const LinkedInputsGroup = memo(
               )} to the same value.`;
 
         const linkButtonWidth = 1.4;
-        const linkButtonHeight = 2;
+        const linkButtonHeight = 1.6;
 
         return (
             <HStack
-                position="relative"
+                alignItems="normal"
+                pr={1}
                 spacing={0}
             >
                 <Box w="full">
@@ -70,28 +71,32 @@ export const LinkedInputsGroup = memo(
                         />
                     ))}
                 </Box>
-                <Box pr={2}>
+                <Box
+                    alignItems="center"
+                    display="flex"
+                    position="relative"
+                >
                     <Box
-                        borderColor="white"
+                        borderColor="white white transparent transparent"
                         borderRadius="0 .5rem 0 0"
                         borderStyle="solid"
                         borderWidth="1px 2px 0 0"
                         bottom={`calc(50% + ${linkButtonHeight / 2}rem)`}
-                        opacity={0.5}
+                        opacity={allConnected ? 0.25 : 0.5}
                         position="absolute"
-                        right={`calc(${linkButtonWidth / 2}rem + 0.5rem - 1px)`}
+                        right={`calc(${linkButtonWidth / 2}rem - 1px)`}
                         top=".5rem"
                         w={2}
                     />
                     <Box
-                        borderColor="white"
+                        borderColor="transparent white white transparent"
                         borderRadius="0 0 .5rem 0"
                         borderStyle="solid"
                         borderWidth="0 2px 1px 0"
                         bottom=".5rem"
-                        opacity={0.5}
+                        opacity={allConnected ? 0.25 : 0.5}
                         position="absolute"
-                        right={`calc(${linkButtonWidth / 2}rem + 0.5rem - 1px)`}
+                        right={`calc(${linkButtonWidth / 2}rem - 1px)`}
                         top={`calc(50% + ${linkButtonHeight / 2}rem)`}
                         w={2}
                     />
@@ -106,7 +111,8 @@ export const LinkedInputsGroup = memo(
                     >
                         <IconButton
                             aria-label={label}
-                            h={`${linkButtonHeight}rem`}
+                            className="nodrag"
+                            h="2rem"
                             icon={
                                 linked ? (
                                     <IoMdLink style={{ transform: 'rotate(90deg)' }} />
@@ -116,8 +122,9 @@ export const LinkedInputsGroup = memo(
                             }
                             isDisabled={isLocked || allConnected}
                             minWidth={0}
+                            ml="-0.25rem"
                             size="md"
-                            variant="outline"
+                            variant="ghost"
                             w={`${linkButtonWidth}rem`}
                             onClick={() => {
                                 if (linked) {

--- a/src/renderer/components/groups/LinkedInputsGroup.tsx
+++ b/src/renderer/components/groups/LinkedInputsGroup.tsx
@@ -1,0 +1,130 @@
+import { Box, HStack, IconButton, Tooltip } from '@chakra-ui/react';
+import { memo, useCallback, useState } from 'react';
+import { IoMdLink } from 'react-icons/io';
+import { IoUnlink } from 'react-icons/io5';
+import { InputId, InputValue } from '../../../common/common-types';
+import { joinEnglish } from '../../../common/util';
+import { NodeState } from '../../helpers/nodeState';
+import { useMemoObject } from '../../hooks/useMemo';
+import { GroupProps } from './props';
+
+export const LinkedInputsGroup = memo(
+    ({ inputs, nodeState, ItemRenderer }: GroupProps<'linked-inputs'>) => {
+        const { inputData, setInputValue, isLocked } = nodeState;
+
+        const [linked, setLinked] = useState<boolean>(() => {
+            const allSameValue = inputs.every((input) => {
+                const value = inputData[input.id];
+                return value === inputData[inputs[0].id];
+            });
+            return allSameValue;
+        });
+
+        const [lastUsedInput, setLastUsedInput] = useState<InputId | null>(null);
+
+        const modifiedNodeState = useMemoObject<NodeState>({
+            ...nodeState,
+            setInputValue: useCallback(
+                (inputId: InputId, value: InputValue): void => {
+                    setInputValue(inputId, value);
+                    setLastUsedInput(inputId);
+
+                    if (linked && typeof value === 'number') {
+                        for (const input of inputs) {
+                            if (input.id !== inputId) {
+                                setInputValue(input.id, value);
+                            }
+                        }
+                    }
+                },
+                [linked, setInputValue, inputs]
+            ),
+        });
+
+        const allConnected = inputs.every((input) => nodeState.connectedInputs.has(input.id));
+
+        const ttLabel = linked
+            ? `The values of ${joinEnglish(
+                  inputs.map((input) => input.label),
+                  'and'
+              )} are currently linked to the same value. Click here to undo this link.`
+            : `Click here to link ${joinEnglish(
+                  inputs.map((input) => input.label),
+                  'and'
+              )} to the same value.`;
+
+        return (
+            <HStack spacing={0}>
+                <Box w="full">
+                    {inputs.map((item) => (
+                        <ItemRenderer
+                            item={item}
+                            key={item.id}
+                            nodeState={modifiedNodeState}
+                        />
+                    ))}
+                </Box>
+                <Box pr={2}>
+                    <Tooltip
+                        closeOnClick
+                        closeOnPointerDown
+                        hasArrow
+                        borderRadius={8}
+                        isDisabled={isLocked || allConnected}
+                        label={ttLabel}
+                        openDelay={2000}
+                    >
+                        <IconButton
+                            aria-label={ttLabel}
+                            h="2rem"
+                            icon={
+                                linked ? (
+                                    <IoMdLink style={{ transform: 'rotate(90deg)' }} />
+                                ) : (
+                                    <IoUnlink style={{ transform: 'rotate(90deg)' }} />
+                                )
+                            }
+                            isDisabled={isLocked || allConnected}
+                            minWidth={0}
+                            size="md"
+                            variant="outline"
+                            w="1.4rem"
+                            onClick={() => {
+                                if (linked) {
+                                    // just unlink
+                                    setLinked(false);
+                                } else {
+                                    // link and set inputs to the same value
+                                    setLinked(true);
+
+                                    let value: InputValue;
+                                    if (
+                                        lastUsedInput !== null &&
+                                        !nodeState.connectedInputs.has(lastUsedInput)
+                                    ) {
+                                        // use the value of the last used input (if not connected)
+                                        value = nodeState.inputData[lastUsedInput];
+                                    } else {
+                                        // use the value of the first unconnected input
+                                        const firstUnconnectedInput = inputs.find(
+                                            (input) => !nodeState.connectedInputs.has(input.id)
+                                        );
+                                        if (firstUnconnectedInput) {
+                                            value = nodeState.inputData[firstUnconnectedInput.id];
+                                        }
+                                    }
+
+                                    if (value !== undefined) {
+                                        for (const input of inputs) {
+                                            setInputValue(input.id, value);
+                                        }
+                                    }
+                                }
+                            }}
+                        />
+                    </Tooltip>
+                </Box>
+            </HStack>
+        );
+    }
+);

--- a/src/renderer/components/inputs/elements/AdvanceNumberInput.tsx
+++ b/src/renderer/components/inputs/elements/AdvanceNumberInput.tsx
@@ -70,17 +70,21 @@ export const AdvancedNumberInput = memo(
         inputHeight,
         noRepeatOnBlur = false,
     }: AdvancedNumberInputProps) => {
+        const getNumericValue = (): number | undefined => {
+            const valAsNumber =
+                precision > 0
+                    ? parseFloat(inputString || String(defaultValue))
+                    : Math.round(parseFloat(inputString || String(defaultValue)));
+
+            if (!Number.isNaN(valAsNumber)) {
+                return Number(clamp(valAsNumber, min, max).toFixed(precision));
+            }
+        };
         const onBlur = noRepeatOnBlur
             ? noop
             : () => {
-                  const valAsNumber =
-                      precision > 0
-                          ? parseFloat(inputString || String(defaultValue))
-                          : Math.round(parseFloat(inputString || String(defaultValue)));
-
-                  if (!Number.isNaN(valAsNumber)) {
-                      const value = Number(clamp(valAsNumber, min, max).toFixed(precision));
-
+                  const value = getNumericValue();
+                  if (value !== undefined) {
                       // Make sure the input value has been altered so onChange gets correct value if adjustment needed
                       setImmediate(() => {
                           setInput(value);
@@ -90,6 +94,15 @@ export const AdvancedNumberInput = memo(
                       });
                   }
               };
+
+        const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+            if (e.key === 'Enter') {
+                const value = getNumericValue();
+                if (value !== undefined) {
+                    setInput(value);
+                }
+            }
+        };
 
         if (small) {
             return (
@@ -132,6 +145,7 @@ export const AdvancedNumberInput = memo(
                             p={1}
                             size={1}
                             w={inputWidth}
+                            onKeyDown={onKeyDown}
                         />
                         <NumberInputStepper w={4}>
                             <NumberIncrementStepper />
@@ -179,6 +193,7 @@ export const AdvancedNumberInput = memo(
                         px={unit ? 2 : 4}
                         size={1}
                         w={inputWidth}
+                        onKeyDown={onKeyDown}
                     />
                     <NumberInputStepper>
                         <NumberIncrementStepper />


### PR DESCRIPTION
As mentioned on Discord, I made a group to link the values of inputs. While not perfect, it's functional. The main issue is that values are linked via `inputData`, so sliders aren't synced in real time, but only when a value is entered (slider is released). 

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/c860c00d-d3c3-42c2-b2c6-4f0abbc1f195)

---

A for the design: it's not done yet. I'll do it tomorrow.
