### PR TITLE
set minimum macOS version to 11.0.0

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -32,6 +32,9 @@ const config = {
         executableName: process.platform === 'linux' ? 'chainner' : 'chaiNNer',
         extraResource: './backend/src/',
         icon: './src/public/icons/cross_platform/icon',
+        appBundleId: 'app.chainner',
+        appCategoryType: 'public.app-category.graphics-design',
+        extendInfo: { LSMinimumSystemVersion: '11.0.0' },
     },
     publishers: [
         {


### PR DESCRIPTION
… and give it the correct category and BundleId

closes #1680

If the OS version it below 11.0.0 it looks like this:

![CleanShot 2023-08-19 at 17 20 06@2x](https://github.com/chaiNNer-org/chaiNNer/assets/2091312/6959642f-9838-49e9-8c9a-4a10148f147a)

![CleanShot 2023-08-19 at 17 18 50@2x](https://github.com/chaiNNer-org/chaiNNer/assets/2091312/94bad7df-dd1e-4660-8a17-e4bf9ebeaf74)
