### PR TITLE
Support BMP in Save Image

### DIFF
--- a/backend/src/nodes/properties/inputs/file_inputs.py
+++ b/backend/src/nodes/properties/inputs/file_inputs.py
@@ -7,7 +7,6 @@ from nodes.base_input import BaseInput
 
 # pylint: disable=relative-beyond-top-level
 from ...impl.image_formats import get_available_image_formats
-from .generic_inputs import DropDownInput
 
 FileInputKind = Union[
     Literal["bin"],
@@ -143,48 +142,6 @@ class DirectoryInput(BaseInput):
         if self.must_exist:
             assert os.path.exists(value), f"Directory {value} does not exist"
         return value
-
-
-def ImageExtensionDropdown() -> DropDownInput:
-    """Input for selecting file type from dropdown"""
-    return DropDownInput(
-        input_type="ImageExtension",
-        label="Image Extension",
-        options=[
-            {
-                "option": "PNG",
-                "value": "png",
-            },
-            {
-                "option": "JPG",
-                "value": "jpg",
-            },
-            {
-                "option": "GIF",
-                "value": "gif",
-            },
-            {
-                "option": "TIFF",
-                "value": "tiff",
-            },
-            {
-                "option": "WEBP",
-                "value": "webp",
-            },
-            {
-                "option": "WEBP (Lossless)",
-                "value": "webp-lossless",
-            },
-            {
-                "option": "TGA",
-                "value": "tga",
-            },
-            {
-                "option": "DDS",
-                "value": "dds",
-            },
-        ],
-    )
 
 
 def BinFileInput(primary_input: bool = False) -> FileInput:


### PR DESCRIPTION
Progress for #1791.

Changes:
- I refactored the image extensions dropdown to use `EnumInput` instead. This makes image formats type safe, which gives me more confidence to change Save Image.
- Renamed "Image Extension" to "Image Format"
- Added `BMP` to image formats.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/36782682-16b1-4528-89d1-0e4e9023f08e)


I also refactored Save Image a little in general. This is preparation for 16bit images (#1934), which I plan to add after this PR.