### PR TITLE
Added support for uncompressed DDS

### DIFF
--- a/backend/src/nodes/impl/dds/format.py
+++ b/backend/src/nodes/impl/dds/format.py
@@ -224,6 +224,11 @@ BC123_FORMATS: Set[DDSFormat] = {
     "DXT5",
 }
 
+PREFER_DX9: Set[DDSFormat] = {
+    "R8G8B8A8_UNORM",
+    "B8G8R8A8_UNORM",
+}
+
 
 def to_dxgi(f: DDSFormat) -> DxgiFormat:
     if f in LEGACY_TO_DXGI:

--- a/backend/src/nodes/properties/inputs/generic_inputs.py
+++ b/backend/src/nodes/properties/inputs/generic_inputs.py
@@ -631,6 +631,10 @@ SUPPORTED_DDS_FORMATS: List[Tuple[DDSFormat, str]] = [
     ("DXT1", "DXT1 (4bpp, Linear, 1-bit Alpha, Legacy)"),
     ("DXT3", "DXT3 (8bpp, Linear, 4-bit Alpha, Legacy)"),
     ("DXT5", "DXT5 (8bpp, Linear, 8-bit Alpha, Legacy)"),
+    ("R8G8B8A8_UNORM_SRGB", "RGBA (32bpp, sRGB, 8-bit Alpha)"),
+    ("R8G8B8A8_UNORM", "RGBA (32bpp, Linear, 8-bit Alpha)"),
+    ("B8G8R8A8_UNORM_SRGB", "BGRA (32bpp, sRGB, 8-bit Alpha)"),
+    ("B8G8R8A8_UNORM", "BGRA (32bpp, Linear, 8-bit Alpha)"),
 ]
 
 

--- a/backend/src/packages/chaiNNer_standard/image/io/save_image.py
+++ b/backend/src/packages/chaiNNer_standard/image/io/save_image.py
@@ -14,6 +14,7 @@ from nodes.impl.dds.format import (
     BC7_FORMATS,
     BC123_FORMATS,
     LEGACY_TO_DXGI,
+    PREFER_DX9,
     WITH_ALPHA,
     DDSFormat,
     to_dxgi,
@@ -234,7 +235,7 @@ def save_image_node(
         img = to_uint8(img, normalized=True)
 
         # remap legacy DX9 formats
-        legacy_dds = dds_format in LEGACY_TO_DXGI
+        legacy_dds = dds_format in LEGACY_TO_DXGI or dds_format in PREFER_DX9
 
         save_as_dds(
             full_path,


### PR DESCRIPTION
Fixes #2184.

This PR add support for saving uncompressed RGBA and BGRA image data in Linear and sRGB. The sRGB variants are saved as DX10 and the linear as DX9. All of these formats store 8 bits/channel.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/7688c749-35ca-4d6d-a25c-1a6883b55073)
