### PR TITLE
Fixed a bug in TypeState's diffing

### DIFF
--- a/src/common/nodes/TypeState.ts
+++ b/src/common/nodes/TypeState.ts
@@ -1,12 +1,26 @@
 import { EvaluationError, NonNeverType, Type, isSameType } from '@chainner/navi';
 import { EdgeData, InputId, NodeData, OutputId, SchemaId } from '../common-types';
 import { log } from '../log';
-import { FunctionDefinition, FunctionInstance } from '../types/function';
+import {
+    FunctionDefinition,
+    FunctionInputAssignmentError,
+    FunctionInstance,
+} from '../types/function';
 import { nullType } from '../types/util';
 import { EMPTY_MAP } from '../util';
 import { EdgeState } from './EdgeState';
 import type { Edge, Node } from 'reactflow';
 
+const assignmentErrorEquals = (
+    a: FunctionInputAssignmentError,
+    b: FunctionInputAssignmentError
+): boolean => {
+    return (
+        a.inputId === b.inputId &&
+        isSameType(a.assignedType, b.assignedType) &&
+        isSameType(a.inputType, b.inputType)
+    );
+};
 const instanceEqual = (a: FunctionInstance, b: FunctionInstance): boolean => {
     if (a.definition !== b.definition) return false;
 
@@ -18,6 +32,11 @@ const instanceEqual = (a: FunctionInstance, b: FunctionInstance): boolean => {
     for (const [key, value] of a.outputs) {
         const otherValue = b.outputs.get(key);
         if (!otherValue || !isSameType(value, otherValue)) return false;
+    }
+
+    if (a.inputErrors.length !== b.inputErrors.length) return false;
+    for (let i = 0; i < a.inputErrors.length; i += 1) {
+        if (!assignmentErrorEquals(a.inputErrors[i], b.inputErrors[i])) return false;
     }
 
     return true;


### PR DESCRIPTION
This fixes a nasty bug I happened to notice a few days ago. 

I added type state diffing in #1917 to be more efficient, but I implemented `instanceEqual` slightly incorrectly. The function did not account for potential assignment errors. This had the effect that when the user changed an upstream value to create an invalid connection, the downstream connected node still got the old `FunctionInstance` from before the error happened in some cases.