### PR TITLE
Update pyright and use library types

### DIFF
--- a/backend/src/gpu.py
+++ b/backend/src/gpu.py
@@ -62,7 +62,7 @@ class NvidiaHelper:
                     name=nv.nvmlDeviceGetName(handle),
                     uuid=nv.nvmlDeviceGetUUID(handle),
                     index=i,
-                    handle=handle,
+                    handle=handle,  # type: ignore
                     arch=nv.nvmlDeviceGetArchitecture(handle),
                 )
             )
@@ -80,7 +80,7 @@ class NvidiaHelper:
     def get_current_vram_usage(self, gpu_index: int = 0) -> tuple[int, int, int]:
         info = nv.nvmlDeviceGetMemoryInfo(self.__gpus[gpu_index].handle)
 
-        return info.total, info.used, info.free
+        return info.total, info.used, info.free  # type: ignore
 
     def supports_fp16(self, gpu_index: int | None = None) -> bool:
         if gpu_index is None:

--- a/backend/src/nodes/impl/caption.py
+++ b/backend/src/nodes/impl/caption.py
@@ -68,7 +68,7 @@ def add_caption(
         font=font,
         anchor="mm",
         align="center",
-        fill=font_color,
+        fill=font_color,  # type: ignore
     )
 
     img = normalize(np.array(pimg))

--- a/backend/src/nodes/impl/dds/format.py
+++ b/backend/src/nodes/impl/dds/format.py
@@ -239,5 +239,5 @@ PREFER_DX9: set[DDSFormat] = {
 
 def to_dxgi(f: DDSFormat) -> DxgiFormat:
     if f in LEGACY_TO_DXGI:
-        return LEGACY_TO_DXGI[cast(LegacyFormat, f)]
+        return LEGACY_TO_DXGI[f]
     return cast(DxgiFormat, f)

--- a/backend/src/nodes/impl/ncnn/auto_split.py
+++ b/backend/src/nodes/impl/ncnn/auto_split.py
@@ -9,7 +9,7 @@ try:
 
     use_gpu = True
 except ImportError:
-    from ncnn import ncnn
+    from ncnn import ncnn  # type: ignore
 
     use_gpu = False
 from sanic.log import logger

--- a/backend/src/nodes/impl/ncnn/session.py
+++ b/backend/src/nodes/impl/ncnn/session.py
@@ -8,7 +8,7 @@ try:
 
     use_gpu = True
 except ImportError:
-    from ncnn import ncnn
+    from ncnn import ncnn  # type: ignore
 
     use_gpu = False
 

--- a/backend/src/nodes/impl/onnx/session.py
+++ b/backend/src/nodes/impl/onnx/session.py
@@ -46,7 +46,10 @@ def create_inference_session(
     else:
         providers = [execution_provider, "CPUExecutionProvider"]
 
-    session = ort.InferenceSession(model.bytes, providers=providers)
+    session = ort.InferenceSession(
+        model.bytes,
+        providers=providers,  # type: ignore
+    )
     return session
 
 

--- a/backend/src/nodes/impl/pil_utils.py
+++ b/backend/src/nodes/impl/pil_utils.py
@@ -84,6 +84,6 @@ def rotate(
         angle,
         resample=resample,  # type: ignore
         expand=bool(expand.value),
-        fillcolor=fill_color,
+        fillcolor=fill_color,  # type: ignore
     )
     return normalize(np.array(pimg))

--- a/backend/src/packages/chaiNNer_ncnn/ncnn/processing/upscale_image.py
+++ b/backend/src/packages/chaiNNer_ncnn/ncnn/processing/upscale_image.py
@@ -10,7 +10,7 @@ try:
 
     use_gpu = True
 except ImportError:
-    from ncnn import ncnn
+    from ncnn import ncnn  # type: ignore
 
     use_gpu = False
 from sanic.log import logger

--- a/backend/src/packages/chaiNNer_ncnn/settings.py
+++ b/backend/src/packages/chaiNNer_ncnn/settings.py
@@ -5,7 +5,7 @@ try:
 
     use_gpu = True
 except ImportError:
-    from ncnn import ncnn
+    from ncnn import ncnn  # type: ignore
 
     use_gpu = False
 

--- a/backend/src/packages/chaiNNer_standard/image/create_images/create_noise.py
+++ b/backend/src/packages/chaiNNer_standard/image/create_images/create_noise.py
@@ -179,7 +179,7 @@ def create_noise_node(
         generator_class = ValueNoise
 
     if fractal_method == FractalMethod.NONE:
-        _add_noise(generator_class, image=img, **kwargs)
+        _add_noise(generator_class, image=img, **kwargs)  # type: ignore
     elif fractal_method == FractalMethod.PINK:
         del kwargs["scale"], kwargs["brightness"]
         total_brightness = 0
@@ -189,7 +189,7 @@ def create_noise_node(
             _add_noise(
                 generator_class,
                 image=img,
-                **kwargs,
+                **kwargs,  # type: ignore
                 scale=scale,
                 brightness=brightness * relative_brightness,
             )

--- a/backend/src/packages/chaiNNer_standard/image/create_images/text_as_image.py
+++ b/backend/src/packages/chaiNNer_standard/image/create_images/text_as_image.py
@@ -203,7 +203,7 @@ def text_as_image_node(
         font=font,
         anchor="mm",
         align=alignment.value,
-        fill=ink,
+        fill=ink,  # type: ignore
     )
 
     img = normalize(np.array(pil_image))

--- a/backend/src/packages/chaiNNer_standard/image_channel/misc/alpha_matting.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/misc/alpha_matting.py
@@ -95,6 +95,7 @@ def alpha_matting_node(
     assert trimap.dtype == np.float64
     alpha = pymatting.estimate_alpha_cf(img, trimap)
     foreground = pymatting.estimate_foreground_ml(img, alpha)
+    assert isinstance(foreground, np.ndarray)
 
     # convert to bgr
     foreground = cv2.cvtColor(foreground, cv2.COLOR_RGB2BGR)

--- a/backend/src/packages/chaiNNer_standard/utility/random/derive_seed.py
+++ b/backend/src/packages/chaiNNer_standard/utility/random/derive_seed.py
@@ -30,7 +30,7 @@ def _to_bytes(s: Source) -> bytes:
         s = s.value
 
     i = int(s)
-    if isinstance(s, int) or s == i:
+    if isinstance(s, int) or s == i:  # type: ignore
         return i.to_bytes(i.bit_length() // 8 + 1, byteorder="big", signed=True)
 
     return struct.pack("d", s)

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -6,7 +6,7 @@
 		"**/__pycache__"
 	],
 	"ignore": [],
-	"typeCheckingMode": "basic"
+	"typeCheckingMode": "basic",
 	"useLibraryCodeForTypes": true,
 	"strictListInference": true,
 	"strictDictionaryInference": true,

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -10,7 +10,7 @@
 	],
 
 	"typeCheckingMode": "basic",
-	"useLibraryCodeForTypes": false,
+	"useLibraryCodeForTypes": true,
 
 	"strictListInference": true,
 	"strictDictionaryInference": true,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ruff==0.1.4
 debugpy
-pyright==1.1.308
+pyright==1.1.338
 pytest


### PR DESCRIPTION
Changes:
- Update pyright to 1.1.338 and fixed the new type errors.
- `"useLibraryCodeForTypes": true`: Spandrel types should now be inferred correctly.