### PR TITLE
Add open delay to status tooltips

### DIFF
--- a/src/renderer/components/node/NodeFooter/Timer.tsx
+++ b/src/renderer/components/node/NodeFooter/Timer.tsx
@@ -63,6 +63,7 @@ export const Timer = memo(({ time }: TimerProps) => {
             closeOnClick={false}
             gutter={24}
             label={`Execution took approximately ${joinEnglish(longParts)}.`}
+            openDelay={150}
             px={2}
             textAlign="center"
         >

--- a/src/renderer/components/node/NodeFooter/ValidityIndicator.tsx
+++ b/src/renderer/components/node/NodeFooter/ValidityIndicator.tsx
@@ -15,80 +15,63 @@ interface ValidityIndicatorProps {
 export const ValidityIndicator = memo(({ validity, animated }: ValidityIndicatorProps) => {
     const { paused } = useContext(ExecutionStatusContext);
 
-    // eslint-disable-next-line no-nested-ternary
-    return animated ? (
-        paused ? (
-            <Tooltip
-                hasArrow
-                borderRadius={8}
-                closeOnClick={false}
-                gutter={24}
-                label="This node is currently paused"
-                px={2}
-                textAlign="center"
-            >
-                <Center className="nodrag">
-                    <Center
-                        bgColor="var(--node-valid-bg)"
-                        borderRadius={100}
-                        h="auto"
-                        w="auto"
-                    >
-                        <Icon
-                            as={IoIosPause}
-                            boxSize="1rem"
-                            color="var(--node-valid-fg)"
-                            cursor="default"
-                            m="auto"
-                        />
-                    </Center>
-                </Center>
-            </Tooltip>
-        ) : (
-            <Tooltip
-                hasArrow
-                borderRadius={8}
-                closeOnClick={false}
-                gutter={24}
-                label="This node is currently running..."
-                px={2}
-                textAlign="center"
-            >
-                <Center className="nodrag">
-                    <Spinner size="xs" />
-                </Center>
-            </Tooltip>
-        )
-    ) : (
-        <Tooltip
-            hasArrow
-            borderRadius={8}
-            closeOnClick={false}
-            gutter={24}
-            label={
-                <Markdown nonInteractive>
-                    {validity.isValid ? 'Node valid' : validity.reason}
-                </Markdown>
-            }
-            px={2}
-            textAlign="center"
-        >
-            <Center className="nodrag">
+    let icon;
+    let text;
+    if (animated) {
+        if (paused) {
+            text = 'This node is currently paused';
+            icon = (
                 <Center
-                    bgColor={validity.isValid ? 'var(--node-valid-bg)' : 'var(--node-invalid-bg)'}
+                    bgColor="var(--node-valid-bg)"
                     borderRadius={100}
                     h="auto"
                     w="auto"
                 >
                     <Icon
-                        as={validity.isValid ? BsCheck : BsExclamation}
+                        as={IoIosPause}
                         boxSize="1rem"
-                        color={validity.isValid ? 'var(--node-valid-fg)' : 'var(--node-invalid-fg)'}
+                        color="var(--node-valid-fg)"
                         cursor="default"
                         m="auto"
                     />
                 </Center>
+            );
+        } else {
+            text = 'This node is currently running...';
+            icon = <Spinner size="xs" />;
+        }
+    } else {
+        text = validity.isValid ? 'Node valid' : validity.reason;
+        icon = (
+            <Center
+                bgColor={validity.isValid ? 'var(--node-valid-bg)' : 'var(--node-invalid-bg)'}
+                borderRadius={100}
+                h="auto"
+                w="auto"
+            >
+                <Icon
+                    as={validity.isValid ? BsCheck : BsExclamation}
+                    boxSize="1rem"
+                    color={validity.isValid ? 'var(--node-valid-fg)' : 'var(--node-invalid-fg)'}
+                    cursor="default"
+                    m="auto"
+                />
             </Center>
+        );
+    }
+
+    return (
+        <Tooltip
+            hasArrow
+            borderRadius={8}
+            closeOnClick={false}
+            gutter={24}
+            label={<Markdown nonInteractive>{text}</Markdown>}
+            openDelay={150}
+            px={2}
+            textAlign="center"
+        >
+            <Center className="nodrag">{icon}</Center>
         </Tooltip>
     );
 });


### PR DESCRIPTION
This adds a slight open delay to the tooltip of the status icon and timer. The delay is slight enough so that the tooltips still feel instant, but it's large enough for the tooltip to not pop half open when you move your mouse to somewhere and it happens to hovers over the icon/timer for a frame. This always bugged me.

I also refactored the validity indicator to avoid code duplication.