### PR TITLE
Fixed handle position of seed input

### DIFF
--- a/src/renderer/global.scss
+++ b/src/renderer/global.scss
@@ -171,7 +171,7 @@ body {
     }
 }
 
-.chainner-handle:has(+ .with-label) {
+.chainner-handle:has(+ .with-label, + * .with-label) {
     margin-top: 1rem;
 }
 


### PR DESCRIPTION
This fixes the handle position of seed inputs. This bug was introduced in #1977.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/bfb52620-c24b-47dd-9e39-ede346366dc8)
