### PR TITLE
Simple fused input-output elements

### DIFF
--- a/backend/src/api/input.py
+++ b/backend/src/api/input.py
@@ -6,7 +6,7 @@ from typing import Any, Literal, Optional, TypedDict, Union
 
 import navi
 
-from .types import InputId
+from .types import InputId, OutputId
 
 InputKind = Literal[
     "number",
@@ -88,6 +88,8 @@ class BaseInput:
         self.id: InputId = InputId(-1)
         self.associated_type: Any = associated_type
 
+        self.fused_with_output: OutputId | None = None
+
         # Optional documentation
         self.description: str | None = None
         self.hint: bool = False
@@ -139,6 +141,7 @@ class BaseInput:
             "hasHandle": self.has_handle,
             "description": self.description,
             "hint": self.hint,
+            "fusedWithOutput": self.fused_with_output,
         }
 
     def with_id(self, input_id: InputId | int):
@@ -155,6 +158,10 @@ class BaseInput:
         if self.associated_type is not None:
             associated_type = self.associated_type
             self.associated_type = Optional[associated_type]
+        return self
+
+    def fused(self, with_output: OutputId | int = 0):
+        self.fused_with_output = OutputId(with_output)
         return self
 
     def __repr__(self):

--- a/backend/src/packages/chaiNNer_standard/utility/color/color.py
+++ b/backend/src/packages/chaiNNer_standard/utility/color/color.py
@@ -13,7 +13,7 @@ from .. import color_group
     description="Outputs the given color.",
     icon="MdColorLens",
     inputs=[
-        ColorInput(),
+        ColorInput().fused(),
     ],
     outputs=[
         ColorOutput(color_type="Input0"),

--- a/backend/src/packages/chaiNNer_standard/utility/value/directory.py
+++ b/backend/src/packages/chaiNNer_standard/utility/value/directory.py
@@ -12,7 +12,9 @@ from .. import value_group
     description="Outputs the given directory.",
     icon="BsFolder",
     inputs=[
-        DirectoryInput("Directory", must_exist=False, hide_label=True, has_handle=True),
+        DirectoryInput(
+            "Directory", must_exist=False, hide_label=True, has_handle=True
+        ).fused(),
     ],
     outputs=[
         DirectoryOutput("Directory", output_type="Input0"),

--- a/backend/src/packages/chaiNNer_standard/utility/value/number.py
+++ b/backend/src/packages/chaiNNer_standard/utility/value/number.py
@@ -19,7 +19,7 @@ from .. import value_group
             precision=100,
             controls_step=1,
             hide_label=True,
-        ),
+        ).fused(),
     ],
     outputs=[
         NumberOutput("Number", output_type="Input0"),

--- a/backend/src/packages/chaiNNer_standard/utility/value/percent.py
+++ b/backend/src/packages/chaiNNer_standard/utility/value/percent.py
@@ -20,10 +20,10 @@ from .. import value_group
             precision=0,
             controls_step=1,
             unit="%",
-        ),
+        ).fused(),
     ],
     outputs=[
-        NumberOutput("%", output_type="Input0"),
+        NumberOutput("Percent", output_type="Input0"),
     ],
 )
 def percent_node(number: int) -> int:

--- a/backend/src/packages/chaiNNer_standard/utility/value/text.py
+++ b/backend/src/packages/chaiNNer_standard/utility/value/text.py
@@ -12,7 +12,9 @@ from .. import value_group
     description="Outputs the given text.",
     icon="MdTextFields",
     inputs=[
-        TextInput("Text", min_length=0, hide_label=True, allow_empty_string=True),
+        TextInput(
+            "Text", min_length=0, hide_label=True, allow_empty_string=True
+        ).fused(),
     ],
     outputs=[
         TextOutput("Text", output_type="Input0"),

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -54,6 +54,7 @@ interface InputBase {
     readonly hasHandle: boolean;
     readonly description?: string;
     readonly hint: boolean;
+    readonly fusedWithOutput?: OutputId | null;
 }
 export interface InputOption {
     option: string;

--- a/src/renderer/components/inputs/InputContainer.tsx
+++ b/src/renderer/components/inputs/InputContainer.tsx
@@ -14,21 +14,21 @@ import { Handle } from '../Handle';
 import { Markdown } from '../Markdown';
 import { TypeTag } from '../TypeTag';
 
-export interface HandleWrapperProps {
+export interface InputHandleProps {
     id: string;
     inputId: InputId;
     connectableType: Type;
     nodeType: NodeType;
 }
 
-export const HandleWrapper = memo(
+export const InputHandle = memo(
     ({
         children,
         id,
         inputId,
         connectableType,
         nodeType,
-    }: React.PropsWithChildren<HandleWrapperProps>) => {
+    }: React.PropsWithChildren<InputHandleProps>) => {
         const { isValidConnection, edgeChanges, useConnectingFrom, typeState } =
             useContext(GlobalVolatileContext);
         const { getEdges, getNode } = useReactFlow();

--- a/src/renderer/components/node/NodeBody.tsx
+++ b/src/renderer/components/node/NodeBody.tsx
@@ -15,6 +15,9 @@ export const NodeBody = memo(({ nodeState, animated = false }: NodeBodyProps) =>
     const { inputs, outputs } = nodeState.schema;
 
     const autoInput = inputs.length === 1 && isAutoInput(inputs[0]);
+    const anyVisibleOutputs = outputs.some((output) => {
+        return !inputs.some((input) => input.fusedWithOutput === output.id);
+    });
 
     return (
         <>
@@ -28,7 +31,7 @@ export const NodeBody = memo(({ nodeState, animated = false }: NodeBodyProps) =>
                 </Box>
             )}
 
-            {outputs.length > 0 && <Box py={1} />}
+            {anyVisibleOutputs && <Box py={1} />}
             <Box
                 bg="var(--bg-700)"
                 w="full"

--- a/src/renderer/components/node/NodeOutputs.tsx
+++ b/src/renderer/components/node/NodeOutputs.tsx
@@ -87,6 +87,10 @@ export const NodeOutputs = memo(({ nodeState, animated }: NodeOutputProps) => {
     return (
         <>
             {schema.outputs.map((output) => {
+                if (schema.inputs.some((i) => i.fusedWithOutput === output.id)) {
+                    return null;
+                }
+
                 const definitionType = functions?.get(output.id) ?? NeverType.instance;
                 const type = nodeState.type.instance?.outputs.get(output.id);
 


### PR DESCRIPTION
Progress towards #1979.

This adds support for a very simple kind of fused input-output elements. All it does is to move the output handle into the input and not display the output. Very simple, but even this is useful for nodes that just output their input value. Unfortunately, this does not include the Pass Through node because of the type tag. I plan to change this in follow-up PRs.

It should be noted this is PR only changes visuals. Nothing about execution or what inputs/outputs are changed.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/b5eb8242-fa1f-4356-bd0d-4a1a71dfe402)
