### PR TITLE
Variable precision for log-scale sliders

### DIFF
--- a/src/renderer/components/inputs/SliderInput.tsx
+++ b/src/renderer/components/inputs/SliderInput.tsx
@@ -29,9 +29,9 @@ const parseScale = (
         case 'linear':
             return LINEAR_SCALE;
         case 'log':
-            return new LogScale(input.min, input.precision);
+            return new LogScale(input.min, input.max, input.precision);
         case 'log-offset':
-            return new LogScale(input.min + 0.66, input.precision);
+            return new LogScale(input.min + 0.66, input.max + 0.66, input.precision);
         case 'sqrt':
             return new PowerScale(0.5, input.min, input.precision);
         default:

--- a/src/renderer/components/inputs/SliderInput.tsx
+++ b/src/renderer/components/inputs/SliderInput.tsx
@@ -31,7 +31,7 @@ const parseScale = (
         case 'log':
             return new LogScale(input.min, input.max, input.precision);
         case 'log-offset':
-            return new LogScale(input.min + 0.66, input.max + 0.66, input.precision);
+            return new LogScale(input.min, input.max, input.precision, 0.66);
         case 'sqrt':
             return new PowerScale(0.5, input.min, input.precision);
         default:

--- a/src/renderer/components/inputs/elements/StyledSlider.tsx
+++ b/src/renderer/components/inputs/elements/StyledSlider.tsx
@@ -24,18 +24,21 @@ export class LogScale implements Scale {
 
     public readonly precision: number;
 
-    constructor(min: number, max: number, precision: number) {
+    public readonly offset: number;
+
+    constructor(min: number, max: number, precision: number, offset = 0) {
         this.min = min;
         this.max = max;
         this.precision = precision;
+        this.offset = offset;
     }
 
     toScale(value: number): number {
-        return Math.log1p(value - this.min);
+        return Math.log1p(value - (this.min + this.offset));
     }
 
     fromScale(scaledValue: number): number {
-        let value = Math.expm1(scaledValue) + this.min;
+        let value = Math.expm1(scaledValue) + (this.min + this.offset);
 
         // 2 digits of precision
         if (this.min < value && value < this.max) {

--- a/src/renderer/components/inputs/elements/StyledSlider.tsx
+++ b/src/renderer/components/inputs/elements/StyledSlider.tsx
@@ -20,10 +20,13 @@ export const LINEAR_SCALE: Scale = { toScale: (n) => n, fromScale: (n) => n };
 export class LogScale implements Scale {
     public readonly min: number;
 
+    public readonly max: number;
+
     public readonly precision: number;
 
-    constructor(min: number, precision: number) {
+    constructor(min: number, max: number, precision: number) {
         this.min = min;
+        this.max = max;
         this.precision = precision;
     }
 
@@ -32,7 +35,20 @@ export class LogScale implements Scale {
     }
 
     fromScale(scaledValue: number): number {
-        const value = Math.expm1(scaledValue) + this.min;
+        let value = Math.expm1(scaledValue) + this.min;
+
+        // 2 digits of precision
+        if (this.min < value && value < this.max) {
+            value = Number(value.toExponential(2));
+            if (value > 0) {
+                // we only want 1 fractional digit for numbers between 2*10^k and 10^(k+1)
+                const k = Math.floor(Math.log10(value));
+                if (value >= 2 * 10 ** k) {
+                    value = Number(value.toExponential(1));
+                }
+            }
+        }
+
         return Number(value.toFixed(this.precision));
     }
 }


### PR DESCRIPTION
This is an improvement for log-scale sliders. Other slider scales are not affected.

Log-scale sliders had the problem that it was basically impossible to input large integer values. Due to the log scale, you would also input values like 257.3. 

This PR fixes this problem by enforcing between 2 and 3 significant digits. The specific rule is that numbers between 1\*10<sup>k</sup> and 2\*10<sup>k</sup> (exclusive) get 3 significant digits and all others get 2 significant digits. This means that slider can input the values 2.5, 5.1, 9.2, 15.7, 19.9, 20, and 26, but not 2.53, 13.11, or 20.1.

While more complex than always enforcing 2 or 3 significant digits, this rule feels very nice to use. Having 3 digits for relatively small numbers gives sliders a feeling for precise control, all while making it possible to easily input large numbers like 50 or 500.

Of course, the fixed precision of the slider will be enforced on top of significant digits.