### PR TITLE
Added anti-aliasing to Threshold node

### DIFF
--- a/backend/src/packages/chaiNNer_standard/__init__.py
+++ b/backend/src/packages/chaiNNer_standard/__init__.py
@@ -70,7 +70,7 @@ package = add_package(
         Dependency(
             display_name="ChaiNNer Extensions",
             pypi_name="chainner_ext",
-            version="0.3.0",
+            version="0.3.1",
             size_estimate=2.0 * MB,
         ),
     ],


### PR DESCRIPTION
The node implementation of https://github.com/chaiNNer-org/chaiNNer-rs/pull/12.

The new `binary_threshold` method will only be used if AA is enabled, so the node will behave exactly as before with when AA isn't enabled.