### PR TITLE
Added overlap blending for auto split

### DIFF
--- a/backend/src/nodes/impl/upscale/auto_split.py
+++ b/backend/src/nodes/impl/upscale/auto_split.py
@@ -154,6 +154,8 @@ def _max_split(
             f"Currently {tile_count_x}x{tile_count_y} tiles each {tile_size_x}x{tile_size_y}px."
         )
 
+        prev_row_result: TileBlender | None = None
+
         for y in range(tile_count_y):
             if y < start_y:
                 continue
@@ -205,7 +207,9 @@ def _max_split(
                         channels=c,
                         direction=BlendDirection.X,
                         blend_fn=half_sin_blend_fn,
+                        _prev=prev_row_result,
                     )
+                    prev_row_result = row_result
                     row_overlap = TileOverlap(pad.top * scale, pad.bottom * scale)
 
                 assert current_scale == scale

--- a/backend/src/nodes/impl/upscale/exact_split.py
+++ b/backend/src/nodes/impl/upscale/exact_split.py
@@ -9,6 +9,7 @@ from sanic.log import logger
 
 from ...utils.utils import Padding, Region, Size, get_h_w_c
 from ..image_utils import BorderType, create_border
+from .tile_blending import BlendDirection, TileBlender, TileOverlap, half_sin_blend_fn
 
 
 def _pad_image(img: np.ndarray, min_size: Size):
@@ -90,7 +91,7 @@ def _exact_split_into_regions(
     exact_w: int,
     exact_h: int,
     overlap: int,
-) -> list[tuple[Region, Padding]]:
+) -> list[list[tuple[Region, Padding]]]:
     """
     Returns a list of disjoint regions along with padding.
     Each region plus its padding is guaranteed to have the given exact size.
@@ -105,10 +106,11 @@ def _exact_split_into_regions(
         f"Image is split into {len(x_segments)}x{len(y_segments)} tiles each exactly {exact_w}x{exact_h}px."
     )
 
-    result: list[tuple[Region, Padding]] = []
+    result: list[list[tuple[Region, Padding]]] = []
     for y in y_segments:
+        row: list[tuple[Region, Padding]] = []
         for x in x_segments:
-            result.append(
+            row.append(
                 (
                     Region(x.start, y.start, x.length, y.length),
                     Padding(
@@ -116,6 +118,7 @@ def _exact_split_into_regions(
                     ),
                 )
             )
+        result.append(row)
     return result
 
 
@@ -134,39 +137,62 @@ def _exact_split_without_padding(
 
     # To allocate the result image, we need to know the upscale factor first,
     # and we only get to know this factor after the first successful upscale.
-    result: np.ndarray | None = None
+    result: TileBlender | None = None
     scale: int = 0
 
     regions = _exact_split_into_regions(w, h, exact_w, exact_h, overlap)
-    for tile, pad in regions:
-        padded_tile = tile.add_padding(pad)
+    for row in regions:
+        row_result: TileBlender | None = None
+        row_overlap: TileOverlap | None = None
 
-        upscale_result = upscale(padded_tile.read_from(img), padded_tile)
+        for tile, pad in row:
+            padded_tile = tile.add_padding(pad)
+            assert padded_tile.size == exact_size
 
-        # figure out by how much the image was upscaled by
-        up_h, up_w, _ = get_h_w_c(upscale_result)
-        current_scale = up_h // padded_tile.height
-        assert current_scale > 0
-        assert padded_tile.height * current_scale == up_h
-        assert padded_tile.width * current_scale == up_w
+            upscale_result = upscale(padded_tile.read_from(img), padded_tile)
 
+            # figure out by how much the image was upscaled by
+            up_h, up_w, _ = get_h_w_c(upscale_result)
+            current_scale = up_h // exact_h
+            assert current_scale > 0
+            assert exact_h * current_scale == up_h
+            assert exact_w * current_scale == up_w
+
+            if row_result is None:
+                # allocate the result image
+                scale = current_scale
+                row_result = TileBlender(
+                    width=w * scale,
+                    height=exact_h * scale,
+                    channels=c,
+                    direction=BlendDirection.X,
+                    blend_fn=half_sin_blend_fn,
+                )
+                row_overlap = TileOverlap(pad.top * scale, pad.bottom * scale)
+
+            assert current_scale == scale
+
+            row_result.add_tile(
+                upscale_result, TileOverlap(pad.left * scale, pad.right * scale)
+            )
+
+        assert row_result is not None
+        assert row_overlap is not None
         if result is None:
-            # allocate the result image
-            scale = current_scale
-            result = np.zeros((h * scale, w * scale, c), dtype=np.float32)
+            result = TileBlender(
+                width=w * scale,
+                height=h * scale,
+                channels=c,
+                direction=BlendDirection.Y,
+                blend_fn=half_sin_blend_fn,
+            )
 
-        assert current_scale == scale
-
-        # remove overlap padding
-        upscale_result = pad.scale(scale).remove_from(upscale_result)
-
-        # copy into result image
-        tile.scale(scale).write_into(result, upscale_result)
+        result.add_tile(row_result.get_result(), row_overlap)
 
     assert result is not None
 
     # remove initially added padding
-    return result
+    return result.get_result()
 
 
 def exact_split(

--- a/backend/src/nodes/impl/upscale/tile_blending.py
+++ b/backend/src/nodes/impl/upscale/tile_blending.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable
+
+import numpy as np
+
+from nodes.utils.utils import get_h_w_c
+
+
+def sin_blend_fn(x: np.ndarray) -> np.ndarray:
+    return (np.sin(x * math.pi - math.pi / 2) + 1) / 2
+
+
+def half_sin_blend_fn(i: np.ndarray) -> np.ndarray:
+    # only use half the overlap
+    i = np.clip(i * 2 - 0.5, 0, 1)
+    return sin_blend_fn(i)
+
+
+class BlendDirection(Enum):
+    X = 0
+    Y = 1
+
+
+@dataclass(frozen=True)
+class TileOverlap:
+    start: int
+    end: int
+
+    @property
+    def total(self) -> int:
+        return self.start + self.end
+
+
+class TileBlender:
+    def __init__(
+        self,
+        width: int,
+        height: int,
+        channels: int,
+        direction: BlendDirection,
+        blend_fn: Callable[[np.ndarray], np.ndarray] = sin_blend_fn,
+    ) -> None:
+        self.direction: BlendDirection = direction
+        self.result: np.ndarray = np.zeros((height, width, channels), dtype=np.float32)
+        self.blend_fn: Callable[[np.ndarray], np.ndarray] = blend_fn
+        self.offset: int = 0
+        self.last_end_overlap: int = 0
+
+    @property
+    def width(self) -> int:
+        return self.result.shape[1]
+
+    @property
+    def height(self) -> int:
+        return self.result.shape[0]
+
+    @property
+    def channels(self) -> int:
+        return self.result.shape[2]
+
+    def add_tile(self, tile: np.ndarray, overlap: TileOverlap) -> None:
+        h, w, c = get_h_w_c(tile)
+        assert c == self.channels
+        o = overlap
+
+        if self.direction == BlendDirection.X:
+            assert h == self.height
+            assert w > o.total
+
+            if self.offset == 0:
+                # the first tile is copied in as is
+                self.result[:, :w, ...] = tile
+
+                assert o.start == 0
+                self.offset += w - o.end
+                self.last_end_overlap = o.end
+
+            else:
+                assert self.offset < self.width, "All tiles were filled in already"
+
+                if self.last_end_overlap < o.start:
+                    # we can't use all the overlap of the current tile, so we have to cut it off
+                    diff = o.start - self.last_end_overlap
+                    tile = tile[:, diff:, ...]
+                    h, w, c = get_h_w_c(tile)
+                    o = TileOverlap(self.last_end_overlap, o.end)
+
+                # copy over the part that doesn't need blending (yet)
+                self.result[
+                    :, self.offset + o.start : self.offset + w - o.start, ...
+                ] = tile[:, o.start * 2 :, ...]
+
+                # blend the overlapping part
+                blend_size = o.start * 2
+                blend = self.blend_fn(
+                    np.arange(blend_size, dtype=np.float32) / (blend_size - 1)
+                )
+                blend = blend.reshape((1, blend_size, 1))
+                blend = np.repeat(blend, repeats=h, axis=0)
+                blend = np.repeat(blend, repeats=c, axis=2)
+
+                left = self.result[
+                    :, self.offset - o.start : self.offset + o.start, ...
+                ]
+                right = tile[:, :blend_size, ...]
+
+                self.result[:, self.offset - o.start : self.offset + o.start, ...] = (
+                    left * (1 - blend) + right * blend
+                )
+
+                self.offset += w - o.total
+                self.last_end_overlap = o.end
+        else:
+            assert w == self.width
+            assert h > o.total
+
+            if self.offset == 0:
+                # the first tile is copied in as is
+                self.result[:h, :, ...] = tile
+
+                assert o.start == 0
+                self.offset += h - o.end
+                self.last_end_overlap = o.end
+
+            else:
+                assert self.offset < self.height, "All tiles were filled in already"
+
+                if self.last_end_overlap < o.start:
+                    # we can't use all the overlap of the current tile, so we have to cut it off
+                    diff = o.start - self.last_end_overlap
+                    tile = tile[diff:, :, ...]
+                    h, w, c = get_h_w_c(tile)
+                    o = TileOverlap(self.last_end_overlap, o.end)
+
+                # copy over the part that doesn't need blending
+                self.result[
+                    self.offset + o.start : self.offset + h - o.start, :, ...
+                ] = tile[o.start * 2 :, :, ...]
+
+                # blend the overlapping part
+                blend_size = o.start * 2
+                blend = self.blend_fn(
+                    np.arange(blend_size, dtype=np.float32) / (blend_size - 1)
+                )
+                blend = blend.reshape((blend_size, 1, 1))
+                blend = np.repeat(blend, repeats=w, axis=1)
+                blend = np.repeat(blend, repeats=c, axis=2)
+
+                left = self.result[
+                    self.offset - o.start : self.offset + o.start, :, ...
+                ]
+                right = tile[: o.start * 2, :, ...]
+
+                self.result[self.offset - o.start : self.offset + o.start, :, ...] = (
+                    left * (1 - blend) + right * blend
+                )
+
+                self.offset += h - o.total
+                self.last_end_overlap = o.end
+
+    def get_result(self) -> np.ndarray:
+        # if self.direction == BlendDirection.X:
+        #     assert self.offset == self.width
+        # else:
+        #     assert self.offset == self.height
+
+        return self.result


### PR DESCRIPTION
This adds smooth blending between neighboring tiles for `auto_split`. This should eliminate many obvious tiling artifacts.

Note that blending is not done as simple linear gradient. It uses a sin function internally to get smoother blending. This function **not** hard-coded. We can use arbitrary functions to get the blending gradient we want. 

The custom blend function we use isn't just a sin. It also discards the outer 50% of the overlap. I.e. for an overlap of 16px, the outer 8px of that overlap are discarded as they are more dissimilar to the neighboring tile than the inner 8px. Doing this virtually eliminates the slight blur blending introduces.

### Demonstration

This is how tiles are blending for a 256x256 image that is being upscaled 4x with a tile size of 64 and overlap of 16. We see that the blending is smooth across all axes.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/7bc4bf59-0f1a-4112-bd7d-2b6c0a4465a6)

While the above image makes the blending easy to see, this configuration is very unlikely in practice. So are the tiles of a 512x512px image upscaled 4x with a tile size of 256 and an overlap of 16:

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/7806b4dd-3043-4d04-ab4a-8bc3d6b1e170)



### Implementation details

The blended final image is iteratively constructed in place. Only the final and the current tile are held in memory. Tiles that have already been added are freed. The final buffer is allocated after we get the first tile in `auto_split`, just like before. 

The only difference is that there are 2 passes. We first blend the tiles of each row of tiles, and then blend the rows. This means that we allocate more memory than before, because we need to keep one whole row in memory.

### Performance

The implementation is about 2x **slower** than the old implementation. 

I measured the overhead of `auto_aplit` (=splitting the image into tiles and then assembling the tiles back together) for 4x upscaling an 1024x1024 image, using a tile size of 256 and an overlap of 16px. The overhead of ~250ms before this change and ~400ms with blending.

While this is quite a bit slower, it also shouldn't matter too much. The overhead of `auto_split` grows with the number of tiles. Since very fast models are typically also require less VRAM, larger tile sizes are viable which reduces the overhead of `auto_split`. Large and slow model typically require more VRAM and therefore require more tiles.

I also optimized a little. The blending itself uses a faster mixing function that avoid temporary arrays. The temporary blend array is reused whenever possible. The result array of rows is also reused whenever possible. 