### PR TITLE
move toast behind overlay

### DIFF
--- a/src/renderer/global.scss
+++ b/src/renderer/global.scss
@@ -211,3 +211,8 @@ body {
 .chakra-modal__content-container {
     z-index: 6000 !important;
 }
+
+// This moves the toasts behind the greay overlay
+.chakra-modal__overlay {
+    z-index: 5700 !important;
+}


### PR DESCRIPTION
Follow-up to #2110. It looks more elegant this way.

![CleanShot 2023-08-17 at 22 45 51@2x](https://github.com/chaiNNer-org/chaiNNer/assets/2091312/4c73f284-f25f-4d3b-bb9d-1e7006b2aebd)
