### PR TITLE
Added a thin line for sliders

### DIFF
--- a/src/renderer/components/inputs/elements/StyledSlider.tsx
+++ b/src/renderer/components/inputs/elements/StyledSlider.tsx
@@ -254,6 +254,17 @@ export const StyledSlider = memo(
                                 bg={borderColor}
                                 cursor="pointer"
                             />
+                            <SliderFilledTrack
+                                bg="transparent"
+                                borderRight={
+                                    min < value && value < max
+                                        ? `1px solid ${textColor}`
+                                        : undefined
+                                }
+                                cursor="pointer"
+                                opacity={0.5}
+                                zIndex={3}
+                            />
                         </>
                     )}
                     {style.type === 'old-label' && (


### PR DESCRIPTION
This is implemented in a hacky way, but it's the only way to get pixel-perfect rendering. The thin line is implemented as a second invisible filled track with a right border. This track is then rendered above everything else, which makes the line render above everything else.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/e753a4ae-c73a-4ddc-9151-2bc5d51af4da)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/9d028d7c-539f-4c11-b4e2-b98dc6595394)
