### PR TITLE
Use Python 3.11 for integrated Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,6 @@ You can right-click in the editor viewport to show an inline nodes list to selec
 
 - Some NCNN users with non-Nvidia GPUs might get all-black outputs. I am not sure what to do to fix this as it appears to be due to the graphics driver crashing as a result of going out of memory. If this happens to you, try manually setting a tiling amount.
 
-- Arch Linux users may need to manually install libxcrypt before chaiNner's integrated Python will correctly start up.
-
 - To use the Clipboard nodes, Linux users need to have xclip or, for wayland users, wl-copy installed.
 
 ## GPU Support

--- a/src/main/python/integratedPython.ts
+++ b/src/main/python/integratedPython.ts
@@ -18,20 +18,20 @@ interface PythonDownload {
 
 const downloads: Record<SupportedPlatform, PythonDownload> = {
     linux: {
-        url: 'https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4+20230726-x86_64-unknown-linux-gnu-install_only.tar.gz',
-        version: '3.11.4',
+        url: 'https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5+20230826-x86_64-unknown-linux-gnu-install_only.tar.gz',
+        version: '3.11.5',
         path: 'python/bin/python3.11',
     },
     darwin: {
         url: isArmMac
-            ? 'https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4+20230726-aarch64-apple-darwin-install_only.tar.gz'
-            : 'https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4+20230726-x86_64-apple-darwin-install_only.tar.gz',
-        version: '3.11.4',
+            ? 'https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5+20230826-aarch64-apple-darwin-install_only.tar.gz'
+            : 'https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5+20230826-x86_64-apple-darwin-install_only.tar.gz',
+        version: '3.11.5',
         path: 'python/bin/python3.11',
     },
     win32: {
-        url: 'https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4+20230726-x86_64-pc-windows-msvc-shared-install_only.tar.gz',
-        version: '3.11.4',
+        url: 'https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5+20230826-x86_64-pc-windows-msvc-shared-install_only.tar.gz',
+        version: '3.11.5',
         path: 'python/python.exe',
     },
 };

--- a/src/main/python/integratedPython.ts
+++ b/src/main/python/integratedPython.ts
@@ -2,7 +2,7 @@ import decompress from 'decompress';
 import fs from 'fs/promises';
 import Downloader from 'nodejs-file-downloader';
 import path from 'path';
-import { eq } from 'semver';
+import semver from 'semver';
 import { PythonInfo } from '../../common/common-types';
 import { isArmMac } from '../../common/env';
 import { log } from '../../common/log';
@@ -74,13 +74,14 @@ export const getIntegratedPython = async (
 
     if (pythonBinExists) {
         const pythonInfo = await checkPythonPaths([pythonPath]);
-        if (eq(pythonInfo.version, version)) {
+        if (semver.eq(pythonInfo.version, version)) {
             return pythonInfo;
         }
-        // Invalid version, remove legacy integrated python
-        const legacyPythonFolder = path.resolve(path.join(directory, '/python'));
-        await fs.rm(legacyPythonFolder, { recursive: true, force: true });
     }
+
+    // Invalid version, remove legacy integrated python
+    const legacyPythonFolder = path.resolve(path.join(directory, '/python'));
+    await fs.rm(legacyPythonFolder, { recursive: true, force: true });
 
     log.info(`Integrated Python not found at ${pythonPath}`);
 

--- a/src/main/python/integratedPython.ts
+++ b/src/main/python/integratedPython.ts
@@ -2,47 +2,38 @@ import decompress from 'decompress';
 import fs from 'fs/promises';
 import Downloader from 'nodejs-file-downloader';
 import path from 'path';
-import { gt, lt } from 'semver';
+import { eq } from 'semver';
 import { PythonInfo } from '../../common/common-types';
 import { isArmMac } from '../../common/env';
 import { log } from '../../common/log';
-import { assertNever, checkFileExists } from '../../common/util';
+import { checkFileExists } from '../../common/util';
 import { SupportedPlatform, getPlatform } from '../platform';
 import { checkPythonPaths } from './checkPythonPaths';
-import { getPythonVersion } from './version';
 
-const downloads: Record<SupportedPlatform, string> = {
-    linux: 'https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4+20230726-x86_64-unknown-linux-gnu-install_only.tar.gz',
-    darwin: isArmMac
-        ? 'https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4+20230726-aarch64-apple-darwin-install_only.tar.gz'
-        : 'https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4+20230726-x86_64-apple-darwin-install_only.tar.gz',
-    win32: 'https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4+20230726-x86_64-pc-windows-msvc-shared-install_only.tar.gz',
-};
+interface PythonDownload {
+    url: string;
+    version: string;
+    path: string;
+}
 
-const get39ExecutableRelativePath = (platform: SupportedPlatform): string => {
-    switch (platform) {
-        case 'win32':
-            return '/python/python.exe';
-        case 'linux':
-            return '/python/bin/python3.9';
-        case 'darwin':
-            return '/python/bin/python3.9';
-        default:
-            return assertNever(platform);
-    }
-};
-
-const getExecutableRelativePath = (platform: SupportedPlatform): string => {
-    switch (platform) {
-        case 'win32':
-            return '/python/python.exe';
-        case 'linux':
-            return '/python/bin/python3.11';
-        case 'darwin':
-            return '/python/bin/python3.11';
-        default:
-            return assertNever(platform);
-    }
+const downloads: Record<SupportedPlatform, PythonDownload> = {
+    linux: {
+        url: 'https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4+20230726-x86_64-unknown-linux-gnu-install_only.tar.gz',
+        version: '3.11.4',
+        path: 'python/bin/python3.11',
+    },
+    darwin: {
+        url: isArmMac
+            ? 'https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4+20230726-aarch64-apple-darwin-install_only.tar.gz'
+            : 'https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4+20230726-x86_64-apple-darwin-install_only.tar.gz',
+        version: '3.11.4',
+        path: 'python/bin/python3.11',
+    },
+    win32: {
+        url: 'https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4+20230726-x86_64-pc-windows-msvc-shared-install_only.tar.gz',
+        version: '3.11.4',
+        path: 'python/python.exe',
+    },
 };
 
 const extractPython = async (
@@ -76,55 +67,49 @@ export const getIntegratedPython = async (
     onProgress: (percentage: number, stage: 'download' | 'extract') => void
 ): Promise<PythonInfo> => {
     const platform = getPlatform();
-    const legacyPythonPath = path.resolve(
-        path.join(directory, get39ExecutableRelativePath(platform))
-    );
+    const { url, version, path: relativePath } = downloads[platform];
 
-    const legacyPythonBinExists = await checkFileExists(legacyPythonPath);
-
-    if (legacyPythonBinExists) {
-        const confirmLegacyPythonVersion = await getPythonVersion(legacyPythonPath);
-        if (gt(confirmLegacyPythonVersion, '3.9.0') && lt(confirmLegacyPythonVersion, '3.10.0')) {
-            const legacyPythonFolder = path.resolve(path.join(directory, '/python'));
-            // Remove legacy integrated python
-            await fs.rm(legacyPythonFolder, { recursive: true, force: true });
-        }
-    }
-
-    const pythonPath = path.resolve(path.join(directory, getExecutableRelativePath(platform)));
-
+    const pythonPath = path.resolve(path.join(directory, relativePath));
     const pythonBinExists = await checkFileExists(pythonPath);
 
-    if (!pythonBinExists) {
-        log.info(`Integrated Python not found at ${pythonPath}`);
+    if (pythonBinExists) {
+        const pythonInfo = await checkPythonPaths([pythonPath]);
+        if (eq(pythonInfo.version, version)) {
+            return pythonInfo;
+        }
+        // Invalid version, remove legacy integrated python
+        const legacyPythonFolder = path.resolve(path.join(directory, '/python'));
+        await fs.rm(legacyPythonFolder, { recursive: true, force: true });
+    }
 
-        const tarName = 'python.tar.gz';
-        const tarPath = path.join(directory, tarName);
+    log.info(`Integrated Python not found at ${pythonPath}`);
 
-        log.info('Downloading integrated Python...');
-        onProgress(0, 'download');
-        await new Downloader({
-            url: downloads[platform],
-            directory,
-            fileName: tarName,
-            cloneFiles: false,
-            onProgress: (percentage) => onProgress(Number(percentage), 'download'),
-        }).download();
+    const tarName = 'python.tar.gz';
+    const tarPath = path.join(directory, tarName);
 
-        log.info('Extracting integrated Python...');
-        onProgress(0, 'extract');
-        await extractPython(directory, tarPath, (percentage) => onProgress(percentage, 'extract'));
+    log.info('Downloading integrated Python...');
+    onProgress(0, 'download');
+    await new Downloader({
+        url,
+        directory,
+        fileName: tarName,
+        cloneFiles: false,
+        onProgress: (percentage) => onProgress(Number(percentage), 'download'),
+    }).download();
 
-        log.info('Removing downloaded files...');
-        await fs.rm(tarPath);
+    log.info('Extracting integrated Python...');
+    onProgress(0, 'extract');
+    await extractPython(directory, tarPath, (percentage) => onProgress(percentage, 'extract'));
 
-        if (platform === 'linux' || platform === 'darwin') {
-            log.info('Granting permissions for integrated python...');
-            try {
-                await fs.chmod(pythonPath, 0o7777);
-            } catch (error) {
-                log.warn(error);
-            }
+    log.info('Removing downloaded files...');
+    await fs.rm(tarPath);
+
+    if (platform === 'linux' || platform === 'darwin') {
+        log.info('Granting permissions for integrated python...');
+        try {
+            await fs.chmod(pythonPath, 0o7777);
+        } catch (error) {
+            log.warn(error);
         }
     }
 


### PR DESCRIPTION
It's a bit hardcodey, but it works. Basically, I just check the version of the existing integrated python during setup, and if it's a version between 3.9 and 3.10 we get rid of it and do everything else like normal.

Everything seems to just work on 3.11 (except pytorch obviously, but that's been resolved by #2143).