### PR TITLE
Make it possible to run under Wayland

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "chainner",
   "productName": "chaiNNer",
+  "desktopName": "chainner.desktop",
   "version": "0.19.4",
   "description": "A flowchart based image processing GUI",
   "main": ".webpack/main",

--- a/src/main/arguments.ts
+++ b/src/main/arguments.ts
@@ -75,6 +75,21 @@ export const parseArgs = (args: readonly string[]): ParsedArguments => {
                     'An internal developer option to use a different backend. Do not use this as this is not a stable option and may change or disappear at any time',
                 hidden: true,
             },
+            // These are never used by chaiNNer, they just let the arguments through the arg parser so chromium can parse them.
+            // Since they aren't used, the defaults don't matter
+            'ozone-platform-hint': {
+                type: 'string',
+                default: '',
+                description:
+                    "On Linux, set to 'auto' to use Wayland if it's available, and X otherwise",
+                hidden: true,
+            },
+            'enable-features': {
+                type: 'string',
+                default: '',
+                description: 'Enable chromium features',
+                hidden: true,
+            },
         })
         .parserConfiguration({ 'unknown-options-as-args': true })
         .parseSync();


### PR DESCRIPTION
Fixes [#1527](https://github.com/chaiNNer-org/chaiNNer/issues/1527) by adding the chromium flags needed to run under Wayland.

### Flags
Since chromium parses the flags regardless of chainner, preventing the arg parser from throwing an error is enough to make the flags work. Technically, this can be done in v0.19.4 already using `chainner open '' --ozone-platform-hint=auto`, but that's cumbersome and not obvious.

Ideally `--ozone-platform-hint` should be enabled by default, but I couldn't find a way to pass it to electron outside of the CLI. The arg parsing would probably have to be done in a wrapper that calls the real chainner binary for this to work.

**References**:
- [Reasons the flags are needed](https://wiki.archlinux.org/title/Wayland#Command_line_flags)
- [ozone-platform-hint docs](https://github.com/chromium/chromium/blob/main/docs/ozone_overview.md#linux-desktop---x11-waterfall-)

### desktopName package.json field
On Wayland, if the .desktop file name doesn't match the [app_id](https://wayland.app/protocols/xdg-shell#xdg_toplevel:request:set_app_id), the compositor won't be able to find .desktop file and thus can't find the icon. With the `desktopName` field unset, electron falls back to `chaiNNer.desktop` as the app_id, but the Linux makers all package the .desktop file as `chainner.desktop`. Since they don't match, the icon is missing. The `desktopName` field can be used to [manually specify the app_id](https://github.com/electron/electron/pull/34855) so everything works as expected.