### PR TITLE
ncnn: Allow configuring multithreading

### DIFF
--- a/backend/src/nodes/impl/ncnn/session.py
+++ b/backend/src/nodes/impl/ncnn/session.py
@@ -39,6 +39,7 @@ def create_ncnn_net(model: NcnnModelWrapper, settings: NcnnSettings) -> ncnn.Net
         net.opt.use_sgemm_convolution = settings.sgemm
         # Configure multithreading
         net.opt.num_threads = settings.threads
+        net.opt.openmp_blocktime = settings.blocktime
 
     # Load model param and bin
     net.load_param_mem(model.model.write_param())

--- a/backend/src/nodes/impl/ncnn/session.py
+++ b/backend/src/nodes/impl/ncnn/session.py
@@ -37,6 +37,8 @@ def create_ncnn_net(model: NcnnModelWrapper, settings: NcnnSettings) -> ncnn.Net
         # Configure Winograd/SGEMM optimizations
         net.opt.use_winograd_convolution = settings.winograd
         net.opt.use_sgemm_convolution = settings.sgemm
+        # Configure multithreading
+        net.opt.num_threads = settings.threads
 
     # Load model param and bin
     net.load_param_mem(model.model.write_param())

--- a/backend/src/packages/chaiNNer_ncnn/settings.py
+++ b/backend/src/packages/chaiNNer_ncnn/settings.py
@@ -92,9 +92,13 @@ def get_settings() -> NcnnSettings:
 
     return NcnnSettings(
         gpu_index=settings.get_int("gpu_index", 0, parse_str=True),
-        winograd=settings.get_bool("winograd", default_net_opt.use_winograd_convolution),
+        winograd=settings.get_bool(
+            "winograd", default_net_opt.use_winograd_convolution
+        ),
         sgemm=settings.get_bool("sgemm", default_net_opt.use_sgemm_convolution),
-        threads=settings.get_int("threads", default_net_opt.num_threads, parse_str=True),
+        threads=settings.get_int(
+            "threads", default_net_opt.num_threads, parse_str=True
+        ),
         blocktime=settings.get_int(
             "blocktime", default_net_opt.openmp_blocktime, parse_str=True
         ),

--- a/backend/src/packages/chaiNNer_ncnn/settings.py
+++ b/backend/src/packages/chaiNNer_ncnn/settings.py
@@ -44,7 +44,7 @@ if not use_gpu:
             label="Use Winograd",
             key="winograd",
             description="Enable Winograd convolution for NCNN. Typically faster but uses more memory.",
-            default=True,
+            default=default_net_opt.use_winograd_convolution,
         )
     )
     package.add_setting(
@@ -52,7 +52,7 @@ if not use_gpu:
             label="Use SGEMM",
             key="sgemm",
             description="Enable SGEMM convolution for NCNN. Typically faster but uses more memory.",
-            default=True,
+            default=default_net_opt.use_sgemm_convolution,
         )
     )
 
@@ -92,8 +92,8 @@ def get_settings() -> NcnnSettings:
 
     return NcnnSettings(
         gpu_index=settings.get_int("gpu_index", 0, parse_str=True),
-        winograd=settings.get_bool("winograd", True),
-        sgemm=settings.get_bool("sgemm", True),
+        winograd=settings.get_bool("winograd", default_net_opt.use_winograd_convolution),
+        sgemm=settings.get_bool("sgemm", default_net_opt.use_sgemm_convolution),
         threads=settings.get_int("threads", default_net_opt.num_threads, parse_str=True),
         blocktime=settings.get_int(
             "blocktime", default_net_opt.openmp_blocktime, parse_str=True

--- a/backend/src/packages/chaiNNer_ncnn/settings.py
+++ b/backend/src/packages/chaiNNer_ncnn/settings.py
@@ -64,6 +64,16 @@ if not use_gpu:
             max=ncnn.Net().opt.num_threads,
         )
     )
+    package.add_setting(
+        NumberSetting(
+            label="Block Time",
+            key="blocktime",
+            description="Milliseconds for threads to busy-wait for more work before going to sleep. Higher values may be faster; lower values may decrease power consumption and CPU usage. Only affects CPU mode.",
+            default=ncnn.Net().opt.openmp_blocktime,
+            min=0,
+            max=400,
+        )
+    )
 
 
 @dataclass(frozen=True)
@@ -72,6 +82,7 @@ class NcnnSettings:
     winograd: bool
     sgemm: bool
     threads: int
+    blocktime: int
 
 
 def get_settings() -> NcnnSettings:
@@ -82,4 +93,7 @@ def get_settings() -> NcnnSettings:
         winograd=settings.get_bool("winograd", True),
         sgemm=settings.get_bool("sgemm", True),
         threads=settings.get_int("threads", ncnn.Net().opt.num_threads, parse_str=True),
+        blocktime=settings.get_int(
+            "blocktime", ncnn.Net().opt.openmp_blocktime, parse_str=True
+        ),
     )

--- a/backend/src/packages/chaiNNer_ncnn/settings.py
+++ b/backend/src/packages/chaiNNer_ncnn/settings.py
@@ -32,6 +32,8 @@ if not is_arm_mac and use_gpu:
     except Exception:
         pass
 
+default_net_opt = ncnn.Net().opt
+
 # Haven't tested disabling Winograd/SGEMM in the ncnn_vulkan fork, so only
 # allow it with upstream ncnn for now. It should work fine regardless of
 # CPU/GPU, but I only tested with CPU. Ditto for multithreading, except it
@@ -59,9 +61,9 @@ if not use_gpu:
             label="Thread Count",
             key="threads",
             description="Number of threads for NCNN. Only affects CPU mode.",
-            default=ncnn.Net().opt.num_threads,
+            default=default_net_opt.num_threads,
             min=1,
-            max=ncnn.Net().opt.num_threads,
+            max=default_net_opt.num_threads,
         )
     )
     package.add_setting(
@@ -69,7 +71,7 @@ if not use_gpu:
             label="Block Time",
             key="blocktime",
             description="Milliseconds for threads to busy-wait for more work before going to sleep. Higher values may be faster; lower values may decrease power consumption and CPU usage. Only affects CPU mode.",
-            default=ncnn.Net().opt.openmp_blocktime,
+            default=default_net_opt.openmp_blocktime,
             min=0,
             max=400,
         )
@@ -92,8 +94,8 @@ def get_settings() -> NcnnSettings:
         gpu_index=settings.get_int("gpu_index", 0, parse_str=True),
         winograd=settings.get_bool("winograd", True),
         sgemm=settings.get_bool("sgemm", True),
-        threads=settings.get_int("threads", ncnn.Net().opt.num_threads, parse_str=True),
+        threads=settings.get_int("threads", default_net_opt.num_threads, parse_str=True),
         blocktime=settings.get_int(
-            "blocktime", ncnn.Net().opt.openmp_blocktime, parse_str=True
+            "blocktime", default_net_opt.openmp_blocktime, parse_str=True
         ),
     )


### PR DESCRIPTION
Informal test results of tweaking these settings on my POWER9 system:

* 31 threads, 20ms block time (ncnn default): 43% CPU usage, 60s to upscale.
* 4 threads, 20ms block time: 9% CPU usage, 72s to upscale.
* 31 threads, 0ms block time: 24% CPU usage, 57s to upscale. (The 3s improvement is within margin of error, I don't think it actually resulted in a speedup, it's just a CPU usage improvement with no significant effect on performance on my system.)