### PR TITLE
Update Spandrel again + fixes

### DIFF
--- a/backend/src/nodes/impl/pytorch/auto_split.py
+++ b/backend/src/nodes/impl/pytorch/auto_split.py
@@ -20,7 +20,10 @@ def pytorch_auto_split(
     tiler: Tiler,
 ) -> np.ndarray:
     model = model.to(device)
-    model.model.half() if use_fp16 else model.model.float()
+    if use_fp16:
+        model.model.half()
+    else:
+        model.model.float()
 
     def upscale(img: np.ndarray, _: object):
         img_tensor = np2tensor(img, change_range=True)

--- a/backend/src/nodes/properties/inputs/pytorch_inputs.py
+++ b/backend/src/nodes/properties/inputs/pytorch_inputs.py
@@ -90,7 +90,7 @@ class InpaintModelInput(ModelInput):
     def __init__(
         self, label: str = "Model", input_type: navi.ExpressionJson = "PyTorchModel"
     ):
-        self.purpose: set[Purpose] = {"Inpaint"}
+        self.purpose: set[Purpose] = {"Inpainting"}
 
         super().__init__(
             label,

--- a/backend/src/packages/chaiNNer_pytorch/__init__.py
+++ b/backend/src/packages/chaiNNer_pytorch/__init__.py
@@ -95,7 +95,7 @@ package = add_package(
         Dependency(
             display_name="Spandrel",
             pypi_name="spandrel",
-            version="0.1.0",
+            version="0.1.1",
             size_estimate=180.7 * KB,
         ),
     ],

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/inpaint.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/inpaint.py
@@ -90,7 +90,7 @@ def inpaint(
             d_mask = (d_mask > 0.5) * 1
             d_mask = d_mask.half() if use_fp16 else d_mask.float()
 
-            result = model.model(d_img, d_mask)
+            result = model(d_img, d_mask)
             result = tensor2np(
                 result.detach().cpu().detach(),
                 change_range=False,

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
@@ -63,7 +63,7 @@ def upscale(
 
         img_out = pytorch_auto_split(
             img,
-            model=model.model,
+            model=model,
             device=device,
             use_fp16=use_fp16,
             tiler=parse_tile_size_input(tile_size, estimate),

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/utility/interpolate_models.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/utility/interpolate_models.py
@@ -5,7 +5,12 @@ import gc
 import numpy as np
 import torch
 from sanic.log import logger
-from spandrel import ModelDescriptor, ModelLoader
+from spandrel import (
+    ImageModelDescriptor,
+    MaskedImageModelDescriptor,
+    ModelDescriptor,
+    ModelLoader,
+)
 
 from nodes.impl.pytorch.utils import np2tensor, tensor2np
 from nodes.properties.inputs import ModelInput, SliderInput
@@ -44,7 +49,17 @@ def check_can_interp(model_a: dict, model_b: dict):
     del interp_50
     with torch.no_grad():
         img_tensor = np2tensor(fake_img, change_range=True).cpu()
-        t_out = model_descriptor.model(img_tensor)
+        if isinstance(model_descriptor, MaskedImageModelDescriptor):
+            np.ones((size, size, 1), dtype=np.float32)
+            mask_tensor = np2tensor(fake_img, change_range=True).cpu()
+            t_out = model_descriptor(img_tensor, mask_tensor)
+        elif isinstance(model_descriptor, ImageModelDescriptor):  # type: ignore <- I get that this can technically never happen, but please just let me write exhaustive checks
+            t_out = model_descriptor(img_tensor)
+        else:
+            logger.warning(
+                "Unknown model type used with interpolation. Since we cannot verify inference works with this model, we will assume the interpolation is valid. Please report."
+            )
+            return True
         if isinstance(t_out, tuple):
             t_out = t_out[0]
         result = tensor2np(t_out.detach(), change_range=False, imtype=np.float32)


### PR DESCRIPTION
My last PR didn't switch to using the new call API, for models like MM-RealSR weren't working. Also, since the call API is type-safe, I was able to see that inpainting models would never be able to be interpolated since we weren't handling their two-image parameter requirement.

I'm unable to use the call API for face inference though, since codeformer has no option for its weight through that. That's not too much of an issue though. 

Side note: We'll probably want to add a method to go alongside the call api that does the same thing. I realized when doing this that when you use the call API, you can't hover over anything to have vscode show you the args of the function.