### PR TITLE
use native clipboard on macos

### DIFF
--- a/src/main/gui/menu.ts
+++ b/src/main/gui/menu.ts
@@ -139,6 +139,22 @@ export const setMainMenu = ({ mainWindow, menuData, enabled = false }: MainMenuA
             ? [
                   { role: 'editMenu' },
                   {
+                      label: 'View',
+                      submenu: [
+                          { role: 'reload', enabled },
+                          { role: 'forceReload', enabled },
+                          { type: 'separator' },
+                          { role: 'resetZoom', enabled },
+                          { role: 'zoomIn', enabled },
+                          { role: 'zoomOut', enabled },
+                          { type: 'separator' },
+                          { role: 'togglefullscreen' },
+                          ...(!app.isPackaged
+                              ? [{ type: 'separator' }, { role: 'toggleDevTools' }]
+                              : []),
+                      ],
+                  },
+                  {
                       label: 'Nodes',
                       submenu: [
                           {
@@ -196,6 +212,7 @@ export const setMainMenu = ({ mainWindow, menuData, enabled = false }: MainMenuA
                           },
                       ],
                   },
+                  { role: 'windowMenu' },
               ]
             : [
                   {
@@ -268,21 +285,23 @@ export const setMainMenu = ({ mainWindow, menuData, enabled = false }: MainMenuA
                           },
                       ],
                   },
+                  {
+                      label: 'View',
+                      submenu: [
+                          { role: 'reload', enabled },
+                          { role: 'forceReload', enabled },
+                          { type: 'separator' },
+                          { role: 'resetZoom', enabled },
+                          { role: 'zoomIn', enabled },
+                          { role: 'zoomOut', enabled },
+                          { type: 'separator' },
+                          { role: 'togglefullscreen' },
+                          ...(!app.isPackaged
+                              ? [{ type: 'separator' }, { role: 'toggleDevTools' }]
+                              : []),
+                      ],
+                  },
               ]),
-        {
-            label: 'View',
-            submenu: [
-                { role: 'reload', enabled },
-                { role: 'forceReload', enabled },
-                { type: 'separator' },
-                { role: 'resetZoom', enabled },
-                { role: 'zoomIn', enabled },
-                { role: 'zoomOut', enabled },
-                { type: 'separator' },
-                { role: 'togglefullscreen' },
-                ...(!app.isPackaged ? [{ type: 'separator' }, { role: 'toggleDevTools' }] : []),
-            ],
-        },
         {
             role: 'help',
             submenu: [

--- a/src/main/gui/menu.ts
+++ b/src/main/gui/menu.ts
@@ -135,76 +135,140 @@ export const setMainMenu = ({ mainWindow, menuData, enabled = false }: MainMenuA
                 isMac ? { role: 'close', enabled } : { role: 'quit', enabled },
             ],
         },
-        {
-            label: 'Edit',
-            submenu: [
-                {
-                    label: 'Undo',
-                    accelerator: 'CmdOrCtrl+Z',
-                    registerAccelerator: false,
-                    click: () => {
-                        mainWindow.webContents.send('history-undo');
-                    },
-                    enabled,
-                },
-                {
-                    label: 'Redo',
-                    accelerator: 'CmdOrCtrl+Y',
-                    registerAccelerator: false,
-                    click: () => {
-                        mainWindow.webContents.send('history-redo');
-                    },
-                    enabled,
-                },
-                { type: 'separator' },
-                {
-                    label: 'Cut',
-                    accelerator: 'CmdOrCtrl+X',
-                    registerAccelerator: false,
-                    click: () => {
-                        mainWindow.webContents.send('cut');
-                    },
-                    enabled,
-                },
-                {
-                    label: 'Copy',
-                    accelerator: 'CmdOrCtrl+C',
-                    registerAccelerator: false,
-                    click: () => {
-                        mainWindow.webContents.send('copy');
-                    },
-                    enabled,
-                },
-                {
-                    label: 'Paste',
-                    accelerator: 'CmdOrCtrl+V',
-                    registerAccelerator: false,
-                    click: () => {
-                        mainWindow.webContents.send('paste');
-                    },
-                    enabled,
-                },
-                { type: 'separator' },
-                {
-                    label: 'Duplicate',
-                    accelerator: 'CmdOrCtrl+D',
-                    registerAccelerator: false,
-                    click: () => {
-                        mainWindow.webContents.send('duplicate');
-                    },
-                    enabled,
-                },
-                {
-                    label: 'Duplicate with Connections',
-                    accelerator: 'CmdOrCtrl+Shift+D',
-                    registerAccelerator: false,
-                    click: () => {
-                        mainWindow.webContents.send('duplicate-with-input-edges');
-                    },
-                    enabled,
-                },
-            ],
-        },
+        ...(isMac
+            ? [
+                  { role: 'editMenu' },
+                  {
+                      label: 'Nodes',
+                      submenu: [
+                          {
+                              label: 'Undo',
+                              click: () => {
+                                  mainWindow.webContents.send('history-undo');
+                              },
+                              enabled,
+                          },
+                          {
+                              label: 'Redo',
+                              click: () => {
+                                  mainWindow.webContents.send('history-redo');
+                              },
+                              enabled,
+                          },
+                          { type: 'separator' },
+                          {
+                              label: 'Cut',
+                              click: () => {
+                                  mainWindow.webContents.send('cut');
+                              },
+                              enabled,
+                          },
+                          {
+                              label: 'Copy',
+                              click: () => {
+                                  mainWindow.webContents.send('copy');
+                              },
+                              enabled,
+                          },
+                          {
+                              label: 'Paste',
+                              click: () => {
+                                  mainWindow.webContents.send('paste');
+                              },
+                              enabled,
+                          },
+                          { type: 'separator' },
+                          {
+                              label: 'Duplicate',
+                              accelerator: 'CmdOrCtrl+D',
+                              click: () => {
+                                  mainWindow.webContents.send('duplicate');
+                              },
+                              enabled,
+                          },
+                          {
+                              label: 'Duplicate with Connections',
+                              accelerator: 'CmdOrCtrl+Shift+D',
+                              click: () => {
+                                  mainWindow.webContents.send('duplicate-with-input-edges');
+                              },
+                              enabled,
+                          },
+                      ],
+                  },
+              ]
+            : [
+                  {
+                      label: 'Edit',
+                      submenu: [
+                          {
+                              label: 'Undo',
+                              accelerator: 'CmdOrCtrl+Z',
+                              registerAccelerator: false,
+                              click: () => {
+                                  mainWindow.webContents.send('history-undo');
+                              },
+                              enabled,
+                          },
+                          {
+                              label: 'Redo',
+                              accelerator: 'CmdOrCtrl+Y',
+                              registerAccelerator: false,
+                              click: () => {
+                                  mainWindow.webContents.send('history-redo');
+                              },
+                              enabled,
+                          },
+                          { type: 'separator' },
+                          {
+                              label: 'Cut',
+                              accelerator: 'CmdOrCtrl+X',
+                              registerAccelerator: false,
+                              click: () => {
+                                  mainWindow.webContents.send('cut');
+                              },
+                              enabled,
+                          },
+                          {
+                              label: 'Copy',
+                              accelerator: 'CmdOrCtrl+C',
+                              registerAccelerator: false,
+                              click: () => {
+                                  mainWindow.webContents.send('copy');
+                              },
+                              enabled,
+                          },
+                          {
+                              label: 'Paste',
+                              accelerator: 'CmdOrCtrl+V',
+                              registerAccelerator: false,
+                              click: () => {
+                                  mainWindow.webContents.send('paste');
+                              },
+                              enabled,
+                          },
+                          { type: 'separator' },
+                          {
+                              label: 'Duplicate',
+                              accelerator: 'CmdOrCtrl+D',
+                              registerAccelerator: false,
+                              click: () => {
+                                  mainWindow.webContents.send('duplicate');
+                              },
+                              enabled,
+                          },
+                          {
+                              label: 'Duplicate with Connections',
+                              accelerator: 'CmdOrCtrl+Shift+D',
+                              registerAccelerator: false,
+                              click: () => {
+                                  mainWindow.webContents.send('duplicate-with-input-edges');
+                              },
+                              enabled,
+                          },
+                      ],
+                  },
+              ]),
         {
             label: 'View',
             submenu: [


### PR DESCRIPTION
On macOS we need the native Edit menu to make all keyboard shortcuts accessable.

The shortcuts can copy/cut/paste text and nodes. But using entries from the menu itself only interacts with text.

Therefore on macOS a new menu is added: "Nodes"

Menu structure:

```
*Nodes
|
|- Undo
|- Redo
|--------
|- Cut
|- Copy
|- Paste
|--------
|- Duplicate
|- Duplicate with Connections
```
This menus sole purpose is to give the user a menu to interact with Nodes.

closes #1590