### PR TITLE
Upgrade to Navi 0.6.0

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize_to_side.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize_to_side.py
@@ -135,25 +135,25 @@ def resize_to_side_conditional(
                     SideSelection::Width => if compareCondition(w) { same } else {
                         Size {
                             width: target,
-                            height: max(int & round((target / w) * h), 1)
+                            height: max(round((target / w) * h), 1)
                         }
                     },
                     SideSelection::Height => if compareCondition(h) { same } else {
                         Size {
-                            width: max(int & round((target / h) * w), 1),
+                            width: max(round((target / h) * w), 1),
                             height: target
                         }
                     },
                     SideSelection::ShorterSide => if compareCondition(min(h, w)) { same } else {
                         Size {
-                            width: max(int & round((target / min(h, w)) * w), 1),
-                            height: max(int & round((target / min(h, w)) * h), 1)
+                            width: max(round((target / min(h, w)) * w), 1),
+                            height: max(round((target / min(h, w)) * h), 1)
                         }
                     },
                     SideSelection::LongerSide => if compareCondition(max(h, w)) { same } else {
                         Size {
-                            width: max(int & round((target / max(h, w)) * w), 1),
-                            height: max(int & round((target / max(h, w)) * h), 1)
+                            width: max(round((target / max(h, w)) * w), 1),
+                            height: max(round((target / max(h, w)) * h), 1)
                         }
                     },
                 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPLv3",
       "dependencies": {
         "@babel/plugin-transform-react-jsx": "^7.17.12",
-        "@chainner/navi": "^0.5.0",
+        "@chainner/navi": "^0.6.0",
         "@chakra-ui/icons": "^2.0.11",
         "@chakra-ui/react": "^2.3.5",
         "@emotion/react": "^11.9.0",
@@ -953,9 +953,9 @@
       "dev": true
     },
     "node_modules/@chainner/navi": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@chainner/navi/-/navi-0.5.0.tgz",
-      "integrity": "sha512-90WKzq27kzUmZhFaJiwsHJjvTSphVhMXJ5sSGRt8rgOynYCaiciUEZJZWwGukkFCuRbNeoD9kBHRHuvop8hA6A=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@chainner/navi/-/navi-0.6.0.tgz",
+      "integrity": "sha512-R3VtwlVArE9ngIduLqMAd8GOOEotVR/Rgy4+d5UobDPIj7c/5Fs9ZXb3j7SrAxlOtRgzrD979SUYuLT0n4+WOA=="
     },
     "node_modules/@chakra-ui/accordion": {
       "version": "2.1.1",
@@ -25845,9 +25845,9 @@
       "dev": true
     },
     "@chainner/navi": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@chainner/navi/-/navi-0.5.0.tgz",
-      "integrity": "sha512-90WKzq27kzUmZhFaJiwsHJjvTSphVhMXJ5sSGRt8rgOynYCaiciUEZJZWwGukkFCuRbNeoD9kBHRHuvop8hA6A=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@chainner/navi/-/navi-0.6.0.tgz",
+      "integrity": "sha512-R3VtwlVArE9ngIduLqMAd8GOOEotVR/Rgy4+d5UobDPIj7c/5Fs9ZXb3j7SrAxlOtRgzrD979SUYuLT0n4+WOA=="
     },
     "@chakra-ui/accordion": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   },
   "dependencies": {
     "@babel/plugin-transform-react-jsx": "^7.17.12",
-    "@chainner/navi": "^0.5.0",
+    "@chainner/navi": "^0.6.0",
     "@chakra-ui/icons": "^2.0.11",
     "@chakra-ui/react": "^2.3.5",
     "@emotion/react": "^11.9.0",

--- a/src/common/nodes/TypeState.ts
+++ b/src/common/nodes/TypeState.ts
@@ -1,7 +1,8 @@
-import { EvaluationError, NonNeverType, StructType, Type, isSameType } from '@chainner/navi';
+import { EvaluationError, NonNeverType, Type, isSameType } from '@chainner/navi';
 import { EdgeData, InputId, NodeData, OutputId, SchemaId } from '../common-types';
 import { log } from '../log';
 import { FunctionDefinition, FunctionInstance } from '../types/function';
+import { nullType } from '../types/util';
 import { EMPTY_MAP } from '../util';
 import { EdgeState } from './EdgeState';
 import type { Edge, Node } from 'reactflow';
@@ -95,7 +96,7 @@ export class TypeState {
                         }
 
                         if (inputValue === undefined && definition.inputNullable.has(id)) {
-                            return new StructType('null');
+                            return nullType;
                         }
 
                         return undefined;

--- a/src/common/types/chainner-scope.ts
+++ b/src/common/types/chainner-scope.ts
@@ -6,6 +6,7 @@ import {
     SourceDocument,
     Type,
     globalScope,
+    makeScoped,
     parseDefinitions,
 } from '@chainner/navi';
 import { lazy } from '../util';
@@ -151,12 +152,12 @@ intrinsic def parseColorJson(json: string): Color;
 export const getChainnerScope = lazy((): Scope => {
     const builder = new ScopeBuilder('Chainner scope', globalScope);
 
-    const intrinsic: Record<string, (...args: NeverType[]) => Type> = {
-        formatPattern: formatTextPattern,
-        regexReplace,
-        padStart,
-        padEnd,
-        padCenter,
+    const intrinsic: Record<string, (scope: Scope, ...args: NeverType[]) => Type> = {
+        formatPattern: makeScoped(formatTextPattern),
+        regexReplace: makeScoped(regexReplace),
+        padStart: makeScoped(padStart),
+        padEnd: makeScoped(padEnd),
+        padCenter: makeScoped(padCenter),
         splitFilePath,
         parseColorJson,
     };
@@ -167,7 +168,7 @@ export const getChainnerScope = lazy((): Scope => {
             if (!(d.name in intrinsic)) {
                 throw new Error(`Unable to find definition for intrinsic ${d.name}`);
             }
-            const fn = intrinsic[d.name] as (...args: Type[]) => Type;
+            const fn = intrinsic[d.name] as (scope: Scope, ...args: Type[]) => Type;
             builder.add(IntrinsicFunctionDefinition.from(d, fn));
         } else {
             builder.add(d);

--- a/src/common/types/explain.ts
+++ b/src/common/types/explain.ts
@@ -3,13 +3,14 @@ import {
     NumberPrimitive,
     NumericLiteralType,
     StringPrimitive,
-    StructType,
+    StructValueType,
     Type,
     UnionType,
     ValueType,
+    isStructInstance,
 } from '@chainner/navi';
 import { joinEnglish } from '../util';
-import { IntNumberType, isColor, isDirectory, isImage } from './util';
+import { IntNumberType, getFields, isColor, isDirectory, isImage } from './util';
 
 const isInt = (n: Type, min = -Infinity, max = Infinity): n is IntIntervalType => {
     return n.underlying === 'number' && n.type === 'int-interval' && n.min === min && n.max === max;
@@ -77,17 +78,14 @@ const explainString = (s: StringPrimitive): string | undefined => {
     if (s.excluded.size === 1 && s.excluded.has('')) return 'a non-empty string';
 };
 
-const explainStruct = (s: StructType, options: ExplainOptions): string | undefined => {
+const explainStruct = (s: StructValueType, options: ExplainOptions): string | undefined => {
     const detailed = (base: string | undefined, detail: string): string | undefined => {
         if (options.detailed && base) return `${base} ${detail}`;
         return base;
     };
 
     if (isImage(s)) {
-        const width = s.fields[0].type;
-        const height = s.fields[1].type;
-        const channels = s.fields[2].type;
-
+        const { width, height, channels } = getFields(s);
         if (isInt(width, 1) && isInt(height, 1)) {
             if (isInt(channels, 1)) return detailed('an image', 'of any size and any colorspace');
             return detailed(formatChannelNumber(channels, 'image'), 'of any size');
@@ -95,18 +93,17 @@ const explainStruct = (s: StructType, options: ExplainOptions): string | undefin
     }
 
     if (isColor(s)) {
-        const channels = s.fields[0].type;
-
+        const { channels } = getFields(s);
         if (isInt(channels, 1)) return detailed('a color', 'of any colorspace');
         return formatChannelNumber(channels, 'color');
     }
 
     if (isDirectory(s)) {
-        const path = s.fields[0].type;
+        const { path } = getFields(s);
         if (path.type === 'string') return 'a directory path';
     }
 
-    if (s.name === 'Seed') {
+    if (isStructInstance(s) && s.descriptor.name === 'Seed') {
         return 'a seed (for randomness)';
     }
 };

--- a/src/common/types/pretty.ts
+++ b/src/common/types/pretty.ts
@@ -1,19 +1,22 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
 /* eslint-disable no-continue */
-import { Type, ValueType } from '@chainner/navi';
+import {
+    NumberPrimitive,
+    StringPrimitive,
+    StructValueType,
+    Type,
+    UnionType,
+    ValueType,
+} from '@chainner/navi';
 import { assertNever } from '../util';
 
-export const prettyPrintType = (type: Type): string => {
+const prettyPrintNumber = (type: NumberPrimitive): string => {
     switch (type.type) {
-        case 'any':
-        case 'never':
         case 'literal':
         case 'number':
-        case 'string':
         case 'interval':
+        case 'non-int-interval':
             return type.toString();
-
-        case 'inverted-set':
-            return `not(${[...type.excluded].map((s) => JSON.stringify(s)).join(' | ')})`;
 
         case 'int-interval':
             if (type.min === -Infinity && type.max === Infinity) {
@@ -27,38 +30,80 @@ export const prettyPrintType = (type: Type): string => {
             }
             return type.toString();
 
-        case 'union': {
-            const literals: number[] = [];
-            const other: ValueType[] = [];
-            for (const item of type.items) {
-                if (item.underlying === 'number') {
-                    if (item.type === 'literal' && Number.isFinite(item.value)) {
-                        literals.push(item.value);
-                        continue;
-                    }
-                    if (item.type === 'int-interval' && item.min + 1 === item.max) {
-                        literals.push(item.min);
-                        literals.push(item.max);
-                        continue;
-                    }
-                }
-                other.push(item);
-            }
+        default:
+            return assertNever(type);
+    }
+};
+const prettyPrintString = (type: StringPrimitive): string => {
+    switch (type.type) {
+        case 'literal':
+        case 'string':
+            return type.toString();
 
-            const union = [...literals, ...other.map(prettyPrintType)].join(' | ');
+        case 'inverted-set':
+            return `not(${[...type.excluded].map((s) => JSON.stringify(s)).join(' | ')})`;
 
-            // hacky way to detect boolean
-            if (union === 'false | true') return 'bool';
-
-            return union;
+        default:
+            return assertNever(type);
+    }
+};
+const prettyPrintStruct = (type: StructValueType): string => {
+    switch (type.type) {
+        case 'instance': {
+            if (type.fields.length === 0) return type.descriptor.name;
+            const fields = type.descriptor.fields
+                .map((f, i) => `${f.name}: ${prettyPrintType(type.fields[i])}`)
+                .join(', ');
+            return `${type.descriptor.name} { ${fields} }`;
         }
+        case 'inverted-set':
+            return `not(${[...type.excluded].map((s) => s.name).join(' | ')})`;
 
         case 'struct':
-            if (type.fields.length === 0) return type.name;
-            return `${type.name} { ${type.fields
-                .map((f) => `${f.name}: ${prettyPrintType(f.type)}`)
-                .join(', ')} }`;
+            return type.toString();
 
+        default:
+            return assertNever(type);
+    }
+};
+const prettyPrintUnion = (type: UnionType): string => {
+    const literals: number[] = [];
+    const other: ValueType[] = [];
+    for (const item of type.items) {
+        if (item.underlying === 'number') {
+            if (item.type === 'literal' && Number.isFinite(item.value)) {
+                literals.push(item.value);
+                continue;
+            }
+            if (item.type === 'int-interval' && item.min + 1 === item.max) {
+                literals.push(item.min);
+                literals.push(item.max);
+                continue;
+            }
+        }
+        other.push(item);
+    }
+
+    const union = [...literals, ...other.map(prettyPrintType)].join(' | ');
+
+    // hacky way to detect boolean
+    if (union === 'false | true') return 'bool';
+
+    return union;
+};
+export const prettyPrintType = (type: Type): string => {
+    switch (type.underlying) {
+        case 'any':
+        case 'never':
+            return type.toString();
+        case 'number':
+            return prettyPrintNumber(type);
+        case 'string':
+            return prettyPrintString(type);
+        case 'struct':
+            return prettyPrintStruct(type);
+        case 'union':
+            return prettyPrintUnion(type);
         default:
             return assertNever(type);
     }

--- a/src/renderer/components/inputs/DirectoryInput.tsx
+++ b/src/renderer/components/inputs/DirectoryInput.tsx
@@ -1,4 +1,4 @@
-import { Type } from '@chainner/navi';
+import { Type, isStringLiteral } from '@chainner/navi';
 import {
     Icon,
     Input,
@@ -15,6 +15,7 @@ import { useTranslation } from 'react-i18next';
 import { BsFolderPlus } from 'react-icons/bs';
 import { MdContentCopy, MdFolder } from 'react-icons/md';
 import { ipcRenderer } from '../../../common/safeIpc';
+import { getFields, isDirectory } from '../../../common/types/util';
 import { useContextMenu } from '../../hooks/useContextMenu';
 import { useInputRefactor } from '../../hooks/useInputRefactor';
 import { useLastDirectory } from '../../hooks/useLastDirectory';
@@ -22,15 +23,10 @@ import { MaybeLabel } from './InputContainer';
 import { InputProps } from './props';
 
 const getDirectoryPath = (type: Type): string | undefined => {
-    if (
-        type.type === 'struct' &&
-        type.name === 'Directory' &&
-        type.fields.length > 0 &&
-        type.fields[0].name === 'path'
-    ) {
-        const pathType = type.fields[0].type;
-        if (pathType.underlying === 'string' && pathType.type === 'literal') {
-            return pathType.value;
+    if (isDirectory(type)) {
+        const { path } = getFields(type);
+        if (isStringLiteral(path)) {
+            return path.value;
         }
     }
     return undefined;


### PR DESCRIPTION
Changes:
- Upgrade to navi@0.6.0
- Removed unnecessary `int` casts. The improved arithmetic in 0.6.0 means that Navi doesn't return +-inf anywhere like before.
- Removed `toJson`. The function was unused.
- Account for scopes. Builtin functions now always get the current scope as the first argument.
- Changing handling of structs. 0.6.0 significantly changed the layout of structs, so I had to change a lot of code.

About how structs changes: Structs kinds were previously differentiated by their name. E.g. the `Image` struct was a different kind than the `Color` struct. Instead of using the name, structs now have a descriptor that identifies the kind. Aside from the name, the descriptor also contains the field names, field definition types, and the default instance of the type (= all fields being the definition type).