### PR TITLE
Simplified printed structs by omitting default fields

### DIFF
--- a/src/renderer/components/NodeDocumentation/ConditionExplanation.tsx
+++ b/src/renderer/components/NodeDocumentation/ConditionExplanation.tsx
@@ -101,7 +101,7 @@ const renderPrimitive = (condition: PossiblePrimitive, options: RenderOptions): 
                         userSelect="text"
                         whiteSpace="pre-line"
                     >
-                        {prettyPrintType(type)}
+                        {prettyPrintType(type, { omitDefaultFields: true })}
                     </Code>
                 </>
             );

--- a/src/renderer/components/NodeDocumentation/NodeDocs.tsx
+++ b/src/renderer/components/NodeDocumentation/NodeDocs.tsx
@@ -54,7 +54,7 @@ const TypeView = memo(({ type }: TypeViewProps) => {
                 userSelect="text"
                 whiteSpace="pre-line"
             >
-                {prettyPrintType(type)}
+                {prettyPrintType(type, { omitDefaultFields: true })}
             </Code>
         </Tooltip>
     );


### PR DESCRIPTION
We don't need to show struct fields that are the declaration type of that fields. E.g. `Image` and `Image { width: int(1..), height: int(1..), channels int(1..) }` communicate the exact same type, but the former is a lot less noisy. Struct fields that are their declaration type can safely be hidden, because they don't contain any information.

This should make doc types are lot more user-friendly.

<details>
<sumary>Examples</summary>


![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/1dec4bb9-53e8-4e02-a3e1-113e7cb62c19)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/5d580ff2-1e57-4f52-a0af-1ff92e00a58d)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/adbd573b-d850-4125-8a86-0b4c61b28b36)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/a679d981-7b4d-4325-93d1-8fec491e821e)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/e73e740c-e825-4182-9116-b1f7da0e071d)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/dcde4a08-11bb-476d-bc61-3b9a0af1796d)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/22ae0ccb-ad35-4b8c-8c30-57d4fdf1eb81)

</details>