### PR TITLE
Fixed order of commands in `lint:fix`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint:js": "eslint . --ext \".js,.jsx,.ts,.tsx\" && stylelint src/**/*.scss",
     "lint:js-ci": "eslint . --ext \".js,.jsx,.ts,.tsx\" --max-warnings 0 && stylelint src/**/*.scss",
     "lint:py": "ruff format backend --check && ruff check backend",
-    "lint:fix": "eslint . --fix --ext \".js,.jsx,.ts,.tsx\" && stylelint src/**/*.scss --fix && ruff format backend && ruff check backend --fix",
+    "lint:fix": "eslint . --fix --ext \".js,.jsx,.ts,.tsx\" && stylelint src/**/*.scss --fix && ruff check backend --fix && ruff format backend",
     "test:js": "jest",
     "test:py": "pytest ./backend/tests/",
     "test:update": "npm run test:js -- -u",


### PR DESCRIPTION
I noticed that `check` has to come before `format`, because `check` might leave behind unformatted code (because of code fixes).