### PR TITLE
Fixed CAS for grayscale images (again)

### DIFF
--- a/backend/src/nodes/impl/cas.py
+++ b/backend/src/nodes/impl/cas.py
@@ -52,5 +52,7 @@ def cas_mix(
     bias: float = 2,
 ) -> np.ndarray:
     mask = create_cas_mask(img, kernel, bias)
-    mask = np.dstack((mask,) * get_h_w_c(sharpened)[2])
+    _, _, c = get_h_w_c(sharpened)
+    if c > 1:
+        mask = np.dstack((mask,) * c)
     return img * (1 - mask) + sharpened * mask  # type: ignore


### PR DESCRIPTION
This fixes the bug in High Boost Filter reported to us on discord.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/e3796725-9b9f-4510-b7c0-e5c753840cf0)
