### PR TITLE
Fixed the current quit() situation

### DIFF
--- a/src/main/gui/create.ts
+++ b/src/main/gui/create.ts
@@ -75,12 +75,8 @@ export const createGuiApp = (args: OpenArguments) => {
         }
     });
 
-    // Quit when all windows are closed, except on macOS. There, it's common
-    // for applications and their menu bar to stay active until the user quits
-    // explicitly with Cmd + Q.
+    // Quit when all windows are closed.
     app.on('window-all-closed', () => {
-        if (process.platform !== 'darwin') {
-            app.quit();
-        }
+        app.quit();
     });
 };

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -46,11 +46,6 @@ const startApp = () => {
         });
     });
 
-    // quit out of app on macOS once all windows are closed
-    app.once('window-all-closed', () => {
-        app.quit();
-    });
-
     if (args.command === 'open') {
         createGuiApp(args);
     } else {


### PR DESCRIPTION
As per my comment in #2049.

The `app.once('window-all-closed', ...)` from #2049 was actually placed in the wrong spot, so I kept the old one instead.