### PR TITLE
Make ncnn memory budget configurable (v2)

### DIFF
--- a/backend/src/packages/chaiNNer_ncnn/ncnn/processing/upscale_image.py
+++ b/backend/src/packages/chaiNNer_ncnn/ncnn/processing/upscale_image.py
@@ -76,18 +76,39 @@ def upscale_impl(
     net = get_ncnn_net(model, settings=settings)
     # Try/except block to catch errors
     try:
-        if use_gpu:
-            vkdev = ncnn.get_gpu_device(settings.gpu_index)
 
-            def estimate_gpu():
+        def estimate():
+            heap_budget_bytes = settings.budget_limit * 1024**3
+
+            # 0 means no limit, we approximate that here by picking 1 PiB,
+            # which presumably no one will ever hit.
+            if heap_budget_bytes == 0:
+                heap_budget_bytes = 1024**5
+
+            model_size_estimate = model.model.bin_length
+
+            if use_gpu:
                 if is_mac:
                     # the actual estimate frequently crashes on mac, so we just use 256
                     return MaxTileSize(256)
 
-                heap_budget = vkdev.get_heap_budget() * 1024 * 1024 * 0.8
-                return MaxTileSize(
-                    estimate_tile_size(heap_budget, model.model.bin_length, img, 4)
+                heap_budget_bytes = min(
+                    heap_budget_bytes, vkdev.get_heap_budget() * 1024 * 1024 * 0.8
                 )
+            else:
+                # Empirically determined (TODO do a more thorough job here)
+                model_size_estimate = model_size_estimate * 5 / 3
+                if net.opt.use_winograd_convolution:
+                    model_size_estimate = model_size_estimate * 11 / 5
+                elif net.opt.use_sgemm_convolution:
+                    model_size_estimate = model_size_estimate * 40 / 5
+
+            return MaxTileSize(
+                estimate_tile_size(heap_budget_bytes, int(model_size_estimate), img, 4)
+            )
+
+        if use_gpu:
+            vkdev = ncnn.get_gpu_device(settings.gpu_index)
 
             with ncnn_allocators(vkdev) as (
                 blob_vkallocator,
@@ -100,16 +121,9 @@ def upscale_impl(
                     output_name=output_name,
                     blob_vkallocator=blob_vkallocator,
                     staging_vkallocator=staging_vkallocator,
-                    tiler=parse_tile_size_input(tile_size, estimate_gpu),
+                    tiler=parse_tile_size_input(tile_size, estimate),
                 )
         else:
-
-            def estimate_cpu():
-                # TODO: Improve tile size estimation in CPU mode.
-                raise ValueError(
-                    "Tile size estimation not supported with NCNN CPU inference"
-                )
-
             return ncnn_auto_split(
                 img,
                 net,
@@ -117,7 +131,7 @@ def upscale_impl(
                 output_name=output_name,
                 blob_vkallocator=None,
                 staging_vkallocator=None,
-                tiler=parse_tile_size_input(tile_size, estimate_cpu),
+                tiler=parse_tile_size_input(tile_size, estimate),
             )
     except (RuntimeError, ValueError):
         raise
@@ -130,7 +144,7 @@ def upscale_impl(
     schema_id="chainner:ncnn:upscale_image",
     name="Upscale Image",
     description="Upscale an image with NCNN. Unlike PyTorch, NCNN has GPU support on all devices, assuming your drivers support Vulkan. \
-            Select a manual number of tiles if you are having issues with the automatic mode.",
+            Select a manual number of tiles or set a memory budget limit if you are having issues with the automatic mode.",
     icon="NCNN",
     inputs=[
         ImageInput().with_id(1),
@@ -141,7 +155,7 @@ def upscale_impl(
             "Tiled upscaling is used to allow large images to be upscaled without hitting memory limits.",
             "This works by splitting the image into tiles (with overlap), upscaling each tile individually, and seamlessly recombining them.",
             "Generally it's recommended to use the largest tile size possible for best performance (with the ideal scenario being no tiling at all), but depending on the model and image size, this may not be possible.",
-            "If you are having issues with the automatic mode, you can manually select a tile size. On certain machines, a very small tile size such as 256 or 128 might be required for it to work at all.",
+            "If you are having issues with the automatic mode, you can manually select a tile size, or set a memory budget limit. On certain machines, a very small tile size such as 256 or 128 might be required for it to work at all.",
         ),
         if_group(
             Condition.type(1, "Image { channels: 4 } ")

--- a/backend/src/packages/chaiNNer_ncnn/settings.py
+++ b/backend/src/packages/chaiNNer_ncnn/settings.py
@@ -77,6 +77,17 @@ if not use_gpu:
         )
     )
 
+package.add_setting(
+    NumberSetting(
+        label="Memory Budget Limit (GiB)",
+        key="budget_limit",
+        description="Maximum memory to use for NCNN inference. 0 means no limit.",
+        default=0,
+        min=0,
+        max=1024**2,
+    )
+)
+
 
 @dataclass(frozen=True)
 class NcnnSettings:
@@ -85,6 +96,7 @@ class NcnnSettings:
     sgemm: bool
     threads: int
     blocktime: int
+    budget_limit: int
 
 
 def get_settings() -> NcnnSettings:
@@ -102,4 +114,5 @@ def get_settings() -> NcnnSettings:
         blocktime=settings.get_int(
             "blocktime", default_net_opt.openmp_blocktime, parse_str=True
         ),
+        budget_limit=settings.get_int("budget_limit", 0, parse_str=True),
     )

--- a/backend/src/packages/chaiNNer_ncnn/settings.py
+++ b/backend/src/packages/chaiNNer_ncnn/settings.py
@@ -81,7 +81,7 @@ package.add_setting(
     NumberSetting(
         label="Memory Budget Limit (GiB)",
         key="budget_limit",
-        description="Maximum memory to use for NCNN inference. 0 means no limit.",
+        description="Maximum memory to use for NCNN inference. 0 means no limit. Memory usage measurement is not completely accurate yet; you may need to significantly adjust this budget limit via trial-and-error if it's not having the effect you want.",
         default=0,
         min=0,
         max=1024**2,


### PR DESCRIPTION
#1867 didn't support automatic estimation of tile size, which was not great for UX. This PR adds that missing support, by allowing the user to choose a custom memory budget. Choosing a memory budget is likely to be better UX than choosing a tile size (since users are likely to have a better knowledge of how much RAM or VRAM they have, than what tile size will work with their hardware and the model they picked). This should also work fine with Vulkan (and is likely to help with [this UX issue](https://github.com/chaiNNer-org/chaiNNer/blob/main/docs/troubleshooting.md#vkqueuesubmit-error-with-ncnn)), though I wasn't able to test that.

This PR is a rewritten version of #2070 and supersedes it; chaiNNer has had enough code churn since then that it was easier to just rewrite as a separate PR. This PR was substantially easier for me to do than messing with rebasing #2088, and is also hopefully easier to review (though #2088 is still worth doing eventually).