### PR TITLE
Never wrap output labels

### DIFF
--- a/src/renderer/components/outputs/GenericOutput.tsx
+++ b/src/renderer/components/outputs/GenericOutput.tsx
@@ -27,6 +27,7 @@ export const GenericOutput = memo(({ output, type }: OutputProps) => {
                 marginInlineEnd="0.5rem"
                 ml={1}
                 textAlign="right"
+                whiteSpace="nowrap"
             >
                 {output.label}
             </Text>


### PR DESCRIPTION
Fake nodes in docs sometimes had the issue what output labels were broken into 2 lines when the type tag was very long. This PR fixes that.