### PR TITLE
Revert app name for windows maker

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -75,7 +75,7 @@ const config = {
         {
             name: '@electron-forge/maker-squirrel',
             config: {
-                name: packageJson.appId,
+                name: packageJson.productName,
                 iconUrl:
                     'https://github.com/chaiNNer-org/chaiNNer/blob/main/src/public/icons/win/icon.ico',
                 setupIcon: './src/public/icons/win/icon.ico',


### PR DESCRIPTION
as @Kim2091 found, changing the windows app name to `app.chainner` now makes it install to a subfolder and not properly update. 
![image](https://github.com/chaiNNer-org/chaiNNer/assets/34788790/eab9f0c0-d94f-4b04-80b8-8bc91693c3ab)

I am reverting this back to the product name. All future installs should resolve this, but anyone installing 0.20.0 on windows probably has two chaiNNer versions installed right now