### PR TITLE
Enforce non-empty images

### DIFF
--- a/backend/src/nodes/properties/outputs/numpy_outputs.py
+++ b/backend/src/nodes/properties/outputs/numpy_outputs.py
@@ -76,7 +76,14 @@ class ImageOutput(NumPyOutput):
     def enforce(self, value) -> np.ndarray:
         assert isinstance(value, np.ndarray)
 
-        _, _, c = get_h_w_c(value)
+        h, w, c = get_h_w_c(value)
+
+        if h == 0 or w == 0:
+            raise ValueError(
+                f"The output {self.label} returned an empty image (w={w} h={h})."
+                f" This is a bug in the implementation of the node."
+                f" Please report this bug."
+            )
 
         if self.channels is not None and c != self.channels:
             expected = format_image_with_channels([self.channels])

--- a/backend/src/packages/chaiNNer_standard/image_channel/all/combine_rgba.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/all/combine_rgba.py
@@ -28,8 +28,8 @@ from . import node_group
             image_type="""
                 let anyImages = bool::or(Input0 == Image, Input1 == Image, Input2 == Image, Input3 == Image);
 
-                def getWidth(i: any) = match i { Image => i.width, _ => uint };
-                def getHeight(i: any) = match i { Image => i.height, _ => uint };
+                def getWidth(i: any) = match i { Image => i.width, _ => Image.width };
+                def getHeight(i: any) = match i { Image => i.height, _ => Image.height };
 
                 let valid = if anyImages { any } else { never };
 

--- a/backend/src/packages/chaiNNer_standard/image_channel/transparency/merge_transparency.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/transparency/merge_transparency.py
@@ -24,8 +24,8 @@ from . import node_group
             image_type="""
                 let anyImages = bool::or(Input0 == Image, Input1 == Image);
 
-                def getWidth(i: any) = match i { Image => i.width, _ => uint };
-                def getHeight(i: any) = match i { Image => i.height, _ => uint };
+                def getWidth(i: any) = match i { Image => i.width, _ => Image.width };
+                def getHeight(i: any) = match i { Image => i.height, _ => Image.height };
 
                 let valid = if anyImages { any } else { never };
 

--- a/backend/src/packages/chaiNNer_standard/image_utility/compositing/stack_images.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/compositing/stack_images.py
@@ -101,13 +101,13 @@ class Orientation(Enum):
                 def getAdjustedWidth(img: Image | null) {
                     match img {
                         null => 0,
-                        _ as i => uint & round(i.width * maxHeight / i.height)
+                        _ as i => int(1..) & round(i.width * maxHeight / i.height)
                     }
                 }
                 def getAdjustedHeight(img: Image | null) {
                     match img {
                         null => 0,
-                        _ as i => uint & round(i.height * maxWidth / i.width)
+                        _ as i => int(1..) & round(i.height * maxWidth / i.width)
                     }
                 }
 

--- a/backend/src/packages/chaiNNer_standard/image_utility/modification/rotate.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/modification/rotate.py
@@ -84,16 +84,16 @@ from .. import modification_group
                 let p2 = transform(w, h);
                 let p3 = transform(0, h);
 
-                let expandWidth = int(1..) & (
+                let expandWidth = Image.width & (
                     ceil(max(p0.x, p1.x, p2.x, p3.x))
                     - floor(min(p0.x, p1.x, p2.x, p3.x))
                 );
-                let expandHeight = int(1..) & (
+                let expandHeight = Image.height & (
                     ceil(max(p0.y, p1.y, p2.y, p3.y))
                     - floor(min(p0.y, p1.y, p2.y, p3.y))
                 );
 
-                struct Size { w: int(1..), h: int(1..) }
+                struct Size { w: number, h: number }
                 let imgSize = Size { w: w, h: h };
                 let transformedSize = match Input3 {
                     RotateSizeChange::Crop => imgSize,

--- a/backend/src/packages/chaiNNer_standard/image_utility/modification/rotate.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/modification/rotate.py
@@ -84,16 +84,16 @@ from .. import modification_group
                 let p2 = transform(w, h);
                 let p3 = transform(0, h);
 
-                let expandWidth = uint & (
+                let expandWidth = int(1..) & (
                     ceil(max(p0.x, p1.x, p2.x, p3.x))
                     - floor(min(p0.x, p1.x, p2.x, p3.x))
                 );
-                let expandHeight = uint & (
+                let expandHeight = int(1..) & (
                     ceil(max(p0.y, p1.y, p2.y, p3.y))
                     - floor(min(p0.y, p1.y, p2.y, p3.y))
                 );
 
-                struct Size { w: number, h: number }
+                struct Size { w: int(1..), h: int(1..) }
                 let imgSize = Size { w: w, h: h };
                 let transformedSize = match Input3 {
                     RotateSizeChange::Crop => imgSize,

--- a/src/common/types/chainner-scope.ts
+++ b/src/common/types/chainner-scope.ts
@@ -31,8 +31,8 @@ struct Audio;
 
 struct ImageFile { path: string }
 struct Image {
-    width: uint,
-    height: uint,
+    width: int(1..),
+    height: int(1..),
     channels: int(1..),
 }
 struct Color { channels: int(1..) }

--- a/src/common/types/explain.ts
+++ b/src/common/types/explain.ts
@@ -88,14 +88,9 @@ const explainStruct = (s: StructType, options: ExplainOptions): string | undefin
         const height = s.fields[1].type;
         const channels = s.fields[2].type;
 
-        if (isInt(width, 0) && isInt(height, 0)) {
+        if (isInt(width, 1) && isInt(height, 1)) {
             if (isInt(channels, 1)) return detailed('an image', 'of any size and any colorspace');
             return detailed(formatChannelNumber(channels, 'image'), 'of any size');
-        }
-        if (isInt(width, 1) && isInt(height, 1)) {
-            if (isInt(channels, 1)) return detailed('an non-empty image', 'of any colorspace');
-            const formatted = formatChannelNumber(channels, 'image');
-            if (formatted) return `${formatted} that isn't empty`;
         }
     }
 


### PR DESCRIPTION
This PR adds explicit checks to enforce non-empty images. I also changed the `Image` type to reflect this change.