### PR TITLE
Improved Remove Background types

### DIFF
--- a/backend/src/packages/chaiNNer_onnx/onnx/processing/remove_background.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/processing/remove_background.py
@@ -39,7 +39,7 @@ from .. import processing_group
         ImageOutput(
             "Image",
             image_type="""
-                let img = Input0;
+                let image = Input0;
                 let model = Input1;
 
                 Image {

--- a/backend/src/packages/chaiNNer_onnx/onnx/processing/remove_background.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/processing/remove_background.py
@@ -25,7 +25,7 @@ from .. import processing_group
         Currently supports u2net models from the rembg project (links found in readme).""",
     icon="ONNX",
     inputs=[
-        ImageInput(),
+        ImageInput(channels=[3, 4]),
         OnnxRemBgModelInput(),
         BoolInput("Post-process Mask", default=False),
         BoolInput("Alpha Matting", default=False),
@@ -38,7 +38,16 @@ from .. import processing_group
     outputs=[
         ImageOutput(
             "Image",
-            image_type="""removeBackground(Input1, Input0)""",
+            image_type="""
+                let img = Input0;
+                let model = Input1;
+
+                Image {
+                    width: image.width,
+                    height: image.height * model.scaleHeight,
+                }
+            """,
+            channels=4,
         ),
         ImageOutput("Mask", image_type=navi.Image(size_as="Input0"), channels=1),
     ],

--- a/src/common/types/chainner-scope.ts
+++ b/src/common/types/chainner-scope.ts
@@ -122,14 +122,6 @@ def convenientUpscale(model: PyTorchModel | NcnnNetwork, image: Image) {
     }
 }
 
-def removeBackground(model: OnnxRemBgModel, image: Image) {
-    Image {
-        width: image.width,
-        height: image.height * model.scaleHeight,
-        channels: 4,
-    }
-}
-
 struct SplitFilePath {
     dir: Directory,
     basename: string,


### PR DESCRIPTION
Changes:

- I inlined the `removeBackground` function because it was only used in one place.
- The main image output now guarantees an RGBA image. This wasn't enforced at runtime before.
- The image input now requires an RGB or RGBA image. Grayscale images are invalid inputs and cause a crash.

**Open question**: Should the image input accept RGBA images in the first place? RGBA images will be converted to RGB internally, so the alpha channel is completely ignored.