### PR TITLE
Ignore file extension case in file image iterator

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/image_file_iterator.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/image_file_iterator.py
@@ -40,7 +40,7 @@ def list_glob(directory: str, globexpr: str, ext_filter: List[str]) -> List[str]
     filtered = glob.globfilter(
         glob.iglob(globexpr, root_dir=directory, flags=flags),
         extension_expr,
-        flags=flags,
+        flags=flags | glob.IGNORECASE,
     )
 
     return sorted(


### PR DESCRIPTION
Fixes the issue reported to us on discord today. Well, I think. It worked for me before, but that might be windows file system being ignore case anyway.