### PR TITLE
Fixed that pip error were silently ignored

### DIFF
--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -25,7 +25,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: ['3.8', '3.9']
+                python-version: ['3.8', '3.9', '3.10', '3.11']
         steps:
             - uses: actions/checkout@v3
             - uses: actions/setup-python@v4
@@ -61,7 +61,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: ['3.8', '3.9', '3.10']
+                python-version: ['3.8', '3.9', '3.10', '3.11']
         steps:
             - uses: actions/checkout@v3
             - uses: actions/setup-python@v4

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -67,4 +67,4 @@ jobs:
             - uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python-version }}
-            - run: python ./backend/src/run.py --close-after-start
+            - run: python ./backend/src/run.py --close-after-start --install-builtin-packages

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -25,7 +25,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: ['3.8', '3.9', '3.10', '3.11']
+                python-version: ['3.8', '3.9']
         steps:
             - uses: actions/checkout@v3
             - uses: actions/setup-python@v4
@@ -61,10 +61,10 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: ['3.8', '3.9', '3.10', '3.11']
+                python-version: ['3.8', '3.9', '3.10']
         steps:
             - uses: actions/checkout@v3
             - uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python-version }}
-            - run: python ./backend/src/run.py --close-after-start --install-builtin-packages
+            - run: python ./backend/src/run.py --close-after-start

--- a/backend/src/dependencies/store.py
+++ b/backend/src/dependencies/store.py
@@ -72,7 +72,7 @@ def install_dependencies_sync(
     if len(dependencies_to_install) == 0:
         return
 
-    subprocess.check_call(
+    exit_code = subprocess.check_call(
         [
             python_path,
             "-m",
@@ -83,6 +83,9 @@ def install_dependencies_sync(
             "--no-warn-script-location",
         ]
     )
+    if exit_code != 0:
+        raise ValueError("An error occurred while installing dependencies.")
+
     for dep_info in dependencies_to_install:
         package_name = dep_info["package_name"]
         version = dep_info["version"]
@@ -189,7 +192,10 @@ async def install_dependencies(
         elif "Installing collected packages" in line:
             await update_progress_cb(f"Installing collected dependencies...", 0.9, None)
 
-    process.wait()
+    exit_code = process.wait()
+    if exit_code != 0:
+        raise ValueError("An error occurred while installing dependencies.")
+
     await update_progress_cb(f"Finished installing dependencies...", 1, None)
 
     for dep_info in dependencies_to_install:

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -520,24 +520,45 @@ async def get_features(_request: Request):
     return json(features_json)
 
 
+@app.get("/sse")
+async def sse(request: Request):
+    ctx = AppContext.get(request.app)
+    headers = {"Cache-Control": "no-cache"}
+    response = await request.respond(headers=headers, content_type="text/event-stream")
+    while True:
+        message = await ctx.queue.get()
+        if response is not None:
+            await response.send(f"event: {message['event']}\n")
+            await response.send(f"data: {stringify(message['data'])}\n\n")
+
+
+@app.get("/setup-sse")
+async def setup_sse(request: Request):
+    ctx = AppContext.get(request.app)
+    headers = {"Cache-Control": "no-cache"}
+    response = await request.respond(headers=headers, content_type="text/event-stream")
+    while True:
+        message = await ctx.setup_queue.get()
+        if response is not None:
+            await response.send(f"event: {message['event']}\n")
+            await response.send(f"data: {stringify(message['data'])}\n\n")
+
+
 async def import_packages(
     config: ServerConfig,
     update_progress_cb: UpdateProgressFn,
 ):
     async def install_deps(dependencies: List[api.Dependency]):
-        try:
-            dep_info: List[DependencyInfo] = [
-                {
-                    "package_name": dep.pypi_name,
-                    "display_name": dep.display_name,
-                    "version": dep.version,
-                    "from_file": None,
-                }
-                for dep in dependencies
-            ]
-            await install_dependencies(dep_info, update_progress_cb, logger)
-        except Exception as ex:
-            logger.error(f"Error installing dependencies: {ex}")
+        dep_info: List[DependencyInfo] = [
+            {
+                "package_name": dep.pypi_name,
+                "display_name": dep.display_name,
+                "version": dep.version,
+                "from_file": None,
+            }
+            for dep in dependencies
+        ]
+        await install_dependencies(dep_info, update_progress_cb, logger)
 
     # Manually import built-in packages to get ordering correct
     # Using importlib here so we don't have to ignore that it isn't used
@@ -567,7 +588,14 @@ async def import_packages(
                 to_install.append(dep)
 
     if len(to_install) > 0:
-        await install_deps(to_install)
+        try:
+            await install_deps(to_install)
+        except Exception as ex:
+            logger.error(f"Error installing dependencies: {ex}")
+            if config.close_after_start:
+                raise ValueError(  # pylint: disable=raise-missing-from
+                    "Error installing dependencies"
+                )
 
     logger.info("Done checking dependencies...")
 
@@ -578,30 +606,6 @@ async def import_packages(
     await update_progress_cb("Loading Nodes...", 1.0, None)
 
     api.registry.load_nodes(__file__)
-
-
-@app.get("/sse")
-async def sse(request: Request):
-    ctx = AppContext.get(request.app)
-    headers = {"Cache-Control": "no-cache"}
-    response = await request.respond(headers=headers, content_type="text/event-stream")
-    while True:
-        message = await ctx.queue.get()
-        if response is not None:
-            await response.send(f"event: {message['event']}\n")
-            await response.send(f"data: {stringify(message['data'])}\n\n")
-
-
-@app.get("/setup-sse")
-async def setup_sse(request: Request):
-    ctx = AppContext.get(request.app)
-    headers = {"Cache-Control": "no-cache"}
-    response = await request.respond(headers=headers, content_type="text/event-stream")
-    while True:
-        message = await ctx.setup_queue.get()
-        if response is not None:
-            await response.send(f"event: {message['event']}\n")
-            await response.send(f"data: {stringify(message['data'])}\n\n")
 
 
 async def apple_silicon_setup():
@@ -670,7 +674,6 @@ async def close_server(sanic_app: Sanic):
 
     try:
         await nodes_available()
-        exit_code = 0
     except Exception as ex:
         logger.error(f"Error waiting for server to start: {ex}")
         exit_code = 1


### PR DESCRIPTION
Pip errors will now cause an exception.

If the `--close-after-start` flag is present, the backend will fail with exit code 1 if deps fail to install.