### PR TITLE
Refactor out onnx conversion + use data for ncnn input name

### DIFF
--- a/backend/src/nodes/impl/pytorch/convert_to_onnx_impl.py
+++ b/backend/src/nodes/impl/pytorch/convert_to_onnx_impl.py
@@ -1,0 +1,42 @@
+from io import BytesIO
+
+import torch
+from spandrel import ModelDescriptor
+
+
+def convert_to_onnx_impl(
+    model: ModelDescriptor,
+    device: torch.device,
+    use_half: bool = False,
+    input_name: str = "input",
+    output_name: str = "output",
+) -> bytes:
+    # https://github.com/onnx/onnx/issues/654
+    dynamic_axes = {
+        input_name: {0: "batch_size", 2: "height", 3: "width"},
+        output_name: {0: "batch_size", 2: "height", 3: "width"},
+    }
+    dummy_input = torch.rand(1, model.input_channels, 64, 64)
+    dummy_input = dummy_input.to(device)
+
+    if use_half:
+        model.model.half()
+        dummy_input = dummy_input.half()
+    else:
+        model.model.float()
+        dummy_input = dummy_input.float()
+
+    with BytesIO() as f:
+        torch.onnx.export(
+            model.model,
+            dummy_input,
+            f,
+            opset_version=14,
+            verbose=False,
+            input_names=[input_name],
+            output_names=[output_name],
+            dynamic_axes=dynamic_axes,
+            do_constant_folding=True,
+        )
+        f.seek(0)
+        return f.read()

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/utility/convert_to_onnx.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/utility/convert_to_onnx.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-from io import BytesIO
-
-import torch
 from spandrel import ImageModelDescriptor
 from spandrel.architectures.SCUNet import SCUNet
 
 from nodes.impl.onnx.model import OnnxGeneric
+from nodes.impl.pytorch.convert_to_onnx_impl import convert_to_onnx_impl
 from nodes.properties.inputs import OnnxFpDropdown, SrModelInput
 from nodes.properties.outputs import OnnxModelOutput, TextOutput
 
@@ -47,37 +45,11 @@ def convert_to_onnx_node(
 
     model.model.eval()
     model = model.to(device)
-    # https://github.com/onnx/onnx/issues/654
-    dynamic_axes = {
-        "input": {0: "batch_size", 2: "height", 3: "width"},
-        "output": {0: "batch_size", 2: "height", 3: "width"},
-    }
-    dummy_input = torch.rand(1, model.input_channels, 64, 64)
-    dummy_input = dummy_input.to(device)
 
-    should_use_fp16 = exec_options.use_fp16 and model.supports_half and fp16
-    if should_use_fp16:
-        model.model.half()
-        dummy_input = dummy_input.half()
-    else:
-        model.model.float()
-        dummy_input = dummy_input.float()
+    use_half = fp16 and model.supports_half
 
-    with BytesIO() as f:
-        torch.onnx.export(
-            model.model,
-            dummy_input,
-            f,
-            opset_version=14,
-            verbose=False,
-            input_names=["input"],
-            output_names=["output"],
-            dynamic_axes=dynamic_axes,
-            do_constant_folding=True,
-        )
-        f.seek(0)
-        onnx_model_bytes = f.read()
+    onnx_model_bytes = convert_to_onnx_impl(model, device, use_half)
 
-    fp_mode = "fp16" if should_use_fp16 else "fp32"
+    fp_mode = "fp16" if use_half else "fp32"
 
     return OnnxGeneric(onnx_model_bytes), fp_mode


### PR DESCRIPTION
Long overdue. This should make it so that nobody has to [manually edit a param file](https://github.com/upscayl/upscayl/wiki/%F0%9F%96%A5%EF%B8%8F-Model-Conversion%E2%80%89%E2%80%93%E2%80%89Get-more-models!#:~:text=Open%20the%20.param%20file%20and%20change%20the%20first%20%22input%22%20on%20the%20second%20column%20and%20all%20%22input%22s%20(usually%202)%20in%20the%20third%20column%20to%20%22data%22.) to get their models to work with upscayl or the realesrgan binary