### PR TITLE
Remove GPU list endpoints

### DIFF
--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -345,47 +345,6 @@ async def kill(request: Request):
         return json(error_response("Error killing execution!", exception), status=500)
 
 
-@app.route("/list-gpus/ncnn", methods=["GET"])
-async def list_ncnn_gpus(_request: Request):
-    """Lists the available GPUs for NCNN"""
-    await nodes_available()
-    try:
-        # pylint: disable=import-outside-toplevel
-        from ncnn_vulkan import ncnn
-
-        result = []
-        for i in range(ncnn.get_gpu_count()):
-            result.append(ncnn.get_gpu_info(i).device_name())
-        return json(result)
-    except Exception as exception:
-        try:
-            from ncnn import ncnn
-
-            result = ["cpu"]
-            return json(result)
-        except Exception as exception2:
-            logger.error(exception, exc_info=True)
-            logger.error(exception2, exc_info=True)
-            return json([])
-
-
-@app.route("/list-gpus/nvidia", methods=["GET"])
-async def list_nvidia_gpus(_request: Request):
-    """Lists the available GPUs for NCNN"""
-    await nodes_available()
-    try:
-        nv = get_nvidia_helper()
-
-        if nv is None:
-            return json([])
-
-        result = nv.list_gpus()
-        return json(result)
-    except Exception as exception:
-        logger.error(exception, exc_info=True)
-        return json([])
-
-
 @app.route("/python-info", methods=["GET"])
 async def python_info(_request: Request):
     version = (

--- a/src/common/Backend.ts
+++ b/src/common/Backend.ts
@@ -220,20 +220,6 @@ export class Backend {
         return this.fetchJson('/clear-cache/individual', 'POST', { id });
     }
 
-    /**
-     * Gets a list of all NCNN GPU devices and their indexes
-     */
-    listNcnnGpus(): Promise<string[]> {
-        return this.fetchJson('/list-gpus/ncnn', 'GET');
-    }
-
-    /**
-     * Gets a list of all Nvidia GPU devices and their indexes
-     */
-    listNvidiaGpus(): Promise<string[]> {
-        return this.fetchJson('/list-gpus/nvidia', 'GET');
-    }
-
     pythonInfo(): Promise<PythonInfo> {
         return this.fetchJson('/python-info', 'GET');
     }

--- a/src/renderer/contexts/DependencyContext.tsx
+++ b/src/renderer/contexts/DependencyContext.tsx
@@ -45,13 +45,11 @@ import {
     PyPiPackage,
     Version,
 } from '../../common/common-types';
-import { isArmMac } from '../../common/env';
 import { log } from '../../common/log';
 import { OnStdio, runPipInstall, runPipUninstall } from '../../common/pip';
 import { noop } from '../../common/util';
 import { versionGt } from '../../common/version';
 import { Markdown } from '../components/Markdown';
-import { useAsyncEffect } from '../hooks/useAsyncEffect';
 import { useMemoObject } from '../hooks/useMemo';
 import { AlertBoxContext, AlertType } from './AlertBoxContext';
 import { BackendContext } from './BackendContext';
@@ -386,15 +384,6 @@ export const DependencyProvider = memo(({ children }: React.PropsWithChildren<un
     const [isConsoleOpen, setIsConsoleOpen] = useState(false);
     const [usePipDirectly, setUsePipDirectly] = useState(false);
 
-    const [hasNvidia, setHasNvidia] = useState(false);
-    useAsyncEffect(
-        () => ({
-            supplier: async () => (await backend.listNvidiaGpus()).length > 0,
-            successEffect: setHasNvidia,
-        }),
-        [backend]
-    );
-
     const { data: installedPyPi, refetch: refetchInstalledPyPi } = useQuery({
         queryKey: 'dependencies',
         queryFn: async () => {
@@ -531,16 +520,6 @@ export const DependencyProvider = memo(({ children }: React.PropsWithChildren<un
                     <ModalCloseButton disabled={currentlyProcessingDeps} />
                     <ModalBody>
                         <VStack w="full">
-                            {!isArmMac && (
-                                <Flex w="full">
-                                    <Text
-                                        flex="1"
-                                        textAlign="left"
-                                    >
-                                        {hasNvidia ? 'CUDA supported' : 'CUDA not supported'}
-                                    </Text>
-                                </Flex>
-                            )}
                             <Flex
                                 align="center"
                                 w="full"


### PR DESCRIPTION
I noticed we still had these around. The NCNN one wasn't being used by anything, and the nvidia one is being used for something on the frontend that basically just tells you if you have an nvidia gpu or not.

The frontend shouldn't care about that (imo). CUDA is only relevant to the pytorch and onnx dependencies, and they already handle changing their deps based on whether the GPU is supported or not.

If we were to do something to show that, i would think we'd do something like the feature system, where we'd have a "CUDA" feature that displays that it is enabled somewhere. idk, i don't really think its that important.