### PR TITLE
Use grab cursor on node selector items

### DIFF
--- a/src/renderer/components/NodeSelectorPanel/RepresentativeNode.tsx
+++ b/src/renderer/components/NodeSelectorPanel/RepresentativeNode.tsx
@@ -58,6 +58,7 @@ export const RepresentativeNode = memo(
                 borderRadius="lg"
                 borderWidth="0px"
                 boxShadow="lg"
+                className="grab-cursor"
                 outline="1px solid"
                 outlineColor={bgColor}
                 overflow="hidden"
@@ -75,6 +76,7 @@ export const RepresentativeNode = memo(
                 <Box
                     bg={bgColor}
                     borderRadius="8px 0 0 8px"
+                    className="grab-cursor"
                     h="auto"
                     ml="5px"
                     overflow="hidden"
@@ -83,6 +85,7 @@ export const RepresentativeNode = memo(
                     w="full"
                 >
                     <HStack
+                        className="grab-cursor"
                         overflow="hidden"
                         pl={2}
                         textOverflow="ellipsis"
@@ -91,6 +94,7 @@ export const RepresentativeNode = memo(
                         <Center
                             alignContent="center"
                             alignItems="center"
+                            className="grab-cursor"
                             h={4}
                             py={3}
                             verticalAlign="middle"
@@ -103,10 +107,12 @@ export const RepresentativeNode = memo(
                         </Center>
                         {!collapsed && (
                             <Flex
+                                className="grab-cursor"
                                 overflow="hidden"
                                 w="300px"
                             >
                                 <Box
+                                    className="grab-cursor"
                                     overflow="hidden"
                                     textOverflow="ellipsis"
                                     verticalAlign="middle"
@@ -114,6 +120,7 @@ export const RepresentativeNode = memo(
                                     <Heading
                                         alignContent="center"
                                         as="h5"
+                                        className="grab-cursor"
                                         fontWeight={700}
                                         h="20px"
                                         lineHeight="20px"
@@ -131,7 +138,7 @@ export const RepresentativeNode = memo(
                                         {name}
                                     </Heading>
                                 </Box>
-                                <Spacer />
+                                <Spacer className="grab-cursor" />
                                 <HStack
                                     overflow="hidden"
                                     px={2}

--- a/src/renderer/components/NodeSelectorPanel/RepresentativeNodeWrapper.tsx
+++ b/src/renderer/components/NodeSelectorPanel/RepresentativeNodeWrapper.tsx
@@ -145,6 +145,7 @@ export const RepresentativeNodeWrapper = memo(
                             <Center
                                 draggable
                                 boxSizing="content-box"
+                                className="grab-cursor"
                                 display="block"
                                 onClick={() => {
                                     setDidSingleClick(true);

--- a/src/renderer/global.scss
+++ b/src/renderer/global.scss
@@ -221,3 +221,7 @@ body {
 div[data-popper-placement] {
     z-index: 6500 !important;
 }
+
+.grab-cursor {
+    cursor: grab !important;
+}


### PR DESCRIPTION
Small little UX thing to make it more intuitive that you can drag and drop selector panel items. Unfortunately, the way I had to add classes for this is really annoying.