### PR TITLE
Use `--no-cache-dir` on all pip installs

### DIFF
--- a/backend/src/dependencies/store.py
+++ b/backend/src/dependencies/store.py
@@ -81,6 +81,7 @@ def install_dependencies_sync(
             *[pin(dep_info) for dep_info in dependencies_to_install],
             "--disable-pip-version-check",
             "--no-warn-script-location",
+            "--no-cache-dir",
         ]
     )
     if exit_code != 0:
@@ -135,6 +136,7 @@ async def install_dependencies(
             "--disable-chainner_pip-version-check",
             "--no-warn-script-location",
             "--progress-bar=json",
+            "--no-cache-dir",
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,

--- a/src/common/pip.ts
+++ b/src/common/pip.ts
@@ -79,7 +79,11 @@ export const runPipInstall = async (
         const deps = dependencies.map((p) => `${p.pypiName}==${p.version}`);
         const findLinks = getFindLinks(dependencies).flatMap((l) => ['--extra-index-url', l]);
 
-        await runPip(info, ['install', '--upgrade', ...deps, ...findLinks], onStdio);
+        await runPip(
+            info,
+            ['install', '--upgrade', ...deps, ...findLinks, '--no-cache-dir'],
+            onStdio
+        );
     } else {
         const { python } = info;
         for (const pkg of dependencies) {

--- a/src/common/pipInstallWithProgress.ts
+++ b/src/common/pipInstallWithProgress.ts
@@ -58,7 +58,7 @@ const downloadWheelAndInstall = async (
                 onStdout('Installing package from whl...\n');
                 const installProcess = spawn(
                     pythonPath,
-                    ['-m', 'pip', 'install', path.join(tempDir, fileName)],
+                    ['-m', 'pip', 'install', path.join(tempDir, fileName), '--no-cache-dir'],
                     { env: sanitizedEnv }
                 );
                 installProcess.stdout.on('data', (data) => {
@@ -93,6 +93,7 @@ export const pipInstallWithProgress = async (
             '--upgrade',
             `${pkg.pypiName}==${pkg.version}`,
             '--disable-pip-version-check',
+            '--no-cache-dir',
         ];
         if (pkg.findLink) {
             args = [...args, '--extra-index-url', pkg.findLink];


### PR DESCRIPTION
Based on the problem both kim and #2231 are having, it seems that cached old versions of numba are being used instead of downloading the latest version. I think it might be a transient dependency of a different dependency, and therefore tries to get installed without a version specified before the one we do specify gets installed, and it pulls an old one from a cache somewhere. Then, since it's an old version and can't be installed with 3.11, it tries to build it from source and errors.

For Kim, this was fixed by clearing her cache and trying again. For #2231, I don't think it was resolved, but I haven't gotten full details yet. I will have them try the next nightly after this is merged and we'll see if that resolves it.

P.S. I hate python