### PR TITLE
Enable 2 ruff rules to enforce type hints

### DIFF
--- a/backend/src/api/input.py
+++ b/backend/src/api/input.py
@@ -74,7 +74,7 @@ class BaseInput:
         input_type: navi.ExpressionJson,
         label: str,
         kind: InputKind = "generic",
-        has_handle=True,
+        has_handle: bool = True,
         associated_type: Any = None,
     ):
         self.input_type: navi.ExpressionJson = input_type
@@ -145,7 +145,7 @@ class BaseInput:
         self.id = InputId(input_id)
         return self
 
-    def with_docs(self, *description: str, hint=False):
+    def with_docs(self, *description: str, hint: bool = False):
         self.description = "\n\n".join(description)
         self.hint = hint
         return self

--- a/backend/src/api/output.py
+++ b/backend/src/api/output.py
@@ -59,10 +59,10 @@ class BaseOutput:
     def __iter__(self):
         yield from self.to_dict().items()
 
-    def get_broadcast_data(self, _value):
+    def get_broadcast_data(self, _value: object):
         return None
 
-    def get_broadcast_type(self, _value) -> navi.ExpressionJson | None:
+    def get_broadcast_type(self, _value: object) -> navi.ExpressionJson | None:
         return None
 
     def enforce(self, value: object) -> object:

--- a/backend/src/gpu.py
+++ b/backend/src/gpu.py
@@ -77,7 +77,7 @@ class NvidiaHelper:
     def list_gpus(self) -> list[str]:
         return [gpu.name for gpu in self.__gpus]
 
-    def get_current_vram_usage(self, gpu_index=0) -> tuple[int, int, int]:
+    def get_current_vram_usage(self, gpu_index: int = 0) -> tuple[int, int, int]:
         info = nv.nvmlDeviceGetMemoryInfo(self.__gpus[gpu_index].handle)
 
         return info.total, info.used, info.free

--- a/backend/src/nodes/impl/cas.py
+++ b/backend/src/nodes/impl/cas.py
@@ -15,7 +15,7 @@ def _luminance(img: np.ndarray) -> np.ndarray:
     return np.dot(img[..., :3], [0.2126, 0.7152, 0.0722])
 
 
-def create_cas_mask(img: np.ndarray, kernel, bias: float = 2) -> np.ndarray:
+def create_cas_mask(img: np.ndarray, kernel: np.ndarray, bias: float = 2) -> np.ndarray:
     """
     Uses contrast adaptive sharpening's method to create a mask to interpolate between the original
     and sharpened image.
@@ -48,7 +48,7 @@ def create_cas_mask(img: np.ndarray, kernel, bias: float = 2) -> np.ndarray:
 def cas_mix(
     img: np.ndarray,
     sharpened: np.ndarray,
-    kernel,
+    kernel: np.ndarray,
     bias: float = 2,
 ) -> np.ndarray:
     mask = create_cas_mask(img, kernel, bias)

--- a/backend/src/nodes/impl/color_transfer/linear_histogram.py
+++ b/backend/src/nodes/impl/color_transfer/linear_histogram.py
@@ -11,7 +11,7 @@ __maintainer__ = "Daniel Steinberg"
 __link__ = "https://github.com/dstein64/colortrans"
 
 
-def matrix_sqrt(x):
+def matrix_sqrt(x: np.ndarray):
     eig_val, eig_vec = np.linalg.eig(x)
     return eig_vec.dot(np.diag(np.sqrt(eig_val.clip(min=0)))).dot(eig_vec.T)
 

--- a/backend/src/nodes/impl/color_transfer/mean_std.py
+++ b/backend/src/nodes/impl/color_transfer/mean_std.py
@@ -39,7 +39,7 @@ def image_stats(img: np.ndarray):
     return a_mean, a_std, b_mean, b_std, c_mean, c_std
 
 
-def min_max_scale(img: np.ndarray, new_range=(0, 255)):
+def min_max_scale(img: np.ndarray, new_range: tuple[float, float] = (0, 255)):
     """Perform min-max scaling to a NumPy array"""
 
     # Get arrays current min and max

--- a/backend/src/nodes/impl/image_utils.py
+++ b/backend/src/nodes/impl/image_utils.py
@@ -107,10 +107,7 @@ def normalize(img: np.ndarray) -> np.ndarray:
     return np.clip(img, 0, 1)
 
 
-def to_uint8(
-    img: np.ndarray,
-    normalized=False,
-) -> np.ndarray:
+def to_uint8(img: np.ndarray, normalized: bool = False) -> np.ndarray:
     """
     Returns a new uint8 image with the given image data.
 
@@ -125,14 +122,11 @@ def to_uint8(
     return (img * 255).round().astype(np.uint8)
 
 
-def to_uint16(
-    img: np.ndarray,
-    normalized=False,
-) -> np.ndarray:
+def to_uint16(img: np.ndarray, normalized: bool = False) -> np.ndarray:
     """
-    Returns a new uint8 image with the given image data.
+    Returns a new uint16 image with the given image data.
 
-    If `normalized` is `False`, then the image will be normalized before being converted to uint8.
+    If `normalized` is `False`, then the image will be normalized before being converted to uint16.
     """
     if img.dtype == np.uint16:
         return img.copy()

--- a/backend/src/nodes/impl/ncnn/auto_split.py
+++ b/backend/src/nodes/impl/ncnn/auto_split.py
@@ -21,14 +21,14 @@ from ..upscale.auto_split import Split, Tiler, auto_split
 
 def ncnn_auto_split(
     img: np.ndarray,
-    net,
+    net,  # noqa: ANN001
     input_name: str,
     output_name: str,
-    blob_vkallocator,
-    staging_vkallocator,
+    blob_vkallocator,  # noqa: ANN001
+    staging_vkallocator,  # noqa: ANN001
     tiler: Tiler,
 ) -> np.ndarray:
-    def upscale(img: np.ndarray, _):
+    def upscale(img: np.ndarray, _: object):
         ex = net.create_extractor()
         if use_gpu:
             ex.set_blob_vkallocator(blob_vkallocator)

--- a/backend/src/nodes/impl/ncnn/model.py
+++ b/backend/src/nodes/impl/ncnn/model.py
@@ -241,7 +241,7 @@ class NcnnParamCollection:
         except KeyError:
             pass
 
-    def __contains__(self, item) -> bool:
+    def __contains__(self, item: int) -> bool:
         if item in self.param_dict:
             return True
         return False

--- a/backend/src/nodes/impl/onnx/auto_split.py
+++ b/backend/src/nodes/impl/onnx/auto_split.py
@@ -20,7 +20,7 @@ def onnx_auto_split(
 
     is_fp16_model = session.get_inputs()[0].type == "tensor(float16)"
 
-    def upscale(img: np.ndarray, _):
+    def upscale(img: np.ndarray, _: object):
         try:
             lr_img = np2nptensor(img, change_range=False)
             lr_img = lr_img.astype(np.float16) if is_fp16_model else lr_img

--- a/backend/src/nodes/impl/onnx/np_tensor_utils.py
+++ b/backend/src/nodes/impl/onnx/np_tensor_utils.py
@@ -44,11 +44,11 @@ def np_rgba_to_bgra(img: np.ndarray) -> np.ndarray:
 
 def np2nptensor(
     img: np.ndarray,
-    bgr2rgb=True,
-    data_range=1.0,  # pylint: disable=unused-argument
-    normalize=False,
-    change_range=True,
-    add_batch=True,
+    bgr2rgb: bool = True,
+    data_range: float = 1.0,
+    normalize: bool = False,
+    change_range: bool = True,
+    add_batch: bool = True,
 ) -> np.ndarray:
     """Converts a numpy image array into a numpy Tensor array.
     Parameters:
@@ -86,11 +86,11 @@ def np2nptensor(
 
 def nptensor2np(
     img: np.ndarray,
-    rgb2bgr=True,
-    remove_batch=True,
-    data_range=255,
-    denormalize=False,
-    change_range=True,
+    rgb2bgr: bool = True,
+    remove_batch: bool = True,
+    data_range: float = 255,
+    denormalize: bool = False,
+    change_range: bool = True,
     imtype: type = np.uint8,
 ) -> np.ndarray:
     """Converts a Tensor array into a numpy image array.

--- a/backend/src/nodes/impl/onnx/utils.py
+++ b/backend/src/nodes/impl/onnx/utils.py
@@ -9,7 +9,7 @@ from onnx.onnx_pb import ModelProto
 OnnxInputShape = Literal["BCHW", "BHWC"]
 
 
-def as_int(value) -> int | None:
+def as_int(value: object) -> int | None:
     if isinstance(value, int):
         return value
     return None

--- a/backend/src/nodes/impl/pytorch/auto_split.py
+++ b/backend/src/nodes/impl/pytorch/auto_split.py
@@ -21,7 +21,7 @@ def pytorch_auto_split(
     model = model.to(device)
     model = model.half() if use_fp16 else model.float()
 
-    def upscale(img: np.ndarray, _):
+    def upscale(img: np.ndarray, _: object):
         img_tensor = np2tensor(img, change_range=True)
 
         d_img = None

--- a/backend/src/nodes/impl/pytorch/model_loading.py
+++ b/backend/src/nodes/impl/pytorch/model_loading.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Any
+
 from sanic.log import logger
 
 from .architecture.DAT import DAT
@@ -23,7 +27,7 @@ class UnsupportedModel(Exception):
     pass
 
 
-def load_state_dict(state_dict) -> PyTorchModel:
+def load_state_dict(state_dict: dict[str, Any]) -> PyTorchModel:
     logger.debug("Loading state dict into pytorch model arch")
 
     state_dict_keys = list(state_dict.keys())

--- a/backend/src/nodes/impl/pytorch/pix_transform/pix_transform_net.py
+++ b/backend/src/nodes/impl/pytorch/pix_transform/pix_transform_net.py
@@ -57,7 +57,7 @@ class PixTransformNet(nn.Module):
             {"params": self.head_net.parameters(), "weight_decay": reg_head}
         ]
 
-    def forward(self, input_):
+    def forward(self, input_):  # noqa: ANN001
         input_spatial = input_[:, self.channels_in - 2 :, :, :]
         input_color = input_[:, 0 : self.channels_in - 2, :, :]
 

--- a/backend/src/nodes/impl/pytorch/utils.py
+++ b/backend/src/nodes/impl/pytorch/utils.py
@@ -40,11 +40,11 @@ def norm(x: Tensor):
 
 def np2tensor(
     img: np.ndarray,
-    bgr2rgb=True,
-    data_range=1.0,  # pylint: disable=unused-argument
-    normalize=False,
-    change_range=True,
-    add_batch=True,
+    bgr2rgb: bool = True,
+    data_range: float = 1.0,
+    normalize: bool = False,
+    change_range: bool = True,
+    add_batch: bool = True,
 ) -> Tensor:
     """Converts a numpy image array into a Tensor array.
     Parameters:
@@ -84,11 +84,11 @@ def np2tensor(
 
 def tensor2np(
     img: Tensor,
-    rgb2bgr=True,
-    remove_batch=True,
-    data_range=255,
-    denormalize=False,
-    change_range=True,
+    rgb2bgr: bool = True,
+    remove_batch: bool = True,
+    data_range: float = 255,
+    denormalize: bool = False,
+    change_range: bool = True,
     imtype: type = np.uint8,
 ) -> np.ndarray:
     """Converts a Tensor array into a numpy image array.

--- a/backend/src/nodes/properties/inputs/file_inputs.py
+++ b/backend/src/nodes/properties/inputs/file_inputs.py
@@ -53,7 +53,7 @@ class FileInput(BaseInput):
             "primaryInput": self.primary_input,
         }
 
-    def enforce(self, value) -> str:
+    def enforce(self, value: object) -> str:
         assert isinstance(value, str)
         assert os.path.exists(value), f"File {value} does not exist"
         assert os.path.isfile(value), f"The path {value} is not a file"
@@ -137,7 +137,7 @@ class DirectoryInput(BaseInput):
             "hideLabel": self.hide_label,
         }
 
-    def enforce(self, value):
+    def enforce(self, value: object):
         assert isinstance(value, str)
         if self.must_exist:
             assert os.path.exists(value), f"Directory {value} does not exist"

--- a/backend/src/nodes/properties/inputs/generic_inputs.py
+++ b/backend/src/nodes/properties/inputs/generic_inputs.py
@@ -91,7 +91,7 @@ class DropDownInput(BaseInput):
     def make_optional(self):
         raise ValueError("DropDownInput cannot be made optional")
 
-    def enforce(self, value):
+    def enforce(self, value: object):
         assert value in self.accepted_values, f"{value} is not a valid option"
         return value
 
@@ -118,7 +118,7 @@ class BoolInput(DropDownInput):
         )
         self.associated_type = bool
 
-    def enforce(self, value) -> bool:
+    def enforce(self, value: object) -> bool:
         value = super().enforce(value)
         return bool(value)
 
@@ -198,7 +198,7 @@ class EnumInput(Generic[T], DropDownInput):
 
         self.associated_type = enum
 
-    def enforce(self, value) -> T:
+    def enforce(self, value: object) -> T:
         value = super().enforce(value)
         return self.enum(value)
 
@@ -209,7 +209,7 @@ class TextInput(BaseInput):
     def __init__(
         self,
         label: str,
-        has_handle=True,
+        has_handle: bool = True,
         min_length: int = 0,
         max_length: int | None = None,
         placeholder: str | None = None,
@@ -243,7 +243,7 @@ class TextInput(BaseInput):
         if allow_numbers:
             self.input_conversions = [InputConversion("number", "toString(Input)")]
 
-    def enforce(self, value) -> str:
+    def enforce(self, value: object) -> str:
         if isinstance(value, float) and int(value) == value:
             # stringify integers values
             value = str(int(value))
@@ -281,7 +281,7 @@ class ClipboardInput(BaseInput):
         super().__init__(["Image", "string", "number"], label, kind="text")
         self.input_conversions = [InputConversion("Image", '"<Image>"')]
 
-    def enforce(self, value):
+    def enforce(self, value: object):
         if isinstance(value, np.ndarray):
             return normalize(value)
 
@@ -297,7 +297,7 @@ class AnyInput(BaseInput):
         super().__init__(input_type="any", label=label)
         self.associated_type = object
 
-    def enforce_(self, value):
+    def enforce_(self, value: object):
         # The behavior for optional inputs and None makes sense for all inputs except this one.
         return value
 
@@ -324,10 +324,12 @@ class SeedInput(NumberInput):
 
         self.associated_type = Seed
 
-    def enforce(self, value) -> Seed:
+    def enforce(self, value: object) -> Seed:
         if isinstance(value, Seed):
             return value
-        return Seed(int(value))
+        if isinstance(value, (int, float, str)):
+            return Seed(int(value))
+        raise ValueError(f"Cannot convert {value} to Seed")
 
     def make_optional(self):
         raise ValueError("SeedInput cannot be made optional")
@@ -381,7 +383,7 @@ class ColorInput(BaseInput):
 
         self.associated_type = Color
 
-    def enforce(self, value) -> Color:
+    def enforce(self, value: object) -> Color:
         if isinstance(value, str):
             # decode color JSON strings from the frontend
             value = Color.from_json(json.loads(value))
@@ -573,7 +575,7 @@ def FillColorDropdown() -> DropDownInput:
 
 
 def TileSizeDropdown(
-    label="Tile Size", estimate=True, default: TileSize | None = None
+    label: str = "Tile Size", estimate: bool = True, default: TileSize | None = None
 ) -> DropDownInput:
     options = []
     if estimate:

--- a/backend/src/nodes/properties/inputs/numeric_inputs.py
+++ b/backend/src/nodes/properties/inputs/numeric_inputs.py
@@ -102,7 +102,7 @@ class NumberInput(BaseInput):
     def make_optional(self):
         raise ValueError("NumberInput and SliderInput cannot be made optional")
 
-    def enforce(self, value):
+    def enforce(self, value: object):
         assert isinstance(value, (int, float))
 
         if math.isnan(value):

--- a/backend/src/nodes/properties/inputs/numpy_inputs.py
+++ b/backend/src/nodes/properties/inputs/numpy_inputs.py
@@ -46,7 +46,7 @@ class ImageInput(BaseInput):
         if self.allow_colors:
             self.associated_type = Union[np.ndarray, Color]
 
-    def enforce(self, value):
+    def enforce(self, value: object):
         if isinstance(value, Color):
             if not self.allow_colors:
                 raise ValueError(
@@ -79,7 +79,7 @@ class ImageInput(BaseInput):
 
         return value
 
-    def get_error_value(self, value) -> ErrorValue:
+    def get_error_value(self, value: object) -> ErrorValue:
         def get_channels(channel: int) -> str:
             if channel == 1:
                 return "Grayscale"

--- a/backend/src/nodes/properties/inputs/onnx_inputs.py
+++ b/backend/src/nodes/properties/inputs/onnx_inputs.py
@@ -23,7 +23,7 @@ class OnnxGenericModelInput(OnnxModelInput):
     ):
         super().__init__(label, navi.intersect(input_type, "OnnxGenericModel"))
 
-    def enforce(self, value):
+    def enforce(self, value: object):
         assert isinstance(value, OnnxModels)
         assert not is_rembg_model(value.bytes), "Expected a non-rembg model"
         return value
@@ -38,7 +38,7 @@ class OnnxRemBgModelInput(OnnxModelInput):
         super().__init__(label, navi.intersect(input_type, "OnnxRemBgModel"))
         self.associated_type = OnnxRemBg
 
-    def enforce(self, value):
+    def enforce(self, value: object):
         assert isinstance(value, OnnxModels)
         assert is_rembg_model(value.bytes), "Expected a rembg model"
         return value

--- a/backend/src/nodes/properties/inputs/pytorch_inputs.py
+++ b/backend/src/nodes/properties/inputs/pytorch_inputs.py
@@ -30,7 +30,7 @@ class ModelInput(BaseInput):
         if torch is not None:
             self.associated_type = PyTorchModel
 
-    def enforce(self, value):
+    def enforce(self, value: object):
         if torch is not None:
             assert isinstance(value, torch.nn.Module), "Expected a PyTorch model."
             assert is_pytorch_model(value), "Expected a supported PyTorch model."
@@ -50,7 +50,7 @@ class SrModelInput(ModelInput):
         if torch is not None:
             self.associated_type = PyTorchSRModel
 
-    def enforce(self, value):
+    def enforce(self, value: object):
         if torch is not None:
             assert isinstance(value, torch.nn.Module), "Expected a PyTorch model."
             assert is_pytorch_sr_model(
@@ -70,7 +70,7 @@ class FaceModelInput(ModelInput):
         if torch is not None:
             self.associated_type = PyTorchFaceModel
 
-    def enforce(self, value):
+    def enforce(self, value: object):
         if torch is not None:
             assert isinstance(value, torch.nn.Module), "Expected a PyTorch model."
             assert is_pytorch_face_model(
@@ -90,7 +90,7 @@ class InpaintModelInput(ModelInput):
         if torch is not None:
             self.associated_type = PyTorchInpaintModel
 
-    def enforce(self, value):
+    def enforce(self, value: object):
         if torch is not None:
             assert isinstance(value, torch.nn.Module), "Expected a PyTorch model."
             assert is_pytorch_inpaint_model(

--- a/backend/src/nodes/properties/outputs/file_outputs.py
+++ b/backend/src/nodes/properties/outputs/file_outputs.py
@@ -24,6 +24,6 @@ class DirectoryOutput(BaseOutput):
     def get_broadcast_type(self, value: str):
         return navi.named("Directory", {"path": navi.literal(value)})
 
-    def enforce(self, value) -> str:
+    def enforce(self, value: object) -> str:
         assert isinstance(value, str)
         return value

--- a/backend/src/nodes/properties/outputs/generic_outputs.py
+++ b/backend/src/nodes/properties/outputs/generic_outputs.py
@@ -25,7 +25,7 @@ class NumberOutput(BaseOutput):
     def get_broadcast_type(self, value: int | float):
         return navi.literal(value)
 
-    def enforce(self, value) -> int | float:
+    def enforce(self, value: object) -> int | float:
         assert isinstance(value, (int, float))
         return value
 
@@ -41,7 +41,7 @@ class TextOutput(BaseOutput):
     def get_broadcast_type(self, value: str):
         return navi.literal(value)
 
-    def enforce(self, value) -> str:
+    def enforce(self, value: object) -> str:
         assert isinstance(value, str)
         return value
 
@@ -60,7 +60,7 @@ class SeedOutput(BaseOutput):
     def __init__(self, label: str = "Seed"):
         super().__init__(output_type="Seed", label=label, kind="generic")
 
-    def enforce(self, value) -> Seed:
+    def enforce(self, value: object) -> Seed:
         assert isinstance(value, Seed)
         return value
 
@@ -80,7 +80,7 @@ class ColorOutput(BaseOutput):
 
         self.channels = channels
 
-    def enforce(self, value) -> Color:
+    def enforce(self, value: object) -> Color:
         assert isinstance(value, Color)
 
         if self.channels is not None and value.channels != self.channels:

--- a/backend/src/nodes/properties/outputs/numpy_outputs.py
+++ b/backend/src/nodes/properties/outputs/numpy_outputs.py
@@ -32,7 +32,7 @@ class NumPyOutput(BaseOutput):
             associated_type=np.ndarray,
         )
 
-    def enforce(self, value) -> np.ndarray:
+    def enforce(self, value: object) -> np.ndarray:
         assert isinstance(value, np.ndarray)
         return value
 
@@ -74,7 +74,7 @@ class ImageOutput(NumPyOutput):
         h, w, c = get_h_w_c(value)
         return navi.Image(width=w, height=h, channels=c)
 
-    def enforce(self, value) -> np.ndarray:
+    def enforce(self, value: object) -> np.ndarray:
         assert isinstance(value, np.ndarray)
 
         h, w, c = get_h_w_c(value)

--- a/backend/src/nodes/utils/checked_cast.py
+++ b/backend/src/nodes/utils/checked_cast.py
@@ -5,6 +5,6 @@ from typing import TypeVar
 T = TypeVar("T")
 
 
-def checked_cast(t: type[T], value) -> T:
+def checked_cast(t: type[T], value: object) -> T:
     assert isinstance(value, t), f"Value is {type(value)}, must be type {t}"
     return value

--- a/backend/src/nodes/utils/unpickler.py
+++ b/backend/src/nodes/utils/unpickler.py
@@ -16,7 +16,7 @@ safe_list = {
 
 
 class RestrictedUnpickler(pickle.Unpickler):
-    def find_class(self, module, name):
+    def find_class(self, module: str, name: str):
         # Only allow required classes to load state dict
         if (module, name) not in safe_list:
             raise pickle.UnpicklingError(f"Global '{module}.{name}' is forbidden")

--- a/backend/src/nodes/utils/utils.py
+++ b/backend/src/nodes/utils/utils.py
@@ -93,7 +93,7 @@ def split_file_path(path: str) -> tuple[str, str, str]:
     return dirname, basename, ext
 
 
-def walk_error_handler(exception_instance):
+def walk_error_handler(exception_instance: Exception):
     logger.warning(
         f"Exception occurred during walk: {exception_instance} Continuing..."
     )

--- a/backend/src/packages/chaiNNer_external/util.py
+++ b/backend/src/packages/chaiNNer_external/util.py
@@ -11,7 +11,7 @@ from nodes.impl.image_utils import normalize, to_uint8
 from nodes.utils.utils import get_h_w_c
 
 
-def nearest_valid_size(width, height):
+def nearest_valid_size(width: int, height: int):
     return (width // 8) * 8, (height // 8) * 8
 
 

--- a/backend/src/packages/chaiNNer_standard/image/create_images/create_noise.py
+++ b/backend/src/packages/chaiNNer_standard/image/create_images/create_noise.py
@@ -35,7 +35,7 @@ class FractalMethod(Enum):
 
 
 def _add_noise(
-    generator_class,
+    generator_class,  # noqa: ANN001
     image: np.ndarray,
     scale: float,
     brightness: float,

--- a/backend/src/packages/chaiNNer_standard/image_filter/blur/box_blur.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/blur/box_blur.py
@@ -27,7 +27,7 @@ def get_kernel_1d(radius: float) -> np.ndarray:
     return kernel
 
 
-def get_kernel_2d(radius_x: float, radius_y) -> np.ndarray:
+def get_kernel_2d(radius_x: float, radius_y: float) -> np.ndarray:
     # Create kernel of dims h * w, rounded up to the closest odd integer
     kernel = np.ones((ceil(radius_y) * 2 + 1, ceil(radius_x) * 2 + 1), np.float32) / (
         (2 * radius_y + 1) * (2 * radius_x + 1)

--- a/backend/src/packages/chaiNNer_standard/image_filter/quantize/quantize_to_reference.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/quantize/quantize_to_reference.py
@@ -18,7 +18,7 @@ def add_xy(img: np.ndarray, scale: float) -> np.ndarray:
     return np.dstack((img, xx * scale, yy * scale))
 
 
-def quantize_image(image, palette):
+def quantize_image(image: np.ndarray, palette: np.ndarray):
     _, _, c = get_h_w_c(image)
     # Flatten image and palette for easy computation
     flat_img = image.reshape((-1, c))

--- a/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/image_statistics.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/image_statistics.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import SupportsFloat
+
 import numpy as np
 
 from nodes.properties.inputs import ImageInput, SliderInput
@@ -37,7 +39,7 @@ def image_statistics_node(
     img: np.ndarray,
     percentile: float,
 ) -> tuple[float, float, float, float]:
-    def to_float(n) -> float:
+    def to_float(n: SupportsFloat) -> float:
         # float32 has ~8 digits of precision.
         # So by rounding to 4 digits, we have 1 digit left over to contain rounding errors
         return round(float(n) * 255, 4)

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -72,7 +72,7 @@ CORS(app)
 
 
 class SSEFilter(logging.Filter):
-    def filter(self, record):
+    def filter(self, record):  # noqa: ANN001
         request = record.request  # type: ignore
         return not (
             (request.endswith(("/sse", "/setup-sse"))) and record.status == 200  # type: ignore
@@ -90,7 +90,7 @@ class ZeroCounter:
     def __enter__(self):
         self.count += 1
 
-    def __exit__(self, _exc_type, _exc_value, _exc_traceback):
+    def __exit__(self, _exc_type: object, _exc_value: object, _exc_traceback: object):
         self.count -= 1
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,9 @@ extend-select = [
     "F",  # pyflakes
     "I",  # isort
     "N",  # pep8-naming
-    # "ANN",   # flake8-annotations
+    # "ANN", # flake8-annotations
+    "ANN001",
+    "ANN002",
     # "ASYNC", # flake8-async
     "PL",  # pylint
     "RUF", # ruff
@@ -43,7 +45,6 @@ extend-select = [
     "SLF", # flake8-self
     # "SIM", # flake8-simplify
     # "TCH", # flake8-tidy-imports
-
 ]
 ignore = [
     "E501",    # Line too long
@@ -61,6 +62,7 @@ ignore = [
     "N818",    # Exception name should end in Error
     "ISC001",  # Implicit string concatenation, conflicts with formatter
 ]
+
 [tool.ruff.format]
 # Like Black, use double quotes for strings.
 quote-style = "double"


### PR DESCRIPTION
Having more type annotations also revealed 2 bugs:

1. Node cache didn't estimate the bytes for nodes with a single output.
2. Seed input didn't guard against input values that aren't convertible to int.