### PR TITLE
Improvements for the `Iterator` API

### DIFF
--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -536,6 +536,7 @@ def add_package(
 
 
 I = TypeVar("I")
+L = TypeVar("L")
 
 
 @dataclass
@@ -544,8 +545,23 @@ class Iterator(Generic[I]):
     expected_length: int
 
     @staticmethod
-    def from_list(l: list[I]):
-        Iterator(lambda: l, len(l))
+    def from_iter(
+        iter_supplier: Callable[[], Iterable[I]], expected_length: int
+    ) -> "Iterator[I]":
+        return Iterator(iter_supplier, expected_length)
+
+    @staticmethod
+    def from_list(l: List[L], map_fn: Callable[[L, int], I]) -> "Iterator[I]":
+        """
+        Creates a new iterator from a list that is mapped using the given
+        function. The iterable will be equivalent to `map(map_fn, l)`.
+        """
+
+        def supplier():
+            for i, x in enumerate(l):
+                yield map_fn(x, i)
+
+        return Iterator(supplier, len(l))
 
 
 N = TypeVar("N")

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/iteration/load_models.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/iteration/load_models.py
@@ -44,17 +44,13 @@ def load_models_node(
 ) -> Iterator[Tuple[PyTorchModel, str, str, str, int]]:
     logger.debug(f"Iterating over models in directory: {directory}")
 
+    def load_model(path: str, index: int):
+        model, dirname, basename = load_model_node(path)
+        # Get relative path from root directory passed by Iterator directory input
+        rel_path = os.path.relpath(dirname, directory)
+        return model, directory, rel_path, basename, index
+
     supported_filetypes = [".pt", ".pth", ".ckpt"]
+    model_files: List[str] = list_all_files_sorted(directory, supported_filetypes)
 
-    just_model_files: List[str] = list_all_files_sorted(directory, supported_filetypes)
-
-    length = len(just_model_files)
-
-    def iterator():
-        for idx, path in enumerate(just_model_files):
-            model, dirname, basename = load_model_node(path)
-            # Get relative path from root directory passed by Iterator directory input
-            rel_path = os.path.relpath(dirname, directory)
-            yield model, directory, rel_path, basename, idx
-
-    return Iterator(iter_supplier=iterator, expected_length=length)
+    return Iterator.from_list(model_files, load_model)

--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/load_images.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/load_images.py
@@ -89,6 +89,12 @@ def load_images_node(
     use_limit: bool,
     limit: int,
 ) -> Iterator[Tuple[np.ndarray, str, str, str, int]]:
+    def load_image(path: str, index: int):
+        img, img_dir, basename = load_image_node(path)
+        # Get relative path from root directory passed by Iterator directory input
+        rel_path = os.path.relpath(img_dir, directory)
+        return img, directory, rel_path, basename, index
+
     supported_filetypes = get_available_image_formats()
 
     if not use_glob:
@@ -101,13 +107,4 @@ def load_images_node(
     if use_limit:
         just_image_files = just_image_files[:limit]
 
-    length = len(just_image_files)
-
-    def iterator():
-        for idx, path in enumerate(just_image_files):
-            img, img_dir, basename = load_image_node(path)
-            # Get relative path from root directory passed by Iterator directory input
-            rel_path = os.path.relpath(img_dir, directory)
-            yield img, directory, rel_path, basename, idx
-
-    return Iterator(iter_supplier=iterator, expected_length=length)
+    return Iterator.from_list(just_image_files, load_image)

--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/load_video.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/load_video.py
@@ -124,4 +124,4 @@ def load_video_node(
             yield in_frame, index, video_dir, video_name, fps, audio_stream
             index += 1
 
-    return Iterator(iter_supplier=iterator, expected_length=frame_count)
+    return Iterator.from_iter(iter_supplier=iterator, expected_length=frame_count)

--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/spritesheet_iterator.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/spritesheet_iterator.py
@@ -70,15 +70,16 @@ def spritesheet_iterator_node(
     individual_h = h // rows
     individual_w = w // columns
 
-    def iterator():
-        index = 0
-        for row in range(rows):
-            for col in range(columns):
-                # Split sprite sheet into a single list of images
-                yield sprite_sheet[
-                    row * individual_h : (row + 1) * individual_h,
-                    col * individual_w : (col + 1) * individual_w,
-                ], index
-                index += 1
+    def get_sprite(_, index: int):
+        row = index // columns
+        col = index % columns
 
-    return Iterator(iter_supplier=iterator, expected_length=rows * columns)
+        sprite = sprite_sheet[
+            row * individual_h : (row + 1) * individual_h,
+            col * individual_w : (col + 1) * individual_w,
+        ]
+
+        return sprite, index
+
+    # We just need the index, so we can pass in a list of None's
+    return Iterator.from_list([None] * (rows * columns), get_sprite)


### PR DESCRIPTION
Changes:
- Fixed `from_list` (note the missing `return`) and added a map function.
- Added `from_iter` static factory method. We will most likely change the internal representation of `Iterator` in the future, so this static factory method allows us to provide a stable API. I wish that I could make the constructor private as well, but this is Python.
- Changed all iterator nodes to use the new static factory methods.

The iterator node I changed the most is the spritesheet iterator. Since we can calculate the current row+column from the index alone, we don't really need a list. So I used a list full of `None`s. Kinda a weird usage of `Iterator.from_list`, but it's valid and works.