### PR TITLE
Add support for saving 16 bit and 32 bit images

### DIFF
--- a/backend/src/nodes/impl/image_utils.py
+++ b/backend/src/nodes/impl/image_utils.py
@@ -111,14 +111,11 @@ def normalize(img: np.ndarray) -> np.ndarray:
 def to_uint8(
     img: np.ndarray,
     normalized=False,
-    dither=False,
 ) -> np.ndarray:
     """
     Returns a new uint8 image with the given image data.
 
     If `normalized` is `False`, then the image will be normalized before being converted to uint8.
-
-    If `dither` is `True`, then dithering will be used to minimize the quantization error.
     """
     if img.dtype == np.uint8:
         return img.copy()
@@ -126,18 +123,25 @@ def to_uint8(
     if not normalized or img.dtype != np.float32:
         img = normalize(img)
 
-    if not dither:
-        return (img * 255).round().astype(np.uint8)
+    return (img * 255).round().astype(np.uint8)
 
-    # random dithering
-    truth = img * 255
-    quant = truth.round()
 
-    err = truth - quant
-    r = np.random.default_rng(0).uniform(0, 1, img.shape).astype(np.float32)
-    quant += np.sign(err) * (np.abs(err) > r)
+def to_uint16(
+    img: np.ndarray,
+    normalized=False,
+) -> np.ndarray:
+    """
+    Returns a new uint8 image with the given image data.
 
-    return quant.astype(np.uint8)
+    If `normalized` is `False`, then the image will be normalized before being converted to uint8.
+    """
+    if img.dtype == np.uint16:
+        return img.copy()
+
+    if not normalized or img.dtype != np.float32:
+        img = normalize(img)
+
+    return (img * 65535).round().astype(np.uint16)
 
 
 def shift(img: np.ndarray, amount_x: int, amount_y: int, fill: FillColor) -> np.ndarray:

--- a/backend/src/packages/chaiNNer_standard/image/io/save_image.py
+++ b/backend/src/packages/chaiNNer_standard/image/io/save_image.py
@@ -128,8 +128,8 @@ class TiffColorDepth(Enum):
                 "Color Depth",
                 default_value=PngColorDepth.U8,
                 option_labels={
-                    PngColorDepth.U8: "8 Bit (Standard)",
-                    PngColorDepth.U16: "16 Bit",
+                    PngColorDepth.U8: "8 Bits/Channel",
+                    PngColorDepth.U16: "16 Bits/Channel",
                 },
             ).with_id(15),
         ),
@@ -168,9 +168,9 @@ class TiffColorDepth(Enum):
                 "Color Depth",
                 default_value=TiffColorDepth.U8,
                 option_labels={
-                    TiffColorDepth.U8: "8 Bit (Standard)",
-                    TiffColorDepth.U16: "16 Bit",
-                    TiffColorDepth.F32: "32 Bit (Floating point)",
+                    TiffColorDepth.U8: "8 Bits/Channel",
+                    TiffColorDepth.U16: "16 Bits/Channel",
+                    TiffColorDepth.F32: "32 Bits/Channel (Float)",
                 },
             ).with_id(16),
         ),


### PR DESCRIPTION
Resolves #1934.

Changes:
- Added support for saving PNG images with either 8 or 16 bits per channel.
- Added support for saving TIFF images with either 8, 16, or 32 bits per channel.
- Removed `dither` option from `to_uint8`. The option is useless now that we have a useable Dither node.

Discussion around how to present these option is still ongoing, so this PR is still a draft.