### PR TITLE
Fail CI on node import errors

### DIFF
--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -67,4 +67,4 @@ jobs:
             - uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python-version }}
-            - run: python ./backend/src/run.py --close-after-start
+            - run: python ./backend/src/run.py --close-after-start --install-builtin-packages --error-on-failed-node

--- a/backend/src/server_config.py
+++ b/backend/src/server_config.py
@@ -23,6 +23,13 @@ class ServerConfig:
     Usage: `--install-builtin-packages`
     """
 
+    error_on_failed_node: bool = False
+    """
+    Errors and exits the server with a non-zero exit code if a node fails to import.
+
+    Usage: `--error-on-failed-node`
+    """
+
     @staticmethod
     def parse_argv() -> "ServerConfig":
         # Remove the first argument, which is the script name.
@@ -44,8 +51,14 @@ class ServerConfig:
             install_builtin_packages = True
             argv.remove("--install-builtin-packages")
 
+        error_on_failed_node = False
+        if "--error-on-failed-node" in argv:
+            error_on_failed_node = True
+            argv.remove("--error-on-failed-node")
+
         return ServerConfig(
             port=port,
             close_after_start=close_after_start,
             install_builtin_packages=install_builtin_packages,
+            error_on_failed_node=error_on_failed_node,
         )


### PR DESCRIPTION
This PR includes 2 changes:

1. I improved the logged warnings for node import errors. It will now look like this:

```
[0] [2023-08-17 15:13:20 +0200] [14164] [WARNING] Failed to import 10 modules:
[0] [2023-08-17 15:13:20 +0200] [14164] [WARNING] No module named 'timm'  ->  packages.chaiNNer_pytorch.pytorch.io.load_model
[0] [2023-08-17 15:13:20 +0200] [14164] [WARNING] No module named 'timm'  ->  packages.chaiNNer_pytorch.pytorch.io.save_model
[0] [2023-08-17 15:13:20 +0200] [14164] [WARNING] No module named 'timm'  ->  packages.chaiNNer_pytorch.pytorch.iteration.model_file_iterator
[0] [2023-08-17 15:13:20 +0200] [14164] [WARNING] No module named 'timm'  ->  packages.chaiNNer_pytorch.pytorch.processing.inpaint
[0] [2023-08-17 15:13:20 +0200] [14164] [WARNING] No module named 'timm'  ->  packages.chaiNNer_pytorch.pytorch.processing.upscale_image
[0] [2023-08-17 15:13:20 +0200] [14164] [WARNING] No module named 'timm'  ->  packages.chaiNNer_pytorch.pytorch.restoration.upscale_face
[0] [2023-08-17 15:13:20 +0200] [14164] [WARNING] No module named 'timm'  ->  packages.chaiNNer_pytorch.pytorch.utility.convert_to_ncnn
[0] [2023-08-17 15:13:20 +0200] [14164] [WARNING] No module named 'timm'  ->  packages.chaiNNer_pytorch.pytorch.utility.convert_to_onnx
[0] [2023-08-17 15:13:20 +0200] [14164] [WARNING] No module named 'timm'  ->  packages.chaiNNer_pytorch.pytorch.utility.get_model_scale
[0] [2023-08-17 15:13:20 +0200] [14164] [WARNING] No module named 'timm'  ->  packages.chaiNNer_pytorch.pytorch.utility.interpolate_models
```

2. I changed the bootstrap CI test to (1) install all deps to get all nodes and (2) to throw an error if any nodes fail to import for any reason.