### PR TITLE
Added support for sub-pixel distance transform

### DIFF
--- a/backend/src/packages/chaiNNer_standard/__init__.py
+++ b/backend/src/packages/chaiNNer_standard/__init__.py
@@ -70,7 +70,7 @@ package = add_package(
         Dependency(
             display_name="ChaiNNer Extensions",
             pypi_name="chainner_ext",
-            version="0.3.2",
+            version="0.3.3",
             size_estimate=2.0 * MB,
         ),
     ],

--- a/backend/src/packages/chaiNNer_standard/__init__.py
+++ b/backend/src/packages/chaiNNer_standard/__init__.py
@@ -70,7 +70,7 @@ package = add_package(
         Dependency(
             display_name="ChaiNNer Extensions",
             pypi_name="chainner_ext",
-            version="0.3.1",
+            version="0.3.2",
             size_estimate=2.0 * MB,
         ),
     ],

--- a/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/distance_transform.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/distance_transform.py
@@ -2,26 +2,16 @@ from __future__ import annotations
 
 import cv2
 import numpy as np
+from chainner_ext import esdf
 
 from nodes.impl.image_utils import as_3d, to_uint8
-from nodes.properties.inputs import ImageInput, NumberInput
+from nodes.properties.inputs import BoolInput, ImageInput, NumberInput
 from nodes.properties.outputs import ImageOutput
 
 from .. import miscellaneous_group
 
 
-@miscellaneous_group.register(
-    schema_id="chainner:image:distance_transform",
-    name="Distance Transform",
-    description="Perform a distance transform on a monochrome bitmap image, producing a signed distance field.",
-    icon="MdBlurOff",
-    inputs=[
-        ImageInput(channels=1),
-        NumberInput("Spread", minimum=1, default=4),
-    ],
-    outputs=[ImageOutput(image_type="Input0")],
-)
-def distance_transform_node(img: np.ndarray, spread: int) -> np.ndarray:
+def binary_sdf(img: np.ndarray, spread: float) -> np.ndarray:
     img = as_3d(to_uint8(img, normalized=True))
     img[img < 128] = 0
     img[img >= 128] = 255
@@ -53,3 +43,29 @@ def distance_transform_node(img: np.ndarray, spread: int) -> np.ndarray:
     signed_distance = np.clip(signed_distance, 0, 1)
 
     return signed_distance.reshape(img.shape)
+
+
+@miscellaneous_group.register(
+    schema_id="chainner:image:distance_transform",
+    name="Distance Transform",
+    description="Perform a distance transform on a monochrome bitmap image, producing a signed distance field.",
+    icon="MdBlurOff",
+    inputs=[
+        ImageInput(channels=1),
+        NumberInput("Spread", minimum=1, default=20),
+        BoolInput("Sub-pixel precision", default=False).with_docs(
+            "If enabled, then anti-aliasing will be accounted for. If not enabled, then the image will be converted to binary (either black or white) before processing.",
+            "Enabling this option will significantly improve the results of anti-aliased shapes, but it cannot be used on anything else. It assumes strictly binary shapes (with optional anti-aliasing), and will return incorrect results for e.g. blurry images. If you cannot guarantee binary image, use the `chainner:image:threshold` node with *Anti-aliasing* enabled.",
+            "Sub-pixel distance transform is implemented using the excellent [ESDF algorithm](https://acko.net/blog/subpixel-distance-transform/) by Steven Wittens.",
+        ),
+    ],
+    outputs=[ImageOutput(image_type="Input0")],
+)
+def distance_transform_node(
+    img: np.ndarray,
+    spread: int,
+    use_esdf: bool,
+) -> np.ndarray:
+    if use_esdf:
+        return esdf(img, spread * 2, 0.5, False, True)
+    return binary_sdf(img, spread)

--- a/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/distance_transform.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/distance_transform.py
@@ -52,7 +52,7 @@ def binary_sdf(img: np.ndarray, spread: float) -> np.ndarray:
     icon="MdBlurOff",
     inputs=[
         ImageInput(channels=1),
-        NumberInput("Spread", minimum=1, default=20),
+        NumberInput("Spread", minimum=1, default=4),
         BoolInput("Sub-pixel precision", default=False).with_docs(
             "If enabled, then anti-aliasing will be accounted for. If not enabled, then the image will be converted to binary (either black or white) before processing.",
             "Enabling this option will significantly improve the results of anti-aliased shapes, but it cannot be used on anything else. It assumes strictly binary shapes (with optional anti-aliasing), and will return incorrect results for e.g. blurry images. If you cannot guarantee binary image, use the `chainner:image:threshold` node with *Anti-aliasing* enabled.",


### PR DESCRIPTION
I recently implemented [ESDF](https://acko.net/blog/subpixel-distance-transform/) in Rust. The chainner-rs PR will come soon. This PR is for adding it to our Distance Transform node.

CI will fail for this PR until I update `chainner_ext`.