### PR TITLE
Add type tags for number ranges

### DIFF
--- a/src/renderer/components/TypeTag.tsx
+++ b/src/renderer/components/TypeTag.tsx
@@ -1,13 +1,20 @@
 import {
+    Bounds,
+    IntIntervalType,
+    IntervalType,
     NeverType,
     Type,
+    intInterval,
     isNumericLiteral,
     isStringLiteral,
     isStructInstance,
+    isSubsetOf,
+    literal,
 } from '@chainner/navi';
 import { Tag, Tooltip, forwardRef } from '@chakra-ui/react';
-import React, { memo } from 'react';
+import React, { ReactNode, memo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { explain } from '../../common/types/explain';
 import { getFields, isColor, isDirectory, isImage, withoutNull } from '../../common/types/util';
 import { assertNever } from '../../common/util';
 
@@ -24,14 +31,134 @@ const getColorMode = (channels: number) => {
     }
 };
 
+const getSimplifiedNumberRange = (type: Type): IntIntervalType | IntervalType | undefined => {
+    if (type.underlying === 'number') {
+        if (type.type === 'interval' || type.type === 'int-interval') {
+            return type;
+        }
+        if (type.type === 'non-int-interval') {
+            if (Number.isFinite(type.min) && Number.isFinite(type.max)) {
+                return new IntervalType(type.min, type.max, Bounds.Inclusive);
+            }
+            return new IntervalType(type.min, type.max, Bounds.Exclusive);
+        }
+    }
+    if (type.underlying === 'union') {
+        let min = Infinity;
+        let max = -Infinity;
+
+        for (const item of type.items) {
+            if (item.underlying === 'number') {
+                if (item.type === 'literal') {
+                    const { value } = item;
+                    if (Number.isNaN(value)) {
+                        // we don't deal with nan
+                        return undefined;
+                    }
+                    min = Math.min(min, value);
+                    max = Math.max(max, value);
+                } else if (item.type === 'number') {
+                    // we don't deal with all numbers
+                    return undefined;
+                } else {
+                    min = Math.min(min, item.min);
+                    max = Math.max(max, item.max);
+                }
+            } else {
+                return undefined;
+            }
+        }
+
+        if (min < max) {
+            if (isSubsetOf(type, intInterval(-Infinity, Infinity))) {
+                return new IntIntervalType(min, max);
+            }
+            return new IntervalType(min, max, Bounds.Inclusive);
+        }
+    }
+};
+
+const collectNumericLiterals = (type: Type, maximum = 4): number[] | undefined => {
+    const set = new Set<number>();
+
+    const items = type.underlying === 'union' ? type.items : [type];
+    for (const item of items) {
+        if (item.underlying === 'number') {
+            if (item.type === 'literal') {
+                set.add(item.value);
+                if (set.size > maximum) {
+                    return undefined;
+                }
+            } else if (item.type === 'int-interval') {
+                const count = item.max - item.min + 1;
+                if (count + set.size > maximum) {
+                    return undefined;
+                }
+                for (let i = item.min; i <= item.max; i += 1) {
+                    set.add(i);
+                }
+            } else {
+                return undefined;
+            }
+        } else {
+            return undefined;
+        }
+    }
+
+    const list = [...set];
+    list.sort((a, b) => a - b);
+    return list;
+};
+
 type TagValue =
-    | { kind: 'literal'; value: string }
+    | { kind: 'literal'; value: string; tooltip?: string }
     | { kind: 'string'; value: string }
     | { kind: 'path'; value: string };
 
 const getTypeText = (type: Type): TagValue[] => {
     if (isNumericLiteral(type)) return [{ kind: 'literal', value: type.toString() }];
     if (isStringLiteral(type)) return [{ kind: 'string', value: type.value }];
+
+    const numberLiterals = collectNumericLiterals(type, 4);
+    if (numberLiterals) {
+        return [
+            {
+                kind: 'literal',
+                value: numberLiterals.map((l) => literal(l).toString()).join(' | '),
+            },
+        ];
+    }
+
+    const rangeType = getSimplifiedNumberRange(type);
+    if (rangeType) {
+        const tooltip = explain(rangeType, { detailed: true });
+        if (rangeType.type === 'interval') {
+            const { min, max } = rangeType;
+            if (Number.isFinite(min) && Number.isFinite(max)) {
+                return [{ kind: 'literal', value: `${min} ~ ${max}`, tooltip }];
+            }
+            if (Number.isFinite(min) && max === Infinity) {
+                const op = rangeType.minExclusive ? '>' : '>=';
+                return [{ kind: 'literal', value: `${op} ${min}`, tooltip }];
+            }
+            if (min === -Infinity && Number.isFinite(max)) {
+                const op = rangeType.maxExclusive ? '<' : '<=';
+                return [{ kind: 'literal', value: `${op} ${max}`, tooltip }];
+            }
+        }
+        if (rangeType.type === 'int-interval') {
+            const { min, max } = rangeType;
+            if (Number.isFinite(min) && Number.isFinite(max)) {
+                return [{ kind: 'literal', value: `int ${min} ~ ${max}`, tooltip }];
+            }
+            if (Number.isFinite(min) && max === Infinity) {
+                return [{ kind: 'literal', value: `int >= ${min}`, tooltip }];
+            }
+            if (min === -Infinity && Number.isFinite(max)) {
+                return [{ kind: 'literal', value: `int <= ${max}`, tooltip }];
+            }
+        }
+    }
 
     const tags: TagValue[] = [];
     if (isImage(type)) {
@@ -148,49 +275,57 @@ const Punctuation = memo(({ children }: React.PropsWithChildren<unknown>) => {
 const TagRenderer = memo(({ tag }: { tag: TagValue }) => {
     const { kind, value } = tag;
 
+    let tt: string | undefined;
+    let text: NonNullable<ReactNode>;
+
     switch (kind) {
         case 'path': {
+            tt = value;
             const maxLength = 14;
-            return (
-                <Tooltip
-                    hasArrow
-                    borderRadius={8}
-                    label={value}
-                    openDelay={500}
-                    px={2}
-                    textAlign="center"
-                >
-                    <TypeTag>
-                        {value.length > maxLength && <Punctuation>…</Punctuation>}
-                        {value.slice(Math.max(0, value.length - maxLength))}
-                    </TypeTag>
-                </Tooltip>
+            text = (
+                <>
+                    {value.length > maxLength && <Punctuation>…</Punctuation>}
+                    {value.slice(Math.max(0, value.length - maxLength))}
+                </>
             );
+            break;
         }
         case 'string': {
+            tt = value;
             const maxLength = 16;
-            return (
-                <Tooltip
-                    hasArrow
-                    borderRadius={8}
-                    label={value}
-                    openDelay={500}
-                    px={2}
-                    textAlign="center"
-                >
-                    <TypeTag>
-                        {value.slice(0, maxLength)}
-                        {value.length > maxLength && <Punctuation>…</Punctuation>}
-                    </TypeTag>
-                </Tooltip>
+            text = (
+                <>
+                    {value.slice(0, maxLength)}
+                    {value.length > maxLength && <Punctuation>…</Punctuation>}
+                </>
             );
+            break;
         }
         case 'literal': {
-            return <TypeTag>{value}</TypeTag>;
+            tt = tag.tooltip;
+            text = value;
+            break;
         }
         default:
             return assertNever(kind);
     }
+
+    if (!tt) {
+        return <TypeTag>{text}</TypeTag>;
+    }
+
+    return (
+        <Tooltip
+            hasArrow
+            borderRadius={8}
+            label={tt}
+            openDelay={500}
+            px={2}
+            textAlign="center"
+        >
+            <TypeTag>{text}</TypeTag>
+        </Tooltip>
+    );
 });
 
 export const TypeTags = memo(({ type, isOptional }: TypeTagsProps) => {


### PR DESCRIPTION
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/73e6daa6-f967-4533-8383-70f91a89c85d)

I added type tags for number ranges. The tags only approximate the actual set of numbers. E.g. the types `0..100` and `0..5 | 95..100` will both be displayed as `0 ~ 100`. This simplification is necessary to display more complex number types, and I also think that the loss in information is okay. The bounds are the most important information (IMO) and those are still displayed correctly. 

Small sets of numbers will be displayed as is. E.g. `1 | int(98..100)` will be displayed as `1 | 98 | 99 | 100` instead of as `1 ~ 100`. This will only work for set with 4 or fewer numbers. So e.g. `int(1..4)` will be displayed as `1 | 2 | 3 | 4`, but `int(1..5)` will be displayed as `1 ~ 5`.

**Open questions:**

- Notation. How should we denote this information? I used type notation for small sets (e.g. `1 | 3 | 4`) and a new range notation for ranges with tilde `~`. Maybe we should use the type notations there as well? E.g. `1..100` vs `1 ~ 100`.