### PR TITLE
Update descriptions for dependencies on a system basis

### DIFF
--- a/backend/src/packages/chaiNNer_ncnn/__init__.py
+++ b/backend/src/packages/chaiNNer_ncnn/__init__.py
@@ -1,12 +1,29 @@
 from sanic.log import logger
 
 from api import MB, Dependency, add_package
-from system import is_mac
+from system import is_arm_mac, is_mac
+
+general = "NCNN uses .bin/.param models to upscale images."
+recommendation = "It is recommended for AMD users"
+
+if is_arm_mac:
+    inst_hint = general
+elif is_mac:
+    inst_hint = f"{general} {recommendation}."
+else:
+    inst_hint = (
+        f"{general} {recommendation} because it supports both AMD and Nvidia GPUs."
+    )
+
 
 package = add_package(
     __file__,
     name="NCNN",
-    description="NCNN uses .bin/.param models to upscale images. NCNN uses Vulkan for GPU acceleration, meaning it supports any modern GPU. Models can be converted from PyTorch to NCNN.",
+    description=(
+        f"{general} NCNN uses Vulkan for GPU"
+        " acceleration, meaning it supports any modern GPU. Models can be converted"
+        " from PyTorch to NCNN."
+    ),
     dependencies=[
         Dependency(
             display_name="NCNN",
@@ -24,8 +41,7 @@ ncnn_category = package.add_category(
     description="Nodes for using the NCNN Neural Network Framework with images.",
     icon="NCNN",
     color="#ED64A6",
-    install_hint="NCNN uses .bin/.param models to upscale images. It is recommended for AMD users because it supports both AMD and Nvidia GPUs.",
+    install_hint=inst_hint,
 )
-
 
 logger.debug(f"Loaded package {package.name}")

--- a/backend/src/packages/chaiNNer_onnx/__init__.py
+++ b/backend/src/packages/chaiNNer_onnx/__init__.py
@@ -2,6 +2,20 @@ from sanic.log import logger
 
 from api import KB, MB, Dependency, add_package
 from gpu import nvidia_is_available
+from system import is_arm_mac
+
+general = "ONNX uses .onnx models to upscale images."
+conversion = "It also helps to convert between PyTorch and NCNN."
+
+if is_arm_mac:
+    package_description = f"{general} {conversion} However, it does not support CoreML."
+    inst_hint = general
+else:
+    package_description = (
+        f"{general} {conversion} It is fastest when CUDA is supported. If TensorRT is"
+        " installed on the system, it can also be configured to use that."
+    )
+    inst_hint = f"{general} It does not support AMD GPUs."
 
 
 def get_onnx_runtime():
@@ -25,7 +39,7 @@ def get_onnx_runtime():
 package = add_package(
     __file__,
     name="ONNX",
-    description="ONNX uses .onnx models to upscale images. It also helps to convert between PyTorch and NCNN. It is fastest when CUDA is supported. If TensorRT is installed on the system, it can also be configured to use that.",
+    description=package_description,
     dependencies=[
         Dependency(
             display_name="ONNX",
@@ -67,7 +81,7 @@ onnx_category = package.add_category(
     description="Nodes for using the ONNX Neural Network Framework with images.",
     icon="ONNX",
     color="#63B3ED",
-    install_hint="ONNX uses .onnx models to upscale images. It does not support AMD GPUs.",
+    install_hint=inst_hint,
 )
 
 

--- a/backend/src/packages/chaiNNer_pytorch/__init__.py
+++ b/backend/src/packages/chaiNNer_pytorch/__init__.py
@@ -8,6 +8,21 @@ from system import is_arm_mac
 
 python_version = sys.version_info
 
+general = "PyTorch uses .pth models to upscale images."
+
+if is_arm_mac:
+    package_description = general
+    inst_hint = f"{general} It is the most widely-used upscaling architecture."
+else:
+    package_description = (
+        f"{general} and is fastest when CUDA is supported (Nvidia GPU). If CUDA is"
+        " unsupported, it will install with CPU support (which is very slow)."
+    )
+    inst_hint = (
+        f"{general} It is the most widely-used upscaling architecture. However, it does"
+        " not support AMD GPUs."
+    )
+
 
 def get_pytorch():
     # 1.13.1 can take advantage of MPS
@@ -34,18 +49,22 @@ def get_pytorch():
                 pypi_name="torch",
                 version="1.10.2+cu113" if nvidia_is_available else "1.10.2",
                 size_estimate=2 * GB if nvidia_is_available else 140 * MB,
-                extra_index_url="https://download.pytorch.org/whl/cu113"
-                if nvidia_is_available
-                else None,
+                extra_index_url=(
+                    "https://download.pytorch.org/whl/cu113"
+                    if nvidia_is_available
+                    else None
+                ),
             ),
             Dependency(
                 display_name="TorchVision",
                 pypi_name="torchvision",
                 version="0.11.3+cu113" if nvidia_is_available else "0.11.3",
                 size_estimate=2 * MB if nvidia_is_available else 800 * KB,
-                extra_index_url="https://download.pytorch.org/whl/cu113"
-                if nvidia_is_available
-                else None,
+                extra_index_url=(
+                    "https://download.pytorch.org/whl/cu113"
+                    if nvidia_is_available
+                    else None
+                ),
             ),
         ]
     else:
@@ -56,18 +75,22 @@ def get_pytorch():
                 pypi_name="torch",
                 version="1.12.1+cu116" if nvidia_is_available else "1.12.1",
                 size_estimate=2 * GB if nvidia_is_available else 140 * MB,
-                extra_index_url="https://download.pytorch.org/whl/cu116"
-                if nvidia_is_available
-                else None,
+                extra_index_url=(
+                    "https://download.pytorch.org/whl/cu116"
+                    if nvidia_is_available
+                    else None
+                ),
             ),
             Dependency(
                 display_name="TorchVision",
                 pypi_name="torchvision",
                 version="0.13.1+cu116" if nvidia_is_available else "0.13.1",
                 size_estimate=2 * MB if nvidia_is_available else 800 * KB,
-                extra_index_url="https://download.pytorch.org/whl/cu116"
-                if nvidia_is_available
-                else None,
+                extra_index_url=(
+                    "https://download.pytorch.org/whl/cu116"
+                    if nvidia_is_available
+                    else None
+                ),
             ),
         ]
 
@@ -75,7 +98,7 @@ def get_pytorch():
 package = add_package(
     __file__,
     name="PyTorch",
-    description="PyTorch uses .pth models to upscale images, and is fastest when CUDA is supported (Nvidia GPU). If CUDA is unsupported, it will install with CPU support (which is very slow).",
+    description=package_description,
     dependencies=[
         *get_pytorch(),
         Dependency(
@@ -98,7 +121,7 @@ pytorch_category = package.add_category(
     description="Nodes for using the PyTorch Neural Network Framework with images.",
     icon="PyTorch",
     color="#DD6B20",
-    install_hint="PyTorch uses .pth models to upscale images. It is the most widely-used upscaling architecture. However, it does not support AMD GPUs.",
+    install_hint=inst_hint,
 )
 
 logger.debug(f"Loaded package {package.name}")


### PR DESCRIPTION
The description for the package is now shown on a system basis, e.g., a Mac user with Apple Silicon will not see AMD or NVIDIA info.

The Package size is moved out of the button and shown next to the package in a bubble.

Install/Upgrade/Uninstall buttons now have the same width and are aligned with Show console.

