### PR TITLE
Filter events in `/run/individual`

### DIFF
--- a/backend/src/events.py
+++ b/backend/src/events.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import asyncio
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Dict, Literal, TypedDict, Union
-
-from attr import dataclass
 
 from api import ErrorValue, InputId, NodeId, OutputId
 

--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -16,7 +16,7 @@ from api import BaseOutput, Collector, InputId, Iterator, NodeData, NodeId, Outp
 from chain.cache import CacheStrategy, OutputCache, StaticCaching, get_cache_strategies
 from chain.chain import Chain, CollectorNode, FunctionNode, NewIteratorNode, Node
 from chain.input import EdgeInput, Input, InputMap
-from events import Event, EventQueue, InputsDict
+from events import Event, EventConsumer, InputsDict
 from progress_controller import Aborted, ProgressController
 from util import timed_supplier
 
@@ -275,7 +275,7 @@ class Executor:
         inputs: InputMap,
         send_broadcast_data: bool,
         loop: asyncio.AbstractEventLoop,
-        queue: EventQueue,
+        queue: EventConsumer,
         pool: ThreadPoolExecutor,
         parent_cache: OutputCache[NodeOutput] | None = None,
     ):
@@ -291,7 +291,7 @@ class Executor:
         self.completed_node_ids = set()
 
         self.loop: asyncio.AbstractEventLoop = loop
-        self.queue: EventQueue = queue
+        self.queue: EventConsumer = queue
         self.pool: ThreadPoolExecutor = pool
 
         self.cache_strategy: dict[NodeId, CacheStrategy] = get_cache_strategies(chain)

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -34,7 +34,7 @@ from chain.json import JsonNode, parse_json
 from chain.optimize import optimize
 from custom_types import UpdateProgressFn
 from dependencies.store import DependencyInfo, install_dependencies, installed_packages
-from events import EventQueue, ExecutionErrorData
+from events import EventConsumer, EventQueue, ExecutionErrorData
 from gpu import get_nvidia_helper
 from process import Executor, NodeExecutionError, NodeOutput
 from progress_controller import Aborted
@@ -242,12 +242,15 @@ async def run_individual(request: Request):
         input_map = InputMap()
         input_map.set_values(node_id, full_data["inputs"])
 
+        # only yield certain types of events
+        queue = EventConsumer.filter(ctx.queue, {"node-finish", "execution-error"})
+
         executor = Executor(
             chain=chain,
             inputs=input_map,
             send_broadcast_data=True,
             loop=app.loop,
-            queue=ctx.queue,
+            queue=queue,
             pool=ctx.pool,
         )
 


### PR DESCRIPTION
This adds support for filtering events emitted by the executor. I did this using a new interface: `EventConsumer`. This interface is essentially an append-only (or write-only) queue. That's all the executor needs anyway, and it makes it easy to implement wrappers around `EventQueue`.

Using this new system, the `/run/individual` request will now only emit `node-finish` and `execution-error` events. So refreshing a starting node should no longer majorly interfere with a currently running execution.