### PR TITLE
Renamed "LUT" to "color palette"

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image_filter/quantize/dither_palette.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/quantize/dither_palette.py
@@ -36,7 +36,8 @@ PALETTE_DITHER_ALGORITHM_LABELS = {
 @quantize_group.register(
     schema_id="chainner:image:palette_dither",
     name="Dither (Palette)",
-    description="Apply one of a variety of dithering algorithms using colors from a given palette. (Only the top row of pixels (y=0) of the palette will be used.)",
+    description="Apply one of a variety of dithering algorithms using colors from a given color palette. (Only the top row of pixels (y=0) of the palette will be used.)",
+    see_also="chainner:image:palette_from_image",
     icon="MdShowChart",
     inputs=[
         ImageInput(),

--- a/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/apply_palette.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/apply_palette.py
@@ -33,21 +33,22 @@ def quantize(img: np.ndarray, levels: int) -> np.ndarray:
 
 @miscellaneous_group.register(
     schema_id="chainner:image:lut",
-    name="Apply LUT",
+    name="Apply Palette",
     description=(
-        "Apply a look up table (LUT) to a grayscale image."
-        " Only the top row of pixels (y=0) of the LUT will be used to do the look up."
+        "Apply a color palette to a grayscale image."
+        " Only the top row of pixels (y=0) of the palette will be used to do the look up."
     ),
+    see_also="chainner:image:palette_from_image",
     icon="MdGradient",
     inputs=[
         ImageInput(channels=1),
-        ImageInput("LUT"),
+        ImageInput("Palette"),
     ],
     outputs=[
         ImageOutput(image_type=navi.Image(size_as="Input0", channels_as="Input1"))
     ],
 )
-def apply_lut_node(
+def apply_palette_node(
     img: np.ndarray,
     lut: np.ndarray,
 ) -> np.ndarray:

--- a/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/palette_from_image.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/palette_from_image.py
@@ -33,9 +33,14 @@ PALETTE_EXTRACTION_METHOD_LABELS = {
 @miscellaneous_group.register(
     schema_id="chainner:image:palette_from_image",
     name="Palette from Image",
-    description=(
-        "Use an image to create a palette.  A palette is an image with one row."
-    ),
+    description=[
+        "Use an image to create a color palette.",
+        "The color palette is returned as an image with one row (height=1). All colors of the palette are in the top row of the image.",
+    ],
+    see_also=[
+        "chainner:image:lut",
+        "chainner:image:palette_dither",
+    ],
     icon="MdGradient",
     inputs=[
         ImageInput(),


### PR DESCRIPTION
Consistently use the term "color palette" instead of "LUT". I also improved the docs a little.