### PR TITLE
Update ONNX + ONNXRuntime + fix mac issues

### DIFF
--- a/backend/src/nodes/impl/onnx/onnx_to_ncnn.py
+++ b/backend/src/nodes/impl/onnx/onnx_to_ncnn.py
@@ -1,7 +1,6 @@
 from typing import Dict, List, Union
 
 import numpy as np
-import onnx
 import onnx.numpy_helper as onph
 from google.protobuf.internal.containers import (
     RepeatedCompositeFieldContainer,

--- a/backend/src/nodes/impl/onnx/session.py
+++ b/backend/src/nodes/impl/onnx/session.py
@@ -4,8 +4,6 @@ from weakref import WeakKeyDictionary
 
 import onnxruntime as ort
 
-from system import is_arm_mac
-
 from ...utils.exec_options import ExecutionOptions
 from .model import OnnxModel
 

--- a/backend/src/nodes/impl/onnx/session.py
+++ b/backend/src/nodes/impl/onnx/session.py
@@ -13,12 +13,7 @@ from .model import OnnxModel
 def create_inference_session(
     model: OnnxModel, exec_options: ExecutionOptions
 ) -> ort.InferenceSession:
-    if is_arm_mac:
-        providers = [
-            "CoreMLExecutionProvider",
-            "CPUExecutionProvider",
-        ]
-    elif exec_options.onnx_execution_provider == "TensorrtExecutionProvider":
+    if exec_options.onnx_execution_provider == "TensorrtExecutionProvider":
         providers = [
             (
                 "TensorrtExecutionProvider",

--- a/backend/src/nodes/impl/onnx/session.py
+++ b/backend/src/nodes/impl/onnx/session.py
@@ -4,6 +4,8 @@ from weakref import WeakKeyDictionary
 
 import onnxruntime as ort
 
+from system import is_arm_mac
+
 from ...utils.exec_options import ExecutionOptions
 from .model import OnnxModel
 
@@ -11,7 +13,12 @@ from .model import OnnxModel
 def create_inference_session(
     model: OnnxModel, exec_options: ExecutionOptions
 ) -> ort.InferenceSession:
-    if exec_options.onnx_execution_provider == "TensorrtExecutionProvider":
+    if is_arm_mac:
+        providers = [
+            "CoreMLExecutionProvider",
+            "CPUExecutionProvider",
+        ]
+    elif exec_options.onnx_execution_provider == "TensorrtExecutionProvider":
         providers = [
             (
                 "TensorrtExecutionProvider",

--- a/backend/src/nodes/impl/onnx/tensorproto_utils.py
+++ b/backend/src/nodes/impl/onnx/tensorproto_utils.py
@@ -1,18 +1,18 @@
 from sys import float_info
 
 import numpy as np
-import onnx
 from onnx import numpy_helper as onph
+from onnx.onnx_pb import AttributeProto, NodeProto, TensorProto
 from sanic.log import logger
 
 INT64_MIN, INT64_MAX = np.iinfo(np.int64).min, np.iinfo(np.int64).max
 FLOAT32_MAX = float_info.max
 
-APT = onnx.AttributeProto
-TPT = onnx.TensorProto
+APT = AttributeProto
+TPT = TensorProto
 
 
-def get_node_attr_ai(node: onnx.NodeProto, key: str) -> np.ndarray:
+def get_node_attr_ai(node: NodeProto, key: str) -> np.ndarray:
     for attr in node.attribute:
         if attr.name == key:
             return np.array(
@@ -22,12 +22,12 @@ def get_node_attr_ai(node: onnx.NodeProto, key: str) -> np.ndarray:
     return np.empty(0, np.int32)
 
 
-def set_node_attr_ai(node: onnx.NodeProto, key: str, value: np.ndarray) -> None:
-    attr_group = onnx.AttributeProto(name=key, floats=value, type=APT.INTS)
+def set_node_attr_ai(node: NodeProto, key: str, value: np.ndarray) -> None:
+    attr_group = AttributeProto(name=key, floats=value, type=APT.INTS)
     node.attribute.append(attr_group)
 
 
-def get_node_attr_af(node: onnx.NodeProto, key: str) -> np.ndarray:
+def get_node_attr_af(node: NodeProto, key: str) -> np.ndarray:
     for attr in node.attribute:
         if attr.name == key:
             return np.array([f for f in attr.floats], np.float32)
@@ -35,7 +35,7 @@ def get_node_attr_af(node: onnx.NodeProto, key: str) -> np.ndarray:
     return np.empty(0, np.float32)
 
 
-def get_node_attr_i(node: onnx.NodeProto, key: str, default: int = 0) -> int:
+def get_node_attr_i(node: NodeProto, key: str, default: int = 0) -> int:
     for attr in node.attribute:
         if attr.name == key:
             return max(min(attr.i, INT64_MAX), INT64_MIN)
@@ -43,7 +43,7 @@ def get_node_attr_i(node: onnx.NodeProto, key: str, default: int = 0) -> int:
     return default
 
 
-def get_node_attr_f(node: onnx.NodeProto, key: str, default: float = 0) -> float:
+def get_node_attr_f(node: NodeProto, key: str, default: float = 0) -> float:
     for attr in node.attribute:
         if attr.name == key:
             return attr.f
@@ -51,7 +51,7 @@ def get_node_attr_f(node: onnx.NodeProto, key: str, default: float = 0) -> float
     return default
 
 
-def get_node_attr_s(node: onnx.NodeProto, key: str, default: str = ""):
+def get_node_attr_s(node: NodeProto, key: str, default: str = ""):
     for attr in node.attribute:
         if attr.name == key:
             return attr.s.decode("ascii")
@@ -59,15 +59,15 @@ def get_node_attr_s(node: onnx.NodeProto, key: str, default: str = ""):
     return default
 
 
-def get_node_attr_tensor(node: onnx.NodeProto, key: str) -> onnx.TensorProto:
+def get_node_attr_tensor(node: NodeProto, key: str) -> TensorProto:
     for attr in node.attribute:
         if attr.name == key:
             return attr.t
 
-    return onnx.TensorProto()
+    return TensorProto()
 
 
-def get_node_attr_from_input_f(tp: onnx.TensorProto) -> float:
+def get_node_attr_from_input_f(tp: TensorProto) -> float:
     shape_data = onph.to_array(tp)
 
     if tp.data_type in (TPT.FLOAT, TPT.FLOAT16, TPT.DOUBLE, TPT.INT32):
@@ -80,7 +80,7 @@ def get_node_attr_from_input_f(tp: onnx.TensorProto) -> float:
     return f
 
 
-def get_node_attr_from_input_ai(tp: onnx.TensorProto) -> np.ndarray:
+def get_node_attr_from_input_ai(tp: TensorProto) -> np.ndarray:
     if tp.data_type == TPT.INT32 or tp.data_type == TPT.INT64:
         shape_data = onph.to_array(tp)
         if shape_data.size == 1:
@@ -100,7 +100,7 @@ def get_node_attr_from_input_ai(tp: onnx.TensorProto) -> np.ndarray:
     return np.empty(0, np.int32)
 
 
-def get_node_attr_from_input_af(tp: onnx.TensorProto) -> np.ndarray:
+def get_node_attr_from_input_af(tp: TensorProto) -> np.ndarray:
     if tp.data_type in (TPT.FLOAT, TPT.FLOAT16, TPT.DOUBLE):
         shape_data = onph.to_array(tp)
         return np.array([val for val in shape_data], shape_data.dtype)
@@ -110,7 +110,7 @@ def get_node_attr_from_input_af(tp: onnx.TensorProto) -> np.ndarray:
     return np.empty(0, np.float32)
 
 
-def get_tensor_proto_data_size(tp: onnx.TensorProto, fpmode: int = TPT.FLOAT) -> int:
+def get_tensor_proto_data_size(tp: TensorProto, fpmode: int = TPT.FLOAT) -> int:
     if tp.raw_data:
         if fpmode == TPT.FLOAT16:
             return len(tp.raw_data) // 2

--- a/backend/src/nodes/impl/onnx/utils.py
+++ b/backend/src/nodes/impl/onnx/utils.py
@@ -2,13 +2,9 @@ from __future__ import annotations
 
 from typing import Literal, Tuple
 
+import onnxoptimizer
 import onnxruntime as ort
 from onnx.onnx_pb import ModelProto
-
-try:
-    import onnxoptimizer
-except ImportError:
-    onnxoptimizer = None
 
 OnnxInputShape = Literal["BCHW", "BHWC"]
 
@@ -54,8 +50,9 @@ def safely_optimize_onnx_model(model_proto: ModelProto) -> ModelProto:
     """
     Optimizes the model using onnxoptimizer. If onnxoptimizer is not installed, the model is returned as is.
     """
-
-    if onnxoptimizer is not None:
+    try:
         passes = onnxoptimizer.get_fuse_and_elimination_passes()
         model_proto = onnxoptimizer.optimize(model_proto, passes)
+    except:
+        pass
     return model_proto

--- a/backend/src/nodes/impl/onnx/utils.py
+++ b/backend/src/nodes/impl/onnx/utils.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import Literal, Tuple
 
-import onnx
 import onnxruntime as ort
+from onnx.onnx_pb import ModelProto
 
 try:
     import onnxoptimizer
@@ -50,7 +50,7 @@ def get_output_shape(
     return parse_onnx_shape(session.get_outputs()[0].shape)
 
 
-def safely_optimize_onnx_model(model_proto: onnx.ModelProto) -> onnx.ModelProto:
+def safely_optimize_onnx_model(model_proto: ModelProto) -> ModelProto:
     """
     Optimizes the model using onnxoptimizer. If onnxoptimizer is not installed, the model is returned as is.
     """

--- a/backend/src/packages/chaiNNer_onnx/__init__.py
+++ b/backend/src/packages/chaiNNer_onnx/__init__.py
@@ -10,7 +10,7 @@ def get_onnx_runtime():
             display_name="ONNX Runtime (GPU)",
             pypi_name="onnxruntime-gpu",
             version="1.15.1",
-            size_estimate=110 * MB,
+            size_estimate=120 * MB,
             import_name="onnxruntime",
         )
     else:

--- a/backend/src/packages/chaiNNer_onnx/__init__.py
+++ b/backend/src/packages/chaiNNer_onnx/__init__.py
@@ -2,18 +2,9 @@ from sanic.log import logger
 
 from api import KB, MB, Dependency, add_package
 from gpu import nvidia_is_available
-from system import is_arm_mac
 
 
 def get_onnx_runtime():
-    if is_arm_mac:
-        return Dependency(
-            display_name="ONNX Runtime (Silicon)",
-            pypi_name="onnxruntime-silicon",
-            version="1.15.0",
-            size_estimate=6.8 * MB,
-            import_name="onnxruntime",
-        )
     if nvidia_is_available:
         return Dependency(
             display_name="ONNX Runtime (GPU)",

--- a/backend/src/packages/chaiNNer_onnx/__init__.py
+++ b/backend/src/packages/chaiNNer_onnx/__init__.py
@@ -2,23 +2,14 @@ from sanic.log import logger
 
 from api import KB, MB, Dependency, add_package
 from gpu import nvidia_is_available
-from system import is_arm_mac
 
 
 def get_onnx_runtime():
-    if is_arm_mac:
-        return Dependency(
-            display_name="ONNX Runtime (Silicon)",
-            pypi_name="onnxruntime-silicon",
-            version="1.13.1",
-            size_estimate=6 * MB,
-            import_name="onnxruntime",
-        )
-    elif nvidia_is_available:
+    if nvidia_is_available:
         return Dependency(
             display_name="ONNX Runtime (GPU)",
             pypi_name="onnxruntime-gpu",
-            version="1.13.1",
+            version="1.15.1",
             size_estimate=110 * MB,
             import_name="onnxruntime",
         )
@@ -26,23 +17,9 @@ def get_onnx_runtime():
         return Dependency(
             display_name="ONNX Runtime",
             pypi_name="onnxruntime",
-            version="1.13.1",
+            version="1.15.1",
             size_estimate=5 * MB,
         )
-
-
-def get_onnx_optimizer():
-    if is_arm_mac:
-        return []
-
-    return [
-        Dependency(
-            display_name="ONNX Optimizer",
-            pypi_name="onnxoptimizer",
-            version="0.3.6",
-            size_estimate=300 * KB,
-        )
-    ]
 
 
 package = add_package(
@@ -53,10 +30,15 @@ package = add_package(
         Dependency(
             display_name="ONNX",
             pypi_name="onnx",
-            version="1.13.0",
+            version="1.14.0",
             size_estimate=12 * MB,
         ),
-        *get_onnx_optimizer(),
+        Dependency(
+            display_name="ONNX Optimizer",
+            pypi_name="onnxoptimizer",
+            version="0.3.13",
+            size_estimate=300 * KB,
+        ),
         get_onnx_runtime(),
         Dependency(
             display_name="Protobuf",

--- a/backend/src/packages/chaiNNer_onnx/__init__.py
+++ b/backend/src/packages/chaiNNer_onnx/__init__.py
@@ -18,7 +18,7 @@ def get_onnx_runtime():
             display_name="ONNX Runtime",
             pypi_name="onnxruntime",
             version="1.15.1",
-            size_estimate=5 * MB,
+            size_estimate=6 * MB,
         )
 
 

--- a/backend/src/packages/chaiNNer_onnx/__init__.py
+++ b/backend/src/packages/chaiNNer_onnx/__init__.py
@@ -2,9 +2,18 @@ from sanic.log import logger
 
 from api import KB, MB, Dependency, add_package
 from gpu import nvidia_is_available
+from system import is_arm_mac
 
 
 def get_onnx_runtime():
+    if is_arm_mac:
+        return Dependency(
+            display_name="ONNX Runtime (Silicon)",
+            pypi_name="onnxruntime-silicon",
+            version="1.15.0",
+            size_estimate=6.8 * MB,
+            import_name="onnxruntime",
+        )
     if nvidia_is_available:
         return Dependency(
             display_name="ONNX Runtime (GPU)",

--- a/backend/src/packages/chaiNNer_onnx/onnx/utility/interpolate_models.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/utility/interpolate_models.py
@@ -7,6 +7,7 @@ import numpy as np
 import onnx
 from google.protobuf.internal.containers import RepeatedCompositeFieldContainer
 from onnx import numpy_helper as onph
+from onnx.onnx_pb import TensorProto
 from sanic.log import logger
 
 from nodes.impl.onnx.model import OnnxModel, load_onnx_model
@@ -23,7 +24,7 @@ def perform_interp(
     model_a_weights: RepeatedCompositeFieldContainer,
     model_b_weights: RepeatedCompositeFieldContainer,
     amount: float,
-) -> List[onnx.TensorProto]:
+) -> List[TensorProto]:
     amount_b = amount / 100
     amount_a = 1 - amount_b
 

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -47,7 +47,7 @@ import {
 import { BsFillPencilFill, BsPaletteFill } from 'react-icons/bs';
 import { FaPython, FaTools } from 'react-icons/fa';
 import { useContext } from 'use-context-selector';
-import { getOnnxTensorRtCacheLocation, hasTensorRt, isArmMac } from '../../common/env';
+import { getOnnxTensorRtCacheLocation, hasTensorRt } from '../../common/env';
 import { log } from '../../common/log';
 import { ipcRenderer } from '../../common/safeIpc';
 import { BackendContext } from '../contexts/BackendContext';
@@ -417,7 +417,6 @@ const PythonSettings = memo(() => {
                       },
                   ]
                 : []),
-            ...(isArmMac ? [{ label: 'CoreML (GPU)', value: 'CoreMLExecutionProvider' }] : []),
         ],
         [nvidiaGpuList]
     );

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -47,7 +47,7 @@ import {
 import { BsFillPencilFill, BsPaletteFill } from 'react-icons/bs';
 import { FaPython, FaTools } from 'react-icons/fa';
 import { useContext } from 'use-context-selector';
-import { getOnnxTensorRtCacheLocation, hasTensorRt } from '../../common/env';
+import { getOnnxTensorRtCacheLocation, hasTensorRt, isArmMac } from '../../common/env';
 import { log } from '../../common/log';
 import { ipcRenderer } from '../../common/safeIpc';
 import { BackendContext } from '../contexts/BackendContext';
@@ -417,6 +417,7 @@ const PythonSettings = memo(() => {
                       },
                   ]
                 : []),
+            ...(isArmMac ? [{ label: 'CoreML', value: 'CoreMLExecutionProvider' }] : []),
         ],
         [nvidiaGpuList]
     );

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -400,7 +400,7 @@ const PythonSettings = memo(() => {
             ...(nvidiaGpuList.length > 0
                 ? [
                       {
-                          label: 'CUDA',
+                          label: 'CUDA (GPU)',
                           value: 'CUDAExecutionProvider',
                       },
                   ]
@@ -412,12 +412,12 @@ const PythonSettings = memo(() => {
             ...(hasTensorRt && nvidiaGpuList.length > 0
                 ? [
                       {
-                          label: 'TensorRT',
+                          label: 'TensorRT (GPU)',
                           value: 'TensorrtExecutionProvider',
                       },
                   ]
                 : []),
-            ...(isArmMac ? [{ label: 'CoreML', value: 'CoreMLExecutionProvider' }] : []),
+            ...(isArmMac ? [{ label: 'CoreML (GPU)', value: 'CoreMLExecutionProvider' }] : []),
         ],
         [nvidiaGpuList]
     );


### PR DESCRIPTION
Should close #2000

I updated onnxruntime. Since it supports apple silicon now, we no longer need onnxruntime-silicon.

I also updated onnxoptimizer, which also conveniently supports macos now. This was the main issue preventing #2000 from being able to convert to NCNN.

Also updated onnx. Doesn't get us anything, but an update won't hurt.