### PR TITLE
Improved header layout

### DIFF
--- a/src/renderer/components/Header/AppInfo.tsx
+++ b/src/renderer/components/Header/AppInfo.tsx
@@ -6,7 +6,6 @@ import {
     AlertDialogFooter,
     AlertDialogHeader,
     AlertDialogOverlay,
-    Box,
     Button,
     HStack,
     Heading,
@@ -84,39 +83,39 @@ export const AppInfo = memo(() => {
 
     return (
         <>
-            <Box w="full">
-                <HStack
-                    ml={0}
-                    mr="auto"
+            <HStack>
+                <Image
+                    boxSize="36px"
+                    draggable={false}
+                    src={logo}
+                />
+                <Heading
+                    display={{ base: 'none', lg: 'inherit' }}
+                    size="md"
                 >
-                    <Image
-                        boxSize="36px"
-                        draggable={false}
-                        src={logo}
-                    />
-                    <Heading size="md">chaiNNer</Heading>
-                    <Tag>Alpha</Tag>
-                    <Tag>{`v${appVersion ?? '#.#.#'}`}</Tag>
-                    {updateVersion && (
-                        <Tooltip
-                            closeOnClick
-                            closeOnMouseDown
-                            borderRadius={8}
-                            label={`Update available (${updateVersion.tag_name})`}
-                            px={2}
-                            py={1}
-                        >
-                            <IconButton
-                                aria-label="Update available"
-                                colorScheme="green"
-                                icon={<DownloadIcon />}
-                                variant="ghost"
-                                onClick={onModalOpen}
-                            />
-                        </Tooltip>
-                    )}
-                </HStack>
-            </Box>
+                    chaiNNer
+                </Heading>
+                <Tag display={{ base: 'none', lg: 'inherit' }}>Alpha</Tag>
+                <Tag>v{appVersion ?? '#.#.#'}</Tag>
+                {updateVersion && (
+                    <Tooltip
+                        closeOnClick
+                        closeOnMouseDown
+                        borderRadius={8}
+                        label={`Update available (${updateVersion.tag_name})`}
+                        px={2}
+                        py={1}
+                    >
+                        <IconButton
+                            aria-label="Update available"
+                            colorScheme="green"
+                            icon={<DownloadIcon />}
+                            variant="ghost"
+                            onClick={onModalOpen}
+                        />
+                    </Tooltip>
+                )}
+            </HStack>
             <Modal
                 isCentered
                 isOpen={isModalOpen}

--- a/src/renderer/components/Header/Header.tsx
+++ b/src/renderer/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import { Box, Center, HStack, SimpleGrid } from '@chakra-ui/react';
+import { Box, Center, HStack } from '@chakra-ui/react';
 import { memo } from 'react';
 import { DependencyManagerButton } from '../DependencyManagerButton';
 import { NodeDocumentationButton } from '../NodeDocumentation/NodeDocumentationModal';
@@ -11,42 +11,29 @@ import { KoFiButton } from './KoFiButton';
 export const Header = memo(() => {
     return (
         <Box
+            alignItems="center"
             bg="var(--header-bg)"
             borderRadius="lg"
-            borderWidth="0px"
+            borderWidth="0"
+            display="flex"
+            gap={4}
             h="56px"
-            w="100%"
+            px={2}
+            w="full"
         >
-            <SimpleGrid
-                columns={3}
-                h="100%"
-                p={2}
-                spacing={1}
-            >
+            <Box>
                 <AppInfo />
-
-                <Center w="full">
-                    <ExecutionButtons />
-                </Center>
-
-                <Box
-                    alignContent="right"
-                    alignItems="right"
-                    w="full"
-                >
-                    <HStack
-                        ml="auto"
-                        mr={0}
-                        width="fit-content"
-                    >
-                        <SystemStats />
-                        <NodeDocumentationButton />
-                        <DependencyManagerButton />
-                        <KoFiButton />
-                        <SettingsButton />
-                    </HStack>
-                </Box>
-            </SimpleGrid>
+            </Box>
+            <Center flexGrow="1">
+                <ExecutionButtons />
+            </Center>
+            <HStack>
+                <SystemStats />
+                <NodeDocumentationButton />
+                <DependencyManagerButton />
+                <KoFiButton />
+                <SettingsButton />
+            </HStack>
         </Box>
     );
 });

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -106,8 +106,6 @@ export const Main = memo(() => {
                                         <Header />
                                         <HStack
                                             h="calc(100vh - 80px)"
-                                            minH="360px"
-                                            minW="720px"
                                             w="full"
                                         >
                                             <NodeSelector />


### PR DESCRIPTION
This PR improves the header layout to work better with small window sizes. The entire header is now useable on all allowed window sizes.

Changes:
- Hide "chaiNNer" and "Alpha" for small windows. The break point for this is 992px, so our name will be visible even on half-screen-sized windows on a 1920x1080 FullHD screen.
- Use flex instead of grid to center the execution buttons.
- Removed min width/height from main. This has nothing to do with the header, but it fixes the node selector moving slightly off-screen for small window sizes.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/fe0106e6-1217-45ee-a255-940b38ccfad3)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/05e55355-e519-4805-9819-6ae849b171e3)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/92850c18-2546-4ebe-87f7-09f43fe545cb)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/6a1d94e5-6931-4486-8c2d-31ff815d0d70)
