### PR TITLE
Added warnings to for nodes with limited color depth

### DIFF
--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -139,7 +139,7 @@ class NodeGroup:
             else:
                 description += (
                     "This node will internally convert input images to 8 bits/channel."
-                    " This is generally only a problem if you intend to save the output as a 16-bit image."
+                    " This is generally only a problem if you intend to save the output with 16 bits/channel or higher."
                 )
 
         def to_list(x: List[S] | S | None) -> List[S]:

--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -127,9 +127,20 @@ class NodeGroup:
         decorators: List[Callable] | None = None,
         see_also: List[str] | str | None = None,
         features: List[FeatureId] | FeatureId | None = None,
+        limited_to_8bpc: bool | str = False,
     ):
         if not isinstance(description, str):
             description = "\n\n".join(description)
+
+        if limited_to_8bpc:
+            description += "\n\n#### Limited color depth\n\n"
+            if isinstance(limited_to_8bpc, str):
+                description += f" {limited_to_8bpc}"
+            else:
+                description += (
+                    "This node will internally convert input images to 8 bits/channel."
+                    " This is generally only a problem if you intend to save the output as a 16-bit image."
+                )
 
         def to_list(x: List[S] | S | None) -> List[S]:
             if x is None:

--- a/backend/src/packages/chaiNNer_external/external_stable_diffusion/automatic1111/image_to_image.py
+++ b/backend/src/packages/chaiNNer_external/external_stable_diffusion/automatic1111/image_to_image.py
@@ -100,6 +100,7 @@ from .. import auto1111_group
     ],
     decorators=[cached],
     features=web_ui,
+    limited_to_8bpc=True,
 )
 def image_to_image_node(
     image: np.ndarray,

--- a/backend/src/packages/chaiNNer_external/external_stable_diffusion/automatic1111/inpaint.py
+++ b/backend/src/packages/chaiNNer_external/external_stable_diffusion/automatic1111/inpaint.py
@@ -129,6 +129,7 @@ class InpaintArea(Enum):
     ],
     decorators=[cached],
     features=web_ui,
+    limited_to_8bpc=True,
 )
 def inpaint_node(
     image: np.ndarray,

--- a/backend/src/packages/chaiNNer_external/external_stable_diffusion/automatic1111/outpaint.py
+++ b/backend/src/packages/chaiNNer_external/external_stable_diffusion/automatic1111/outpaint.py
@@ -159,6 +159,7 @@ class OutpaintingMethod(Enum):
     ],
     decorators=[cached],
     features=web_ui,
+    limited_to_8bpc=True,
 )
 def outpaint_node(
     image: np.ndarray,

--- a/backend/src/packages/chaiNNer_external/external_stable_diffusion/automatic1111/upscale.py
+++ b/backend/src/packages/chaiNNer_external/external_stable_diffusion/automatic1111/upscale.py
@@ -127,6 +127,7 @@ UPSCALER_MODE_LABELS = {
     ],
     decorators=[cached],
     features=web_ui,
+    limited_to_8bpc=True,
 )
 def upscale_node(
     image: np.ndarray,

--- a/backend/src/packages/chaiNNer_ncnn/ncnn/processing/upscale_image.py
+++ b/backend/src/packages/chaiNNer_ncnn/ncnn/processing/upscale_image.py
@@ -142,6 +142,7 @@ def upscale_impl(
     outputs=[
         ImageOutput(image_type="""convenientUpscale(Input0, Input1)"""),
     ],
+    limited_to_8bpc=True,
 )
 def upscale_image_node(
     img: np.ndarray, model: NcnnModelWrapper, tile_size: TileSize

--- a/backend/src/packages/chaiNNer_onnx/onnx/processing/remove_background.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/processing/remove_background.py
@@ -42,6 +42,7 @@ from .. import processing_group
         ),
         ImageOutput("Mask", image_type=navi.Image(size_as="Input0"), channels=1),
     ],
+    limited_to_8bpc=True,
 )
 def remove_background_node(
     img: np.ndarray,

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/restoration/upscale_face.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/restoration/upscale_face.py
@@ -146,6 +146,7 @@ def upscale(
             channels=3,
         )
     ],
+    limited_to_8bpc=True,
 )
 def upscale_face_node(
     img: np.ndarray,

--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/video_frame_iterator.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/video_frame_iterator.py
@@ -197,6 +197,7 @@ def iterator_helper_write_output_frame_node(
         },
     ],
     side_effects=True,
+    limited_to_8bpc="The video will be read and written as 8-bit RGB.",
 )
 async def video_frame_iterator_node(path: str, context: IteratorContext) -> None:
     logger.debug(f"{ffmpeg_path=}, {ffprobe_path=}")

--- a/backend/src/packages/chaiNNer_standard/image/io/save_image.py
+++ b/backend/src/packages/chaiNNer_standard/image/io/save_image.py
@@ -199,6 +199,7 @@ class TiffColorDepth(Enum):
     ],
     outputs=[],
     side_effects=True,
+    limited_to_8bpc="Image will be saved with 8 bits/channel by default. Some formats support higher bit depths.",
 )
 def save_image_node(
     img: np.ndarray,

--- a/backend/src/packages/chaiNNer_standard/image/io/view_image_external.py
+++ b/backend/src/packages/chaiNNer_standard/image/io/view_image_external.py
@@ -27,6 +27,7 @@ from .. import io_group
     inputs=[ImageInput()],
     outputs=[],
     side_effects=True,
+    limited_to_8bpc="The temporary file is an 8-bit PNG.",
 )
 def view_image_external_node(img: np.ndarray) -> None:
     tempdir = mkdtemp(prefix="chaiNNer-")

--- a/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/threshold_adaptive.py
+++ b/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/threshold_adaptive.py
@@ -36,6 +36,7 @@ from .. import adjustments_group
         NumberInput("Mean Subtraction"),
     ],
     outputs=[ImageOutput(image_type="Input0")],
+    limited_to_8bpc=True,
 )
 def threshold_adaptive_node(
     img: np.ndarray,

--- a/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize_factor.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize_factor.py
@@ -41,6 +41,7 @@ from .. import resize_group
             assume_normalized=True,
         )
     ],
+    limited_to_8bpc=True,
 )
 def resize_factor_node(
     img: np.ndarray, scale: float, interpolation: InterpolationMethod

--- a/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize_resolution.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize_resolution.py
@@ -35,6 +35,7 @@ from .. import resize_group
             assume_normalized=True,
         )
     ],
+    limited_to_8bpc=True,
 )
 def resize_resolution_node(
     img: np.ndarray,

--- a/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize_to_side.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize_to_side.py
@@ -167,6 +167,7 @@ def resize_to_side_conditional(
             assume_normalized=True,
         )
     ],
+    limited_to_8bpc=True,
 )
 def resize_to_side_node(
     img: np.ndarray,

--- a/backend/src/packages/chaiNNer_standard/image_filter/blur/median_blur.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/blur/median_blur.py
@@ -20,6 +20,7 @@ from .. import blur_group
         SliderInput("Radius", minimum=0, maximum=1000, default=1, scale="log"),
     ],
     outputs=[ImageOutput(image_type="Input0")],
+    limited_to_8bpc=True,
 )
 def median_blur_node(
     img: np.ndarray,

--- a/backend/src/packages/chaiNNer_standard/image_filter/correction/average_color_fix.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/correction/average_color_fix.py
@@ -34,6 +34,7 @@ from .. import correction_group
         ),
     ],
     outputs=[ImageOutput(image_type="Input0")],
+    limited_to_8bpc=True,
 )
 def average_color_fix_node(
     input_img: np.ndarray, ref_img: np.ndarray, scale_factor: float

--- a/backend/src/packages/chaiNNer_standard/image_filter/noise/fast_nl_means.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/noise/fast_nl_means.py
@@ -43,6 +43,7 @@ from .. import noise_group
         NumberInput("Search radius", minimum=1, default=10, maximum=30, precision=0),
     ],
     outputs=[ImageOutput(image_type="Input0")],
+    limited_to_8bpc=True,
 )
 def fast_nl_means_node(
     img: np.ndarray,

--- a/backend/src/packages/chaiNNer_standard/image_utility/compositing/add_caption.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/compositing/add_caption.py
@@ -34,6 +34,7 @@ from .. import compositing_group
             assume_normalized=True,
         )
     ],
+    limited_to_8bpc=True,
 )
 def add_caption_node(
     img: np.ndarray, caption: str, size: int, position: CaptionPosition

--- a/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/inpaint.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/inpaint.py
@@ -57,6 +57,7 @@ class InpaintAlgorithm(Enum):
             )
         ).with_never_reason("The given image and mask must have the same resolution.")
     ],
+    limited_to_8bpc=True,
 )
 def inpaint_node(
     img: np.ndarray,

--- a/backend/src/packages/chaiNNer_standard/image_utility/modification/rotate.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/modification/rotate.py
@@ -120,6 +120,7 @@ from .. import modification_group
             assume_normalized=True,
         )
     ],
+    limited_to_8bpc=True,
 )
 def rotate_node(
     img: np.ndarray,

--- a/backend/src/packages/chaiNNer_standard/material_textures/conversion/metal_to_specular.py
+++ b/backend/src/packages/chaiNNer_standard/material_textures/conversion/metal_to_specular.py
@@ -81,6 +81,7 @@ def metal_to_spec(
             channels=1,
         ),
     ],
+    limited_to_8bpc=True,
 )
 def metal_to_specular_node(
     albedo: np.ndarray,

--- a/backend/src/packages/chaiNNer_standard/material_textures/conversion/specular_to_metal.py
+++ b/backend/src/packages/chaiNNer_standard/material_textures/conversion/specular_to_metal.py
@@ -109,6 +109,7 @@ def spec_to_metal(
             channels=1,
         ),
     ],
+    limited_to_8bpc=True,
 )
 def specular_to_metal_node(
     diff: np.ndarray,

--- a/backend/src/packages/chaiNNer_standard/utility/clipboard/copy_to_clipboard.py
+++ b/backend/src/packages/chaiNNer_standard/utility/clipboard/copy_to_clipboard.py
@@ -18,6 +18,7 @@ from .. import clipboard_group
     ],
     outputs=[],
     side_effects=True,
+    limited_to_8bpc="The image will be copied to clipboard with 8 bits/channel.",
 )
 def copy_to_clipboard_node(value: str | np.ndarray) -> None:
     if isinstance(value, np.ndarray):


### PR DESCRIPTION
Resolves #819.

This adds a warning to all nodes that limit the color depth of the input image in a meaningful way. This makes it clear that most nodes support 16-bit (and higher) images.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/8738a978-0e65-4302-8821-63c3506d14a3)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/14e291f1-c32d-431e-93e3-a9b6f3ce8b3a)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/021b0612-f0ea-40e6-ba9d-143245e89e02)
