### PR TITLE
Added `if_not_connected` option to type conditions

### DIFF
--- a/backend/src/nodes/groups.py
+++ b/backend/src/nodes/groups.py
@@ -54,6 +54,7 @@ class _TypeConditionJson(TypedDict):
     kind: Literal["type"]
     input: InputId
     condition: navi.ExpressionJson
+    ifNotConnected: bool
 
 
 class Condition:
@@ -116,7 +117,11 @@ class Condition:
         )
 
     @staticmethod
-    def type(input_id: int, condition: navi.ExpressionJson) -> Condition:
+    def type(
+        input_id: int,
+        condition: navi.ExpressionJson,
+        if_not_connected: bool = False,
+    ) -> Condition:
         """
         A condition to check whether a certain input is compatible a certain type.
         Here "compatible" is defined as overlapping.
@@ -126,6 +131,7 @@ class Condition:
                 "kind": "type",
                 "input": InputId(input_id),
                 "condition": condition,
+                "ifNotConnected": if_not_connected,
             }
         )
 

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -176,6 +176,7 @@ export interface TypeCondition {
     readonly kind: 'type';
     readonly input: InputId;
     readonly condition: ExpressionJson;
+    readonly ifNotConnected: boolean;
 }
 
 interface GroupBase {

--- a/src/common/nodes/condition.ts
+++ b/src/common/nodes/condition.ts
@@ -47,7 +47,7 @@ export const testInputCondition = (
             const value = getInputValue(c.enum, inputData);
             return Array.isArray(values) ? values.includes(value) : values === value;
         },
-        type: ({ input, condition: type }) => {
+        type: ({ input, condition: type, ifNotConnected }) => {
             const inputType = getInputType(input);
             if (!inputType) return false;
 
@@ -63,7 +63,7 @@ export const testInputCondition = (
             // So we will only show the conditional inputs if the input has been assigned a value.
             if (getInputValue(input, inputData) === undefined && !isConnected(input)) {
                 // the input type is the declaration type
-                return false;
+                return ifNotConnected;
             }
 
             return true;


### PR DESCRIPTION
As discussed on discord, this adds an `if_not_connected` option to type conditions. This allows to alter the default behavior of type conditions if no value is connected to an input.