### PR TITLE
Add ruff flake8 comprehensions and future-annotations rules

### DIFF
--- a/backend/src/api/group.py
+++ b/backend/src/api/group.py
@@ -1,4 +1,6 @@
-from typing import Any, Dict, Generic, List, NewType, Optional, TypeVar, Union
+from __future__ import annotations
+
+from typing import Any, Generic, NewType, TypeVar, Union
 
 from .input import BaseInput
 from .types import InputId
@@ -14,17 +16,17 @@ class GroupInfo:
         self,
         group_id: GroupId,
         kind: str,
-        options: Optional[Dict[str, Any]] = None,
+        options: dict[str, Any] | None = None,
     ) -> None:
         self.id: GroupId = group_id
         self.kind: str = kind
-        self.options: Dict[str, Any] = {} if options is None else options
+        self.options: dict[str, Any] = {} if options is None else options
 
 
 class Group(Generic[T]):
-    def __init__(self, info: GroupInfo, items: List[T]) -> None:
+    def __init__(self, info: GroupInfo, items: list[T]) -> None:
         self.info: GroupInfo = info
-        self.items: List[T] = items
+        self.items: list[T] = items
 
     def to_dict(self):
         return {
@@ -40,10 +42,10 @@ NestedIdGroup = Group[Union[InputId, "NestedIdGroup"]]
 
 
 # pylint: disable-next=redefined-builtin
-def group(kind: str, options: Optional[Dict[str, Any]] = None, id: int = -1):
+def group(kind: str, options: dict[str, Any] | None = None, id: int = -1):
     info = GroupInfo(GroupId(id), kind, options)
 
-    def ret(*items: Union[BaseInput, NestedGroup]) -> NestedGroup:
+    def ret(*items: BaseInput | NestedGroup) -> NestedGroup:
         return Group(info, list(items))
 
     return ret

--- a/backend/src/api/node_check.py
+++ b/backend/src/api/node_check.py
@@ -120,7 +120,7 @@ def is_subset_of(a: _Ty, b: _Ty) -> bool:
 
 def is_tuple(t: _Ty) -> bool:
     s = str(t)
-    return s.startswith("typing.Tuple[") or s.startswith("tuple[")
+    return s.startswith(("typing.Tuple[", "tuple["))
 
 
 def get_type_annotations(fn: Callable) -> dict[str, _Ty]:

--- a/backend/src/chain/input.py
+++ b/backend/src/chain/input.py
@@ -1,4 +1,6 @@
-from typing import Dict, List, Optional, Union
+from __future__ import annotations
+
+from typing import Union
 
 from api import NodeId
 
@@ -18,11 +20,11 @@ Input = Union[EdgeInput, ValueInput]
 
 
 class InputMap:
-    def __init__(self, parent: Optional["InputMap"] = None) -> None:
-        self.__data: Dict[NodeId, List[Input]] = {}
-        self.parent: Optional[InputMap] = parent
+    def __init__(self, parent: InputMap | None = None) -> None:
+        self.__data: dict[NodeId, list[Input]] = {}
+        self.parent: InputMap | None = parent
 
-    def get(self, node_id: NodeId) -> List[Input]:
+    def get(self, node_id: NodeId) -> list[Input]:
         values = self.__data.get(node_id, None)
         if values is not None:
             return values
@@ -32,16 +34,16 @@ class InputMap:
 
         raise AssertionError(f"Unknown node id {node_id}")
 
-    def set(self, node_id: NodeId, values: List[Input]):
+    def set(self, node_id: NodeId, values: list[Input]):
         self.__data[node_id] = values
 
-    def set_values(self, node_id: NodeId, values: List[object]):
+    def set_values(self, node_id: NodeId, values: list[object]):
         self.__data[node_id] = [ValueInput(x) for x in values]
 
-    def set_append(self, node_id: NodeId, values: List[Input]):
+    def set_append(self, node_id: NodeId, values: list[Input]):
         inputs = [*self.get(node_id), *values]
         self.set(node_id, inputs)
 
-    def set_append_values(self, node_id: NodeId, values: List[object]):
+    def set_append_values(self, node_id: NodeId, values: list[object]):
         inputs = [*self.get(node_id), *[ValueInput(x) for x in values]]
         self.set(node_id, inputs)

--- a/backend/src/chain/json.py
+++ b/backend/src/chain/json.py
@@ -1,4 +1,6 @@
-from typing import List, Literal, Optional, Tuple, TypedDict, Union
+from __future__ import annotations
+
+from typing import Literal, TypedDict, Union
 
 from api import NodeId
 
@@ -31,8 +33,8 @@ JsonInput = Union[JsonEdgeInput, JsonValueInput]
 class JsonNode(TypedDict):
     id: NodeId
     schemaId: str
-    inputs: List[JsonInput]
-    parent: Optional[NodeId]
+    inputs: list[JsonInput]
+    parent: NodeId | None
     nodeType: str
 
 
@@ -46,11 +48,11 @@ class IndexEdge:
         self.to_index = to_index
 
 
-def parse_json(json: List[JsonNode]) -> Tuple[Chain, InputMap]:
+def parse_json(json: list[JsonNode]) -> tuple[Chain, InputMap]:
     chain = Chain()
     input_map = InputMap()
 
-    index_edges: List[IndexEdge] = []
+    index_edges: list[IndexEdge] = []
 
     for json_node in json:
         if json_node["nodeType"] == "newIterator":
@@ -61,7 +63,7 @@ def parse_json(json: List[JsonNode]) -> Tuple[Chain, InputMap]:
             node = FunctionNode(json_node["id"], json_node["schemaId"])
         chain.add_node(node)
 
-        inputs: List[Input] = []
+        inputs: list[Input] = []
         for index, i in enumerate(json_node["inputs"]):
             if i["type"] == "edge":
                 inputs.append(EdgeInput(i["id"], i["index"]))

--- a/backend/src/dependencies/install_server_deps.py
+++ b/backend/src/dependencies/install_server_deps.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import subprocess
 from json import loads as json_parse
-from typing import List
 
 from .store import (
     DependencyInfo,
@@ -28,7 +29,7 @@ except Exception as e:
     print(f"Failed to get installed packages: {e}")
 
 
-deps: List[DependencyInfo] = [
+deps: list[DependencyInfo] = [
     {
         "package_name": "sanic",
         "display_name": "Sanic",

--- a/backend/src/dependencies/store.py
+++ b/backend/src/dependencies/store.py
@@ -1,17 +1,19 @@
+from __future__ import annotations
+
 import json
 import os
 import re
 import subprocess
 import sys
 from logging import Logger
-from typing import Dict, List, Optional, Tuple, TypedDict, Union
+from typing import TypedDict
 
 from custom_types import UpdateProgressFn
 
 python_path = sys.executable
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
-installed_packages: Dict[str, Union[str, None]] = {}
+installed_packages: dict[str, str | None] = {}
 
 COLLECTING_REGEX = re.compile(r"Collecting ([a-zA-Z0-9-_]+)")
 
@@ -20,9 +22,9 @@ DEP_MAX_PROGRESS = 0.8
 
 class DependencyInfo(TypedDict):
     package_name: str
-    display_name: Optional[str]
-    version: Optional[str]
-    from_file: Optional[str]
+    display_name: str | None
+    version: str | None
+    from_file: str | None
 
 
 def pin(dependency: DependencyInfo) -> str:
@@ -41,7 +43,7 @@ def pin(dependency: DependencyInfo) -> str:
     return f"{package_name}=={version}"
 
 
-def coerce_semver(version: str) -> Tuple[int, int, int]:
+def coerce_semver(version: str) -> tuple[int, int, int]:
     regex = r"(\d+)(?:\.(\d+)(?:\.(\d+))?)?"
     match = re.search(regex, version)
     if match:
@@ -53,7 +55,7 @@ def coerce_semver(version: str) -> Tuple[int, int, int]:
     return (0, 0, 0)
 
 
-def get_deps_to_install(dependencies: List[DependencyInfo]):
+def get_deps_to_install(dependencies: list[DependencyInfo]):
     dependencies_to_install = []
     for dependency in dependencies:
         version = installed_packages.get(dependency["package_name"], None)
@@ -68,7 +70,7 @@ def get_deps_to_install(dependencies: List[DependencyInfo]):
 
 
 def install_dependencies_sync(
-    dependencies: List[DependencyInfo],
+    dependencies: list[DependencyInfo],
 ):
     dependencies_to_install = get_deps_to_install(dependencies)
     if len(dependencies_to_install) == 0:
@@ -96,9 +98,9 @@ def install_dependencies_sync(
 
 
 async def install_dependencies(
-    dependencies: List[DependencyInfo],
-    update_progress_cb: Optional[UpdateProgressFn] = None,
-    logger: Optional[Logger] = None,
+    dependencies: list[DependencyInfo],
+    update_progress_cb: UpdateProgressFn | None = None,
+    logger: Logger | None = None,
 ):
     # If there's no progress callback, just install the dependencies synchronously
     if update_progress_cb is None:

--- a/backend/src/events.py
+++ b/backend/src/events.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import asyncio
-from typing import Dict, Literal, Optional, TypedDict, Union
+from typing import Dict, Literal, TypedDict, Union
 
 from api import ErrorValue, InputId, NodeId, OutputId
 
@@ -22,15 +24,15 @@ class ExecutionErrorSource(TypedDict):
 class ExecutionErrorData(TypedDict):
     message: str
     exception: str
-    source: Optional[ExecutionErrorSource]
+    source: ExecutionErrorSource | None
 
 
 class NodeFinishData(TypedDict):
     nodeId: NodeId
-    executionTime: Optional[float]
-    data: Optional[Dict[OutputId, object]]
-    types: Optional[Dict[OutputId, object]]
-    progressPercent: Optional[float]
+    executionTime: float | None
+    data: dict[OutputId, object] | None
+    types: dict[OutputId, object] | None
+    progressPercent: float | None
 
 
 class NodeStartData(TypedDict):
@@ -48,7 +50,7 @@ class NodeProgressUpdateData(TypedDict):
 class BackendStatusData(TypedDict):
     message: str
     progress: float
-    statusProgress: Optional[float]
+    statusProgress: float | None
 
 
 # Events
@@ -85,7 +87,7 @@ class BackendStatusEvent(TypedDict):
 
 
 class BackendStateEvent(TypedDict):
-    event: Union[Literal["backend-ready"], Literal["backend-started"]]
+    event: Literal["backend-ready"] | Literal["backend-started"]
     data: None
 
 

--- a/backend/src/gpu.py
+++ b/backend/src/gpu.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import List, Tuple, Union
 
 import pynvml as nv
 from sanic.log import logger
@@ -53,7 +54,7 @@ class NvidiaHelper:
 
         self.__num_gpus = nv.nvmlDeviceGetCount()
 
-        self.__gpus: List[_GPU] = []
+        self.__gpus: list[_GPU] = []
         for i in range(self.__num_gpus):
             handle = nv.nvmlDeviceGetHandleByIndex(i)
             self.__gpus.append(
@@ -73,15 +74,15 @@ class NvidiaHelper:
     def num_gpus(self):
         return self.__num_gpus
 
-    def list_gpus(self) -> List[str]:
+    def list_gpus(self) -> list[str]:
         return [gpu.name for gpu in self.__gpus]
 
-    def get_current_vram_usage(self, gpu_index=0) -> Tuple[int, int, int]:
+    def get_current_vram_usage(self, gpu_index=0) -> tuple[int, int, int]:
         info = nv.nvmlDeviceGetMemoryInfo(self.__gpus[gpu_index].handle)
 
         return info.total, info.used, info.free
 
-    def supports_fp16(self, gpu_index: Union[int, None] = None) -> bool:
+    def supports_fp16(self, gpu_index: int | None = None) -> bool:
         if gpu_index is None:
             return all(supports_fp16(gpu) for gpu in self.__gpus)
         gpu = self.__gpus[gpu_index]

--- a/backend/src/nodes/impl/color/convert.py
+++ b/backend/src/nodes/impl/color/convert.py
@@ -111,7 +111,7 @@ def convert(
         raise ValueError(f"Conversion {input_.name} -> {output.name} is not possible.")
 
     logger.debug(
-        f"Converting color using the path {' -> '.join(map(lambda x: x.name, path))}"
+        f"Converting color using the path {' -> '.join(x.name for x in path)}"
     )
 
     for i in range(1, len(path)):

--- a/backend/src/nodes/impl/color/convert.py
+++ b/backend/src/nodes/impl/color/convert.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
-from typing import Callable, Dict, Generic, Iterable, List, Set, Tuple, TypeVar, Union
+from typing import Callable, Generic, Iterable, TypeVar
 
 import numpy as np
 from sanic.log import logger
@@ -21,7 +23,7 @@ def color_space_from_id(id_: int) -> ColorSpace:
     raise ValueError(f"There is no color space with the id {id_}.")
 
 
-def color_space_or_detector_from_id(id_: int) -> Union[ColorSpace, ColorSpaceDetector]:
+def color_space_or_detector_from_id(id_: int) -> ColorSpace | ColorSpaceDetector:
     for c in color_spaces_or_detectors:
         if c.id == id_:
             return c
@@ -34,18 +36,18 @@ T = TypeVar("T")
 @dataclass(order=True)
 class __ProcessingItem(Generic[T]):  # noqa: N801
     cost: int
-    path: List[T] = field(compare=False)
+    path: list[T] = field(compare=False)
 
 
 def get_shortest_path(
     start: T,
     is_destination: Callable[[T], bool],
-    get_next: Callable[[T], Iterable[Tuple[int, T]]],
-) -> Union[List[T], None]:
+    get_next: Callable[[T], Iterable[tuple[int, T]]],
+) -> list[T] | None:
     """A simple implementation of Dijkstra's"""
 
-    processed: Set[T] = set()
-    front: Dict[T, __ProcessingItem] = {
+    processed: set[T] = set()
+    front: dict[T, __ProcessingItem] = {
         start: __ProcessingItem(cost=0, path=[start]),
     }
 
@@ -80,7 +82,7 @@ def get_shortest_path(
                 old.path.append(to)
 
 
-__conversions_map: Dict[ColorSpace, List[Conversion]] = {}
+__conversions_map: dict[ColorSpace, list[Conversion]] = {}
 for conversion in conversions:
     l = __conversions_map.get(conversion.input, [])
     if len(l) == 0:
@@ -90,7 +92,7 @@ for conversion in conversions:
 
 def convert(
     img: np.ndarray,
-    input_: Union[ColorSpace, ColorSpaceDetector],
+    input_: ColorSpace | ColorSpaceDetector,
     output: ColorSpace,
 ) -> np.ndarray:
     if isinstance(input_, ColorSpaceDetector):
@@ -110,9 +112,7 @@ def convert(
     if path is None:
         raise ValueError(f"Conversion {input_.name} -> {output.name} is not possible.")
 
-    logger.debug(
-        f"Converting color using the path {' -> '.join(x.name for x in path)}"
-    )
+    logger.debug(f"Converting color using the path {' -> '.join(x.name for x in path)}")
 
     for i in range(1, len(path)):
         curr_in = path[i - 1]

--- a/backend/src/nodes/impl/color/convert_model.py
+++ b/backend/src/nodes/impl/color/convert_model.py
@@ -1,4 +1,6 @@
-from typing import Callable, Dict, Iterable, Tuple
+from __future__ import annotations
+
+from typing import Callable, Iterable
 
 import numpy as np
 
@@ -19,7 +21,7 @@ class ColorSpaceDetector:
         assert 1000 <= id_ and id_ < 2000
         self.id = id_
         self.name = name
-        self.channel_map: Dict[int, ColorSpace] = {}
+        self.channel_map: dict[int, ColorSpace] = {}
         for cs in color_spaces:
             assert cs.channels not in self.channel_map
             self.channel_map[cs.channels] = cs
@@ -66,7 +68,7 @@ ConvertFn = Callable[[np.ndarray], np.ndarray]
 class Conversion:
     def __init__(
         self,
-        direction: Tuple[ColorSpace, ColorSpace],
+        direction: tuple[ColorSpace, ColorSpace],
         convert: ConvertFn,
         cost: int = 1,
     ):

--- a/backend/src/nodes/impl/dds/format.py
+++ b/backend/src/nodes/impl/dds/format.py
@@ -1,4 +1,6 @@
-from typing import Dict, Literal, Set, Union, cast
+from __future__ import annotations
+
+from typing import Literal, Union, cast
 
 DxgiFormat = Literal[
     "UNKNOWN",
@@ -141,13 +143,13 @@ Legacy DX9 formats. Those are the FourCC of those formats.
 
 DDSFormat = Union[DxgiFormat, LegacyFormat]
 
-LEGACY_TO_DXGI: Dict[LegacyFormat, DxgiFormat] = {
+LEGACY_TO_DXGI: dict[LegacyFormat, DxgiFormat] = {
     "DXT1": "BC1_UNORM",
     "DXT3": "BC2_UNORM",
     "DXT5": "BC3_UNORM",
 }
 
-SRGB_FORMATS: Set[DxgiFormat] = {
+SRGB_FORMATS: set[DxgiFormat] = {
     "BC1_UNORM_SRGB",
     "BC2_UNORM_SRGB",
     "BC3_UNORM_SRGB",
@@ -157,7 +159,7 @@ SRGB_FORMATS: Set[DxgiFormat] = {
     "B8G8R8X8_UNORM_SRGB",
 }
 
-WITH_ALPHA: Set[DDSFormat] = {
+WITH_ALPHA: set[DDSFormat] = {
     "R32G32B32A32_TYPELESS",
     "R32G32B32A32_FLOAT",
     "R32G32B32A32_UINT",
@@ -203,12 +205,12 @@ WITH_ALPHA: Set[DDSFormat] = {
     "DXT5",
 }
 
-BC7_FORMATS: Set[DxgiFormat] = {
+BC7_FORMATS: set[DxgiFormat] = {
     "BC7_TYPELESS",
     "BC7_UNORM",
     "BC7_UNORM_SRGB",
 }
-BC123_FORMATS: Set[DDSFormat] = {
+BC123_FORMATS: set[DDSFormat] = {
     "BC1_TYPELESS",
     "BC1_UNORM",
     "BC1_UNORM_SRGB",
@@ -224,7 +226,7 @@ BC123_FORMATS: Set[DDSFormat] = {
     "DXT5",
 }
 
-PREFER_DX9: Set[DDSFormat] = {
+PREFER_DX9: set[DDSFormat] = {
     "R8G8B8A8_UNORM",
     "B8G8R8A8_UNORM",
     "B5G5R5A1_UNORM",

--- a/backend/src/nodes/impl/dds/texconv.py
+++ b/backend/src/nodes/impl/dds/texconv.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import platform
 import shutil
@@ -5,7 +7,6 @@ import subprocess
 import sys
 import uuid
 from tempfile import mkdtemp
-from typing import List
 
 import numpy as np
 from sanic.log import logger
@@ -31,7 +32,7 @@ def __decode(b: bytes) -> str:
             return str(b)
 
 
-def __run_texconv(args: List[str], error_message: str):
+def __run_texconv(args: list[str], error_message: str):
     if platform.system() != "Windows":
         # texconv is only supported on Windows.
         raise ValueError(

--- a/backend/src/nodes/impl/dithering/constants.py
+++ b/backend/src/nodes/impl/dithering/constants.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from enum import Enum
-from typing import Dict
 
 from chainner_ext import DiffusionAlgorithm
 
@@ -26,7 +27,7 @@ ERROR_PROPAGATION_MAP_LABELS = {
     ErrorDiffusionMap.SIERRA_LITE: "Sierra Lite",
 }
 
-DIFFUSION_ALGORITHM_MAP: Dict[ErrorDiffusionMap, DiffusionAlgorithm] = {
+DIFFUSION_ALGORITHM_MAP: dict[ErrorDiffusionMap, DiffusionAlgorithm] = {
     ErrorDiffusionMap.FLOYD_STEINBERG: DiffusionAlgorithm.FloydSteinberg,
     ErrorDiffusionMap.JARVIS_ET_AL: DiffusionAlgorithm.JarvisJudiceNinke,
     ErrorDiffusionMap.STUCKI: DiffusionAlgorithm.Stucki,

--- a/backend/src/nodes/impl/image_formats.py
+++ b/backend/src/nodes/impl/image_formats.py
@@ -73,4 +73,4 @@ def get_pil_formats():
 
 def get_available_image_formats():
     all_formats = [*get_opencv_formats(), *get_pil_formats()]
-    return sorted(list(set(all_formats)))
+    return sorted(set(all_formats))

--- a/backend/src/nodes/impl/ncnn/model.py
+++ b/backend/src/nodes/impl/ncnn/model.py
@@ -171,12 +171,12 @@ class NcnnParam:
         self,
         pid: str,
         name: str,
-        value: float | (int | list[float | int]),
+        value: float | int | list[float | int],
         default: float | int,
     ) -> None:
         self.id: str = pid
         self.name: str = name
-        self.value: float | (int | list[float | int]) = value
+        self.value: float | int | list[float | int] = value
         self.default: float | int = default
 
 
@@ -222,7 +222,7 @@ class NcnnParamCollection:
 
             return NcnnParam(idstr, param["paramPhase"], value, default_value)
 
-    def __setitem__(self, pid: int, value: float | (int | list[float | int])) -> None:
+    def __setitem__(self, pid: int, value: float | int | list[float | int]) -> None:
         idstr = str(pid)
         param_dict = param_schema[self.op]
         try:
@@ -324,13 +324,13 @@ class NcnnLayer:
             {} if weight_data is None else weight_data
         )
 
-    def add_param(self, pid: int, value: float | (int | list[float | int])) -> None:
+    def add_param(self, pid: int, value: float | int | list[float | int]) -> None:
         self.params[pid] = value
 
     def add_weight(
         self,
         weight_name: str,
-        data: float | (int | np.ndarray),
+        data: float | int | np.ndarray,
         quantize_tag: bytes = b"",
     ) -> int:
         if isinstance(data, float):

--- a/backend/src/nodes/impl/ncnn/model.py
+++ b/backend/src/nodes/impl/ncnn/model.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import os
 from copy import deepcopy
 from io import BufferedReader, StringIO
 from json import load as jload
-from typing import Dict, List, Tuple, Union
 
 import numpy as np
 from sanic.log import logger
@@ -170,24 +171,24 @@ class NcnnParam:
         self,
         pid: str,
         name: str,
-        value: Union[float, int, List[Union[float, int]]],
-        default: Union[float, int],
+        value: float | (int | list[float | int]),
+        default: float | int,
     ) -> None:
         self.id: str = pid
         self.name: str = name
-        self.value: Union[float, int, List[Union[float, int]]] = value
-        self.default: Union[float, int] = default
+        self.value: float | (int | list[float | int]) = value
+        self.default: float | int = default
 
 
 class NcnnParamCollection:
     def __init__(
         self,
         op: str,
-        param_dict: Union[Dict[int, NcnnParam], None] = None,
+        param_dict: dict[int, NcnnParam] | None = None,
     ) -> None:
         self.op: str = op
-        self.param_dict: Dict[int, NcnnParam] = {} if param_dict is None else param_dict
-        self.weight_order: Dict[str, List[int]] = (
+        self.param_dict: dict[int, NcnnParam] = {} if param_dict is None else param_dict
+        self.weight_order: dict[str, list[int]] = (
             param_schema[self.op]["weightOrder"] if self.op else {}
         )
 
@@ -221,9 +222,7 @@ class NcnnParamCollection:
 
             return NcnnParam(idstr, param["paramPhase"], value, default_value)
 
-    def __setitem__(
-        self, pid: int, value: Union[float, int, List[Union[float, int]]]
-    ) -> None:
+    def __setitem__(self, pid: int, value: float | (int | list[float | int])) -> None:
         idstr = str(pid)
         param_dict = param_schema[self.op]
         try:
@@ -307,33 +306,31 @@ class NcnnLayer:
         name: str = "",
         num_inputs: int = 0,
         num_outputs: int = 0,
-        inputs: Union[List[str], None] = None,
-        outputs: Union[List[str], None] = None,
-        params: Union[NcnnParamCollection, None] = None,
-        weight_data: Union[Dict[str, NcnnWeight], None] = None,
+        inputs: list[str] | None = None,
+        outputs: list[str] | None = None,
+        params: NcnnParamCollection | None = None,
+        weight_data: dict[str, NcnnWeight] | None = None,
     ):
         self.op_type: str = op_type
         self.name: str = name
         self.num_inputs: int = num_inputs
         self.num_outputs: int = num_outputs
-        self.inputs: List[str] = [] if inputs is None else inputs
-        self.outputs: List[str] = [] if outputs is None else outputs
+        self.inputs: list[str] = [] if inputs is None else inputs
+        self.outputs: list[str] = [] if outputs is None else outputs
         self.params: NcnnParamCollection = (
             NcnnParamCollection(op_type) if params is None else params
         )
-        self.weight_data: Dict[str, NcnnWeight] = (
+        self.weight_data: dict[str, NcnnWeight] = (
             {} if weight_data is None else weight_data
         )
 
-    def add_param(
-        self, pid: int, value: Union[float, int, List[Union[float, int]]]
-    ) -> None:
+    def add_param(self, pid: int, value: float | (int | list[float | int])) -> None:
         self.params[pid] = value
 
     def add_weight(
         self,
         weight_name: str,
-        data: Union[float, int, np.ndarray],
+        data: float | (int | np.ndarray),
         quantize_tag: bytes = b"",
     ) -> int:
         if isinstance(data, float):
@@ -362,7 +359,7 @@ class NcnnModel:
     ) -> None:
         self.node_count: int = node_count
         self.blob_count: int = blob_count
-        self.layers: List[NcnnLayer] = []
+        self.layers: list[NcnnLayer] = []
         self.bin_length = 0
 
     @property
@@ -370,7 +367,7 @@ class NcnnModel:
         return "7767517"
 
     @staticmethod
-    def load_from_file(param_path: str = "", bin_path: str = "") -> "NcnnModel":
+    def load_from_file(param_path: str = "", bin_path: str = "") -> NcnnModel:
         if bin_path == "":
             bin_path = param_path.replace(".param", ".bin")
         elif param_path == "":
@@ -397,10 +394,10 @@ class NcnnModel:
     @staticmethod
     def interp_layers(
         a: NcnnLayer, b: NcnnLayer, alpha_a: float
-    ) -> Tuple[NcnnLayer, bytes]:
+    ) -> tuple[NcnnLayer, bytes]:
         weights_a = a.weight_data
         weights_b = b.weight_data
-        weights_interp: Dict[str, NcnnWeight] = {}
+        weights_interp: dict[str, NcnnWeight] = {}
         layer_bytes = b""
 
         if weights_a:
@@ -468,7 +465,7 @@ class NcnnModel:
     def add_layer(self, layer: NcnnLayer) -> None:
         self.layers.append(layer)
 
-    def parse_param_layer(self, layer_str: str) -> Tuple[str, NcnnLayer]:
+    def parse_param_layer(self, layer_str: str) -> tuple[str, NcnnLayer]:
         param_list = layer_str.strip().split()
         op_type, name = param_list[:2]
         assert op_type != "MemoryData", "This NCNN param file contains invalid layers"
@@ -517,7 +514,7 @@ class NcnnModel:
 
     def load_layer_weights(
         self, binf: BufferedReader, op_type: str, layer: NcnnLayer
-    ) -> Dict[str, NcnnWeight]:
+    ) -> dict[str, NcnnWeight]:
         weight_dict = {}
         if op_type == "BatchNorm":
             channels_data = checked_cast(int, layer.params[0].value) * 4
@@ -693,7 +690,7 @@ class NcnnModel:
         with open(filename, "wb") as f:
             f.write(self.serialize_weights())
 
-    def interpolate(self, model_b: "NcnnModel", alpha: float) -> "NcnnModel":
+    def interpolate(self, model_b: NcnnModel, alpha: float) -> NcnnModel:
         interp_model = deepcopy(self)
 
         layer_a_weights = [(i, l) for i, l in enumerate(self.layers) if l.weight_data]
@@ -731,7 +728,7 @@ class NcnnModelWrapper:
         self.fp: str = fp
 
     @staticmethod
-    def get_broadcast_data(model: NcnnModel) -> Tuple[int, int, int, int, str]:
+    def get_broadcast_data(model: NcnnModel) -> tuple[int, int, int, int, str]:
         scale = 1.0
         in_nc = 0
         out_nc = 0
@@ -787,7 +784,7 @@ class NcnnModelWrapper:
         return int(scale), in_nc, out_nc, nf, fp
 
     @staticmethod
-    def get_nf_and_in_nc(layer: NcnnLayer) -> Tuple[int, int]:
+    def get_nf_and_in_nc(layer: NcnnLayer) -> tuple[int, int]:
         nf = layer.params[0].value
         kernel_w = layer.params[1].value
         try:

--- a/backend/src/nodes/impl/ncnn/model.py
+++ b/backend/src/nodes/impl/ncnn/model.py
@@ -477,8 +477,8 @@ class NcnnModel:
         num_outputs = int(param_list[3])
         input_end = 4 + num_inputs
         output_end = input_end + num_outputs
-        inputs = [i for i in param_list[4:input_end]]
-        outputs = [o for o in param_list[input_end:output_end]]
+        inputs = list(param_list[4:input_end])
+        outputs = list(param_list[input_end:output_end])
 
         params = param_list[output_end:]
         param_dict = {}

--- a/backend/src/nodes/impl/noise.py
+++ b/backend/src/nodes/impl/noise.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from enum import Enum
-from typing import Callable, List
+from typing import Callable
 
 import numpy as np
 
@@ -9,8 +11,8 @@ from .image_utils import as_target_channels
 
 def __add_noises(
     image: np.ndarray,
-    noise_gen: Callable[[int, int], List[np.ndarray]],
-    combine: Callable[[np.ndarray, List[np.ndarray]], np.ndarray],
+    noise_gen: Callable[[int, int], list[np.ndarray]],
+    combine: Callable[[np.ndarray, list[np.ndarray]], np.ndarray],
 ) -> np.ndarray:
     img = image
     h, w, c = get_h_w_c(img)
@@ -108,7 +110,7 @@ def salt_and_pepper_noise(
         salt = rng.choice([0, 1], (h, w, noise_c), p=[1 - amt, amt]).astype(np.uint8)
         return [pepper, salt]
 
-    def combine(i: np.ndarray, n: List[np.ndarray]):
+    def combine(i: np.ndarray, n: list[np.ndarray]):
         pepper, salt = n
         return np.where(salt == 1, 1, np.where(pepper == 0, 0, i))
 

--- a/backend/src/nodes/impl/noise_functions/simplex.py
+++ b/backend/src/nodes/impl/noise_functions/simplex.py
@@ -7,8 +7,9 @@ Simplex noise demystified, Stefan Gustavson (2005)
 http://staffwww.itn.liu.se/~stegu/simplexnoise/simplexnoise.pdf
 """
 
+from __future__ import annotations
+
 import itertools
-from typing import Optional
 
 import numpy as np
 
@@ -43,7 +44,7 @@ SCALE = {
 
 
 class SimplexNoise:
-    def __init__(self, dimensions: int, seed: Optional[int], r2: float = 0.5):
+    def __init__(self, dimensions: int, seed: int | None, r2: float = 0.5):
         if dimensions <= 0:
             raise ValueError
         if dimensions == 1:

--- a/backend/src/nodes/impl/normals/edge_filter.py
+++ b/backend/src/nodes/impl/normals/edge_filter.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import math
 from enum import Enum
-from typing import Dict, List, Tuple
 
 import numpy as np
 
@@ -32,7 +33,7 @@ class EdgeFilter(Enum):
     MULTI_GAUSS = "multi-gauss"
 
 
-FILTERS_X: Dict[EdgeFilter, np.ndarray] = {
+FILTERS_X: dict[EdgeFilter, np.ndarray] = {
     EdgeFilter.SOBEL: np.array(
         [
             [+1, 0, -1],
@@ -95,7 +96,7 @@ FILTERS_X: Dict[EdgeFilter, np.ndarray] = {
 }
 
 
-def create_gauss_kernel(parameters: List[Tuple[float, float]]) -> np.ndarray:
+def create_gauss_kernel(parameters: list[tuple[float, float]]) -> np.ndarray:
     """
     Parameters is a list of tuples (sigma, weight).
     """
@@ -150,8 +151,8 @@ def create_gauss_kernel(parameters: List[Tuple[float, float]]) -> np.ndarray:
 
 def get_filter_kernels(
     edge_filter: EdgeFilter,
-    gauss_parameter: List[Tuple[float, float]],
-) -> Tuple[np.ndarray, np.ndarray]:
+    gauss_parameter: list[tuple[float, float]],
+) -> tuple[np.ndarray, np.ndarray]:
     """
     Returns the x and y kernels of the given edge filter.
     """

--- a/backend/src/nodes/impl/onnx/np_tensor_utils.py
+++ b/backend/src/nodes/impl/onnx/np_tensor_utils.py
@@ -1,11 +1,11 @@
-from typing import Tuple, Type
+from __future__ import annotations
 
 import numpy as np
 
 from ..image_utils import MAX_VALUES_BY_DTYPE, as_3d
 
 
-def np_denorm(x: np.ndarray, min_max: Tuple[float, float] = (-1.0, 1.0)) -> np.ndarray:
+def np_denorm(x: np.ndarray, min_max: tuple[float, float] = (-1.0, 1.0)) -> np.ndarray:
     """Denormalize from [-1,1] range to [0,1]
     formula: xi' = (xi - mu)/sigma
     Example: "out = (x + 1.0) / 2.0" for denorm
@@ -91,7 +91,7 @@ def nptensor2np(
     data_range=255,
     denormalize=False,
     change_range=True,
-    imtype: Type = np.uint8,
+    imtype: type = np.uint8,
 ) -> np.ndarray:
     """Converts a Tensor array into a numpy image array.
     Parameters:

--- a/backend/src/nodes/impl/onnx/onnx_to_ncnn.py
+++ b/backend/src/nodes/impl/onnx/onnx_to_ncnn.py
@@ -1,6 +1,5 @@
 # ruff: noqa: N806
-
-from typing import Dict, List, Union
+from __future__ import annotations
 
 import numpy as np
 import onnx.numpy_helper as onph
@@ -59,21 +58,21 @@ ROT = ReductionOpTypes
 class Onnx2NcnnConverter:
     def __init__(self, onnx_model: ModelProto):
         self.onnx_graph: GraphProto = onnx_model.graph
-        self.mutable_graph_nodes: List[NodeProto] = list(self.onnx_graph.node)
+        self.mutable_graph_nodes: list[NodeProto] = list(self.onnx_graph.node)
         self.node_count: int = len(self.onnx_graph.node)
-        self.weights: Dict[str, TensorProto] = {
+        self.weights: dict[str, TensorProto] = {
             initializer.name: initializer for initializer in self.onnx_graph.initializer
         }
 
-        self.producers: Dict[str, None] = {i.name: None for i in self.onnx_graph.input}
-        self.node_reference: Dict[str, int] = {}
-        self.blob_names: Dict[str, None] = {}
+        self.producers: dict[str, None] = {i.name: None for i in self.onnx_graph.input}
+        self.node_reference: dict[str, int] = {}
+        self.blob_names: dict[str, None] = {}
 
     @staticmethod
     def add_weight(
         layer: NcnnLayer,
         weight_name: str,
-        data: Union[float, int, np.ndarray, TensorProto],
+        data: float | (int | (np.ndarray | TensorProto)),
         quantize_tag: bytes = b"",
     ) -> int:
         if isinstance(data, TensorProto):
@@ -83,7 +82,7 @@ class Onnx2NcnnConverter:
 
     @staticmethod
     def clear_container(
-        container: Union[RepeatedCompositeFieldContainer, RepeatedScalarFieldContainer],
+        container: RepeatedCompositeFieldContainer | RepeatedScalarFieldContainer,
     ) -> None:
         for _ in range(len(container)):
             container.pop()
@@ -115,7 +114,7 @@ class Onnx2NcnnConverter:
                     set_node_attr_ai(gather, "ends", np.array([index + 1], np.int32))
                     set_node_attr_ai(gather, "axis", np.array([axis], np.int32))
 
-    def fuse_weight_reshape(self, reduced_node_count: List[int]) -> None:
+    def fuse_weight_reshape(self, reduced_node_count: list[int]) -> None:
         for i in range(self.node_count):
             node = self.mutable_graph_nodes[i]
             if node.op_type == "Reshape":
@@ -141,7 +140,7 @@ class Onnx2NcnnConverter:
                     reduced_node_count[0] += 1
                     i += 1  # noqa
 
-    def fuse_weight_transpose(self, reduced_node_count: List[int]) -> None:
+    def fuse_weight_transpose(self, reduced_node_count: list[int]) -> None:
         for i in range(self.node_count):
             node = self.mutable_graph_nodes[i]
             if node.op_type == "Transpose":
@@ -177,7 +176,7 @@ class Onnx2NcnnConverter:
                     reduced_node_count[0] += 1
                     i += 1  # noqa
 
-    def fuse_shufflechannel(self, reduced_node_count: List[int]) -> None:
+    def fuse_shufflechannel(self, reduced_node_count: list[int]) -> None:
         for i in range(self.node_count):
             node = self.mutable_graph_nodes[i]
 
@@ -281,7 +280,7 @@ class Onnx2NcnnConverter:
                 reduced_node_count[0] += 2
                 i += 2  # noqa
 
-    def fuse_shufflechannel_split(self, reduced_node_count: List[int]) -> None:
+    def fuse_shufflechannel_split(self, reduced_node_count: list[int]) -> None:
         for i in range(self.node_count):
             node = self.mutable_graph_nodes[i]
 
@@ -342,7 +341,7 @@ class Onnx2NcnnConverter:
                 reduced_node_count[0] += 1
                 i += 1  # noqa
 
-    def fuse_hardswish(self, reduced_node_count: List[int]) -> None:
+    def fuse_hardswish(self, reduced_node_count: list[int]) -> None:
         for i in range(self.node_count):
             node = self.mutable_graph_nodes[i]
 
@@ -493,7 +492,7 @@ class Onnx2NcnnConverter:
                 reduced_node_count[0] += 1
                 i += 1  # noqa
 
-    def fuse_hardsigmoid(self, reduced_node_count: List[int]) -> None:
+    def fuse_hardsigmoid(self, reduced_node_count: list[int]) -> None:
         for i in range(self.node_count):
             node = self.mutable_graph_nodes[i]
 
@@ -590,7 +589,7 @@ class Onnx2NcnnConverter:
                 reduced_node_count[0] += 2
                 i += 2  # noqa
 
-    def fuse_swish(self, reduced_node_count: List[int]) -> None:
+    def fuse_swish(self, reduced_node_count: list[int]) -> None:
         for i in range(self.node_count):
             node = self.mutable_graph_nodes[i]
 
@@ -622,7 +621,7 @@ class Onnx2NcnnConverter:
                 reduced_node_count[0] += 1
                 i += 1  # noqa
 
-    def fuse_batchnorm1d_squeeze_unsqueeze(self, reduced_node_count: List[int]) -> None:
+    def fuse_batchnorm1d_squeeze_unsqueeze(self, reduced_node_count: list[int]) -> None:
         for i in range(self.node_count):
             node = self.mutable_graph_nodes[i]
 
@@ -660,7 +659,7 @@ class Onnx2NcnnConverter:
                 reduced_node_count[0] += 2
                 i += 2  # noqa
 
-    def fuse_unsqueeze_prelu(self, reduced_node_count: List[int]) -> None:
+    def fuse_unsqueeze_prelu(self, reduced_node_count: list[int]) -> None:
         for i in range(self.node_count):
             node = self.mutable_graph_nodes[i]
 
@@ -700,7 +699,7 @@ class Onnx2NcnnConverter:
                 reduced_node_count[0] += 1
                 i += 1  # noqa
 
-    def fuse_normalize(self, reduced_node_count: List[int]) -> None:
+    def fuse_normalize(self, reduced_node_count: list[int]) -> None:
         for i in range(self.node_count):
             node = self.mutable_graph_nodes[i]
 
@@ -793,7 +792,7 @@ class Onnx2NcnnConverter:
                 reduced_node_count[0] += 4 if has_shape_node else 3
                 i += 4 if has_shape_node else 3  # noqa
 
-    def fuse_groupnorm(self, reduced_node_count: List[int]) -> None:
+    def fuse_groupnorm(self, reduced_node_count: list[int]) -> None:
         for i in range(self.node_count):
             node = self.mutable_graph_nodes[i]
 
@@ -927,7 +926,7 @@ class Onnx2NcnnConverter:
                 reduced_node_count[0] += 4
                 i += 4  # noqa
 
-    def fuse_layernorm(self, reduced_node_count: List[int]) -> None:
+    def fuse_layernorm(self, reduced_node_count: list[int]) -> None:
         for i in range(self.node_count):
             node = self.mutable_graph_nodes[i]
 
@@ -1108,7 +1107,7 @@ class Onnx2NcnnConverter:
                     reduced_node_count[0] += 8
                     i += 8  # noqa
 
-    def fuse_flatten(self, reduced_node_count: List[int]) -> None:
+    def fuse_flatten(self, reduced_node_count: list[int]) -> None:
         for i in range(self.node_count):
             node = self.mutable_graph_nodes[i]
 
@@ -1220,7 +1219,7 @@ class Onnx2NcnnConverter:
                 reduced_node_count[0] += 5
                 i += 5  # noqa
 
-    def fuse_pixelshuffle(self, reduced_node_count: List[int]) -> None:
+    def fuse_pixelshuffle(self, reduced_node_count: list[int]) -> None:
         for i in range(self.node_count):
             node = self.mutable_graph_nodes[i]
 
@@ -1318,7 +1317,7 @@ class Onnx2NcnnConverter:
                 reduced_node_count[0] += 2
                 i += 2  # noqa
 
-    def fuse_reorg(self, reduced_node_count: List[int]) -> None:
+    def fuse_reorg(self, reduced_node_count: list[int]) -> None:
         for i in range(self.node_count):
             node = self.mutable_graph_nodes[i]
 
@@ -1413,7 +1412,7 @@ class Onnx2NcnnConverter:
                 reduced_node_count[0] += 2
                 i += 2  # noqa
 
-    def fuse_expand_broadcast(self, reduced_node_count: List[int]) -> None:
+    def fuse_expand_broadcast(self, reduced_node_count: list[int]) -> None:
         for i in range(self.node_count):
             node = self.mutable_graph_nodes[i]
 
@@ -1449,7 +1448,7 @@ class Onnx2NcnnConverter:
                 reduced_node_count[0] += 1
                 i += 1  # noqa
 
-    def fuse_lstm_gru_rnn(self, reduced_node_count: List[int]) -> None:
+    def fuse_lstm_gru_rnn(self, reduced_node_count: list[int]) -> None:
         for i in range(self.node_count):
             node = self.mutable_graph_nodes[i]
 
@@ -1649,7 +1648,7 @@ class Onnx2NcnnConverter:
                 reduced_node_count[0] += 1
                 i += 1  # noqa
 
-    def fuse_multiheadattention(self, reduced_node_count: List[int]) -> None:
+    def fuse_multiheadattention(self, reduced_node_count: list[int]) -> None:
         for i in range(self.node_count):
             node = self.mutable_graph_nodes[i]
 

--- a/backend/src/nodes/impl/onnx/onnx_to_ncnn.py
+++ b/backend/src/nodes/impl/onnx/onnx_to_ncnn.py
@@ -72,7 +72,7 @@ class Onnx2NcnnConverter:
     def add_weight(
         layer: NcnnLayer,
         weight_name: str,
-        data: float | (int | (np.ndarray | TensorProto)),
+        data: float | int | np.ndarray | TensorProto,
         quantize_tag: bytes = b"",
     ) -> int:
         if isinstance(data, TensorProto):

--- a/backend/src/nodes/impl/onnx/onnx_to_ncnn.py
+++ b/backend/src/nodes/impl/onnx/onnx_to_ncnn.py
@@ -59,7 +59,7 @@ ROT = ReductionOpTypes
 class Onnx2NcnnConverter:
     def __init__(self, onnx_model: ModelProto):
         self.onnx_graph: GraphProto = onnx_model.graph
-        self.mutable_graph_nodes: List[NodeProto] = [n for n in self.onnx_graph.node]
+        self.mutable_graph_nodes: List[NodeProto] = list(self.onnx_graph.node)
         self.node_count: int = len(self.onnx_graph.node)
         self.weights: Dict[str, TensorProto] = {
             initializer.name: initializer for initializer in self.onnx_graph.initializer
@@ -3738,8 +3738,8 @@ class Onnx2NcnnConverter:
                             np.delete(axes, i)
                             break
 
-                layer.add_param(9, [starts.size, *[s for s in starts]])
-                layer.add_param(10, [ends.size, *[e for e in ends]])
+                layer.add_param(9, [starts.size, *list(starts)])
+                layer.add_param(10, [ends.size, *list(ends)])
                 if axes.size:
                     assert np.all(
                         axes != 0 and axes <= 3 and axes >= -3
@@ -3758,7 +3758,7 @@ class Onnx2NcnnConverter:
                 assert axis >= 1, f"Unsupported axis {axis} in Split"
 
                 if splits.size:
-                    layer.add_param(0, [output_size, *[s for s in splits[:-1]], -233])
+                    layer.add_param(0, [output_size, *list(splits[:-1]), -233])
                 else:
                     layer.add_param(
                         0, [output_size, *[-233 for _ in range(output_size)]]

--- a/backend/src/nodes/impl/onnx/tensorproto_utils.py
+++ b/backend/src/nodes/impl/onnx/tensorproto_utils.py
@@ -30,7 +30,7 @@ def set_node_attr_ai(node: NodeProto, key: str, value: np.ndarray) -> None:
 def get_node_attr_af(node: NodeProto, key: str) -> np.ndarray:
     for attr in node.attribute:
         if attr.name == key:
-            return np.array([f for f in attr.floats], np.float32)
+            return np.array(list(attr.floats), np.float32)
 
     return np.empty(0, np.float32)
 
@@ -103,7 +103,7 @@ def get_node_attr_from_input_ai(tp: TensorProto) -> np.ndarray:
 def get_node_attr_from_input_af(tp: TensorProto) -> np.ndarray:
     if tp.data_type in (TPT.FLOAT, TPT.FLOAT16, TPT.DOUBLE):
         shape_data = onph.to_array(tp)
-        return np.array([val for val in shape_data], shape_data.dtype)
+        return np.array(list(shape_data), shape_data.dtype)
     else:
         logger.error(f"Unknown data type {tp.data_type}")
 

--- a/backend/src/nodes/impl/pil_utils.py
+++ b/backend/src/nodes/impl/pil_utils.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from enum import Enum
-from typing import Tuple
 
 import numpy as np
 from PIL import Image
@@ -42,7 +43,7 @@ class RotateSizeChange(Enum):
 
 
 def resize(
-    img: np.ndarray, out_dims: Tuple[int, int], interpolation: InterpolationMethod
+    img: np.ndarray, out_dims: tuple[int, int], interpolation: InterpolationMethod
 ) -> np.ndarray:
     """Perform PIL resize"""
 

--- a/backend/src/nodes/impl/pytorch/pix_transform/pix_transform.py
+++ b/backend/src/nodes/impl/pytorch/pix_transform/pix_transform.py
@@ -71,8 +71,8 @@ def pix_transform(
 
     guide_patches = torch.zeros((m * m, guide_tensor.shape[0], d, d)).to(device)
     source_pixels = torch.zeros((m * m, 1)).to(device)
-    for i in range(0, m):
-        for j in range(0, m):
+    for i in range(m):
+        for j in range(m):
             guide_patches[j + i * m, :, :, :] = guide_tensor[
                 :, i * d : (i + 1) * d, j * d : (j + 1) * d
             ]
@@ -103,7 +103,7 @@ def pix_transform(
     ###############################################################################################
 
     epochs = params.batch_size * params.iteration // (m * m)
-    for _epoch in range(0, epochs):
+    for _epoch in range(epochs):
         for x, y in train_loader:
             optimizer.zero_grad()
 

--- a/backend/src/nodes/impl/rembg/bg.py
+++ b/backend/src/nodes/impl/rembg/bg.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from __future__ import annotations
 
 import numpy as np
 import onnxruntime as ort
@@ -74,7 +74,7 @@ def naive_cutout(img: PILImage, mask: PILImage) -> PILImage:
     return cutout
 
 
-def get_concat_v_multi(imgs: List[PILImage]) -> PILImage:
+def get_concat_v_multi(imgs: list[PILImage]) -> PILImage:
     pivot = imgs.pop(0)
     for im in imgs:
         pivot = get_concat_v(pivot, im)
@@ -111,7 +111,7 @@ def remove_bg(
     alpha_matting_background_threshold: int = 10,
     alpha_matting_erode_size: int = 10,
     post_process_mask: bool = False,
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     # Flip channels to RGB mode and convert to PIL Image
     img = (img * 255).astype(np.uint8)
     _, _, c = get_h_w_c(img)

--- a/backend/src/nodes/impl/rembg/session_base.py
+++ b/backend/src/nodes/impl/rembg/session_base.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Tuple
+from __future__ import annotations
 
 import numpy as np
 import onnxruntime as ort
@@ -10,16 +10,16 @@ class BaseSession:
     def __init__(
         self,
         inner_session: ort.InferenceSession,
-        mean: Tuple[float, float, float],
-        std: Tuple[float, float, float],
-        size: Tuple[int, int],
+        mean: tuple[float, float, float],
+        std: tuple[float, float, float],
+        size: tuple[int, int],
     ):
         self.inner_session = inner_session
         self.mean = mean
         self.std = std
         self.size = size
 
-    def normalize(self, img: PILImage) -> Dict[str, np.ndarray]:
+    def normalize(self, img: PILImage) -> dict[str, np.ndarray]:
         im = img.convert("RGB").resize(self.size, Image.LANCZOS)
         im_ary = np.array(im)
         im_ary = im_ary / np.max(im_ary)
@@ -35,5 +35,5 @@ class BaseSession:
 
         return {model_input_name: np.expand_dims(tmp_img, 0).astype(np.float32)}
 
-    def predict(self, _: PILImage) -> List[PILImage]:
+    def predict(self, _: PILImage) -> list[PILImage]:
         raise NotImplementedError

--- a/backend/src/nodes/impl/rembg/session_cloth.py
+++ b/backend/src/nodes/impl/rembg/session_cloth.py
@@ -1,4 +1,4 @@
-from typing import List
+from __future__ import annotations
 
 import numpy as np
 from PIL import Image
@@ -54,7 +54,7 @@ pallete3 = [
 
 
 class ClothSession(BaseSession):
-    def predict(self, img: PILImage) -> List[PILImage]:
+    def predict(self, img: PILImage) -> list[PILImage]:
         ort_outs = self.inner_session.run(None, self.normalize(img))
 
         pred = ort_outs

--- a/backend/src/nodes/impl/rembg/session_factory.py
+++ b/backend/src/nodes/impl/rembg/session_factory.py
@@ -1,4 +1,4 @@
-from typing import Type
+from __future__ import annotations
 
 import onnxruntime as ort
 
@@ -9,7 +9,7 @@ from .session_simple import SimpleSession
 
 
 def new_session(session: ort.InferenceSession) -> BaseSession:
-    session_class: Type[BaseSession]
+    session_class: type[BaseSession]
 
     input_width = get_input_shape(session)[2]
 

--- a/backend/src/nodes/impl/rembg/session_simple.py
+++ b/backend/src/nodes/impl/rembg/session_simple.py
@@ -1,4 +1,4 @@
-from typing import List
+from __future__ import annotations
 
 import numpy as np
 from PIL import Image
@@ -8,7 +8,7 @@ from .session_base import BaseSession
 
 
 class SimpleSession(BaseSession):
-    def predict(self, img: PILImage) -> List[PILImage]:
+    def predict(self, img: PILImage) -> list[PILImage]:
         ort_outs = self.inner_session.run(None, self.normalize(img))
 
         pred = ort_outs[0][:, 0, :, :]

--- a/backend/src/nodes/impl/upscale/auto_split.py
+++ b/backend/src/nodes/impl/upscale/auto_split.py
@@ -154,13 +154,13 @@ def _max_split(
             f"Currently {tile_count_x}x{tile_count_y} tiles each {tile_size_x}x{tile_size_y}px."
         )
 
-        for y in range(0, tile_count_y):
+        for y in range(tile_count_y):
             if restart:
                 break
             if y < start_y:
                 continue
 
-            for x in range(0, tile_count_x):
+            for x in range(tile_count_x):
                 if y == start_y and x < start_x:
                     continue
 

--- a/backend/src/nodes/impl/upscale/convenient_upscale.py
+++ b/backend/src/nodes/impl/upscale/convenient_upscale.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from __future__ import annotations
 
 import numpy as np
 
@@ -7,7 +7,7 @@ from ..image_op import ImageOp, clipped
 from ..image_utils import as_target_channels
 
 
-def with_black_and_white_backgrounds(img: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+def with_black_and_white_backgrounds(img: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     c = get_h_w_c(img)[2]
     assert c == 4
 

--- a/backend/src/nodes/impl/upscale/grayscale.py
+++ b/backend/src/nodes/impl/upscale/grayscale.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from enum import Enum
-from typing import List
 
 import numpy as np
 
@@ -12,7 +13,7 @@ class SplitMode(Enum):
     RGB = 1
     LAB = 2
 
-    def split(self, img: np.ndarray) -> List[np.ndarray]:
+    def split(self, img: np.ndarray) -> list[np.ndarray]:
         if img.ndim == 2:
             return [img]
 
@@ -38,7 +39,7 @@ class SplitMode(Enum):
         else:
             raise AssertionError()
 
-    def combine(self, channels: List[np.ndarray]) -> np.ndarray:
+    def combine(self, channels: list[np.ndarray]) -> np.ndarray:
         l = len(channels)
         assert l > 0
 
@@ -67,7 +68,7 @@ def grayscale_split(
     """
 
     input_channels = mode.split(img)
-    output_channels: List[np.ndarray] = []
+    output_channels: list[np.ndarray] = []
     for channel in input_channels:
         output_channels.append(process(channel))
 

--- a/backend/src/nodes/properties/inputs/numeric_inputs.py
+++ b/backend/src/nodes/properties/inputs/numeric_inputs.py
@@ -12,8 +12,8 @@ from ...utils.utils import round_half_up
 def clamp_number(
     value: float | int,
     precision: int,
-    min_value: float | (int | None),
-    max_value: float | (int | None),
+    min_value: float | int | None,
+    max_value: float | int | None,
 ) -> float | int:
     # Convert proper number type
     value = round_half_up(value) if precision == 0 else round(value, precision)
@@ -32,8 +32,8 @@ def clamp_number(
 
 
 def get_number_type(
-    min_value: float | (int | None),
-    max_value: float | (int | None),
+    min_value: float | int | None,
+    max_value: float | int | None,
     precision: int,
 ) -> navi.ExpressionJson:
     if precision > 0:
@@ -49,10 +49,10 @@ class NumberInput(BaseInput):
         self,
         label: str,
         precision: int = 0,
-        controls_step: float | (int | None) = None,
+        controls_step: float | int | None = None,
         default: float | int = 0,
-        minimum: float | (int | None) = 0,
-        maximum: float | (int | None) = None,
+        minimum: float | int | None = 0,
+        maximum: float | int | None = None,
         unit: str | None = None,
         note_expression: str | None = None,
         kind: InputKind = "number",
@@ -118,8 +118,8 @@ class SliderInput(NumberInput):
         self,
         label: str,
         precision: int = 0,
-        controls_step: float | (int | None) = None,
-        slider_step: float | (int | None) = None,
+        controls_step: float | int | None = None,
+        slider_step: float | int | None = None,
         minimum: float | int = 0,
         maximum: float | int = 100,
         default: float | int = 50,

--- a/backend/src/nodes/properties/inputs/numeric_inputs.py
+++ b/backend/src/nodes/properties/inputs/numeric_inputs.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import math
-from typing import List, Literal, Tuple, Union
+from typing import Literal
 
 import navi
 from api import BaseInput, InputConversion, InputKind
@@ -8,11 +10,11 @@ from ...utils.utils import round_half_up
 
 
 def clamp_number(
-    value: Union[float, int],
+    value: float | int,
     precision: int,
-    min_value: Union[float, int, None],
-    max_value: Union[float, int, None],
-) -> Union[float, int]:
+    min_value: float | (int | None),
+    max_value: float | (int | None),
+) -> float | int:
     # Convert proper number type
     value = round_half_up(value) if precision == 0 else round(value, precision)
 
@@ -30,8 +32,8 @@ def clamp_number(
 
 
 def get_number_type(
-    min_value: Union[float, int, None],
-    max_value: Union[float, int, None],
+    min_value: float | (int | None),
+    max_value: float | (int | None),
     precision: int,
 ) -> navi.ExpressionJson:
     if precision > 0:
@@ -47,12 +49,12 @@ class NumberInput(BaseInput):
         self,
         label: str,
         precision: int = 0,
-        controls_step: Union[float, int, None] = None,
-        default: Union[float, int] = 0,
-        minimum: Union[float, int, None] = 0,
-        maximum: Union[float, int, None] = None,
-        unit: Union[str, None] = None,
-        note_expression: Union[str, None] = None,
+        controls_step: float | (int | None) = None,
+        default: float | int = 0,
+        minimum: float | (int | None) = 0,
+        maximum: float | (int | None) = None,
+        unit: str | None = None,
+        note_expression: str | None = None,
         kind: InputKind = "number",
         hide_trailing_zeros: bool = True,
         hide_label: bool = False,
@@ -61,7 +63,7 @@ class NumberInput(BaseInput):
         super().__init__("number", label, kind=kind, has_handle=has_handle)
         self.precision = precision
         # controls_step is for increment/decrement arrows.
-        self.controls_step: Union[float, int] = (
+        self.controls_step: float | int = (
             controls_step if controls_step is not None else 10**-precision
         )
         self.default = default
@@ -116,16 +118,16 @@ class SliderInput(NumberInput):
         self,
         label: str,
         precision: int = 0,
-        controls_step: Union[float, int, None] = None,
-        slider_step: Union[float, int, None] = None,
-        minimum: Union[float, int] = 0,
-        maximum: Union[float, int] = 100,
-        default: Union[float, int] = 50,
-        unit: Union[str, None] = None,
-        note_expression: Union[str, None] = None,
-        ends: Tuple[Union[str, None], Union[str, None]] = (None, None),
+        controls_step: float | (int | None) = None,
+        slider_step: float | (int | None) = None,
+        minimum: float | int = 0,
+        maximum: float | int = 100,
+        default: float | int = 50,
+        unit: str | None = None,
+        note_expression: str | None = None,
+        ends: tuple[str | None, str | None] = (None, None),
         hide_trailing_zeros: bool = False,
-        gradient: Union[List[str], None] = None,
+        gradient: list[str] | None = None,
         scale: Literal["linear", "log", "log-offset", "sqrt"] = "linear",
         has_handle: bool = True,
     ):

--- a/backend/src/nodes/properties/outputs/numpy_outputs.py
+++ b/backend/src/nodes/properties/outputs/numpy_outputs.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import base64
-from typing import Optional, Tuple
 
 import cv2
 import numpy as np
@@ -48,7 +49,7 @@ class ImageOutput(NumPyOutput):
         image_type: navi.ExpressionJson = "Image",
         kind: OutputKind = "image",
         has_handle: bool = True,
-        channels: Optional[int] = None,
+        channels: int | None = None,
         assume_normalized: bool = False,
     ):
         super().__init__(
@@ -58,7 +59,7 @@ class ImageOutput(NumPyOutput):
             has_handle=has_handle,
         )
 
-        self.channels: Optional[int] = channels
+        self.channels: int | None = channels
         self.assume_normalized: bool = assume_normalized
 
     def get_broadcast_data(self, value: np.ndarray):
@@ -119,7 +120,7 @@ def preview_encode(
     target_size: int = 512,
     grace: float = 1.2,
     lossless: bool = False,
-) -> Tuple[str, np.ndarray]:
+) -> tuple[str, np.ndarray]:
     """
     resize the image, so the preview loads faster and doesn't lag the UI
     512 was chosen as the default target because a 512x512 RGBA 8bit PNG is at most 1MB in size

--- a/backend/src/nodes/properties/outputs/pytorch_outputs.py
+++ b/backend/src/nodes/properties/outputs/pytorch_outputs.py
@@ -1,4 +1,4 @@
-from typing import List
+from __future__ import annotations
 
 import navi
 from api import BaseOutput, OutputKind
@@ -7,7 +7,7 @@ from ...impl.pytorch.types import PyTorchModel
 from ...utils.format import format_channel_numbers
 
 
-def _get_sizes(value: PyTorchModel) -> List[str]:
+def _get_sizes(value: PyTorchModel) -> list[str]:
     if "SRVGG" in value.model_arch:
         return [f"{value.num_feat}nf", f"{value.num_conv}nc"]
     elif (

--- a/backend/src/nodes/utils/checked_cast.py
+++ b/backend/src/nodes/utils/checked_cast.py
@@ -1,8 +1,10 @@
-from typing import Type, TypeVar
+from __future__ import annotations
+
+from typing import TypeVar
 
 T = TypeVar("T")
 
 
-def checked_cast(t: Type[T], value) -> T:
+def checked_cast(t: type[T], value) -> T:
     assert isinstance(value, t), f"Value is {type(value)}, must be type {t}"
     return value

--- a/backend/src/nodes/utils/format.py
+++ b/backend/src/nodes/utils/format.py
@@ -1,4 +1,6 @@
-from typing import Callable, Iterable, List, Literal, TypeVar
+from __future__ import annotations
+
+from typing import Callable, Iterable, Literal, TypeVar
 
 T = TypeVar("T")
 Conj = Literal["and", "or"]
@@ -22,7 +24,7 @@ def join_english(
 
 
 def format_image_with_channels(
-    channels: List[int],
+    channels: list[int],
     conj: Conj = "and",
     plural: bool = False,
 ) -> str:
@@ -44,7 +46,7 @@ def format_image_with_channels(
 
 
 def format_color_with_channels(
-    channels: List[int],
+    channels: list[int],
     conj: Conj = "and",
     plural: bool = False,
 ) -> str:

--- a/backend/src/nodes/utils/format.py
+++ b/backend/src/nodes/utils/format.py
@@ -29,7 +29,7 @@ def format_image_with_channels(
     assert len(channels) > 0
 
     named = {1: "grayscale", 3: "RGB", 4: "RGBA"}
-    if all([x in named for x in channels]):
+    if all(x in named for x in channels):
         if plural:
             return join_english(channels, lambda c: named[c], conj=conj) + " images"
         else:
@@ -51,7 +51,7 @@ def format_color_with_channels(
     assert len(channels) > 0
 
     named = {1: "grayscale", 3: "RGB", 4: "RGBA"}
-    if all([x in named for x in channels]):
+    if all(x in named for x in channels):
         if plural:
             return join_english(channels, lambda c: named[c], conj=conj) + " colors"
         else:

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/utility/interpolate_models.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/utility/interpolate_models.py
@@ -20,7 +20,7 @@ def perform_interp(model_a: dict, model_b: dict, amount: int):
         amount_b = amount / 100
         amount_a = 1 - amount_b
 
-        state_dict = dict()
+        state_dict = {}
         for k, v_1 in model_a.items():
             v_2 = model_b[k]
             state_dict[k] = (amount_a * v_1) + (amount_b * v_2)

--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/load_images.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/load_images.py
@@ -40,7 +40,7 @@ def list_glob(directory: str, globexpr: str, ext_filter: list[str]) -> list[str]
     )
 
     return sorted(
-        list(set(map(lambda f: str(Path(directory) / f), filtered))),
+        {str(Path(directory) / f) for f in filtered},
         key=alphanumeric_sort,
     )
 

--- a/backend/src/packages/chaiNNer_standard/image/video_frames/save_video.py
+++ b/backend/src/packages/chaiNNer_standard/image/video_frames/save_video.py
@@ -213,12 +213,12 @@ def save_video_node(
     video_save_path = os.path.join(save_dir, f"{video_name}.{extension}")
 
     # Common output settings
-    output_params = dict(
-        filename=video_save_path,
-        pix_fmt="yuv420p",
-        r=fps,
-        movflags="faststart",
-    )
+    output_params = {
+        "filename": video_save_path,
+        "pix_fmt": "yuv420p",
+        "r": fps,
+        "movflags": "faststart",
+    }
 
     # Append parameters
     output_params["vcodec"] = encoder.value
@@ -230,7 +230,7 @@ def save_video_node(
         output_params["crf"] = crf
 
     # Append additional parameters
-    global_params = list()
+    global_params = []
     if advanced and additional_parameters is not None:
         additional_parameters = " " + " ".join(additional_parameters.split())
         additional_parameters_array = additional_parameters.split(" -")[1:]
@@ -313,10 +313,10 @@ def save_video_node(
             audio_video_path = f"{base}_av{ext}"
 
             # Default and auto -> copy
-            output_params = dict(
-                vcodec="copy",
-                acodec="copy",
-            )
+            output_params = {
+                "vcodec": "copy",
+                "acodec": "copy",
+            }
             if writer.container == VideoContainer.WEBM:
                 if writer.audio_settings in [
                     AudioSettings.TRANSCODE,

--- a/backend/src/packages/chaiNNer_standard/image_filter/blur/lens_blur.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/blur/lens_blur.py
@@ -106,9 +106,9 @@ def lens_blur(
     ]
     components = normalize_kernels(components, parameters)
     img = np.power(img, exposure_gamma)
-    component_output = list()
+    component_output = []
     for component, component_params in zip(components, parameters):
-        channels = list()
+        channels = []
         component_real = np.real(component)
         component_imag = np.imag(component)
         component_real_t = component_real.transpose()

--- a/backend/src/packages/chaiNNer_standard/utility/random/derive_seed.py
+++ b/backend/src/packages/chaiNNer_standard/utility/random/derive_seed.py
@@ -53,7 +53,7 @@ def _to_bytes(s: Source) -> bytes:
     ],
 )
 def derive_seed_node(seed: Seed, *sources: Source | None) -> Seed:
-    if all([s is None for s in sources]):
+    if all(s is None for s in sources):
         # return seed as is if there are no sources of randomness
         # this is useful for extracting out seeds
         return seed

--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -218,8 +218,8 @@ class _Timer:
 
 
 def compute_broadcast(output: Output, node_outputs: Iterable[BaseOutput]):
-    data: dict[OutputId, object] = dict()
-    types: dict[OutputId, object] = dict()
+    data: dict[OutputId, object] = {}
+    types: dict[OutputId, object] = {}
     for index, node_output in enumerate(node_outputs):
         try:
             value = output[index]

--- a/backend/src/response.py
+++ b/backend/src/response.py
@@ -1,4 +1,6 @@
-from typing import Literal, Optional, TypedDict, Union
+from __future__ import annotations
+
+from typing import Literal, TypedDict
 
 from events import ExecutionErrorSource
 from process import NodeExecutionError
@@ -13,7 +15,7 @@ class ErrorResponse(TypedDict):
     type: Literal["error"]
     message: str
     exception: str
-    source: Optional[ExecutionErrorSource]
+    source: ExecutionErrorSource | None
 
 
 class NoExecutorResponse(TypedDict):
@@ -32,8 +34,8 @@ def success_response(message: str) -> SuccessResponse:
 
 def error_response(
     message: str,
-    exception: Union[str, Exception],
-    source: Optional[ExecutionErrorSource] = None,
+    exception: str | Exception,
+    source: ExecutionErrorSource | None = None,
 ) -> ErrorResponse:
     if source is None and isinstance(exception, NodeExecutionError):
         source = {

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -75,7 +75,7 @@ class SSEFilter(logging.Filter):
     def filter(self, record):
         request = record.request  # type: ignore
         return not (
-            (request.endswith("/sse") or request.endswith("/setup-sse"))
+            (request.endswith(("/sse", "/setup-sse")))
             and record.status == 200  # type: ignore
         )
 

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -50,7 +50,7 @@ class AppContext:
     def __init__(self):
         self.config: ServerConfig = None  # type: ignore
         self.executor: Optional[Executor] = None
-        self.cache: Dict[NodeId, NodeOutput] = dict()
+        self.cache: Dict[NodeId, NodeOutput] = {}
         # This will be initialized by after_server_start.
         # This is necessary because we don't know Sanic's event loop yet.
         self.queue: EventQueue = None  # type: ignore

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -75,8 +75,7 @@ class SSEFilter(logging.Filter):
     def filter(self, record):
         request = record.request  # type: ignore
         return not (
-            (request.endswith(("/sse", "/setup-sse")))
-            and record.status == 200  # type: ignore
+            (request.endswith(("/sse", "/setup-sse"))) and record.status == 200  # type: ignore
         )
 
 

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import gc
 import importlib
@@ -8,7 +10,7 @@ import traceback
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict, dataclass
 from json import dumps as stringify
-from typing import Dict, List, Optional, Tuple, TypedDict, Union
+from typing import TypedDict
 
 import psutil
 from sanic import Sanic
@@ -49,8 +51,8 @@ from system import is_arm_mac
 class AppContext:
     def __init__(self):
         self.config: ServerConfig = None  # type: ignore
-        self.executor: Optional[Executor] = None
-        self.cache: Dict[NodeId, NodeOutput] = {}
+        self.executor: Executor | None = None
+        self.cache: dict[NodeId, NodeOutput] = {}
         # This will be initialized by after_server_start.
         # This is necessary because we don't know Sanic's event loop yet.
         self.queue: EventQueue = None  # type: ignore
@@ -58,7 +60,7 @@ class AppContext:
         self.pool = ThreadPoolExecutor(max_workers=4)
 
     @staticmethod
-    def get(app_instance: Sanic) -> "AppContext":
+    def get(app_instance: Sanic) -> AppContext:
         assert isinstance(app_instance.ctx, AppContext)
         return app_instance.ctx
 
@@ -144,7 +146,7 @@ async def nodes(_request: Request):
 
 
 class RunRequest(TypedDict):
-    data: List[JsonNode]
+    data: list[JsonNode]
     options: JsonExecutionOptions
     sendBroadcastData: bool
 
@@ -216,7 +218,7 @@ async def run(request: Request):
 
 class RunIndividualRequest(TypedDict):
     id: NodeId
-    inputs: List[object]
+    inputs: list[object]
     schemaId: str
     options: JsonExecutionOptions
 
@@ -457,7 +459,7 @@ async def get_packages(_request: Request):
 async def get_installed_dependencies(_request: Request):
     await nodes_available()
 
-    installed_deps: Dict[str, str] = {}
+    installed_deps: dict[str, str] = {}
     for package in api.registry.packages.values():
         for pkg_dep in package.dependencies:
             installed_version = installed_packages.get(pkg_dep.pypi_name, None)
@@ -471,13 +473,13 @@ async def get_installed_dependencies(_request: Request):
 async def get_features(_request: Request):
     await nodes_available()
 
-    features: List[Tuple[api.Feature, api.Package]] = []
+    features: list[tuple[api.Feature, api.Package]] = []
     for package in api.registry.packages.values():
         for feature in package.features:
             features.append((feature, package))
 
     # check all features in parallel
-    async def check(feature: api.Feature) -> Union[api.FeatureState, None]:
+    async def check(feature: api.Feature) -> api.FeatureState | None:
         if feature.behavior is None:
             # no behavior assigned
             return None
@@ -488,7 +490,7 @@ async def get_features(_request: Request):
             return api.FeatureState.disabled(str(e))
 
     # because good API design just isn't pythonic, asyncio.gather will return List[Any].
-    results: List[Union[api.FeatureState, None]] = await asyncio.gather(
+    results: list[api.FeatureState | None] = await asyncio.gather(
         *[check(f) for f, _ in features]
     )
 
@@ -537,8 +539,8 @@ async def import_packages(
     config: ServerConfig,
     update_progress_cb: UpdateProgressFn,
 ):
-    async def install_deps(dependencies: List[api.Dependency]):
-        dep_info: List[DependencyInfo] = [
+    async def install_deps(dependencies: list[api.Dependency]):
+        dep_info: list[DependencyInfo] = [
             {
                 "package_name": dep.pypi_name,
                 "display_name": dep.display_name,
@@ -559,7 +561,7 @@ async def import_packages(
 
     logger.info("Checking dependencies...")
 
-    to_install: List[api.Dependency] = []
+    to_install: list[api.Dependency] = []
     for package in api.registry.packages.values():
         logger.info(f"Checking dependencies for {package.name}...")
 
@@ -594,7 +596,7 @@ async def import_packages(
 
     load_errors = api.registry.load_nodes(__file__)
     if len(load_errors) > 0:
-        import_errors: List[api.LoadErrorInfo] = []
+        import_errors: list[api.LoadErrorInfo] = []
         for e in load_errors:
             if not isinstance(e.error, ModuleNotFoundError):
                 logger.warning(f"Failed to load {e.module} ({e.file}):")
@@ -620,7 +622,7 @@ async def setup(sanic_app: Sanic):
     setup_queue = AppContext.get(sanic_app).setup_queue
 
     async def update_progress(
-        message: str, progress: float, status_progress: Union[float, None] = None
+        message: str, progress: float, status_progress: float | None = None
     ):
         await setup_queue.put_and_wait(
             {

--- a/backend/src/util.py
+++ b/backend/src/util.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import time
-from typing import Callable, Tuple, TypeVar
+from typing import Callable, TypeVar
 
 T = TypeVar("T")
 
 
-def timed_supplier(supplier: Callable[[], T]) -> Callable[[], Tuple[T, float]]:
+def timed_supplier(supplier: Callable[[], T]) -> Callable[[], tuple[T, float]]:
     def wrapper():
         start = time.time()
         result = supplier()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,19 @@ extend-select = [
     "B",   # flake8-bugbear
     # "A",   # flake8-builtins
     # "COM", # flake8-commas
-    "C4", # flake8-comprehensions
-    "FA", # flake8-future-annotations
+    "C4",  # flake8-comprehensions
+    "FA",  # flake8-future-annotations
+    "ISC", # flake8-implicit-str-concat
+    "ICN", # flake8-import-conventions
+    "G",   # flake8-logging-format
+    # "INP", # flake8-implicit-namespaces
+    "PIE", # flake8-pie
+    # "PYI", # flake8-pyi
+    "Q", # flake8-quotes
+    # "RET", # flake8-return
+    "SLF", # flake8-self
+    # "SIM", # flake8-simplify
+    # "TCH", # flake8-tidy-imports
 
 ]
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ ignore = [
     "PLW0603", # Using the global statement
     "N999",    # Invalid module name (which triggers for chaiNNer)
     "N818",    # Exception name should end in Error
+    "ISC001",  # Implicit string concatenation, conflicts with formatter
 ]
 [tool.ruff.format]
 # Like Black, use double quotes for strings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ extend-select = [
     # "A",   # flake8-builtins
     # "COM", # flake8-commas
     "C4", # flake8-comprehensions
+    "FA", # flake8-future-annotations
 
 ]
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,10 @@ extend-select = [
     "PL",  # pylint
     "RUF", # ruff
     "B",   # flake8-bugbear
+    # "A",   # flake8-builtins
+    # "COM", # flake8-commas
+    "C4", # flake8-comprehensions
+
 ]
 ignore = [
     "E501",    # Line too long


### PR DESCRIPTION
This is to be rebased after #2305. I wanted to keep these separate as to not grow the size of that PR.

We were missing a bunch of `from __future__ import annotations` in files. This means that we also missed a bunch of the `List -> list` types of fixes in those files. So this rule fixes both the fact that those files would break in old python versions, and it gets rid of the typing imports in those files.

Also, the comprehensions rule improved code in a few places.

And I enabled some rules that actively changed nothing, and left some commented that i plan on working through later.