### PR TITLE
Make ncnn memory budget configurable

### DIFF
--- a/backend/src/nodes/impl/pytorch/utils.py
+++ b/backend/src/nodes/impl/pytorch/utils.py
@@ -32,6 +32,7 @@ def to_pytorch_execution_options(options: ExecutionOptions):
         fp16=options.fp16,
         pytorch_gpu_index=options.pytorch_gpu_index,
         ncnn_gpu_index=options.ncnn_gpu_index,
+        ncnn_budget_limit=options.ncnn_budget_limit,
         onnx_gpu_index=options.onnx_gpu_index,
         onnx_execution_provider=options.onnx_execution_provider,
         onnx_should_tensorrt_cache=options.onnx_should_tensorrt_cache,

--- a/backend/src/nodes/utils/exec_options.py
+++ b/backend/src/nodes/utils/exec_options.py
@@ -11,6 +11,7 @@ class ExecutionOptions:
         fp16: bool,
         pytorch_gpu_index: int,
         ncnn_gpu_index: int,
+        ncnn_budget_limit: int,
         onnx_gpu_index: int,
         onnx_execution_provider: str,
         onnx_should_tensorrt_cache: bool,
@@ -21,6 +22,7 @@ class ExecutionOptions:
         self.__fp16 = fp16
         self.__pytorch_gpu_index = pytorch_gpu_index
         self.__ncnn_gpu_index = ncnn_gpu_index
+        self.__ncnn_budget_limit = ncnn_budget_limit
         self.__onnx_gpu_index = onnx_gpu_index
         self.__onnx_execution_provider = onnx_execution_provider
         self.__onnx_should_tensorrt_cache = onnx_should_tensorrt_cache
@@ -34,7 +36,7 @@ class ExecutionOptions:
             os.makedirs(onnx_tensorrt_cache_path)
 
         logger.debug(
-            f"PyTorch execution options: fp16: {fp16}, device: {self.full_device} | NCNN execution options: gpu_index: {ncnn_gpu_index} | ONNX execution options: gpu_index: {onnx_gpu_index}, execution_provider: {onnx_execution_provider}, should_tensorrt_cache: {onnx_should_tensorrt_cache}, tensorrt_cache_path: {onnx_tensorrt_cache_path}, should_tensorrt_fp16: {onnx_should_tensorrt_fp16}"
+            f"PyTorch execution options: fp16: {fp16}, device: {self.full_device} | NCNN execution options: gpu_index: {ncnn_gpu_index}, budget_limit: {ncnn_budget_limit} | ONNX execution options: gpu_index: {onnx_gpu_index}, execution_provider: {onnx_execution_provider}, should_tensorrt_cache: {onnx_should_tensorrt_cache}, tensorrt_cache_path: {onnx_tensorrt_cache_path}, should_tensorrt_fp16: {onnx_should_tensorrt_fp16}"
         )
 
     @property
@@ -54,6 +56,10 @@ class ExecutionOptions:
     @property
     def ncnn_gpu_index(self):
         return self.__ncnn_gpu_index
+
+    @property
+    def ncnn_budget_limit(self):
+        return self.__ncnn_budget_limit
 
     @property
     def onnx_gpu_index(self):
@@ -77,7 +83,7 @@ class ExecutionOptions:
 
 
 __global_exec_options = ExecutionOptions(
-    "cpu", False, 0, 0, 0, "CPUExecutionProvider", False, "", False
+    "cpu", False, 0, 0, 1024**5, 0, "CPUExecutionProvider", False, "", False
 )
 
 
@@ -97,6 +103,7 @@ class JsonExecutionOptions(TypedDict):
     isFp16: bool
     pytorchGPU: int
     ncnnGPU: int
+    ncnnBudgetLimit: int
     onnxGPU: int
     onnxExecutionProvider: str
     onnxShouldTensorRtCache: bool
@@ -110,6 +117,7 @@ def parse_execution_options(json: JsonExecutionOptions) -> ExecutionOptions:
         fp16=json["isFp16"],
         pytorch_gpu_index=json["pytorchGPU"],
         ncnn_gpu_index=json["ncnnGPU"],
+        ncnn_budget_limit=json["ncnnBudgetLimit"],
         onnx_gpu_index=json["onnxGPU"],
         onnx_execution_provider=json["onnxExecutionProvider"],
         onnx_should_tensorrt_cache=json["onnxShouldTensorRtCache"],

--- a/src/common/Backend.ts
+++ b/src/common/Backend.ts
@@ -72,6 +72,7 @@ export interface BackendExecutionOptions {
     isFp16: boolean;
     pytorchGPU: number;
     ncnnGPU: number;
+    ncnnBudgetLimit: number;
     onnxGPU: number;
     onnxExecutionProvider: string;
     onnxShouldTensorRtCache: boolean;

--- a/src/main/cli/run.ts
+++ b/src/main/cli/run.ts
@@ -133,6 +133,7 @@ const getExecutionOptions = (): BackendExecutionOptions => {
         isFp16: getSetting('is-fp16', false),
         pytorchGPU: getSetting('pytorch-gpu', 0),
         ncnnGPU: getSetting('ncnn-gpu', 0),
+        ncnnBudgetLimit: getSetting('ncnn-budget-limit', 1024 ** 5),
         onnxGPU: getSetting('onnx-gpu', 0),
         onnxExecutionProvider: getSetting('onnx-execution-provider', 'CUDAExecutionProvider'),
         onnxShouldTensorRtCache: getSetting('onnx-should-tensorrt-cache', false),

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -355,6 +355,7 @@ const PythonSettings = memo(() => {
         useIsFp16,
         usePyTorchGPU,
         useNcnnGPU,
+        useNcnnBudgetLimit,
         useOnnxGPU,
         useOnnxExecutionProvider,
         useOnnxShouldTensorRtCache,
@@ -394,6 +395,8 @@ const PythonSettings = memo(() => {
         }),
         [backend]
     );
+
+    const [ncnnBudgetLimit, setNcnnBudgetLimit] = useNcnnBudgetLimit;
 
     useEffect(() => {
         if (isCpu && isFp16) {
@@ -599,6 +602,28 @@ const PythonSettings = memo(() => {
                                 onChange={setNcnnGPU}
                             />
                         )}
+                        <SettingsItem
+                            description="Maximum memory to use for NCNN inference."
+                            title="NCNN memory budget limit (GiB)"
+                        >
+                            <NumberInput
+                                min={0}
+                                value={ncnnBudgetLimit / 1024 ** 3}
+                                onChange={(number: string) => {
+                                    const value = Number(number);
+
+                                    if (!Number.isNaN(value)) {
+                                        setNcnnBudgetLimit(value * 1024 ** 3);
+                                    }
+                                }}
+                            >
+                                <NumberInputField />
+                                <NumberInputStepper>
+                                    <NumberIncrementStepper />
+                                    <NumberDecrementStepper />
+                                </NumberInputStepper>
+                            </NumberInput>
+                        </SettingsItem>
                     </VStack>
                 </TabPanel>
                 <TabPanel px={0}>

--- a/src/renderer/contexts/SettingsContext.tsx
+++ b/src/renderer/contexts/SettingsContext.tsx
@@ -12,6 +12,7 @@ interface Settings {
     useIsFp16: GetSetState<boolean>;
     usePyTorchGPU: GetSetState<number>;
     useNcnnGPU: GetSetState<number>;
+    useNcnnBudgetLimit: GetSetState<number>;
     useOnnxGPU: GetSetState<number>;
     useOnnxExecutionProvider: GetSetState<string>;
     useOnnxShouldTensorRtCache: GetSetState<boolean>;
@@ -47,6 +48,7 @@ export const SettingsProvider = memo(({ children }: React.PropsWithChildren<unkn
     const useIsFp16 = useMemoArray(useLocalStorage('is-fp16', false));
     const usePyTorchGPU = useMemoArray(useLocalStorage('pytorch-gpu', 0));
     const useNcnnGPU = useMemoArray(useLocalStorage('ncnn-gpu', 0));
+    const useNcnnBudgetLimit = useMemoArray(useLocalStorage('ncnn-budget-limit', 1024 ** 5));
     const useOnnxGPU = useMemoArray(useLocalStorage('onnx-gpu', 0));
     const useOnnxExecutionProvider = useMemoArray(
         useLocalStorage('onnx-execution-provider', 'CUDAExecutionProvider')
@@ -109,6 +111,7 @@ export const SettingsProvider = memo(({ children }: React.PropsWithChildren<unkn
         useIsFp16,
         usePyTorchGPU,
         useNcnnGPU,
+        useNcnnBudgetLimit,
         useOnnxGPU,
         useOnnxExecutionProvider,
         useOnnxShouldTensorRtCache,

--- a/src/renderer/hooks/useBackendExecutionOptions.ts
+++ b/src/renderer/hooks/useBackendExecutionOptions.ts
@@ -12,6 +12,7 @@ export const useBackendExecutionOptions = (): BackendExecutionOptions => {
         useIsFp16,
         usePyTorchGPU,
         useNcnnGPU,
+        useNcnnBudgetLimit,
         useOnnxGPU,
         useOnnxExecutionProvider,
         useOnnxShouldTensorRtCache,
@@ -22,6 +23,7 @@ export const useBackendExecutionOptions = (): BackendExecutionOptions => {
     const [isFp16] = useIsFp16;
     const [pytorchGPU] = usePyTorchGPU;
     const [ncnnGPU] = useNcnnGPU;
+    const [ncnnBudgetLimit] = useNcnnBudgetLimit;
     const [onnxGPU] = useOnnxGPU;
     const [onnxExecutionProvider] = useOnnxExecutionProvider;
     const [onnxShouldTensorRtCache] = useOnnxShouldTensorRtCache;
@@ -43,6 +45,7 @@ export const useBackendExecutionOptions = (): BackendExecutionOptions => {
         isFp16,
         pytorchGPU,
         ncnnGPU,
+        ncnnBudgetLimit,
         onnxGPU,
         onnxExecutionProvider,
         onnxShouldTensorRtCache,


### PR DESCRIPTION
#1867 didn't support automatic estimation of tile size, which was not great for UX. This PR adds that missing support, by allowing the user to choose a custom memory budget. Choosing a memory budget is likely to be better UX than choosing a tile size (since users are likely to have a better knowledge of how much RAM or VRAM they have, than what tile size will work with their hardware and the model they picked). This should also work fine with Vulkan (and is likely to help with [this UX issue](https://github.com/chaiNNer-org/chaiNNer/blob/main/docs/troubleshooting.md#vkqueuesubmit-error-with-ncnn)), though I wasn't able to test that.