### PR TITLE
Add Generate Threshold node

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/generate_threshold.py
+++ b/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/generate_threshold.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Dict
+
+import cv2
+import numpy as np
+
+from nodes.impl.image_utils import to_uint8
+from nodes.properties.inputs import EnumInput, ImageInput
+from nodes.properties.outputs import NumberOutput
+from nodes.utils.utils import get_h_w_c
+
+from .. import adjustments_group
+
+
+class AutoThreshold(Enum):
+    OTSU = 0
+    TRIANGLE = 1
+
+
+_AUTO_THRESHOLD_LABELS: Dict[AutoThreshold, str] = {
+    AutoThreshold.OTSU: "Otsu's Method",
+    AutoThreshold.TRIANGLE: "Triangle Method",
+}
+
+
+@adjustments_group.register(
+    schema_id="chainner:image:generate_threshold",
+    name="Generate Threshold",
+    description="Automatically determines an optimal threshold value for the given image.",
+    icon="MdShowChart",
+    inputs=[
+        ImageInput(),
+        EnumInput(AutoThreshold, "Method", option_labels=_AUTO_THRESHOLD_LABELS),
+    ],
+    outputs=[
+        NumberOutput("Threshold", output_type="0..100"),
+    ],
+    see_also=[
+        "chainner:image:threshold",
+    ],
+)
+def generate_threshold_node(img: np.ndarray, method: AutoThreshold) -> float:
+    if get_h_w_c(img)[2] != 1:
+        # these methods need grayscale images, so we'll use the mean across all channels
+        img = np.mean(img, axis=-1)
+
+    # otsu and triangle methods are only implemented for uint8 images
+    img = to_uint8(img, normalized=True)
+
+    if method == AutoThreshold.OTSU:
+        threshold, _ = cv2.threshold(img, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)
+    elif method == AutoThreshold.TRIANGLE:
+        threshold, _ = cv2.threshold(
+            img, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_TRIANGLE
+        )
+
+    return threshold / 255 * 100

--- a/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/threshold.py
+++ b/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/threshold.py
@@ -34,6 +34,10 @@ from .. import adjustments_group
         ThresholdInput(),
     ],
     outputs=[ImageOutput(image_type="Input0")],
+    see_also=[
+        "chainner:image:generate_threshold",
+        "chainner:image:threshold_adaptive",
+    ],
 )
 def threshold_node(
     img: np.ndarray, thresh: float, maxval: float, thresh_type: int


### PR DESCRIPTION
Fixes #1955.

This adds a node to generate the threshold value for the Threshold node. The node currently supports Otsu's method and the triangle method, both implemented by OpenCV. Unfortunately, OpenCV implements these methods as part of `cv2.threshold(...)` and only for 8-bit grayscale images. So we waste some computation to filter the image, but it's not much.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/e6884cf1-27bf-4f6d-b184-56157b240c06)
