### PR TITLE
Delay `/nodes` during restarts

### DIFF
--- a/src/renderer/contexts/BackendContext.tsx
+++ b/src/renderer/contexts/BackendContext.tsx
@@ -264,22 +264,25 @@ export const BackendProvider = memo(
             restartingRef.current = true;
             restartPromiseRef.current = (async () => {
                 let error;
-                do {
-                    needsNewRestartRef.current = false;
-                    try {
-                        backend.abort();
-                        // eslint-disable-next-line no-await-in-loop
-                        await ipcRenderer.invoke('restart-backend');
-                        error = null;
-                    } catch (e) {
-                        error = e;
-                    }
-                    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                } while (needsNewRestartRef.current);
+                try {
+                    do {
+                        needsNewRestartRef.current = false;
+                        try {
+                            backend.abort();
+                            // eslint-disable-next-line no-await-in-loop
+                            await ipcRenderer.invoke('restart-backend');
+                            error = null;
+                        } catch (e) {
+                            error = e;
+                        }
+                        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+                    } while (needsNewRestartRef.current);
+                } finally {
+                    // Done. At this point, the backend either restarted or failed trying
+                    restartingRef.current = false;
+                    restartPromiseRef.current = undefined;
+                }
 
-                // Done. At this point, the backend either restarted or failed trying
-                restartingRef.current = false;
-                restartPromiseRef.current = undefined;
                 refreshNodes();
 
                 if (error !== null) {


### PR DESCRIPTION
This hopefully fixes #2038. 

The idea is to delay the actual fetch until the backend is no longer restarting. Spin to win, basically.

@stonerl Could you please test whether this fixes the issue? I can't reproduce the bug locally, so I can't test it myself.