### PR TITLE
Add "Separate Alpha" checkbox to upscale nodes

### DIFF
--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
@@ -117,7 +117,10 @@ def upscale(
             and Condition.type(0, "PyTorchModel { outputChannels: 1 | 3 } ")
         )(
             BoolInput("Separate Alpha", default=False).with_docs(
-                "Normally when dealing with an image with alpha, "
+                "Normally when dealing with an image with alpha, we take the difference between an"
+                " upscale with a black background and an upscale with a white background to get the"
+                " alpha channel. However, under certain circumstances it may be more desirable to"
+                " upscale the alpha channel separately from the RGB channels."
             )
         ),
     ],

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
@@ -18,7 +18,12 @@ from nodes.impl.upscale.auto_split_tiles import (
 )
 from nodes.impl.upscale.convenient_upscale import convenient_upscale
 from nodes.impl.upscale.tiler import MaxTileSize
-from nodes.properties.inputs import ImageInput, SrModelInput, TileSizeDropdown
+from nodes.properties.inputs import (
+    BoolInput,
+    ImageInput,
+    SrModelInput,
+    TileSizeDropdown,
+)
 from nodes.properties.outputs import ImageOutput
 from nodes.utils.exec_options import ExecutionOptions, get_execution_options
 from nodes.utils.utils import get_h_w_c
@@ -107,6 +112,14 @@ def upscale(
                 hint=True,
             )
         ),
+        if_group(
+            Condition.type(1, "Image { channels: 4 } ")
+            and Condition.type(0, "PyTorchModel { outputChannels: 1 | 3 } ")
+        )(
+            BoolInput("Separate Alpha", default=False).with_docs(
+                "Normally when dealing with an image with alpha, "
+            )
+        ),
     ],
     outputs=[
         ImageOutput(
@@ -119,6 +132,7 @@ def upscale_image_node(
     img: np.ndarray,
     model: PyTorchSRModel,
     tile_size: TileSize,
+    separate_alpha: bool,
 ) -> np.ndarray:
     """Upscales an image with a pretrained model"""
 
@@ -136,9 +150,12 @@ def upscale_image_node(
         f" {out_nc})"
     )
 
+    should_separate_alpha = separate_alpha and c == 4 and out_nc < 4
+
     return convenient_upscale(
         img,
         in_nc,
         out_nc,
         lambda i: upscale(i, model, tile_size, exec_options),
+        should_separate_alpha,
     )


### PR DESCRIPTION
I've finally decided that this is probably worth adding so people don't have to do the channel splitting manually. As much as I think it's good to have people do things themselves, sometimes convenience is warranted. I'll do a "Seamless Edges" checkbox next.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/34788790/bdaff118-fe01-4b97-a141-5a6199659aba)
