### PR TITLE
Add "Overwrite Files" bool to all save nodes

### DIFF
--- a/backend/src/packages/chaiNNer_ncnn/ncnn/io/save_model.py
+++ b/backend/src/packages/chaiNNer_ncnn/ncnn/io/save_model.py
@@ -3,7 +3,7 @@ import os
 from sanic.log import logger
 
 from nodes.impl.ncnn.model import NcnnModelWrapper
-from nodes.properties.inputs import DirectoryInput, NcnnModelInput, TextInput
+from nodes.properties.inputs import BoolInput, DirectoryInput, NcnnModelInput, TextInput
 
 from .. import io_group
 
@@ -17,16 +17,27 @@ from .. import io_group
         NcnnModelInput(),
         DirectoryInput(has_handle=True),
         TextInput("Param/Bin Name"),
+        BoolInput("Overwrite Files", default=False),
     ],
     outputs=[],
     side_effects=True,
 )
-def save_model_node(model: NcnnModelWrapper, directory: str, name: str) -> None:
+def save_model_node(
+    model: NcnnModelWrapper, directory: str, name: str, overwrite_files: bool
+) -> None:
     full_bin = f"{name}.bin"
     full_param = f"{name}.param"
     full_bin_path = os.path.join(directory, full_bin)
     full_param_path = os.path.join(directory, full_param)
 
-    logger.debug(f"Writing NCNN model to paths: {full_bin_path} {full_param_path}")
-    model.model.write_bin(full_bin_path)
-    model.model.write_param(full_param_path)
+    if overwrite_files or not os.path.exists(full_bin_path):
+        logger.debug(f"Writing NCNN bin to path: {full_bin_path}")
+        model.model.write_bin(full_bin_path)
+    else:
+        logger.debug(f"File already exists at path: {full_bin_path}, skipping.")
+
+    if overwrite_files or not os.path.exists(full_param_path):
+        logger.debug(f"Writing NCNN param to path: {full_param_path}")
+        model.model.write_param(full_param_path)
+    else:
+        logger.debug(f"File already exists at path: {full_param_path}, skipping.")

--- a/backend/src/packages/chaiNNer_onnx/onnx/io/save_model.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/io/save_model.py
@@ -5,7 +5,7 @@ import os
 from sanic.log import logger
 
 from nodes.impl.onnx.model import OnnxModel
-from nodes.properties.inputs import DirectoryInput, OnnxModelInput, TextInput
+from nodes.properties.inputs import BoolInput, DirectoryInput, OnnxModelInput, TextInput
 
 from .. import io_group
 
@@ -19,12 +19,18 @@ from .. import io_group
         OnnxModelInput(),
         DirectoryInput(has_handle=True),
         TextInput("Model Name"),
+        BoolInput("Overwrite Files", default=False),
     ],
     outputs=[],
     side_effects=True,
 )
-def save_model_node(model: OnnxModel, directory: str, model_name: str) -> None:
+def save_model_node(
+    model: OnnxModel, directory: str, model_name: str, overwrite_files: bool
+) -> None:
     full_path = f"{os.path.join(directory, model_name)}.onnx"
-    logger.debug(f"Writing file to path: {full_path}")
-    with open(full_path, "wb") as f:
-        f.write(model.bytes)
+    if overwrite_files or not os.path.exists(full_path):
+        logger.debug(f"Writing file to path: {full_path}")
+        with open(full_path, "wb") as f:
+            f.write(model.bytes)
+    else:
+        logger.debug(f"File already exists at path: {full_path}, skipping.")

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/io/save_model.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/io/save_model.py
@@ -6,7 +6,7 @@ import torch
 from sanic.log import logger
 
 from nodes.impl.pytorch.types import PyTorchModel
-from nodes.properties.inputs import DirectoryInput, ModelInput, TextInput
+from nodes.properties.inputs import BoolInput, DirectoryInput, ModelInput, TextInput
 
 from .. import io_group
 
@@ -23,12 +23,18 @@ from .. import io_group
         ModelInput(),
         DirectoryInput(has_handle=True),
         TextInput("Model Name"),
+        BoolInput("Overwrite Files", default=False),
     ],
     outputs=[],
     side_effects=True,
 )
-def save_model_node(model: PyTorchModel, directory: str, name: str) -> None:
+def save_model_node(
+    model: PyTorchModel, directory: str, name: str, overwrite_files: bool
+) -> None:
     full_file = f"{name}.pth"
     full_path = os.path.join(directory, full_file)
-    logger.debug(f"Writing model to path: {full_path}")
-    torch.save(model.state, full_path)
+    if overwrite_files or not os.path.exists(full_path):
+        logger.debug(f"Writing model to path: {full_path}")
+        torch.save(model.state, full_path)
+    else:
+        logger.debug(f"File already exists at path: {full_path}, skipping.")

--- a/backend/src/packages/chaiNNer_standard/image/io/save_image.py
+++ b/backend/src/packages/chaiNNer_standard/image/io/save_image.py
@@ -197,6 +197,7 @@ class TiffColorDepth(Enum):
                 BoolInput("Separate Alpha for Mip Maps", default=False).with_id(13),
             ),
         ),
+        BoolInput("Overwrite Files", default=False),
     ],
     outputs=[],
     side_effects=True,
@@ -220,10 +221,16 @@ def save_image_node(
     dds_dithering: bool,
     dds_mipmap_levels: int,
     dds_separate_alpha: bool,
+    overwrite_files: bool,
 ) -> None:
     """Write an image to the specified path and return write status"""
 
     full_path = get_full_path(base_directory, relative_path, filename, image_format)
+
+    if os.path.exists(full_path) and not overwrite_files:
+        logger.debug(f"File already exists at path: {full_path}, skipping.")
+        return
+
     logger.debug(f"Writing image to path: {full_path}")
 
     # Create directory if it doesn't exist


### PR DESCRIPTION
New users keep connecting their load image inputs to their outputs and accidentally overwriting their images. With this, you'd now have to explicitly allow that.