### PR TITLE
Improved screenshots

### DIFF
--- a/src/renderer/components/ReactFlowBox.tsx
+++ b/src/renderer/components/ReactFlowBox.tsx
@@ -426,9 +426,6 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
 
     return (
         <Box
-            bg="var(--chain-editor-bg)"
-            borderRadius="lg"
-            borderWidth="0px"
             className={animateChain ? '' : 'no-chain-animation'}
             h="100%"
             ref={wrapperRef}
@@ -452,6 +449,7 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
                 style={{
                     zIndex: 0,
                     borderRadius: '0.5rem',
+                    backgroundColor: 'var(--chain-editor-bg)',
                 }}
                 onConnect={createConnection}
                 onConnectEnd={onConnectStop}


### PR DESCRIPTION
This PR fixes 2 minor issues with screenshots:

1. I disabled border radius to prevent it from showing up in screenshots.
2. I gave the screenshot a background color to prevent a slightly transparent border around the screenshot.

The following are parts of a screenshot that was shared in our discord.
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/5d4f58bb-b3b4-48ad-97ff-22382adabd90)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/bacfaba5-874a-4230-ad2e-e2bd3512deb4)

These problems are now fixed.