### PR TITLE
Move type-only imports into type checking block (ruff TCH rule)

### DIFF
--- a/backend/src/api/api.py
+++ b/backend/src/api/api.py
@@ -4,6 +4,7 @@ import importlib
 import os
 from dataclasses import dataclass, field
 from typing import (
+    TYPE_CHECKING,
     Awaitable,
     Callable,
     Generic,
@@ -16,10 +17,7 @@ from typing import (
 
 from sanic.log import logger
 
-import navi
-
 from .group import Group, GroupId, NestedGroup, NestedIdGroup
-from .input import BaseInput
 from .node_check import (
     NAME_CHECK_LEVEL,
     TYPE_CHECK_LEVEL,
@@ -28,9 +26,14 @@ from .node_check import (
     check_naming_conventions,
     check_schema_types,
 )
-from .output import BaseOutput
 from .settings import SettingsJson, get_execution_options
 from .types import InputId, NodeType, OutputId, RunFn
+
+if TYPE_CHECKING:
+    import navi
+
+    from .input import BaseInput
+    from .output import BaseOutput
 
 KB = 1024**1
 MB = 1024**2

--- a/backend/src/api/input.py
+++ b/backend/src/api/input.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Literal, Optional, TypedDict, Union
-
-import navi
+from typing import TYPE_CHECKING, Any, Literal, Optional, TypedDict, Union
 
 from .types import InputId
+
+if TYPE_CHECKING:
+    import navi
 
 InputKind = Literal[
     "number",

--- a/backend/src/api/node_check.py
+++ b/backend/src/api/node_check.py
@@ -5,10 +5,11 @@ import inspect
 import os
 import pathlib
 from enum import Enum
-from typing import Any, Callable, NewType, Union, cast, get_args
+from typing import TYPE_CHECKING, Any, Callable, NewType, Union, cast, get_args
 
-from .input import BaseInput
-from .output import BaseOutput
+if TYPE_CHECKING:
+    from .input import BaseInput
+    from .output import BaseOutput
 
 _Ty = NewType("_Ty", object)
 

--- a/backend/src/api/output.py
+++ b/backend/src/api/output.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from typing import Any, Literal
-
-import navi
+from typing import TYPE_CHECKING, Any, Literal
 
 from .types import OutputId
+
+if TYPE_CHECKING:
+    import navi
 
 OutputKind = Literal["image", "large-image", "tagged", "generic"]
 

--- a/backend/src/chain/cache.py
+++ b/backend/src/chain/cache.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import gc
-from typing import Generic, Iterable, TypeVar
+from typing import TYPE_CHECKING, Generic, Iterable, TypeVar
 
 from sanic.log import logger
 
-from api import NodeId
-
 from .chain import Chain, Edge, FunctionNode, NewIteratorNode
+
+if TYPE_CHECKING:
+    from api import NodeId
 
 
 class CacheStrategy:

--- a/backend/src/chain/input.py
+++ b/backend/src/chain/input.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
-from api import NodeId
+if TYPE_CHECKING:
+    from api import NodeId
 
 
 class EdgeInput:

--- a/backend/src/chain/json.py
+++ b/backend/src/chain/json.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal, TypedDict, Union
-
-from api import NodeId
+from typing import TYPE_CHECKING, Literal, TypedDict, Union
 
 from .chain import (
     Chain,
@@ -14,6 +12,9 @@ from .chain import (
     NewIteratorNode,
 )
 from .input import EdgeInput, Input, InputMap, ValueInput
+
+if TYPE_CHECKING:
+    from api import NodeId
 
 
 class JsonEdgeInput(TypedDict):

--- a/backend/src/dependencies/store.py
+++ b/backend/src/dependencies/store.py
@@ -5,10 +5,12 @@ import os
 import re
 import subprocess
 import sys
-from logging import Logger
-from typing import TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
-from custom_types import UpdateProgressFn
+if TYPE_CHECKING:
+    from logging import Logger
+
+    from custom_types import UpdateProgressFn
 
 python_path = sys.executable
 dir_path = os.path.dirname(os.path.realpath(__file__))

--- a/backend/src/nodes/groups.py
+++ b/backend/src/nodes/groups.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Iterable, List, Literal, Tuple, TypedDict, Union
+from typing import TYPE_CHECKING, Iterable, List, Literal, Tuple, TypedDict, Union
 
-import navi
 from api import BaseInput, InputId, NestedGroup, group
+
+if TYPE_CHECKING:
+    import navi
 
 InputValue = Union[int, str]
 EnumValues = Union[

--- a/backend/src/nodes/impl/color/convert.py
+++ b/backend/src/nodes/impl/color/convert.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Callable, Generic, Iterable, TypeVar
+from typing import TYPE_CHECKING, Callable, Generic, Iterable, TypeVar
 
-import numpy as np
 from sanic.log import logger
 
 from .convert_data import color_spaces, color_spaces_or_detectors, conversions
@@ -14,6 +13,9 @@ from .convert_model import (
     assert_input_channels,
     assert_output_channels,
 )
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 def color_space_from_id(id_: int) -> ColorSpace:

--- a/backend/src/nodes/impl/dds/texconv.py
+++ b/backend/src/nodes/impl/dds/texconv.py
@@ -7,13 +7,16 @@ import subprocess
 import sys
 import uuid
 from tempfile import mkdtemp
+from typing import TYPE_CHECKING
 
-import numpy as np
 from sanic.log import logger
 
 from ...utils.utils import split_file_path
 from ..image_utils import cv_save_image
 from .format import SRGB_FORMATS, DxgiFormat
+
+if TYPE_CHECKING:
+    import numpy as np
 
 __TEXCONV_DIR = os.path.join(
     os.path.dirname(sys.modules["__main__"].__file__),  # type: ignore

--- a/backend/src/nodes/impl/ncnn/session.py
+++ b/backend/src/nodes/impl/ncnn/session.py
@@ -12,9 +12,13 @@ except ImportError:
 
     use_gpu = False
 
-from packages.chaiNNer_ncnn.settings import NcnnSettings
 
-from .model import NcnnModelWrapper
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from packages.chaiNNer_ncnn.settings import NcnnSettings
+
+    from .model import NcnnModelWrapper
 
 
 def create_ncnn_net(model: NcnnModelWrapper, settings: NcnnSettings) -> ncnn.Net:

--- a/backend/src/nodes/impl/onnx/auto_split.py
+++ b/backend/src/nodes/impl/onnx/auto_split.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import gc
+from typing import TYPE_CHECKING
 
 import numpy as np
-import onnxruntime as ort
 
 from ..upscale.auto_split import Tiler, auto_split
 from .np_tensor_utils import np2nptensor, nptensor2np
+
+if TYPE_CHECKING:
+    import onnxruntime as ort
 
 
 def onnx_auto_split(

--- a/backend/src/nodes/impl/onnx/np_tensor_utils.py
+++ b/backend/src/nodes/impl/onnx/np_tensor_utils.py
@@ -45,7 +45,7 @@ def np_rgba_to_bgra(img: np.ndarray) -> np.ndarray:
 def np2nptensor(
     img: np.ndarray,
     bgr2rgb=True,
-    data_range=1.0,  # pylint: disable=unused-argument
+    data_range=1.0,  # noqa: ARG001
     normalize=False,
     change_range=True,
     add_batch=True,

--- a/backend/src/nodes/impl/onnx/onnx_to_ncnn.py
+++ b/backend/src/nodes/impl/onnx/onnx_to_ncnn.py
@@ -1,12 +1,10 @@
 # ruff: noqa: N806
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import onnx.numpy_helper as onph
-from google.protobuf.internal.containers import (
-    RepeatedCompositeFieldContainer,
-    RepeatedScalarFieldContainer,
-)
 from onnx.onnx_pb import AttributeProto, GraphProto, ModelProto, NodeProto, TensorProto
 from sanic.log import logger
 
@@ -42,6 +40,12 @@ from .tensorproto_utils import (
     get_tensor_proto_data_size,
     set_node_attr_ai,
 )
+
+if TYPE_CHECKING:
+    from google.protobuf.internal.containers import (
+        RepeatedCompositeFieldContainer,
+        RepeatedScalarFieldContainer,
+    )
 
 UOT = UnaryOpTypes
 BOT = BinaryOpTypes

--- a/backend/src/nodes/impl/onnx/session.py
+++ b/backend/src/nodes/impl/onnx/session.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from weakref import WeakKeyDictionary
 
 import onnxruntime as ort
 
-from .model import OnnxModel
+if TYPE_CHECKING:
+    from .model import OnnxModel
 
 
 def create_inference_session(

--- a/backend/src/nodes/impl/onnx/utils.py
+++ b/backend/src/nodes/impl/onnx/utils.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import onnxoptimizer
-import onnxruntime as ort
-from onnx.onnx_pb import ModelProto
+
+if TYPE_CHECKING:
+    import onnxruntime as ort
+    from onnx.onnx_pb import ModelProto
 
 OnnxInputShape = Literal["BCHW", "BHWC"]
 

--- a/backend/src/nodes/impl/pytorch/auto_split.py
+++ b/backend/src/nodes/impl/pytorch/auto_split.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import gc
+from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
 
 from ..upscale.auto_split import Split, Tiler, auto_split
-from .types import PyTorchModel
 from .utils import np2tensor, safe_cuda_cache_empty, tensor2np
+
+if TYPE_CHECKING:
+    from .types import PyTorchModel
 
 
 @torch.inference_mode()

--- a/backend/src/nodes/impl/pytorch/pix_transform/auto_split.py
+++ b/backend/src/nodes/impl/pytorch/pix_transform/auto_split.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import gc
+from typing import TYPE_CHECKING
 
 import numpy as np
-import torch
 
 from ....utils.utils import Region, Size, get_h_w_c
 from ...image_op import to_op
@@ -13,6 +13,9 @@ from ...upscale.passthrough import passthrough_single_color
 from ...upscale.tiler import Tiler
 from ..utils import safe_cuda_cache_empty
 from .pix_transform import Params, pix_transform
+
+if TYPE_CHECKING:
+    import torch
 
 
 class _PixTiler(Tiler):

--- a/backend/src/nodes/impl/pytorch/utils.py
+++ b/backend/src/nodes/impl/pytorch/utils.py
@@ -41,7 +41,7 @@ def norm(x: Tensor):
 def np2tensor(
     img: np.ndarray,
     bgr2rgb=True,
-    data_range=1.0,  # pylint: disable=unused-argument
+    data_range=1.0,  # noqa: ARG001
     normalize=False,
     change_range=True,
     add_batch=True,

--- a/backend/src/nodes/impl/rembg/bg.py
+++ b/backend/src/nodes/impl/rembg/bg.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
-import onnxruntime as ort
 from cv2 import (
     BORDER_DEFAULT,
     COLOR_BGR2RGB,
@@ -15,13 +16,16 @@ from cv2 import (
     morphologyEx,
 )
 from PIL import Image
-from PIL.Image import Image as PILImage
 from pymatting import estimate_alpha_cf, estimate_foreground_ml
 from scipy.ndimage import binary_erosion
 
 from ...impl.image_utils import normalize
 from ...utils.utils import get_h_w_c
 from .session_factory import new_session
+
+if TYPE_CHECKING:
+    import onnxruntime as ort
+    from PIL.Image import Image as PILImage
 
 kernel = getStructuringElement(MORPH_ELLIPSE, (3, 3))
 

--- a/backend/src/nodes/impl/rembg/session_base.py
+++ b/backend/src/nodes/impl/rembg/session_base.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
-import onnxruntime as ort
 from PIL import Image
-from PIL.Image import Image as PILImage
+
+if TYPE_CHECKING:
+    import onnxruntime as ort
+    from PIL.Image import Image as PILImage
 
 
 class BaseSession:

--- a/backend/src/nodes/impl/rembg/session_cloth.py
+++ b/backend/src/nodes/impl/rembg/session_cloth.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 from PIL import Image
-from PIL.Image import Image as PILImage
 from scipy.special import log_softmax
 
 from .session_base import BaseSession
+
+if TYPE_CHECKING:
+    from PIL.Image import Image as PILImage
 
 pallete1 = [
     0,

--- a/backend/src/nodes/impl/rembg/session_factory.py
+++ b/backend/src/nodes/impl/rembg/session_factory.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
-import onnxruntime as ort
+from typing import TYPE_CHECKING
 
 from ...impl.onnx.utils import get_input_shape
-from .session_base import BaseSession
 from .session_cloth import ClothSession
 from .session_simple import SimpleSession
+
+if TYPE_CHECKING:
+    import onnxruntime as ort
+
+    from .session_base import BaseSession
 
 
 def new_session(session: ort.InferenceSession) -> BaseSession:

--- a/backend/src/nodes/impl/rembg/session_simple.py
+++ b/backend/src/nodes/impl/rembg/session_simple.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 from PIL import Image
-from PIL.Image import Image as PILImage
 
 from .session_base import BaseSession
+
+if TYPE_CHECKING:
+    from PIL.Image import Image as PILImage
 
 
 class SimpleSession(BaseSession):

--- a/backend/src/nodes/impl/upscale/auto_split.py
+++ b/backend/src/nodes/impl/upscale/auto_split.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
 import math
-from typing import Callable, Union
+from typing import TYPE_CHECKING, Callable, Union
 
 import numpy as np
 from sanic.log import logger
 
 from ...utils.utils import Region, Size, get_h_w_c
 from .exact_split import exact_split
-from .tiler import Tiler
+
+if TYPE_CHECKING:
+    from .tiler import Tiler
 
 
 class Split:

--- a/backend/src/nodes/impl/upscale/grayscale.py
+++ b/backend/src/nodes/impl/upscale/grayscale.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from ..color.convert import convert
 from ..color.convert_data import LAB, RGB
-from ..image_op import ImageOp
+
+if TYPE_CHECKING:
+    from ..image_op import ImageOp
 
 
 class SplitMode(Enum):

--- a/backend/src/packages/chaiNNer_external/external_stable_diffusion/automatic1111/clip_interrogate.py
+++ b/backend/src/packages/chaiNNer_external/external_stable_diffusion/automatic1111/clip_interrogate.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
 
 from nodes.node_cache import cached
 from nodes.properties.inputs import ImageInput
@@ -10,6 +10,9 @@ from ...features import web_ui
 from ...util import encode_base64_image
 from ...web_ui import STABLE_DIFFUSION_INTERROGATE_PATH, get_api
 from .. import auto1111_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 @auto1111_group.register(

--- a/backend/src/packages/chaiNNer_external/external_stable_diffusion/automatic1111/image_to_image.py
+++ b/backend/src/packages/chaiNNer_external/external_stable_diffusion/automatic1111/image_to_image.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
 
 from nodes.groups import seed_group
 from nodes.node_cache import cached
@@ -13,7 +13,6 @@ from nodes.properties.inputs import (
     TextInput,
 )
 from nodes.properties.outputs import ImageOutput
-from nodes.utils.seed import Seed
 from nodes.utils.utils import get_h_w_c
 
 from ...features import web_ui
@@ -27,6 +26,11 @@ from ...web_ui import (
     get_api,
 )
 from .. import auto1111_group
+
+if TYPE_CHECKING:
+    import numpy as np
+
+    from nodes.utils.seed import Seed
 
 
 @auto1111_group.register(

--- a/backend/src/packages/chaiNNer_external/external_stable_diffusion/automatic1111/inpaint.py
+++ b/backend/src/packages/chaiNNer_external/external_stable_diffusion/automatic1111/inpaint.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-
-import numpy as np
+from typing import TYPE_CHECKING
 
 import navi
 from nodes.groups import if_enum_group, seed_group
@@ -16,7 +15,6 @@ from nodes.properties.inputs import (
     TextInput,
 )
 from nodes.properties.outputs import ImageOutput
-from nodes.utils.seed import Seed
 from nodes.utils.utils import get_h_w_c
 
 from ...features import web_ui
@@ -31,6 +29,11 @@ from ...web_ui import (
     get_api,
 )
 from .. import auto1111_group
+
+if TYPE_CHECKING:
+    import numpy as np
+
+    from nodes.utils.seed import Seed
 
 
 class InpaintArea(Enum):

--- a/backend/src/packages/chaiNNer_external/external_stable_diffusion/automatic1111/outpaint.py
+++ b/backend/src/packages/chaiNNer_external/external_stable_diffusion/automatic1111/outpaint.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 from enum import Enum
 from math import ceil
-from typing import Any
-
-import numpy as np
+from typing import TYPE_CHECKING, Any
 
 from nodes.groups import if_enum_group, seed_group
 from nodes.node_cache import cached
@@ -17,7 +15,6 @@ from nodes.properties.inputs import (
     TextInput,
 )
 from nodes.properties.outputs import ImageOutput
-from nodes.utils.seed import Seed
 from nodes.utils.utils import get_h_w_c
 
 from ...features import web_ui
@@ -32,6 +29,11 @@ from ...web_ui import (
     get_api,
 )
 from .. import auto1111_group
+
+if TYPE_CHECKING:
+    import numpy as np
+
+    from nodes.utils.seed import Seed
 
 
 class OutpaintingMethod(Enum):

--- a/backend/src/packages/chaiNNer_external/external_stable_diffusion/automatic1111/text_to_image.py
+++ b/backend/src/packages/chaiNNer_external/external_stable_diffusion/automatic1111/text_to_image.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
 
 from nodes.groups import seed_group
 from nodes.node_cache import cached
@@ -12,7 +12,6 @@ from nodes.properties.inputs import (
     TextInput,
 )
 from nodes.properties.outputs import ImageOutput
-from nodes.utils.seed import Seed
 from nodes.utils.utils import get_h_w_c
 
 from ...features import web_ui
@@ -24,6 +23,11 @@ from ...web_ui import (
     get_api,
 )
 from .. import auto1111_group
+
+if TYPE_CHECKING:
+    import numpy as np
+
+    from nodes.utils.seed import Seed
 
 
 @auto1111_group.register(

--- a/backend/src/packages/chaiNNer_external/external_stable_diffusion/automatic1111/upscale.py
+++ b/backend/src/packages/chaiNNer_external/external_stable_diffusion/automatic1111/upscale.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-
-import numpy as np
+from typing import TYPE_CHECKING
 
 from nodes.groups import Condition, if_enum_group, if_group
 from nodes.node_cache import cached
@@ -25,6 +24,9 @@ from ...web_ui import (
     get_api,
 )
 from .. import auto1111_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 class UpscalerMode(Enum):

--- a/backend/src/packages/chaiNNer_ncnn/ncnn/batch_processing/load_models.py
+++ b/backend/src/packages/chaiNNer_ncnn/ncnn/batch_processing/load_models.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
 from sanic.log import logger
 
 from api import Iterator, IteratorOutputInfo
-from nodes.impl.ncnn.model import NcnnModelWrapper
 from nodes.properties.inputs import DirectoryInput
 from nodes.properties.outputs import (
     DirectoryOutput,
@@ -17,6 +17,9 @@ from nodes.utils.utils import list_all_files_sorted
 
 from .. import batch_processing_group
 from ..io.load_model import load_model_node
+
+if TYPE_CHECKING:
+    from nodes.impl.ncnn.model import NcnnModelWrapper
 
 
 @batch_processing_group.register(

--- a/backend/src/packages/chaiNNer_ncnn/ncnn/processing/upscale_image.py
+++ b/backend/src/packages/chaiNNer_ncnn/ncnn/processing/upscale_image.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from contextlib import contextmanager
 
 import cv2
-import numpy as np
 
 try:
     from ncnn_vulkan import ncnn
@@ -13,11 +12,12 @@ except ImportError:
     from ncnn import ncnn
 
     use_gpu = False
+from typing import TYPE_CHECKING
+
 from sanic.log import logger
 
 from nodes.groups import Condition, if_group
 from nodes.impl.ncnn.auto_split import ncnn_auto_split
-from nodes.impl.ncnn.model import NcnnModelWrapper
 from nodes.impl.ncnn.session import get_ncnn_net
 from nodes.impl.upscale.auto_split_tiles import (
     TileSize,
@@ -38,6 +38,11 @@ from system import is_mac
 
 from ...settings import get_settings
 from .. import processing_group
+
+if TYPE_CHECKING:
+    import numpy as np
+
+    from nodes.impl.ncnn.model import NcnnModelWrapper
 
 
 @contextmanager

--- a/backend/src/packages/chaiNNer_ncnn/ncnn/utility/get_model_scale.py
+++ b/backend/src/packages/chaiNNer_ncnn/ncnn/utility/get_model_scale.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
-from nodes.impl.ncnn.model import NcnnModelWrapper
+from typing import TYPE_CHECKING
+
 from nodes.properties.inputs import NcnnModelInput
 from nodes.properties.outputs import NumberOutput
 
 from .. import utility_group
+
+if TYPE_CHECKING:
+    from nodes.impl.ncnn.model import NcnnModelWrapper
 
 
 @utility_group.register(

--- a/backend/src/packages/chaiNNer_onnx/onnx/batch_processing/load_models.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/batch_processing/load_models.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
 from sanic.log import logger
 
 from api import Iterator, IteratorOutputInfo
-from nodes.impl.onnx.model import OnnxModel
 from nodes.properties.inputs import DirectoryInput
 from nodes.properties.outputs import (
     DirectoryOutput,
@@ -17,6 +17,9 @@ from nodes.utils.utils import list_all_files_sorted
 
 from .. import batch_processing_group
 from ..io.load_model import load_model_node
+
+if TYPE_CHECKING:
+    from nodes.impl.onnx.model import OnnxModel
 
 
 @batch_processing_group.register(

--- a/backend/src/packages/chaiNNer_onnx/onnx/io/save_model.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/io/save_model.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
 from sanic.log import logger
 
-from nodes.impl.onnx.model import OnnxModel
 from nodes.properties.inputs import DirectoryInput, OnnxModelInput, TextInput
 
 from .. import io_group
+
+if TYPE_CHECKING:
+    from nodes.impl.onnx.model import OnnxModel
 
 
 @io_group.register(

--- a/backend/src/packages/chaiNNer_onnx/onnx/processing/remove_background.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/processing/remove_background.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
 
 import navi
 from nodes.groups import Condition, if_group
-from nodes.impl.onnx.model import OnnxRemBg
 from nodes.impl.onnx.session import get_onnx_session
 from nodes.impl.rembg.bg import remove_bg
 from nodes.properties.inputs import ImageInput, OnnxRemBgModelInput
@@ -14,6 +13,11 @@ from nodes.properties.outputs import ImageOutput
 
 from ...settings import get_settings
 from .. import processing_group
+
+if TYPE_CHECKING:
+    import numpy as np
+
+    from nodes.impl.onnx.model import OnnxRemBg
 
 
 @processing_group.register(

--- a/backend/src/packages/chaiNNer_onnx/onnx/processing/upscale_image.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/processing/upscale_image.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-import numpy as np
-import onnxruntime as ort
+from typing import TYPE_CHECKING
+
 from sanic.log import logger
 
 from nodes.groups import Condition, if_group
 from nodes.impl.onnx.auto_split import onnx_auto_split
-from nodes.impl.onnx.model import OnnxModel
 from nodes.impl.onnx.session import get_onnx_session
 from nodes.impl.onnx.utils import get_input_shape, get_output_shape
 from nodes.impl.upscale.auto_split_tiles import (
@@ -27,6 +26,12 @@ from nodes.utils.utils import get_h_w_c
 
 from ...settings import get_settings
 from .. import processing_group
+
+if TYPE_CHECKING:
+    import numpy as np
+    import onnxruntime as ort
+
+    from nodes.impl.onnx.model import OnnxModel
 
 
 def upscale(

--- a/backend/src/packages/chaiNNer_onnx/onnx/utility/convert_to_ncnn.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/utility/convert_to_ncnn.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import onnx
 
 from nodes.impl.ncnn.model import NcnnModelWrapper
-from nodes.impl.onnx.model import OnnxModel
 from nodes.impl.onnx.onnx_to_ncnn import Onnx2NcnnConverter
 from nodes.impl.onnx.utils import safely_optimize_onnx_model
 from nodes.properties.inputs import OnnxFpDropdown, OnnxModelInput
 from nodes.properties.outputs import NcnnModelOutput, TextOutput
 
 from .. import utility_group
+
+if TYPE_CHECKING:
+    from nodes.impl.onnx.model import OnnxModel
 
 FP_MODE_32 = 0
 

--- a/backend/src/packages/chaiNNer_onnx/onnx/utility/interpolate_models.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/utility/interpolate_models.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from typing import TYPE_CHECKING
 
 import numpy as np
 import onnx
-from google.protobuf.internal.containers import RepeatedCompositeFieldContainer
 from onnx import numpy_helper as onph
-from onnx.onnx_pb import TensorProto
 from sanic.log import logger
 
 from nodes.impl.onnx.model import OnnxModel, load_onnx_model
@@ -17,6 +16,10 @@ from nodes.properties.outputs import NumberOutput, OnnxModelOutput
 
 from .. import utility_group
 from ..processing.upscale_image import upscale_image_node
+
+if TYPE_CHECKING:
+    from google.protobuf.internal.containers import RepeatedCompositeFieldContainer
+    from onnx.onnx_pb import TensorProto
 
 
 def perform_interp(

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/io/load_model.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/io/load_model.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
 import torch
 from safetensors.torch import load_file
 from sanic.log import logger
 
 from nodes.impl.pytorch.model_loading import load_state_dict
-from nodes.impl.pytorch.types import PyTorchModel
 from nodes.properties.inputs import PthFileInput
 from nodes.properties.outputs import DirectoryOutput, FileNameOutput, ModelOutput
 from nodes.utils.unpickler import RestrictedUnpickle
@@ -15,6 +15,9 @@ from nodes.utils.utils import split_file_path
 
 from ...settings import get_settings
 from .. import io_group
+
+if TYPE_CHECKING:
+    from nodes.impl.pytorch.types import PyTorchModel
 
 
 def parse_ckpt_state_dict(checkpoint: dict):

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/io/save_model.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/io/save_model.py
@@ -2,15 +2,18 @@ from __future__ import annotations
 
 import os
 from enum import Enum
+from typing import TYPE_CHECKING
 
 import torch
 from safetensors.torch import save_file
 from sanic.log import logger
 
-from nodes.impl.pytorch.types import PyTorchModel
 from nodes.properties.inputs import DirectoryInput, EnumInput, ModelInput, TextInput
 
 from .. import io_group
+
+if TYPE_CHECKING:
+    from nodes.impl.pytorch.types import PyTorchModel
 
 
 class WeightFormat(Enum):

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/iteration/load_models.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/iteration/load_models.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
 from sanic.log import logger
 
 from api import Iterator, IteratorOutputInfo
-from nodes.impl.pytorch.types import PyTorchModel
 from nodes.properties.inputs import DirectoryInput
 from nodes.properties.outputs import DirectoryOutput, NumberOutput, TextOutput
 from nodes.properties.outputs.pytorch_outputs import ModelOutput
@@ -13,6 +13,9 @@ from nodes.utils.utils import list_all_files_sorted
 
 from .. import batch_processing_group
 from ..io.load_model import load_model_node
+
+if TYPE_CHECKING:
+    from nodes.impl.pytorch.types import PyTorchModel
 
 
 @batch_processing_group.register(

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/guided_upscale.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/guided_upscale.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
 
 from nodes.impl.pytorch.pix_transform.auto_split import pix_transform_auto_split
 from nodes.impl.pytorch.pix_transform.pix_transform import Params
@@ -10,6 +10,9 @@ from nodes.properties.outputs import ImageOutput
 
 from ...settings import get_settings
 from .. import processing_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 @processing_group.register(

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/inpaint.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/inpaint.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import gc
+from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
 
 import navi
 from nodes.impl.image_utils import as_3d
-from nodes.impl.pytorch.types import PyTorchInpaintModel
 from nodes.impl.pytorch.utils import np2tensor, safe_cuda_cache_empty, tensor2np
 from nodes.properties.inputs import ImageInput
 from nodes.properties.inputs.pytorch_inputs import InpaintModelInput
@@ -16,6 +16,9 @@ from nodes.utils.utils import get_h_w_c
 
 from ...settings import PyTorchSettings, get_settings
 from .. import processing_group
+
+if TYPE_CHECKING:
+    from nodes.impl.pytorch.types import PyTorchInpaintModel
 
 
 def ceil_modulo(x: int, mod: int) -> int:

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
+
 import torch
 from sanic.log import logger
 
 from nodes.groups import Condition, if_group
 from nodes.impl.pytorch.auto_split import pytorch_auto_split
-from nodes.impl.pytorch.types import PyTorchSRModel
 from nodes.impl.upscale.auto_split_tiles import (
     TileSize,
     estimate_tile_size,
@@ -25,6 +25,11 @@ from nodes.utils.utils import get_h_w_c
 
 from ...settings import PyTorchSettings, get_settings
 from .. import processing_group
+
+if TYPE_CHECKING:
+    import numpy as np
+
+    from nodes.impl.pytorch.types import PyTorchSRModel
 
 
 def upscale(

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/restoration/upscale_face.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/restoration/upscale_face.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
 import cv2
 import numpy as np
@@ -12,7 +13,6 @@ from torchvision.transforms.functional import normalize as tv_normalize
 
 from nodes.groups import Condition, if_group
 from nodes.impl.image_utils import to_uint8
-from nodes.impl.pytorch.types import PyTorchFaceModel
 from nodes.impl.pytorch.utils import np2tensor, safe_cuda_cache_empty, tensor2np
 from nodes.properties.inputs import FaceModelInput, ImageInput, NumberInput, SliderInput
 from nodes.properties.outputs import ImageOutput
@@ -20,6 +20,9 @@ from nodes.utils.utils import get_h_w_c
 
 from ...settings import PyTorchSettings, get_settings
 from .. import restoration_group
+
+if TYPE_CHECKING:
+    from nodes.impl.pytorch.types import PyTorchFaceModel
 
 
 def denormalize(img: np.ndarray):

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/utility/convert_to_ncnn.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/utility/convert_to_ncnn.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from nodes.impl.ncnn.model import NcnnModelWrapper
+from typing import TYPE_CHECKING
+
 from nodes.impl.pytorch.architecture.DAT import DAT
 from nodes.impl.pytorch.architecture.HAT import HAT
 from nodes.impl.pytorch.architecture.OmniSR.OmniSR import OmniSR
@@ -8,12 +9,15 @@ from nodes.impl.pytorch.architecture.SCUNet import SCUNet
 from nodes.impl.pytorch.architecture.SRFormer import SRFormer
 from nodes.impl.pytorch.architecture.Swin2SR import Swin2SR
 from nodes.impl.pytorch.architecture.SwinIR import SwinIR
-from nodes.impl.pytorch.types import PyTorchSRModel
 from nodes.properties.inputs import OnnxFpDropdown, SrModelInput
 from nodes.properties.outputs import NcnnModelOutput, TextOutput
 
 from .. import utility_group
 from .convert_to_onnx import convert_to_onnx_node
+
+if TYPE_CHECKING:
+    from nodes.impl.ncnn.model import NcnnModelWrapper
+    from nodes.impl.pytorch.types import PyTorchSRModel
 
 try:
     from ....chaiNNer_onnx.onnx.utility.convert_to_ncnn import FP_MODE_32

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/utility/convert_to_onnx.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/utility/convert_to_onnx.py
@@ -1,17 +1,20 @@
 from __future__ import annotations
 
 from io import BytesIO
+from typing import TYPE_CHECKING
 
 import torch
 
 from nodes.impl.onnx.model import OnnxGeneric
 from nodes.impl.pytorch.architecture.SCUNet import SCUNet
-from nodes.impl.pytorch.types import PyTorchSRModel
 from nodes.properties.inputs import OnnxFpDropdown, SrModelInput
 from nodes.properties.outputs import OnnxModelOutput, TextOutput
 
 from ...settings import get_settings
 from .. import utility_group
+
+if TYPE_CHECKING:
+    from nodes.impl.pytorch.types import PyTorchSRModel
 
 
 @utility_group.register(

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/utility/get_model_scale.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/utility/get_model_scale.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
-from nodes.impl.pytorch.types import PyTorchModel
+from typing import TYPE_CHECKING
+
 from nodes.properties.inputs import ModelInput
 from nodes.properties.outputs import NumberOutput
 
 from .. import utility_group
+
+if TYPE_CHECKING:
+    from nodes.impl.pytorch.types import PyTorchModel
 
 
 @utility_group.register(

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/utility/interpolate_models.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/utility/interpolate_models.py
@@ -1,18 +1,21 @@
 from __future__ import annotations
 
 import gc
+from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
 from sanic.log import logger
 
 from nodes.impl.pytorch.model_loading import load_state_dict
-from nodes.impl.pytorch.types import PyTorchModel
 from nodes.impl.pytorch.utils import np2tensor, tensor2np
 from nodes.properties.inputs import ModelInput, SliderInput
 from nodes.properties.outputs import ModelOutput, NumberOutput
 
 from .. import utility_group
+
+if TYPE_CHECKING:
+    from nodes.impl.pytorch.types import PyTorchModel
 
 
 def perform_interp(model_a: dict, model_b: dict, amount: int):

--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/load_image_pairs.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/load_image_pairs.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import os
-
-import numpy as np
+from typing import TYPE_CHECKING
 
 from api import Iterator, IteratorOutputInfo
 from nodes.groups import Condition, if_group
@@ -18,6 +17,9 @@ from nodes.utils.utils import list_all_files_sorted
 
 from .. import batch_processing_group
 from ..io.load_image import load_image_node
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 @batch_processing_group.register(

--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/load_images.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/load_images.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-import numpy as np
 from wcmatch import glob
 
 from api import Iterator, IteratorOutputInfo
@@ -20,6 +20,9 @@ from nodes.utils.utils import alphanumeric_sort
 
 from .. import batch_processing_group
 from ..io.load_image import load_image_node
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 def extension_filter(lst: list[str]) -> str:

--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/split_spritesheet.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/split_spritesheet.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
 
 from api import Iterator, IteratorOutputInfo
 from nodes.properties.inputs import ImageInput, NumberInput
@@ -8,6 +8,9 @@ from nodes.properties.outputs import ImageOutput, NumberOutput
 from nodes.utils.utils import get_h_w_c
 
 from .. import batch_processing_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 @batch_processing_group.register(

--- a/backend/src/packages/chaiNNer_standard/image/create_images/create_color.py
+++ b/backend/src/packages/chaiNNer_standard/image/create_images/create_color.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
 
 import navi
-from nodes.impl.color.color import Color
 from nodes.properties.inputs import ColorInput, NumberInput
 from nodes.properties.outputs import ImageOutput
 
 from .. import create_images_group
+
+if TYPE_CHECKING:
+    import numpy as np
+
+    from nodes.impl.color.color import Color
 
 
 @create_images_group.register(

--- a/backend/src/packages/chaiNNer_standard/image/create_images/create_noise.py
+++ b/backend/src/packages/chaiNNer_standard/image/create_images/create_noise.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -18,9 +19,11 @@ from nodes.properties.inputs import (
     SliderInput,
 )
 from nodes.properties.outputs import ImageOutput
-from nodes.utils.seed import Seed
 
 from .. import create_images_group
+
+if TYPE_CHECKING:
+    from nodes.utils.seed import Seed
 
 
 class NoiseMethod(Enum):

--- a/backend/src/packages/chaiNNer_standard/image/io/save_image.py
+++ b/backend/src/packages/chaiNNer_standard/image/io/save_image.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import os
 from enum import Enum
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import cv2
-import numpy as np
 from PIL import Image
 from sanic.log import logger
 
@@ -35,6 +34,9 @@ from nodes.properties.inputs import (
 from nodes.utils.utils import get_h_w_c
 
 from .. import io_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 class ImageFormat(Enum):

--- a/backend/src/packages/chaiNNer_standard/image/io/view_image.py
+++ b/backend/src/packages/chaiNNer_standard/image/io/view_image.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
 
 from nodes.properties.inputs import ImageInput
 from nodes.properties.outputs import LargeImageOutput
 
 from .. import io_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 @io_group.register(

--- a/backend/src/packages/chaiNNer_standard/image/io/view_image_external.py
+++ b/backend/src/packages/chaiNNer_standard/image/io/view_image_external.py
@@ -5,15 +5,18 @@ import platform
 import subprocess
 import time
 from tempfile import mkdtemp
+from typing import TYPE_CHECKING
 
 import cv2
-import numpy as np
 from sanic.log import logger
 
 from nodes.impl.image_utils import to_uint8
 from nodes.properties.inputs import ImageInput
 
 from .. import io_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 @io_group.register(

--- a/backend/src/packages/chaiNNer_standard/image/video_frames/save_video.py
+++ b/backend/src/packages/chaiNNer_standard/image/video_frames/save_video.py
@@ -3,12 +3,10 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from enum import Enum
-from subprocess import Popen
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import cv2
 import ffmpeg
-import numpy as np
 from sanic.log import logger
 
 from api import Collector, IteratorInputInfo
@@ -35,6 +33,11 @@ from nodes.properties.inputs.numeric_inputs import NumberInput
 from nodes.utils.utils import get_h_w_c
 
 from .. import video_frames_group
+
+if TYPE_CHECKING:
+    from subprocess import Popen
+
+    import numpy as np
 
 ffmpeg_path = os.environ.get("STATIC_FFMPEG_PATH", "ffmpeg")
 ffprobe_path = os.environ.get("STATIC_FFPROBE_PATH", "ffprobe")

--- a/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/gamma.py
+++ b/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/gamma.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
 
 from nodes.properties.inputs import BoolInput, ImageInput, SliderInput
 from nodes.properties.outputs import ImageOutput
 from nodes.utils.utils import get_h_w_c
 
 from .. import adjustments_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 @adjustments_group.register(

--- a/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/invert_color.py
+++ b/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/invert_color.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
 
 from nodes.properties.inputs import ImageInput
 from nodes.properties.outputs import ImageOutput
 from nodes.utils.utils import get_h_w_c
 
 from .. import adjustments_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 @adjustments_group.register(

--- a/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/opacity.py
+++ b/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/opacity.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
 
 import navi
 from nodes.impl.pil_utils import convert_to_bgra
@@ -9,6 +9,9 @@ from nodes.properties.outputs import ImageOutput
 from nodes.utils.utils import get_h_w_c
 
 from .. import adjustments_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 @adjustments_group.register(

--- a/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/threshold.py
+++ b/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/threshold.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import TYPE_CHECKING
 
 import cv2
-import numpy as np
 from chainner_ext import binary_threshold
 
 from nodes.groups import if_enum_group
@@ -11,6 +11,9 @@ from nodes.properties.inputs import BoolInput, EnumInput, ImageInput, SliderInpu
 from nodes.properties.outputs import ImageOutput
 
 from .. import adjustments_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 class ThresholdType(Enum):

--- a/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/threshold_adaptive.py
+++ b/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/threshold_adaptive.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import TYPE_CHECKING
 
 import cv2
-import numpy as np
 
 from nodes.impl.image_utils import to_uint8
 from nodes.properties.inputs import EnumInput, ImageInput, NumberInput, SliderInput
 from nodes.properties.outputs import ImageOutput
 
 from .. import adjustments_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 class AdaptiveThresholdType(Enum):

--- a/backend/src/packages/chaiNNer_standard/image_channel/misc/fill_alpha.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/misc/fill_alpha.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import TYPE_CHECKING
 
-import numpy as np
 from chainner_ext import (
     fill_alpha_extend_color,
     fill_alpha_fragment_blur,
@@ -14,6 +14,9 @@ from nodes.properties.inputs import EnumInput, ImageInput
 from nodes.properties.outputs import ImageOutput
 
 from . import node_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 class AlphaFillMethod(Enum):

--- a/backend/src/packages/chaiNNer_standard/image_channel/transparency/merge_transparency.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/transparency/merge_transparency.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 
-from nodes.impl.color.color import Color
 from nodes.impl.image_utils import as_target_channels
 from nodes.properties.inputs import ImageInput
 from nodes.properties.outputs import ImageOutput
 
 from . import node_group
+
+if TYPE_CHECKING:
+    from nodes.impl.color.color import Color
 
 
 @node_group.register(

--- a/backend/src/packages/chaiNNer_standard/image_channel/transparency/split_transparency.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/transparency/split_transparency.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
 
 import navi
 from nodes.impl.image_utils import as_target_channels
@@ -8,6 +8,9 @@ from nodes.properties.inputs import ImageInput
 from nodes.properties.outputs import ImageOutput
 
 from . import node_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 @node_group.register(

--- a/backend/src/packages/chaiNNer_standard/image_dimension/border/create_border.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/border/create_border.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
 
 import navi
 from nodes.groups import if_enum_group
-from nodes.impl.color.color import Color
 from nodes.impl.image_utils import BorderType, create_border
 from nodes.properties.inputs import BorderInput, ColorInput, ImageInput, NumberInput
 from nodes.properties.outputs import ImageOutput
 from nodes.utils.utils import Padding
 
 from .. import border_group
+
+if TYPE_CHECKING:
+    import numpy as np
+
+    from nodes.impl.color.color import Color
 
 
 @border_group.register(

--- a/backend/src/packages/chaiNNer_standard/image_dimension/border/create_edges.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/border/create_edges.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
 
 import navi
 from nodes.groups import if_enum_group
-from nodes.impl.color.color import Color
 from nodes.impl.image_utils import BorderType, create_border
 from nodes.properties.inputs import BorderInput, ColorInput, ImageInput, NumberInput
 from nodes.properties.outputs import ImageOutput
 from nodes.utils.utils import Padding
 
 from .. import border_group
+
+if TYPE_CHECKING:
+    import numpy as np
+
+    from nodes.impl.color.color import Color
 
 
 @border_group.register(

--- a/backend/src/packages/chaiNNer_standard/image_dimension/crop/crop.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/crop/crop.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-
-import numpy as np
+from typing import TYPE_CHECKING
 
 from nodes.groups import if_enum_group
 from nodes.properties.inputs import EnumInput, ImageInput, NumberInput
@@ -10,6 +9,9 @@ from nodes.properties.outputs import ImageOutput
 from nodes.utils.utils import get_h_w_c
 
 from .. import crop_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 class CropMode(Enum):

--- a/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize_factor.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize_factor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
+
 from sanic.log import logger
 
 import navi
@@ -10,6 +11,9 @@ from nodes.properties.outputs import ImageOutput
 from nodes.utils.utils import get_h_w_c, round_half_up
 
 from .. import resize_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 @resize_group.register(

--- a/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize_resolution.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize_resolution.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
+
 from sanic.log import logger
 
 import navi
@@ -9,6 +10,9 @@ from nodes.properties.inputs import ImageInput, InterpolationInput, NumberInput
 from nodes.properties.outputs import ImageOutput
 
 from .. import resize_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 @resize_group.register(

--- a/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize_to_side.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize_to_side.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import TYPE_CHECKING
 
-import numpy as np
 from sanic.log import logger
 
 from nodes.impl.pil_utils import InterpolationMethod, resize
@@ -16,6 +16,9 @@ from nodes.properties.outputs import ImageOutput
 from nodes.utils.utils import get_h_w_c, round_half_up
 
 from .. import resize_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 class SideSelection(Enum):

--- a/backend/src/packages/chaiNNer_standard/image_dimension/resize/tile_fill.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/resize/tile_fill.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
 
 import navi
 from nodes.impl.tile import TileMode, tile_image
@@ -8,6 +8,9 @@ from nodes.properties.inputs import EnumInput, ImageInput, NumberInput
 from nodes.properties.outputs import ImageOutput
 
 from .. import resize_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 @resize_group.register(

--- a/backend/src/packages/chaiNNer_standard/image_dimension/utility/get_dimensions.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/utility/get_dimensions.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
 
 from nodes.properties.inputs import ImageInput
 from nodes.properties.outputs import NumberOutput
 from nodes.utils.utils import get_h_w_c
 
 from .. import utility_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 @utility_group.register(

--- a/backend/src/packages/chaiNNer_standard/image_filter/blur/gaussian_blur.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/blur/gaussian_blur.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
 
 from nodes.groups import linked_inputs_group
 from nodes.impl.image_utils import fast_gaussian_blur
@@ -8,6 +8,9 @@ from nodes.properties.inputs import ImageInput, SliderInput
 from nodes.properties.outputs import ImageOutput
 
 from .. import blur_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 @blur_group.register(

--- a/backend/src/packages/chaiNNer_standard/image_filter/blur/median_blur.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/blur/median_blur.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import cv2
-import numpy as np
 
 from nodes.impl.image_utils import to_uint8
 from nodes.properties.inputs import ImageInput, SliderInput
 from nodes.properties.outputs import ImageOutput
 
 from .. import blur_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 @blur_group.register(

--- a/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/canny_edge_detection.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/canny_edge_detection.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import cv2
-import numpy as np
 
 import navi
 from nodes.impl.image_utils import to_uint8
@@ -9,6 +10,9 @@ from nodes.properties.inputs import ImageInput, NumberInput
 from nodes.properties.outputs import ImageOutput
 
 from .. import miscellaneous_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 @miscellaneous_group.register(

--- a/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/dilate.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/dilate.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import TYPE_CHECKING
 
 import cv2
-import numpy as np
 
 from nodes.properties.inputs import EnumInput, ImageInput, SliderInput
 from nodes.properties.outputs import ImageOutput
 
 from .. import miscellaneous_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 class MorphShape(Enum):

--- a/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/erode.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/erode.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import TYPE_CHECKING
 
 import cv2
-import numpy as np
 
 from nodes.properties.inputs import EnumInput, ImageInput, SliderInput
 from nodes.properties.outputs import ImageOutput
 
 from .. import miscellaneous_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 class MorphShape(Enum):

--- a/backend/src/packages/chaiNNer_standard/image_filter/noise/add_noise.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/noise/add_noise.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-
-import numpy as np
+from typing import TYPE_CHECKING
 
 from nodes.groups import seed_group
 from nodes.impl.noise import (
@@ -15,9 +14,13 @@ from nodes.impl.noise import (
 )
 from nodes.properties.inputs import EnumInput, ImageInput, SeedInput, SliderInput
 from nodes.properties.outputs import ImageOutput
-from nodes.utils.seed import Seed
 
 from .. import noise_group
+
+if TYPE_CHECKING:
+    import numpy as np
+
+    from nodes.utils.seed import Seed
 
 
 class NoiseType(Enum):

--- a/backend/src/packages/chaiNNer_standard/image_filter/quantize/dither.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/quantize/dither.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import TYPE_CHECKING
 
-import numpy as np
 from chainner_ext import (
     UniformQuantization,
     error_diffusion_dither,
@@ -23,6 +23,9 @@ from nodes.properties.inputs import EnumInput, ImageInput, NumberInput
 from nodes.properties.outputs import ImageOutput
 
 from .. import quantize_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 _THRESHOLD_MAP: dict[ThresholdMap, int] = {
     ThresholdMap.BAYER_2: 2,

--- a/backend/src/packages/chaiNNer_standard/image_filter/quantize/dither_palette.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/quantize/dither_palette.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import TYPE_CHECKING
 
-import numpy as np
 from chainner_ext import (
     PaletteQuantization,
     error_diffusion_dither,
@@ -22,6 +22,9 @@ from nodes.properties.outputs import ImageOutput
 from nodes.utils.utils import get_h_w_c
 
 from .. import quantize_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 class PaletteDitherAlgorithm(Enum):

--- a/backend/src/packages/chaiNNer_standard/image_utility/compositing/add_caption.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/compositing/add_caption.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
 
 from nodes.impl.caption import CaptionPosition, add_caption
 from nodes.properties.inputs import EnumInput, ImageInput, NumberInput, TextInput
 from nodes.properties.outputs import ImageOutput
 
 from .. import compositing_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 @compositing_group.register(

--- a/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/change_colorspace.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/change_colorspace.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
 
 import navi
 from nodes.groups import from_to_dropdowns_group, if_enum_group
@@ -19,6 +19,9 @@ from nodes.properties.inputs import (
 from nodes.properties.outputs import ImageOutput
 
 from .. import miscellaneous_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 COLOR_SPACES_WITH_ALPHA_PARTNER = [
     c.id for c in color_spaces if get_alpha_partner(c) is not None

--- a/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/inpaint.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/inpaint.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import TYPE_CHECKING
 
 import cv2
-import numpy as np
 
 import navi
 from nodes.impl.image_utils import to_uint8
@@ -11,6 +11,9 @@ from nodes.properties.inputs import EnumInput, ImageInput, NumberInput
 from nodes.properties.outputs import ImageOutput
 
 from .. import miscellaneous_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 class InpaintAlgorithm(Enum):

--- a/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/pick_color.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/pick_color.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
 
 from nodes.impl.color.color import Color
 from nodes.properties.inputs import ImageInput, NumberInput
@@ -8,6 +8,9 @@ from nodes.properties.outputs import ColorOutput
 from nodes.utils.utils import get_h_w_c
 
 from .. import miscellaneous_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 @miscellaneous_group.register(

--- a/backend/src/packages/chaiNNer_standard/image_utility/modification/flip.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/modification/flip.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
 
 from nodes.impl.image_utils import FlipAxis
 from nodes.properties.inputs import EnumInput, ImageInput
 from nodes.properties.outputs import ImageOutput
 
 from .. import modification_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 @modification_group.register(

--- a/backend/src/packages/chaiNNer_standard/image_utility/modification/rotate.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/modification/rotate.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
 
 from nodes.impl.pil_utils import (
     FillColor,
@@ -18,6 +18,9 @@ from nodes.properties.inputs import (
 from nodes.properties.outputs import ImageOutput
 
 from .. import modification_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 @modification_group.register(

--- a/backend/src/packages/chaiNNer_standard/image_utility/modification/shift.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/modification/shift.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
 
 import navi
 from nodes.impl.image_utils import FillColor, shift
@@ -8,6 +8,9 @@ from nodes.properties.inputs import FillColorDropdown, ImageInput, NumberInput
 from nodes.properties.outputs import ImageOutput
 
 from .. import modification_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 @modification_group.register(

--- a/backend/src/packages/chaiNNer_standard/material_textures/normal_map/add_normals.py
+++ b/backend/src/packages/chaiNNer_standard/material_textures/normal_map/add_normals.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
 
 import navi
 from nodes.impl.normals.addition import AdditionMethod, add_normals
@@ -9,6 +9,9 @@ from nodes.properties.inputs import EnumInput, ImageInput, SliderInput
 from nodes.properties.outputs import ImageOutput
 
 from .. import normal_map_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 @normal_map_group.register(

--- a/backend/src/packages/chaiNNer_standard/material_textures/normal_map/normalize_normal_map.py
+++ b/backend/src/packages/chaiNNer_standard/material_textures/normal_map/normalize_normal_map.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
 
 import navi
 from nodes.impl.normals.util import gr_to_xyz, xyz_to_bgr
@@ -8,6 +8,9 @@ from nodes.properties.inputs import ImageInput
 from nodes.properties.outputs import ImageOutput
 
 from .. import normal_map_group
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 @normal_map_group.register(

--- a/backend/src/packages/chaiNNer_standard/utility/color/color.py
+++ b/backend/src/packages/chaiNNer_standard/utility/color/color.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
-from nodes.impl.color.color import Color
+from typing import TYPE_CHECKING
+
 from nodes.properties.inputs import ColorInput
 from nodes.properties.outputs import ColorOutput
 
 from .. import color_group
+
+if TYPE_CHECKING:
+    from nodes.impl.color.color import Color
 
 
 @color_group.register(

--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -14,7 +14,6 @@ from api import BaseOutput, Collector, InputId, Iterator, NodeData, NodeId, Outp
 from chain.cache import CacheStrategy, OutputCache, StaticCaching, get_cache_strategies
 from chain.chain import Chain, CollectorNode, FunctionNode, NewIteratorNode, Node
 from chain.input import EdgeInput, Input, InputMap
-from events import Event, EventQueue, InputsDict
 from progress_controller import Aborted, ProgressController
 from util import timed_supplier
 

--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
-import asyncio
 import functools
 import gc
 import time
 import uuid
-from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Iterable, List, Union
+from typing import TYPE_CHECKING, Iterable, List, Union
 
 from sanic.log import logger
 
@@ -19,6 +17,12 @@ from chain.input import EdgeInput, Input, InputMap
 from events import Event, EventQueue, InputsDict
 from progress_controller import Aborted, ProgressController
 from util import timed_supplier
+
+if TYPE_CHECKING:
+    import asyncio
+    from concurrent.futures import ThreadPoolExecutor
+
+    from events import Event, EventQueue, InputsDict
 
 Output = List[object]
 

--- a/backend/src/response.py
+++ b/backend/src/response.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from typing import Literal, TypedDict
+from typing import TYPE_CHECKING, Literal, TypedDict
 
-from events import ExecutionErrorSource
 from process import NodeExecutionError
+
+if TYPE_CHECKING:
+    from events import ExecutionErrorSource
 
 
 class SuccessResponse(TypedDict):

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -10,12 +10,11 @@ import traceback
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict, dataclass
 from json import dumps as stringify
-from typing import TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
 import psutil
 from sanic import Sanic
 from sanic.log import access_logger, logger
-from sanic.request import Request
 from sanic.response import json
 from sanic_cors import CORS
 
@@ -32,7 +31,6 @@ from chain.chain import Chain, FunctionNode
 from chain.input import InputMap
 from chain.json import JsonNode, parse_json
 from chain.optimize import optimize
-from custom_types import UpdateProgressFn
 from dependencies.store import DependencyInfo, install_dependencies, installed_packages
 from events import EventQueue, ExecutionErrorData
 from gpu import get_nvidia_helper
@@ -46,6 +44,11 @@ from response import (
 )
 from server_config import ServerConfig
 from system import is_arm_mac
+
+if TYPE_CHECKING:
+    from sanic.request import Request
+
+    from custom_types import UpdateProgressFn
 
 
 class AppContext:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,10 @@ extend-select = [
     "SLF", # flake8-self
     # "SIM", # flake8-simplify
     "TCH", # flake8-tidy-imports
-
+    "ARG", # flake8-arguments
+    # "PTH", # flake8-pathlib
+    # "NPY", # numpy-specific rules
+    # "PERF", # performance rules
 ]
 ignore = [
     "E501",    # Line too long

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ extend-select = [
     # "RET", # flake8-return
     "SLF", # flake8-self
     # "SIM", # flake8-simplify
-    # "TCH", # flake8-tidy-imports
+    "TCH", # flake8-tidy-imports
 
 ]
 ignore = [


### PR DESCRIPTION

Another draft until #2308 is merged and i can rebase this. It changed a lot of files so i want it to be separate. 

This is something really cool that apparently you can do, and this rule handles it automatically

![image](https://github.com/chaiNNer-org/chaiNNer/assets/34788790/aa5d1fa5-927e-4bd1-bf6c-36d9f0940992)
