### PR TITLE
Update minor/patch version of electron

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,7 @@
         "copy-webpack-plugin": "^11.0.0",
         "cross-env": "^7.0.3",
         "css-loader": "^6.7.1",
-        "electron": "^23.0.0",
+        "electron": "^23.3.11",
         "electron-installer-common": "^0.10.3",
         "eslint": "^8.16.0",
         "eslint-config-airbnb": "^19.0.4",
@@ -10104,9 +10104,9 @@
       "dev": true
     },
     "node_modules/electron": {
-      "version": "23.3.9",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-23.3.9.tgz",
-      "integrity": "sha512-dUhWG7Lljms0CfiifP/IVGHLTi8wmHpCOEO3Gyy/PhRyN0/nBsqg/0PnOD4BmM1GdeAFd/KjI/aeJhkdJxNagw==",
+      "version": "23.3.11",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-23.3.11.tgz",
+      "integrity": "sha512-pWjOHe8PDgrACFdPW/QlkDJS5UtG0qdOs6pOYKd0tTgRT8PK5UPxcptgHs0oKi2TAAA3TrVt+BIB3QtRAuc5vQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -32997,9 +32997,9 @@
       "dev": true
     },
     "electron": {
-      "version": "23.3.9",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-23.3.9.tgz",
-      "integrity": "sha512-dUhWG7Lljms0CfiifP/IVGHLTi8wmHpCOEO3Gyy/PhRyN0/nBsqg/0PnOD4BmM1GdeAFd/KjI/aeJhkdJxNagw==",
+      "version": "23.3.11",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-23.3.11.tgz",
+      "integrity": "sha512-pWjOHe8PDgrACFdPW/QlkDJS5UtG0qdOs6pOYKd0tTgRT8PK5UPxcptgHs0oKi2TAAA3TrVt+BIB3QtRAuc5vQ==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "copy-webpack-plugin": "^11.0.0",
     "cross-env": "^7.0.3",
     "css-loader": "^6.7.1",
-    "electron": "^23.0.0",
+    "electron": "^23.3.11",
     "electron-installer-common": "^0.10.3",
     "eslint": "^8.16.0",
     "eslint-config-airbnb": "^19.0.4",


### PR DESCRIPTION
I figured we should do this before updating in hopes that the minor and patch versions fix the "object has been destroyed" issues. Assuming those are from an electron related bug and not something we did wrong.

Should be pretty safe to do I think.