### PR TITLE
Support reading .ckpt files

### DIFF
--- a/backend/src/nodes/properties/inputs/file_inputs.py
+++ b/backend/src/nodes/properties/inputs/file_inputs.py
@@ -102,7 +102,7 @@ def PthFileInput(primary_input: bool = False) -> FileInput:
         input_type_name="PthFile",
         label="Model",
         file_kind="pth",
-        filetypes=[".pt", ".pth"],
+        filetypes=[".pt", ".pth", ".ckpt"],
         primary_input=primary_input,
     )
 

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/io/load_model.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/io/load_model.py
@@ -65,16 +65,36 @@ def load_model_node(path: str) -> Tuple[PyTorchModel, str, str]:
 
     try:
         logger.debug(f"Reading state dict from path: {path}")
+        extension = os.path.splitext(path)[1].lower()
 
-        if os.path.splitext(path)[1].lower() == ".pt":
+        if extension == ".pt":
             state_dict = torch.jit.load(  # type: ignore
                 path, map_location=pytorch_device
             ).state_dict()
-        else:
+        elif extension == ".pth":
             state_dict = torch.load(
                 path,
                 map_location=pytorch_device,
                 pickle_module=RestrictedUnpickle,  # type: ignore
+            )
+        elif extension == ".ckpt":
+            checkpoint = torch.load(
+                path,
+                map_location=pytorch_device,
+                pickle_module=RestrictedUnpickle,  # type: ignore
+            )
+            if "state_dict" in checkpoint:
+                state_dict = {}
+                for i, j in checkpoint["state_dict"].items():
+                    if "netG." in i:
+                        key = i.replace("netG.", "")
+                        state_dict[key] = j
+            else:
+                # Assume it's a state dict, might as well
+                state_dict = checkpoint
+        else:
+            raise ValueError(
+                f"Unsupported model file extension {extension}. Please try a supported model type."
             )
 
         model = load_state_dict(state_dict)

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/io/load_model.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/io/load_model.py
@@ -22,7 +22,7 @@ from .. import io_group
     name="Load Model",
     description=[
         (
-            "Load PyTorch state dict (.pth) or TorchScript (.pt) file into an"
+            "Load PyTorch state dict (.pth), TorchScript (.pt), or Checkpoint (.ckpt) files into an"
             " auto-detected supported model architecture."
         ),
         (


### PR DESCRIPTION
This adds basic support for reading models saved in .ckpt format. I only tested this with ones saved via @styler00dollar's Colab-traiNNer, so i don't know if this applies to anything else that allows training things like esrgan or compact with pytorch-lightning (if that even exists in the first place aside from Colab-traiNNer). But this at least gives a bit of a starting point for being able to support other things that use ckpt files.

Why is this useful? Well, it kinda isn't right now. But maybe it will be in the future for things like DiffBIR where the models are released as ckpts.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/34788790/f8c6b42f-163f-4c5d-87be-2578b1153044)
