### PR TITLE
Added divider before "Open Documentation" in node menu

### DIFF
--- a/src/renderer/hooks/useNodeMenu.tsx
+++ b/src/renderer/hooks/useNodeMenu.tsx
@@ -6,7 +6,7 @@ import {
     RepeatIcon,
     UnlockIcon,
 } from '@chakra-ui/icons';
-import { MenuItem, MenuList } from '@chakra-ui/react';
+import { MenuDivider, MenuItem, MenuList } from '@chakra-ui/react';
 import { BsFillJournalBookmarkFill, BsLayerForward } from 'react-icons/bs';
 import { MdPlayArrow, MdPlayDisabled } from 'react-icons/md';
 import { useContext } from 'use-context-selector';
@@ -98,6 +98,7 @@ export const useNodeMenu = (
                     Release
                 </MenuItem>
             )}
+            <MenuDivider />
             <MenuItem
                 icon={<BsFillJournalBookmarkFill />}
                 onClick={() => {


### PR DESCRIPTION
I think this looks better.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/605b20bd-02d1-4d6f-b83c-0177106435c1)
