### PR TITLE
Set fp16 as default behavior if user has supported Nvidia GPU (or arm mac)

### DIFF
--- a/backend/src/gpu.py
+++ b/backend/src/gpu.py
@@ -43,10 +43,8 @@ def can_gpu_fp16(gpu: _GPU):
     if gpu.arch == nv.NVML_DEVICE_ARCH_TURING:
         # There may be a more robust way to check this, but for now I think this will do.
         return "RTX" in gpu.name
-    if gpu.arch not in FP16_ARCH_ABILITY_MAP and gpu.arch > nv.NVML_DEVICE_ARCH_HOPPER:
-        # Future proofing. We can be reasonably sure that future architectures will support FP16.
-        return True
-    return FP16_ARCH_ABILITY_MAP[gpu.arch]
+    # Future proofing. We can be reasonably sure that future architectures will support FP16.
+    return FP16_ARCH_ABILITY_MAP.get(gpu.arch, gpu.arch > nv.NVML_DEVICE_ARCH_HOPPER)
 
 
 class NvidiaHelper:

--- a/backend/src/gpu.py
+++ b/backend/src/gpu.py
@@ -38,7 +38,7 @@ FP16_ARCH_ABILITY_MAP = {
 }
 
 
-def can_gpu_fp16(gpu: _GPU):
+def supports_fp16(gpu: _GPU):
     # This generation also contains the GTX 1600 cards, which do not support FP16.
     if gpu.arch == nv.NVML_DEVICE_ARCH_TURING:
         # There may be a more robust way to check this, but for now I think this will do.
@@ -81,11 +81,12 @@ class NvidiaHelper:
 
         return info.total, info.used, info.free
 
-    def get_can_fp16(self, gpu_index: Union[int, None] = None) -> bool:
+    @property
+    def supports_fp16(self, gpu_index: Union[int, None] = None) -> bool:
         if gpu_index is None:
-            return all(can_gpu_fp16(gpu) for gpu in self.__gpus)
+            return all(supports_fp16(gpu) for gpu in self.__gpus)
         gpu = self.__gpus[gpu_index]
-        return can_gpu_fp16(gpu)
+        return supports_fp16(gpu)
 
 
 _cachedNvidiaHelper = None

--- a/backend/src/gpu.py
+++ b/backend/src/gpu.py
@@ -81,7 +81,6 @@ class NvidiaHelper:
 
         return info.total, info.used, info.free
 
-    @property
     def supports_fp16(self, gpu_index: Union[int, None] = None) -> bool:
         if gpu_index is None:
             return all(supports_fp16(gpu) for gpu in self.__gpus)

--- a/backend/src/gpu.py
+++ b/backend/src/gpu.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Tuple
+from typing import List, Tuple, Union
 
 import pynvml as nv
 from sanic.log import logger
@@ -70,7 +70,7 @@ class NvidiaHelper:
 
         return info.total, info.used, info.free
 
-    def get_can_fp16(self, gpu_index: int | None = None) -> bool:
+    def get_can_fp16(self, gpu_index: Union[int, None] = None) -> bool:
         if gpu_index is None:
             return all(FP16_ABILITY_MAP[gpu.arch] for gpu in self.__gpus)
         arch = self.__gpus[gpu_index].arch

--- a/backend/src/packages/chaiNNer_onnx/settings.py
+++ b/backend/src/packages/chaiNNer_onnx/settings.py
@@ -69,7 +69,7 @@ if not is_arm_mac:
 
     should_fp16 = False
     if nv is not None:
-        should_fp16 = nv.supports_fp16
+        should_fp16 = nv.supports_fp16()
 
     package.add_setting(
         ToggleSetting(

--- a/backend/src/packages/chaiNNer_onnx/settings.py
+++ b/backend/src/packages/chaiNNer_onnx/settings.py
@@ -69,7 +69,7 @@ if not is_arm_mac:
 
     should_fp16 = False
     if nv is not None:
-        should_fp16 = nv.get_can_fp16()
+        should_fp16 = nv.supports_fp16
 
     package.add_setting(
         ToggleSetting(

--- a/backend/src/packages/chaiNNer_onnx/settings.py
+++ b/backend/src/packages/chaiNNer_onnx/settings.py
@@ -13,8 +13,9 @@ from system import is_arm_mac
 
 from . import package
 
+nv = get_nvidia_helper()
+
 if not is_arm_mac:
-    nv = get_nvidia_helper()
     gpu_list = nv.list_gpus() if nv is not None else []
 
     package.add_setting(
@@ -66,12 +67,16 @@ if not is_arm_mac:
         )
     )
 
+    should_fp16 = False
+    if nv is not None:
+        should_fp16 = nv.get_can_fp16()
+
     package.add_setting(
         ToggleSetting(
             label="Use TensorRT FP16 Mode",
             key="tensorrt_fp16_mode",
             description="Runs TensorRT in half-precision (FP16) mode for less VRAM usage. RTX GPUs also get a speedup.",
-            default=False,
+            default=should_fp16,
             disabled="TensorrtExecutionProvider" not in execution_providers,
         )
     )

--- a/backend/src/packages/chaiNNer_pytorch/settings.py
+++ b/backend/src/packages/chaiNNer_pytorch/settings.py
@@ -37,7 +37,7 @@ package.add_setting(
 
 should_fp16 = False
 if nv is not None:
-    should_fp16 = nv.supports_fp16
+    should_fp16 = nv.supports_fp16()
 else:
     should_fp16 = is_arm_mac
 

--- a/backend/src/packages/chaiNNer_pytorch/settings.py
+++ b/backend/src/packages/chaiNNer_pytorch/settings.py
@@ -3,9 +3,12 @@ from dataclasses import dataclass
 import torch
 
 from api import DropdownSetting, ToggleSetting
+from gpu import get_nvidia_helper
 from system import is_arm_mac
 
 from . import package
+
+nv = get_nvidia_helper()
 
 if not is_arm_mac:
     gpu_list = []
@@ -32,6 +35,10 @@ package.add_setting(
     ),
 )
 
+should_fp16 = False
+if nv is not None:
+    should_fp16 = nv.get_can_fp16()
+
 package.add_setting(
     ToggleSetting(
         label="Use FP16 Mode",
@@ -41,7 +48,7 @@ package.add_setting(
             if is_arm_mac
             else "Runs PyTorch in half-precision (FP16) mode for less VRAM usage. RTX GPUs also get a speedup."
         ),
-        default=False,
+        default=should_fp16 or is_arm_mac,
     ),
 )
 

--- a/backend/src/packages/chaiNNer_pytorch/settings.py
+++ b/backend/src/packages/chaiNNer_pytorch/settings.py
@@ -37,7 +37,9 @@ package.add_setting(
 
 should_fp16 = False
 if nv is not None:
-    should_fp16 = nv.get_can_fp16()
+    should_fp16 = nv.supports_fp16
+else:
+    should_fp16 = is_arm_mac
 
 package.add_setting(
     ToggleSetting(
@@ -48,7 +50,7 @@ package.add_setting(
             if is_arm_mac
             else "Runs PyTorch in half-precision (FP16) mode for less VRAM usage. RTX GPUs also get a speedup."
         ),
-        default=should_fp16 or is_arm_mac,
+        default=should_fp16,
     ),
 )
 


### PR DESCRIPTION
Since we're resetting settings, I thought this would be pretty important to do. Whether or not a GPU can fp16 is determined by the arch enum kindly provided by the pynvml package. Now, users won't accidentally have fp16 off.

In the future, we could also do the same kind of thing for bf16 and implement support for that to speed up things like swinir on supported gpus.