### PR TITLE
Use `font.getbbox` instead of `font.getsize` to be forward-compatible with PIL 10

### DIFF
--- a/backend/src/nodes/impl/caption.py
+++ b/backend/src/nodes/impl/caption.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import os
 import sys
 from enum import Enum
+from typing import Tuple
 
 import cv2
 import numpy as np
@@ -13,6 +16,17 @@ from .image_utils import normalize, to_uint8
 class CaptionPosition(Enum):
     BOTTOM = "bottom"
     TOP = "top"
+
+
+def get_font_size(
+    font: ImageFont.ImageFont | ImageFont.FreeTypeFont, text: str
+) -> Tuple[int, int]:
+    """Get font [width, height] of the given text"""
+    # (left, top, right, bottom)
+    caption_bb = font.getbbox(text)
+    font_width = caption_bb[2] - caption_bb[0]
+    font_height = caption_bb[3] - caption_bb[1]
+    return font_width, font_height
 
 
 def add_caption(
@@ -44,7 +58,7 @@ def add_caption(
         text_y = round(size / 2)
     font_color = (255,) * c
 
-    fw, _ = font.getsize(caption)
+    fw, _ = get_font_size(font, caption)
     # scale font size to fit image
     if fw > w:
         font = ImageFont.truetype(font_path, round(fontsize * w / fw))

--- a/backend/src/nodes/impl/caption.py
+++ b/backend/src/nodes/impl/caption.py
@@ -18,9 +18,7 @@ class CaptionPosition(Enum):
     TOP = "top"
 
 
-def get_font_size(
-    font: ImageFont.ImageFont | ImageFont.FreeTypeFont, text: str
-) -> Tuple[int, int]:
+def get_font_size(font: ImageFont.FreeTypeFont, text: str) -> Tuple[int, int]:
     """Get font [width, height] of the given text"""
     # (left, top, right, bottom)
     caption_bb = font.getbbox(text)

--- a/backend/src/packages/chaiNNer_standard/image/create_images/text_as_image.py
+++ b/backend/src/packages/chaiNNer_standard/image/create_images/text_as_image.py
@@ -7,6 +7,7 @@ from enum import Enum
 import numpy as np
 from PIL import Image, ImageDraw, ImageFont
 
+from nodes.impl.caption import get_font_size
 from nodes.impl.color.color import Color
 from nodes.impl.image_utils import normalize, to_uint8
 from nodes.properties.inputs import (
@@ -170,14 +171,14 @@ def text_as_image_node(
 
     # Use a text as reference to get max size
     font = ImageFont.truetype(font_path, size=100)
-    w_ref, h_ref = font.getsize(max_line)[0], font.getsize("[§]")[1]
+    w_ref, h_ref = get_font_size(font, max_line)[0], get_font_size(font, "[§]")[1]
 
     # Calculate font size to fill the specified image size
     w = int(width * 100.0 / w_ref)
     h = int(height * 100.0 / (h_ref * line_count))
     font_size = min(w, h)
     font = ImageFont.truetype(font_path, size=font_size)
-    w_text, h_text = font.getsize(max_line)
+    w_text, h_text = get_font_size(font, max_line)
     h_text *= line_count
 
     # Text color


### PR DESCRIPTION
This makes chainner work with both PIL 10 and PIL 9. This is good, because PIL 9 won't support py 3.12.

Fixes #2212 