### PR TITLE
Add a way to set & get general settings

### DIFF
--- a/backend/src/settings.py
+++ b/backend/src/settings.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+from typing import Any
+
+from api import SettingsParser
+from nodes.utils.exec_options import get_execution_options
+
+
+@dataclass(frozen=True)
+class GeneralSettings:
+    example: bool
+
+
+def get_global_settings() -> Any:
+    settings = SettingsParser(get_execution_options().get_package_settings("general"))
+
+    return GeneralSettings(
+        example=settings.get_bool("example", default=False),
+    )

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -31,6 +31,7 @@ import { memo, useCallback, useState } from 'react';
 import { BsFillPencilFill, BsPaletteFill } from 'react-icons/bs';
 import { FaPython, FaTools } from 'react-icons/fa';
 import { useContext } from 'use-context-selector';
+import { SettingKey, SettingValue } from '../../common/common-types';
 import { isMac } from '../../common/env';
 import { ipcRenderer } from '../../common/safeIpc';
 import { BackendContext } from '../contexts/BackendContext';
@@ -213,6 +214,23 @@ const PythonSettings = memo(() => {
 
     const packagesWithSettings = packages.filter((pkg) => pkg.settings.length);
 
+    const setBackendPackageSetting = (pkg: string, key: SettingKey, value: SettingValue) =>
+        setBackendSettings((prev) =>
+            produce(prev, (draftState) => {
+                // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+                if (!draftState[pkg]) {
+                    // eslint-disable-next-line no-param-reassign
+                    draftState[pkg] = {};
+                }
+                // eslint-disable-next-line no-param-reassign
+                draftState.general[key] = value;
+            })
+        );
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const setGeneralBackendSetting = (key: SettingKey, value: SettingValue) =>
+        setBackendPackageSetting('general', key, value);
+
     return (
         <Tabs
             isFitted
@@ -315,17 +333,7 @@ const PythonSettings = memo(() => {
                                     <SettingItem
                                         key={setting.key}
                                         setValue={(value) => {
-                                            setBackendSettings((prev) =>
-                                                produce(prev, (draftState) => {
-                                                    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                                                    if (!draftState[pkg.id]) {
-                                                        // eslint-disable-next-line no-param-reassign
-                                                        draftState[pkg.id] = {};
-                                                    }
-                                                    // eslint-disable-next-line no-param-reassign
-                                                    draftState[pkg.id][setting.key] = value;
-                                                })
-                                            );
+                                            setBackendPackageSetting(pkg.id, setting.key, value);
                                         }}
                                         setting={setting}
                                         value={thisSetting}


### PR DESCRIPTION
#2088 needs a way to set and get general settings for use by the backend. I have added that way of doing that in this PR, even though it is currently not used for anything.

In an ideal world, these general settings would also be defined by the backend. However, I don't want @stonerl to have to redo his whole PR more than he already has to. I'd much rather have him just adopt this system and we can move over stuff later.

If it's not clear, you would call `setGeneralBackendSetting` on the frontend to set a general setting, and `from settings import get_global_settings` to get the method that gets the settings. 