### PR TITLE
Allow unsafe ruff fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ src = ["backend/src"]
 # ignore vendored code
 extend-exclude = ["**/pytorch/architecture/**"]
 
+unsafe-fixes = true
+
 [tool.ruff.lint]
 # Add the `line-too-long` rule to the enforced rule set.
 extend-select = [


### PR DESCRIPTION
This allows auto-applying fixes that are unsafe (=can change the meaning of code). Some generally useful fixes (e.g. `Union[A,B]` -> `A|B`) are unsafe, so I think we should just enable them and be careful when making and reviewing ruff PRs.