### PR TITLE
Fixed BC5 DDS loading

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image/io/load_image.py
+++ b/backend/src/packages/chaiNNer_standard/image/io/load_image.py
@@ -106,8 +106,8 @@ def _for_ext(ext: str | Iterable[str], decoder: _Decoder) -> _Decoder:
 _decoders: List[Tuple[str, _Decoder]] = [
     ("pil-jpeg", _for_ext([".jpg", ".jpeg"], _read_pil)),
     ("cv", _read_cv),
-    ("pil", _read_pil),
     ("texconv-dds", _read_dds),
+    ("pil", _read_pil),
 ]
 
 valid_formats = get_available_image_formats()


### PR DESCRIPTION
This fixes chainner decoding BC5 SNORM DDS files incorrectly.

The problem was https://github.com/python-pillow/Pillow/issues/7386, so the fix is to simply read DDS files with texconv. PIL was only the preferred DDS decoder because it's faster, but that doesn't matter when it's incorrect.