### PR TITLE
ncnn: Allow disabling Winograd/SGEMM

### DIFF
--- a/backend/src/packages/chaiNNer_ncnn/ncnn/processing/upscale_image.py
+++ b/backend/src/packages/chaiNNer_ncnn/ncnn/processing/upscale_image.py
@@ -73,7 +73,12 @@ def upscale_impl(
     tile_size: TileSize,
 ):
     settings = get_settings()
-    net = get_ncnn_net(model, settings.gpu_index)
+    net = get_ncnn_net(
+        model,
+        gpu_index=settings.gpu_index,
+        winograd=settings.winograd,
+        sgemm=settings.sgemm,
+    )
     # Try/except block to catch errors
     try:
         if use_gpu:

--- a/backend/src/packages/chaiNNer_ncnn/ncnn/processing/upscale_image.py
+++ b/backend/src/packages/chaiNNer_ncnn/ncnn/processing/upscale_image.py
@@ -73,12 +73,7 @@ def upscale_impl(
     tile_size: TileSize,
 ):
     settings = get_settings()
-    net = get_ncnn_net(
-        model,
-        gpu_index=settings.gpu_index,
-        winograd=settings.winograd,
-        sgemm=settings.sgemm,
-    )
+    net = get_ncnn_net(model, settings=settings)
     # Try/except block to catch errors
     try:
         if use_gpu:

--- a/backend/src/packages/chaiNNer_ncnn/settings.py
+++ b/backend/src/packages/chaiNNer_ncnn/settings.py
@@ -9,7 +9,7 @@ except ImportError:
 
     use_gpu = False
 
-from api import DropdownSetting
+from api import DropdownSetting, ToggleSetting
 from system import is_arm_mac
 
 from . import package
@@ -32,10 +32,33 @@ if not is_arm_mac and use_gpu:
     except:
         pass
 
+# Haven't tested disabling Winograd/SGEMM in the ncnn_vulkan fork, so only
+# allow it with upstream ncnn for now. It should work fine regardless of
+# CPU/GPU, but I only tested with CPU.
+if not use_gpu:
+    package.add_setting(
+        ToggleSetting(
+            label="Use Winograd",
+            key="winograd",
+            description="Enable Winograd convolution for NCNN. Typically faster but uses more memory.",
+            default=True,
+        )
+    )
+    package.add_setting(
+        ToggleSetting(
+            label="Use SGEMM",
+            key="sgemm",
+            description="Enable SGEMM convolution for NCNN. Typically faster but uses more memory.",
+            default=True,
+        )
+    )
+
 
 @dataclass(frozen=True)
 class NcnnSettings:
     gpu_index: int
+    winograd: bool
+    sgemm: bool
 
 
 def get_settings() -> NcnnSettings:
@@ -43,4 +66,6 @@ def get_settings() -> NcnnSettings:
 
     return NcnnSettings(
         gpu_index=settings.get_int("gpu_index", 0, parse_str=True),
+        winograd=settings.get_bool("winograd", True),
+        sgemm=settings.get_bool("sgemm", True),
     )


### PR DESCRIPTION
Should be helpful on memory-constrained systems.

In my test run, disabling both Winograd and SGEMM decreased memory usage for a CPU upscale from 10.3 GiB to 4.9 GiB, at the cost of increasing inference time from 58s to 3m0s.

I'm a little uneasy with the parameter count of `create_ncnn_net`; I think it might be better if it accepted a single `NcnnSettings` object instead of each setting being a separate parameter. Happy to make that refactor if you concur it would be better.