### PR TITLE
More macOS bugfixes/enhancements

### DIFF
--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -4,6 +4,7 @@ import gc
 import importlib
 import logging
 import sys
+import os
 import traceback
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict, dataclass
@@ -16,6 +17,8 @@ from sanic.log import access_logger, logger
 from sanic.request import Request
 from sanic.response import json
 from sanic_cors import CORS
+
+from system import is_arm_mac
 
 import api
 from base_types import NodeId
@@ -49,6 +52,9 @@ from response import (
 )
 from server_config import ServerConfig
 
+# enable mps fallback on apple silicon
+if is_arm_mac:
+    os.environ['PYTORCH_ENABLE_MPS_FALLBACK'] = '1'
 
 class AppContext:
     def __init__(self):

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -3,8 +3,8 @@ import functools
 import gc
 import importlib
 import logging
-import sys
 import os
+import sys
 import traceback
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict, dataclass
@@ -17,8 +17,6 @@ from sanic.log import access_logger, logger
 from sanic.request import Request
 from sanic.response import json
 from sanic_cors import CORS
-
-from system import is_arm_mac
 
 import api
 from base_types import NodeId
@@ -51,6 +49,8 @@ from response import (
     successResponse,
 )
 from server_config import ServerConfig
+from system import is_arm_mac
+
 
 class AppContext:
     def __init__(self):
@@ -99,12 +99,14 @@ runIndividualCounter = ZeroCounter()
 
 setup_task = None
 
+
 async def nodes_available():
     if setup_task is not None:
         await setup_task
 
 
 access_logger.addFilter(SSEFilter())
+
 
 @app.route("/nodes")
 async def nodes(_request: Request):
@@ -539,9 +541,11 @@ async def setup_sse(request: Request):
             await response.send(f"event: {message['event']}\n")
             await response.send(f"data: {stringify(message['data'])}\n\n")
 
+
 async def apple_silicon_setup():
     # enable mps fallback on apple silicon
-    os.environ['PYTORCH_ENABLE_MPS_FALLBACK'] = '1'
+    os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
+
 
 async def setup(sanic_app: Sanic):
     setup_queue = AppContext.get(sanic_app).setup_queue

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@octokit/rest": "^19.0.13",
         "@react-nano/use-event-source": "^0.12.0",
         "adm-zip": "^0.5.10",
-        "appdmg": "*",
         "bezier-js": "^6.1.0",
         "chakra-ui-markdown-renderer": "^4.1.0",
         "chokidar": "^3.5.3",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -46,6 +46,11 @@ const startApp = () => {
         });
     });
 
+    // quit out of app on macOS once all windows are closed
+    app.once('window-all-closed', () => {
+        app.quit();
+    })
+
     if (args.command === 'open') {
         createGuiApp(args);
     } else {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -49,7 +49,7 @@ const startApp = () => {
     // quit out of app on macOS once all windows are closed
     app.once('window-all-closed', () => {
         app.quit();
-    })
+    });
 
     if (args.command === 'open') {
         createGuiApp(args);


### PR DESCRIPTION
After closing the window on macOS, the app just stays in the dock & you can click it but it won't reopen. It will call `app.quit()` now once all window instances are closed.

![gif](https://cdn.discordapp.com/attachments/1046934124134400061/1136630083885465652/CleanShot_2023-08-03_at_14.01.53.gif)

SwinIR throws an error with the mps backend, because the aten::roll operator isn't implemented for mps yet. 
I've set the environment variable to fall back to CPU on unsupported operators. This fixes the error & allows running SwinIR on the GPU, instead of fully on the CPU and brings a performance improvement of 3x.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/108760201/d06488ca-1e66-4599-95e9-0008ddfd5a27)
