### PR TITLE
Fixed color popover in docs modal

### DIFF
--- a/src/renderer/global.scss
+++ b/src/renderer/global.scss
@@ -202,3 +202,7 @@ body {
         margin-bottom: 0 !important;
     }
 }
+
+.chakra-modal__overlay ~ .chakra-portal > .chakra-popover__popper:has(> .chainner-color-selector) {
+    z-index: 10000 !important;
+}


### PR DESCRIPTION
This fixes the color popover appearing below the docs modal by overriding the z index of the popover. The CSS selector is a bit complex, because I wanted to apply the z index only to color popovers that need it.

Also, I needed to do in CSS, because Chakra does not support styles (or even class names) for the popover container.