### PR TITLE
`nodrag` for view image button

### DIFF
--- a/src/renderer/components/outputs/DefaultImageOutput.tsx
+++ b/src/renderer/components/outputs/DefaultImageOutput.tsx
@@ -30,6 +30,7 @@ export const DefaultImageOutput = memo(({ output, id, schema, type }: OutputProp
                 }}
                 bgColor="var(--node-image-preview-button-bg)"
                 borderRadius="md"
+                className="nodrag"
                 cursor="pointer"
                 h="1.75rem"
                 maxH="1.75rem"


### PR DESCRIPTION
I noticed that the view image was draggable, which made it hard to click sometimes.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/a92c27a6-f7e2-470e-9594-6d39331f3d44)
