### PR TITLE
Fixed `no-drag` being reverted

### DIFF
--- a/src/renderer/components/outputs/LargeImageOutput.tsx
+++ b/src/renderer/components/outputs/LargeImageOutput.tsx
@@ -91,7 +91,6 @@ export const LargeImageOutput = memo(
                 w="full"
             >
                 <Resizable
-                    className="nodrag"
                     defaultSize={size}
                     enable={{
                         top: false,


### PR DESCRIPTION
I accidentally reverted part of #2214 in #2225 after I incorrectly resolved a merge conflict.