### PR TITLE
Fixed error messages for input enforce errors

### DIFF
--- a/backend/src/nodes/properties/inputs/numpy_inputs.py
+++ b/backend/src/nodes/properties/inputs/numpy_inputs.py
@@ -79,10 +79,7 @@ class ImageInput(BaseInput):
 
         return value
 
-    def get_error_value(self, value: np.ndarray | Color | None) -> ErrorValue:
-        if value is None:
-            return super().get_error_value(value)
-
+    def get_error_value(self, value: object) -> ErrorValue:
         def get_channels(channel: int) -> str:
             if channel == 1:
                 return "Grayscale"
@@ -97,12 +94,14 @@ class ImageInput(BaseInput):
                 "type": "formatted",
                 "formatString": f"{get_channels(value.channels)} Color",
             }
-        else:
+        elif isinstance(value, np.ndarray):
             h, w, c = get_h_w_c(value)
             return {
                 "type": "formatted",
                 "formatString": f"{get_channels(c)} Image {w}x{h}",
             }
+        else:
+            return super().get_error_value(value)
 
 
 class VideoInput(BaseInput):

--- a/backend/src/nodes/properties/inputs/numpy_inputs.py
+++ b/backend/src/nodes/properties/inputs/numpy_inputs.py
@@ -79,7 +79,7 @@ class ImageInput(BaseInput):
 
         return value
 
-    def get_error_value(self, value: object) -> ErrorValue:
+    def get_error_value(self, value) -> ErrorValue:
         def get_channels(channel: int) -> str:
             if channel == 1:
                 return "Grayscale"

--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -23,14 +23,56 @@ from progress_controller import Aborted, ProgressController, ProgressToken
 Output = List[object]
 
 
-def enforce_inputs(inputs: Iterable[object], node: NodeData) -> List[object]:
-    if node.type == "iteratorHelper":
-        return list(inputs)
+def collect_input_information(
+    node: NodeData,
+    inputs: List[object],
+    enforced: bool = True,
+) -> InputsDict:
+    try:
+        input_dict: InputsDict = {}
 
-    enforced_inputs: List[object] = []
-    for index, value in enumerate(inputs):
-        enforced_inputs.append(node.inputs[index].enforce_(value))
-    return enforced_inputs
+        for value, node_input in zip(inputs, node.inputs):
+            if not enforced:
+                try:
+                    value = node_input.enforce_(value)
+                except Exception as e:
+                    logger.error(
+                        f"Error enforcing input {node_input.label} (id {node_input.id})",
+                        e,
+                    )
+                    # We'll just try using the un-enforced value. Maybe it'll work.
+
+            try:
+                input_dict[node_input.id] = node_input.get_error_value(value)
+            except Exception as e:
+                logger.error(
+                    f"Error getting error value for input {node_input.label} (id {node_input.id})",
+                    e,
+                )
+
+        return input_dict
+    except Exception as outer_e:
+        # this method must not throw
+        logger.error(f"Error collecting input information.", outer_e)
+        return {}
+
+
+def enforce_inputs(
+    inputs: Iterable[object], node: NodeData, node_id: NodeId
+) -> List[object]:
+    inputs = list(inputs)
+
+    if node.type == "iteratorHelper":
+        return inputs
+
+    try:
+        enforced_inputs: List[object] = []
+        for index, value in enumerate(inputs):
+            enforced_inputs.append(node.inputs[index].enforce_(value))
+        return enforced_inputs
+    except Exception as e:
+        input_dict = collect_input_information(node, inputs, enforced=False)
+        raise NodeExecutionError(node_id, node, str(e), input_dict) from e
 
 
 def enforce_output(raw_output: object, node: NodeData) -> Output:
@@ -59,7 +101,7 @@ def enforce_output(raw_output: object, node: NodeData) -> Output:
 def run_node(node: NodeData, inputs: Iterable[object], node_id: NodeId) -> Output:
     assert node.type == "regularNode" or node.type == "iteratorHelper"
 
-    enforced_inputs = enforce_inputs(inputs, node)
+    enforced_inputs = enforce_inputs(inputs, node, node_id)
     try:
         raw_output = node.run(*enforced_inputs)
         return enforce_output(raw_output, node)
@@ -69,28 +111,19 @@ def run_node(node: NodeData, inputs: Iterable[object], node_id: NodeId) -> Outpu
         raise
     except Exception as e:
         # collect information to provide good error messages
-        input_dict: InputsDict = {}
-        for index, node_input in enumerate(node.inputs):
-            try:
-                input_value = enforced_inputs[index]
-                input_dict[node_input.id] = node_input.get_error_value(input_value)
-            except Exception as inner_e:
-                logger.error(
-                    f"Error getting error value for input {node_input.label} (id {node_input.id})",
-                    inner_e,
-                )
-
+        input_dict = collect_input_information(node, enforced_inputs)
         raise NodeExecutionError(node_id, node, str(e), input_dict) from e
 
 
 async def run_iterator_node(
     node: NodeData,
     inputs: Iterable[object],
+    node_id: NodeId,
     context: IteratorContext,
 ) -> Output:
     assert node.type == "iterator"
 
-    raw_output = await node.run(*enforce_inputs(inputs, node), context=context)
+    raw_output = await node.run(*enforce_inputs(inputs, node, node_id), context=context)
     return enforce_output(raw_output, node)
 
 
@@ -390,6 +423,7 @@ class Executor:
                     run_iterator_node,
                     node_instance,
                     inputs,
+                    node.id,
                     IteratorContext(self, node.id),
                 )
             )


### PR DESCRIPTION
This PR fixes error messages like this:

![image](https://media.discordapp.net/attachments/930865725135011851/1136145939539689533/image.png)

Error messages will now have proper input values even if input enforcement fails.