### PR TITLE
Use slider in Gamma node

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/gamma.py
+++ b/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/gamma.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from nodes.properties.inputs import BoolInput, ImageInput, NumberInput
+from nodes.properties.inputs import BoolInput, ImageInput, SliderInput
 from nodes.properties.outputs import ImageOutput
 from nodes.utils.utils import get_h_w_c
 
@@ -16,13 +16,14 @@ from .. import adjustments_group
     icon="ImBrightnessContrast",
     inputs=[
         ImageInput(),
-        NumberInput(
+        SliderInput(
             "Gamma",
             minimum=0.01,
             maximum=100,
             default=1,
             precision=4,
             controls_step=0.1,
+            scale="log",
         ),
         BoolInput("Invert Gamma", default=False),
     ],


### PR DESCRIPTION
Gamma is now consistent with other nodes with a gamma input.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/a2c4271d-f732-43d7-9669-f392b3a5b22b)
