### PR TITLE
Rework how nodes are sorted

### DIFF
--- a/backend/src/api/api.py
+++ b/backend/src/api/api.py
@@ -538,9 +538,7 @@ class PackageRegistry:
         failed_checks: list[CheckFailedError] = []
 
         for package in list(self.packages.values()):
-            for file_path in reversed(
-                list(_iter_py_files(os.path.dirname(package.where)))
-            ):
+            for file_path in _iter_py_files(os.path.dirname(package.where)):
                 _, name = os.path.split(file_path)
 
                 if not name.startswith("_"):

--- a/backend/src/packages/chaiNNer_standard/image_dimension/__init__.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/__init__.py
@@ -4,3 +4,9 @@ border_group = image_dimensions_category.add_node_group("Border")
 crop_group = image_dimensions_category.add_node_group("Crop")
 resize_group = image_dimensions_category.add_node_group("Resize")
 utility_group = image_dimensions_category.add_node_group("Utility")
+
+resize_group.order = [
+    "chainner:image:resize_factor",
+    "chainner:image:resize_resolution",
+    "chainner:image:resize_to_side",
+]

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -118,7 +118,8 @@ async def nodes(_request: Request):
         node_dict = {
             "schemaId": node.schema_id,
             "name": node.name,
-            "category": sub.category.name,
+            "category": sub.category.id,
+            "nodeGroup": sub.id,
             "inputs": [x.to_dict() for x in node.inputs],
             "outputs": [x.to_dict() for x in node.outputs],
             "groupLayout": [
@@ -127,7 +128,6 @@ async def nodes(_request: Request):
             "description": node.description,
             "seeAlso": node.see_also,
             "icon": node.icon,
-            "subcategory": sub.name,
             "nodeType": node.type,
             "hasSideEffects": node.side_effects,
             "deprecated": node.deprecated,

--- a/src/common/Backend.ts
+++ b/src/common/Backend.ts
@@ -2,6 +2,7 @@ import * as undici from 'undici';
 import {
     BackendJsonNode,
     Category,
+    CategoryId,
     FeatureState,
     InputId,
     InputValue,
@@ -66,7 +67,7 @@ export type BackendExecutorActionResponse =
 export interface BackendNodesResponse {
     nodes: NodeSchema[];
     categories: Category[];
-    categoriesMissingNodes: string[];
+    categoriesMissingNodes: CategoryId[];
 }
 export interface BackendRunRequest {
     data: BackendJsonNode[];

--- a/src/common/CategoryMap.ts
+++ b/src/common/CategoryMap.ts
@@ -1,0 +1,33 @@
+import { Category, CategoryId, NodeGroup, NodeGroupId } from './common-types';
+
+export class CategoryMap {
+    /**
+     * An ordered list of all categories supported by the backend.
+     *
+     * Some categories might be empty.
+     */
+    readonly categories: readonly Category[];
+
+    private readonly lookup: ReadonlyMap<CategoryId, Category>;
+
+    private readonly lookupGroup: ReadonlyMap<NodeGroupId, NodeGroup>;
+
+    static readonly EMPTY: CategoryMap = new CategoryMap([]);
+
+    constructor(categories: readonly Category[]) {
+        // defensive copy
+        this.categories = [...categories];
+        this.lookup = new Map(categories.map((c) => [c.id, c] as const));
+        this.lookupGroup = new Map(
+            categories.flatMap((c) => c.groups).map((g) => [g.id, g] as const)
+        );
+    }
+
+    get(id: CategoryId): Category | undefined {
+        return this.lookup.get(id);
+    }
+
+    getGroup(id: NodeGroupId): NodeGroup | undefined {
+        return this.lookupGroup.get(id);
+    }
+}

--- a/src/common/SchemaMap.ts
+++ b/src/common/SchemaMap.ts
@@ -1,4 +1,12 @@
-import { InputData, InputId, InputValue, NodeSchema, SchemaId } from './common-types';
+import {
+    CategoryId,
+    InputData,
+    InputId,
+    InputValue,
+    NodeGroupId,
+    NodeSchema,
+    SchemaId,
+} from './common-types';
 import { log } from './log';
 
 const BLANK_SCHEMA: NodeSchema = {
@@ -6,8 +14,8 @@ const BLANK_SCHEMA: NodeSchema = {
     outputs: [],
     groupLayout: [],
     icon: '',
-    category: '',
-    subcategory: '',
+    category: '' as CategoryId,
+    nodeGroup: '' as NodeGroupId,
     name: '',
     description: '',
     seeAlso: [],

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -244,8 +244,8 @@ export type GroupState = Readonly<Record<GroupId, unknown>>;
 
 export interface NodeSchema {
     readonly name: string;
-    readonly category: string;
-    readonly subcategory: string;
+    readonly category: CategoryId;
+    readonly nodeGroup: NodeGroupId;
     readonly description: string;
     readonly seeAlso: readonly SchemaId[];
     readonly icon: string;
@@ -423,13 +423,22 @@ export interface WindowSize {
     readonly height: number;
 }
 
+export type CategoryId = string & { readonly __categoryId: never };
 export interface Category {
-    name: string;
-    description: string;
-    icon: string;
-    color: string;
-    installHint?: string;
-    excludedFromCheck: string[];
+    readonly id: CategoryId;
+    readonly name: string;
+    readonly description: string;
+    readonly icon: string;
+    readonly color: string;
+    readonly installHint?: string;
+    readonly groups: readonly NodeGroup[];
+}
+export type NodeGroupId = string & { readonly __nodeGroupId: never };
+export interface NodeGroup {
+    readonly id: NodeGroupId;
+    readonly category: CategoryId;
+    readonly name: string;
+    readonly order: readonly SchemaId[];
 }
 
 export type ColorJson = GrayscaleColorJson | RgbColorJson | RgbaColorJson;

--- a/src/common/nodes/sort.ts
+++ b/src/common/nodes/sort.ts
@@ -1,0 +1,32 @@
+import { CategoryMap } from '../CategoryMap';
+import { NodeGroup, NodeSchema } from '../common-types';
+import { groupBy } from '../util';
+
+const sortGroupNodes = (nodes: readonly NodeSchema[], group: NodeGroup): NodeSchema[] => {
+    const ordered: NodeSchema[] = [];
+    const unordered: NodeSchema[] = [];
+
+    for (const n of nodes) {
+        if (group.order.includes(n.schemaId)) {
+            ordered.push(n);
+        } else {
+            unordered.push(n);
+        }
+    }
+
+    ordered.sort((a, b) => group.order.indexOf(a.schemaId) - group.order.indexOf(b.schemaId));
+
+    unordered.sort((a, b) => {
+        return a.name.localeCompare(b.name);
+    });
+
+    return [...ordered, ...unordered];
+};
+
+export const sortNodes = (nodes: readonly NodeSchema[], categories: CategoryMap): NodeSchema[] => {
+    const byGroup = groupBy(nodes, 'nodeGroup');
+
+    return categories.categories
+        .flatMap((c) => c.groups)
+        .flatMap((g) => sortGroupNodes(byGroup.get(g.id) ?? [], g));
+};

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -284,3 +284,37 @@ export const isAutoInput = (input: Input): boolean =>
     input.kind === 'generic' && input.optional && !input.hasHandle;
 
 export const escapeRegExp = (string: string) => string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+export function groupBy<T, K extends keyof T>(iter: Iterable<T>, key: K): Map<T[K], T[]>;
+export function groupBy<T, K>(iter: Iterable<T>, selector: (item: T) => K): Map<K, T[]>;
+// eslint-disable-next-line prefer-arrow-functions/prefer-arrow-functions
+export function groupBy<T>(
+    iter: Iterable<T>,
+    key: keyof T | ((item: T) => unknown)
+): Map<unknown, T[]> {
+    const map = new Map<unknown, T[]>();
+
+    if (typeof key === 'function') {
+        for (const item of iter) {
+            const k = key(item);
+            let list = map.get(k);
+            if (list === undefined) {
+                list = [];
+                map.set(k, list);
+            }
+            list.push(item);
+        }
+    } else {
+        for (const item of iter) {
+            const k = item[key];
+            let list = map.get(k);
+            if (list === undefined) {
+                list = [];
+                map.set(k, list);
+            }
+            list.push(item);
+        }
+    }
+
+    return map;
+}

--- a/src/renderer/components/NodeDocumentation/NodesList.tsx
+++ b/src/renderer/components/NodeDocumentation/NodesList.tsx
@@ -2,9 +2,9 @@ import { Box, Center, HStack, Text, VStack } from '@chakra-ui/react';
 import { memo, useEffect, useMemo, useRef, useState } from 'react';
 import { useContext } from 'use-context-selector';
 import { SchemaId } from '../../../common/common-types';
+import { groupBy } from '../../../common/util';
 import { BackendContext } from '../../contexts/BackendContext';
 import { NodeDocumentationContext } from '../../contexts/NodeDocumentationContext';
-import { getNodesByCategory } from '../../helpers/nodeSearchFuncs';
 import { IconFactory } from '../CustomIcons';
 import { SearchBar } from '../SearchBar';
 
@@ -33,14 +33,14 @@ export const NodesList = memo(
             return filtered.filter((s) => searchScores.has(s.schemaId));
         }, [schemata.schemata, searchScores]);
 
-        const byCategories = useMemo(() => getNodesByCategory(filteredSchema), [filteredSchema]);
+        const byCategories = useMemo(() => groupBy(filteredSchema, 'category'), [filteredSchema]);
 
         const sortedCategories = useMemo(() => {
-            if (!searchScores) return categories;
+            if (!searchScores) return categories.categories;
 
-            return [...categories].sort((a, b) => {
-                const aNodes = byCategories.get(a.name) ?? [];
-                const bNodes = byCategories.get(b.name) ?? [];
+            return [...categories.categories].sort((a, b) => {
+                const aNodes = byCategories.get(a.id) ?? [];
+                const bNodes = byCategories.get(b.id) ?? [];
                 const aMaxScore = Math.max(...aNodes.map((n) => searchScores.get(n.schemaId) ?? 0));
                 const bMaxScore = Math.max(...bNodes.map((n) => searchScores.get(n.schemaId) ?? 0));
                 return bMaxScore - aMaxScore;
@@ -101,7 +101,7 @@ export const NodesList = memo(
                             <Text>No nodes found</Text>
                         ) : (
                             sortedCategories.map((category) => {
-                                const categoryNodes = byCategories.get(category.name);
+                                const categoryNodes = byCategories.get(category.id);
 
                                 if (!categoryNodes || categoryNodes.length === 0) {
                                     return null;
@@ -117,7 +117,7 @@ export const NodesList = memo(
 
                                 return (
                                     <Box
-                                        key={category.name}
+                                        key={category.id}
                                         w="full"
                                     >
                                         <Center

--- a/src/renderer/components/NodeSelectorPanel/RegularAccordionItem.tsx
+++ b/src/renderer/components/NodeSelectorPanel/RegularAccordionItem.tsx
@@ -12,6 +12,7 @@ import {
 } from '@chakra-ui/react';
 import React, { memo } from 'react';
 import { Category, NodeSchema } from '../../../common/common-types';
+import { groupBy } from '../../../common/util';
 import { IconFactory } from '../CustomIcons';
 import { RepresentativeNodeWrapper } from './RepresentativeNodeWrapper';
 import { SubcategoryHeading } from './SubcategoryHeading';
@@ -76,31 +77,38 @@ export const RegularAccordionItem = memo(
 
 interface SubcategoriesProps {
     collapsed: boolean;
-    subcategoryMap: Map<string, NodeSchema[]>;
+    category: Category;
+    categoryNodes: readonly NodeSchema[];
 }
 
-export const Subcategories = memo(({ collapsed, subcategoryMap }: SubcategoriesProps) => {
+export const Subcategories = memo(({ collapsed, category, categoryNodes }: SubcategoriesProps) => {
+    const byGroup = groupBy(categoryNodes, 'nodeGroup');
     return (
         <>
-            {[...subcategoryMap].map(([subcategory, nodes]) => (
-                <Box key={subcategory}>
-                    <Center>
-                        <SubcategoryHeading
-                            collapsed={collapsed}
-                            subcategory={subcategory}
-                        />
-                    </Center>
-                    <Box>
-                        {nodes.map((node) => (
-                            <RepresentativeNodeWrapper
+            {category.groups.map((group) => {
+                const nodes = byGroup.get(group.id);
+                if (!nodes) return null;
+
+                return (
+                    <Box key={group.id}>
+                        <Center>
+                            <SubcategoryHeading
                                 collapsed={collapsed}
-                                key={node.schemaId}
-                                node={node}
+                                group={group}
                             />
-                        ))}
+                        </Center>
+                        <Box>
+                            {nodes.map((node) => (
+                                <RepresentativeNodeWrapper
+                                    collapsed={collapsed}
+                                    key={node.schemaId}
+                                    node={node}
+                                />
+                            ))}
+                        </Box>
                     </Box>
-                </Box>
-            ))}
+                );
+            })}
         </>
     );
 });

--- a/src/renderer/components/NodeSelectorPanel/RepresentativeNode.tsx
+++ b/src/renderer/components/NodeSelectorPanel/RepresentativeNode.tsx
@@ -2,16 +2,14 @@ import { StarIcon } from '@chakra-ui/icons';
 import { Box, Center, Flex, HStack, Heading, Spacer } from '@chakra-ui/react';
 import { memo, useState } from 'react';
 import { useContext } from 'use-context-selector';
-import { NodeType, SchemaId } from '../../../common/common-types';
+import { CategoryId, NodeType, SchemaId } from '../../../common/common-types';
 import { BackendContext } from '../../contexts/BackendContext';
 import { getCategoryAccentColor } from '../../helpers/accentColors';
 import { useNodeFavorites } from '../../hooks/useNodeFavorites';
 import { IconFactory } from '../CustomIcons';
 
 interface RepresentativeNodeProps {
-    category: string;
-    // eslint-disable-next-line react/no-unused-prop-types
-    subcategory: string;
+    category: CategoryId;
     icon: string;
     name: string;
     collapsed?: boolean;

--- a/src/renderer/components/NodeSelectorPanel/RepresentativeNodeWrapper.tsx
+++ b/src/renderer/components/NodeSelectorPanel/RepresentativeNodeWrapper.tsx
@@ -191,7 +191,6 @@ export const RepresentativeNodeWrapper = memo(
                                     name={node.name}
                                     nodeType={node.nodeType}
                                     schemaId={node.schemaId}
-                                    subcategory={node.subcategory}
                                 />
                             </Center>
                         </Tooltip>

--- a/src/renderer/components/NodeSelectorPanel/SubcategoryHeading.tsx
+++ b/src/renderer/components/NodeSelectorPanel/SubcategoryHeading.tsx
@@ -1,36 +1,35 @@
 import { Divider, HStack, Text } from '@chakra-ui/react';
 import { memo } from 'react';
+import { NodeGroup } from '../../../common/common-types';
 
 interface SubcategoryHeadingProps {
-    subcategory: string;
+    group: NodeGroup;
     collapsed?: boolean;
 }
 
-export const SubcategoryHeading = memo(
-    ({ subcategory, collapsed = false }: SubcategoryHeadingProps) => {
-        return (
-            <HStack
-                h={6}
-                w="full"
-            >
-                {collapsed ? (
+export const SubcategoryHeading = memo(({ group, collapsed = false }: SubcategoryHeadingProps) => {
+    return (
+        <HStack
+            h={6}
+            w="full"
+        >
+            {collapsed ? (
+                <Divider orientation="horizontal" />
+            ) : (
+                <>
                     <Divider orientation="horizontal" />
-                ) : (
-                    <>
-                        <Divider orientation="horizontal" />
-                        <Text
-                            casing="uppercase"
-                            color="#71809699"
-                            fontSize="sm"
-                            py={0.5}
-                            whiteSpace="nowrap"
-                        >
-                            {subcategory}
-                        </Text>
-                        <Divider orientation="horizontal" />
-                    </>
-                )}
-            </HStack>
-        );
-    }
-);
+                    <Text
+                        casing="uppercase"
+                        color="#71809699"
+                        fontSize="sm"
+                        py={0.5}
+                        whiteSpace="nowrap"
+                    >
+                        {group.name}
+                    </Text>
+                    <Divider orientation="horizontal" />
+                </>
+            )}
+        </HStack>
+    );
+});

--- a/src/renderer/helpers/accentColors.ts
+++ b/src/renderer/helpers/accentColors.ts
@@ -6,7 +6,8 @@ import {
     evaluate,
     isDisjointWith,
 } from '@chainner/navi';
-import { Category } from '../../common/common-types';
+import { CategoryMap } from '../../common/CategoryMap';
+import { CategoryId } from '../../common/common-types';
 import { getChainnerScope } from '../../common/types/chainner-scope';
 import { lazy } from '../../common/util';
 
@@ -41,6 +42,6 @@ export const getTypeAccentColors = (inputType: Type): readonly [string, ...strin
     return colors.length > 0 ? (colors as [string, ...string[]]) : defaultColorList;
 };
 
-export const getCategoryAccentColor = (categories: readonly Category[], category: string) => {
-    return categories.find((c) => c.name === category)?.color ?? '#718096';
+export const getCategoryAccentColor = (categories: CategoryMap, category: CategoryId) => {
+    return categories.get(category)?.color ?? '#718096';
 };


### PR DESCRIPTION
Changes:
- Categories and node groups have IDs now. No more "name == id". The value for those ids is the name though. We can change that if needed though.
- Node groups are now a datatype in the frontend too. This means that we can add more metadata to change their appearance/behavior in the future.
- Refactored some frontend code.

The basic idea now is that the backend declares the order of categories, node groups, and some nodes (`order`), but it does not enforce it. So nodes from `/nodes` may be in any order. The frontend is responsible for applying that order. It currently does via the `sortNodes` method. Basically, the first thing the frontend does when getting the response from `/nodes` is to sort them. Not sure whether the backend should just do that as well.