### PR TITLE
Optimized box blur

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image_filter/blur/box_blur.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/blur/box_blur.py
@@ -86,6 +86,23 @@ def box_blur_node(
     if radius_x == 0 or radius_y == 0:
         return img
 
+    use_optimized_int = (
+        # both radii are integers
+        int(radius_x) == radius_x
+        and int(radius_y) == radius_y
+        # you can't tell the difference between a float and an integer when the radius is large enough
+        or radius_x > 200
+        and radius_y > 200
+    )
+
+    if use_optimized_int:
+        # we can use an optimized box blur implementation
+        radius_x = int(round(radius_x))
+        radius_y = int(round(radius_y))
+        return cv2.blur(
+            img, (radius_x * 2 + 1, radius_y * 2 + 1), borderType=cv2.BORDER_REFLECT_101
+        )
+
     # Separable filter is faster for relatively small kernels, but after a certain size it becomes
     # slower than filter2D's DFT implementation. The exact cutoff depends on the hardware.
     avg_radius = math.sqrt(radius_x * radius_y)


### PR DESCRIPTION
I noticed that our box blur was *slower* than gauss for large radii, so I know that something was wrong. We were using a `cv2.filter2D` based box blur. While this is correct, it's not ideal for performance. Box blur is a highly optimizable filter, so `cv2.filter2D` is far too general.

I used `cv2.blur` (which implements a highly optimized box blur) whenever possible. Since `cv2.blur` only supports integer radii, I only use it when the radii are integers and when the radii are so large that the difference between N.5 and N is not noticeable.

With my 2k example image, the box blur node takes this long:

| Radius | Old (s) | New (s) | Change |
| ------ | ------- | ------- | ------ |
| 3      | 0.051   | 0.051   | 1x     |
| 6      | 0.058   | 0.058   | 1x     |
| 10     | 0.067   | 0.06    | 1.1x   |
| 20     | 0.062   | 0.062   | 1x     |
| 50     | 0.11    | 0.062   | 1.8x   |
| 100    | 0.61    | 0.065   | 9.4x   |
| 500    | 0.91    | 0.083   | 11x    |
| 1000   | 1.2     | 0.1     | 12x    |