### PR TITLE
Drop python 3.8 as a supported version

### DIFF
--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -25,7 +25,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: ['3.8', '3.9']
+                python-version: ['3.9']
         steps:
             - uses: actions/checkout@v3
             - uses: actions/setup-python@v4
@@ -61,7 +61,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: ['3.8', '3.9', '3.10']
+                python-version: ['3.9', '3.10']
         steps:
             - uses: actions/checkout@v3
             - uses: actions/setup-python@v4

--- a/backend/src/node_check.py
+++ b/backend/src/node_check.py
@@ -120,7 +120,7 @@ def is_subset_of(a: _Ty, b: _Ty) -> bool:
 
 
 def get_type_annotations(fn: Callable) -> Dict[str, _Ty]:
-    """Get the annotations for a function, with support for Python 3.8+"""
+    """Get the annotations for a function, with support for Python 3.9+"""
     ann = getattr(fn, "__annotations__", None)
 
     if ann is None:

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -173,7 +173,7 @@ def blur_node(img: np.ndarray, radius: float) -> np.ndarray:
 
 If you forget type hints or get them wrong, you will get a warning or an error when you try to register the node. The input and output metadata is used to validate your type hints. E.g. if you forget the `| None` for optional inputs, you will get a warning.
 
-Note: We support Python 3.8 and 3.9, so you need to add `from __future__ import annotations` to the top of your file to use the union operator (`|`) in type hints.
+Note: We support Python 3.9, so you need to add `from __future__ import annotations` to the top of your file to use the union operator (`|`) in type hints.
 
 ### Types
 
@@ -213,7 +213,7 @@ Let's take a look at the inputs and outputs of the Create Border node. This node
 
 ### Documentation
 
-Inputs and outputs both allow optional documentation to be added to add more information about it to the Node Documentation modal. You can add documentation to an input or output using the `.with_docs()` method, like so: 
+Inputs and outputs both allow optional documentation to be added to add more information about it to the Node Documentation modal. You can add documentation to an input or output using the `.with_docs()` method, like so:
 
 ```python
     inputs=[

--- a/src/main/backend/setup.ts
+++ b/src/main/backend/setup.ts
@@ -64,7 +64,7 @@ const getPythonInfo = async (
                     title: 'Python not installed or invalid version',
                     message:
                         'It seems like you do not have a valid version of Python installed on your system, or something went wrong with your installed instance.' +
-                        ' Please install Python (3.8+) if you would like to use system Python. You can get Python from https://www.python.org/downloads/.' +
+                        ' Please install Python (3.9+) if you would like to use system Python. You can get Python from https://www.python.org/downloads/.' +
                         ' Be sure to select the add to PATH option. ChaiNNer will use its integrated Python for now.',
                     options: [
                         {
@@ -80,7 +80,7 @@ const getPythonInfo = async (
                 title: 'Error checking for valid Python instance',
                 message:
                     'It seems like you do not have a valid version of Python installed on your system, or something went wrong with your installed instance.' +
-                    ' Please install Python (3.8+) to use this application. You can get Python from https://www.python.org/downloads/. Be sure to select the add to PATH option.',
+                    ' Please install Python (3.9+) to use this application. You can get Python from https://www.python.org/downloads/. Be sure to select the add to PATH option.',
                 options: [
                     {
                         title: 'Get Python',

--- a/src/main/python/checkPythonPaths.ts
+++ b/src/main/python/checkPythonPaths.ts
@@ -12,6 +12,6 @@ export const checkPythonPaths = async (pythonsToCheck: string[]): Promise<Python
     }
 
     throw new Error(
-        `No Python binaries in [${pythonsToCheck.join(', ')}] found or supported version (3.8+)`
+        `No Python binaries in [${pythonsToCheck.join(', ')}] found or supported version (3.9+)`
     );
 };

--- a/src/main/python/version.ts
+++ b/src/main/python/version.ts
@@ -7,4 +7,4 @@ export const getPythonVersion = async (python: string) => {
     return parse(version);
 };
 
-export const isSupportedPythonVersion = (version: Version) => versionGte(version, '3.7.0');
+export const isSupportedPythonVersion = (version: Version) => versionGte(version, '3.9.0');


### PR DESCRIPTION
It appears numpy has dropped support for 3.8, therefore we shall also drop support for 3.8.