### PR TITLE
Enable ruff numpy rules

### DIFF
--- a/backend/src/nodes/impl/noise_functions/simplex.py
+++ b/backend/src/nodes/impl/noise_functions/simplex.py
@@ -88,9 +88,8 @@ class SimplexNoise:
             # Use the canonical table from the reference implementation
             self.permutation_table = PERMUTATION_TABLE_ARRAY
         else:
-            np.random.seed(seed)
             self.permutation_table = np.arange(self.gradients.shape[0] * 16)
-            np.random.shuffle(self.permutation_table)
+            np.random.default_rng(seed).shuffle(self.permutation_table)
 
     def evaluate(self, points: np.ndarray):
         n_points = points.shape[0]

--- a/backend/src/nodes/impl/noise_functions/value.py
+++ b/backend/src/nodes/impl/noise_functions/value.py
@@ -10,9 +10,8 @@ class ValueNoise:
         self.values = np.arange(16, dtype="float32")
         self.values = self.values / max(self.values)
 
-        np.random.seed(seed)
         self.permutation_table = np.arange(self.values.size * 16)
-        np.random.shuffle(self.permutation_table)
+        np.random.default_rng(seed).shuffle(self.permutation_table)
 
     def evaluate(self, points: np.ndarray):
         block, fractional = np.divmod(points, 1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ extend-select = [
     "SLF", # flake8-self
     # "SIM", # flake8-simplify
     # "TCH", # flake8-tidy-imports
+    "NPY", # NumPy-specific rules
 
 ]
 ignore = [


### PR DESCRIPTION
The rules mainly point out deprecated stuff, which is good. In this case, it found 2 uses of `np.random.seed` that slipped through.