### PR TITLE
add .nvmrc and .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,8 @@
+NODEVERSION=18
+nvmrc=~/.nvm/nvm.sh
+if [ -e $nvmrc ]; then
+  source $nvmrc
+  nvm use $NODEVERSION
+fi
+
+PATH_add node_modules/.bin


### PR DESCRIPTION
When nvm and direnv are installed, cd into the project folder loads the correct node.js version.

This is just a QOL improvement. If a developer has neither of the tools installed, then these files will be ignored.

