### PR TITLE
remove conditional for open-file event

### DIFF
--- a/src/main/gui/main-window.ts
+++ b/src/main/gui/main-window.ts
@@ -3,7 +3,6 @@ import EventSource from 'eventsource';
 import { t } from 'i18next';
 import { BackendEventMap } from '../../common/Backend';
 import { Version, WindowSize } from '../../common/common-types';
-import { isMac } from '../../common/env';
 import { log } from '../../common/log';
 import { BrowserWindowWithSafeIpc, ipcMain } from '../../common/safeIpc';
 import { SaveFile, openSaveFile } from '../../common/SaveFile';
@@ -126,39 +125,38 @@ const registerEventHandlerPreSetup = (
         mainWindow.webContents.send('window-blur');
     });
 
-    if (isMac) {
-        // Open file with chaiNNer on macOS
-        app.on('open-file', (event, filePath) => {
-            (async () => {
-                const file = filePath;
-                if (file) {
-                    const result = await openSaveFile(file);
-                    mainWindow.webContents.send('file-open', result);
-                }
-            })().catch(log.error);
-        });
-    } else {
-        // Opening file with chaiNNer on other platforms
-        if (args.file) {
-            const result = openSaveFile(args.file);
-            ipcMain.handle('get-cli-open', () => result);
-        } else {
-            ipcMain.handle('get-cli-open', () => undefined);
-        }
+    // Open file with chaiNNer on macOS
+    app.on('open-file', (event, filePath) => {
+        event.preventDefault();
+        (async () => {
+            const file = filePath;
+            if (file) {
+                const result = await openSaveFile(file);
+                mainWindow.webContents.send('file-open', result);
+            }
+        })().catch(log.error);
+    });
 
-        app.on('second-instance', (_event, commandLine) => {
-            (async () => {
-                const { file } = parseArgs(commandLine.slice(app.isPackaged ? 2 : 3));
-                if (file) {
-                    const result = await openSaveFile(file);
-                    mainWindow.webContents.send('file-open', result);
-                }
-                // Focus main window if a second instance was attempted
-                if (mainWindow.isMinimized()) mainWindow.restore();
-                mainWindow.focus();
-            })().catch(log.error);
-        });
+    // Opening file with chaiNNer on other platforms
+    if (args.file) {
+        const result = openSaveFile(args.file);
+        ipcMain.handle('get-cli-open', () => result);
+    } else {
+        ipcMain.handle('get-cli-open', () => undefined);
     }
+
+    app.on('second-instance', (_event, commandLine) => {
+        (async () => {
+            const { file } = parseArgs(commandLine.slice(app.isPackaged ? 2 : 3));
+            if (file) {
+                const result = await openSaveFile(file);
+                mainWindow.webContents.send('file-open', result);
+            }
+            // Focus main window if a second instance was attempted
+            if (mainWindow.isMinimized()) mainWindow.restore();
+            mainWindow.focus();
+        })().catch(log.error);
+    });
 };
 
 const registerEventHandlerPostSetup = (


### PR DESCRIPTION
The conditional resulted in throwing some errors when dropping a file to the node canvas. Since this event is only handled on macOS, it can be removed.