### PR TITLE
Clamp YUV->RGB out of gamut

### DIFF
--- a/backend/src/nodes/impl/color/convert_data.py
+++ b/backend/src/nodes/impl/color/convert_data.py
@@ -257,7 +257,7 @@ conversions: List[Conversion] = [
     ),
     Conversion(
         direction=(YUV, RGB),
-        convert=lambda i: cv2.cvtColor(__rev3(i), cv2.COLOR_YUV2BGR),
+        convert=lambda i: np.clip(cv2.cvtColor(__rev3(i), cv2.COLOR_YUV2BGR), 0, 1),
         cost=__CHROMA_LOST,
     ),
     # HSV/HSL


### PR DESCRIPTION
This fixes a bug reported to us on discord. As I explained there, not all possible YUV values produce valid RGB. Some may produce negative RGB values. Our conversion did not account for this, and the Change Colorspace node is marked as `assume_normalized` for performance reasons, so negative RGB values were passed onto other nodes which did not expect them.

The fix is to simply clamp the RGB values we get from the YUV->RGB conversion.

Example: In this chain, I swap U and V which can cause invalid RGB values.
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/a3d97fba-3f2e-44b4-ba7d-6ded3a8718f9)

Before:
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/4f84dd90-e138-49e0-90f1-1a5d0a5be64c)

After:
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/22045f81-9e3c-4e98-9b2d-cd281a5ef44b)
