### PR TITLE
Changed default tile size to 256 for ONNX

### DIFF
--- a/backend/src/nodes/impl/upscale/auto_split_tiles.py
+++ b/backend/src/nodes/impl/upscale/auto_split_tiles.py
@@ -36,6 +36,7 @@ TileSize = NewType("TileSize", int)
 ESTIMATE = TileSize(0)
 NO_TILING = TileSize(-1)
 MAX_TILE_SIZE = TileSize(-2)
+TILE_SIZE_256 = TileSize(256)
 
 
 def parse_tile_size_input(tile_size: TileSize, estimate: Callable[[], Tiler]) -> Tiler:

--- a/backend/src/nodes/properties/inputs/generic_inputs.py
+++ b/backend/src/nodes/properties/inputs/generic_inputs.py
@@ -474,7 +474,9 @@ def FillColorDropdown() -> DropDownInput:
     )
 
 
-def TileSizeDropdown(label="Tile Size", estimate=True) -> DropDownInput:
+def TileSizeDropdown(
+    label="Tile Size", estimate=True, default: TileSize | None = None
+) -> DropDownInput:
     options = []
     if estimate:
         options.append({"option": "Auto (estimate)", "value": 0})
@@ -490,6 +492,7 @@ def TileSizeDropdown(label="Tile Size", estimate=True) -> DropDownInput:
         label=label,
         options=options,
         associated_type=TileSize,
+        default_value=default,
     )
 
 

--- a/backend/src/packages/chaiNNer_onnx/onnx/processing/upscale_image.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/processing/upscale_image.py
@@ -10,7 +10,11 @@ from nodes.impl.onnx.auto_split import onnx_auto_split
 from nodes.impl.onnx.model import OnnxModel
 from nodes.impl.onnx.session import get_onnx_session
 from nodes.impl.onnx.utils import get_input_shape, get_output_shape
-from nodes.impl.upscale.auto_split_tiles import TileSize, parse_tile_size_input
+from nodes.impl.upscale.auto_split_tiles import (
+    TILE_SIZE_256,
+    TileSize,
+    parse_tile_size_input,
+)
 from nodes.impl.upscale.convenient_upscale import convenient_upscale
 from nodes.impl.upscale.tiler import ExactTileSize
 from nodes.properties.inputs import ImageInput, OnnxGenericModelInput, TileSizeDropdown
@@ -50,7 +54,7 @@ def upscale(
     inputs=[
         ImageInput().with_id(1),
         OnnxGenericModelInput().with_id(0),
-        TileSizeDropdown(estimate=False)
+        TileSizeDropdown(estimate=False, default=TILE_SIZE_256)
         .with_id(2)
         .with_docs(
             "Tiled upscaling is used to allow large images to be upscaled without hitting memory limits.",


### PR DESCRIPTION
This should make it possible for people with only 4GB of VRAM to upscale using ESRGAN models. 

I chose 256, because it only required 3.2 GB of RAM to upscale an 1k RGB image on my system. 512 required 9.1GB, which makes it a non-starter for cards with only 8GB VRAM. 

378 required only 5.3GB of VRAM, but took 3 times as long as 256 and 512 on my system (about 30sec (256/512) vs 1min 30sec (378)). I don't know whether other systems behave similarly, but I don't want to risk it. 