### PR TITLE
Add "tabs" style for dropdown inputs

### DIFF
--- a/backend/src/nodes/properties/inputs/generic_inputs.py
+++ b/backend/src/nodes/properties/inputs/generic_inputs.py
@@ -40,13 +40,14 @@ class TypedOption(TypedDict):
 
 DropDownOption = Union[UntypedOption, TypedOption]
 
-DropDownStyle = Literal["dropdown", "checkbox"]
+DropDownStyle = Literal["dropdown", "checkbox", "tabs"]
 """
 This specified the preferred style in which the frontend may display the dropdown.
 
 - `dropdown`: This is the default style. The dropdown will simply be displayed as a dropdown.
 - `checkbox`: If the dropdown has 2 options, then it will be displayed as a checkbox.
   The first option will be interpreted as the yes/true option while the second option will be interpreted as the no/false option.
+- `tabs`: The options are displayed as tab list. The label of the input itself will *not* be displayed.
 """
 
 
@@ -155,6 +156,7 @@ class EnumInput(Generic[T], DropDownInput):
         type_name: str | None = None,
         option_labels: dict[T, str] | None = None,
         extra_definitions: str | None = None,
+        preferred_style: DropDownStyle = "dropdown",
     ):
         if type_name is None:
             type_name = enum.__name__
@@ -186,6 +188,7 @@ class EnumInput(Generic[T], DropDownInput):
             label=label,
             options=options,
             default_value=default.value if default is not None else None,
+            preferred_style=preferred_style,
         )
 
         self.type_definitions = (

--- a/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/stretch_contrast.py
+++ b/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/stretch_contrast.py
@@ -23,7 +23,7 @@ def _stretch(img: np.ndarray, range_min: float, range_max: float) -> np.ndarray:
 
 
 class StretchMode(Enum):
-    AUTOMATIC = 0
+    AUTO = 0
     PERCENTILE = 1
     MANUAL = 2
 
@@ -35,8 +35,8 @@ class StretchMode(Enum):
     icon="ImContrast",
     inputs=[
         ImageInput(channels=[1, 3, 4]),
-        EnumInput(StretchMode).with_id(1),
-        if_enum_group(1, [StretchMode.AUTOMATIC, StretchMode.PERCENTILE])(
+        EnumInput(StretchMode, preferred_style="tabs").with_id(1),
+        if_enum_group(1, [StretchMode.AUTO, StretchMode.PERCENTILE])(
             BoolInput("Keep Colors", default=True),
         ),
         if_enum_group(1, StretchMode.PERCENTILE)(
@@ -71,7 +71,7 @@ def stretch_contrast_node(
     manual_max: float,
 ) -> np.ndarray:
     def get_range_of(i: np.ndarray) -> tuple[float, float]:
-        if mode == StretchMode.AUTOMATIC:
+        if mode == StretchMode.AUTO:
             return float(np.min(i)), float(np.max(i))
         elif mode == StretchMode.PERCENTILE:
             return float(np.percentile(i, percentile)), float(

--- a/backend/src/packages/chaiNNer_standard/image_dimension/crop/crop.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/crop/crop.py
@@ -25,7 +25,7 @@ class CropMode(Enum):
     icon="MdCrop",
     inputs=[
         ImageInput(),
-        EnumInput(CropMode, default=CropMode.BORDER).with_id(1),
+        EnumInput(CropMode, default=CropMode.BORDER, preferred_style="tabs").with_id(1),
         if_enum_group(1, CropMode.BORDER)(
             NumberInput("Amount", unit="px").with_id(2),
         ),

--- a/backend/src/packages/chaiNNer_standard/utility/color/color_from.py
+++ b/backend/src/packages/chaiNNer_standard/utility/color/color_from.py
@@ -11,7 +11,7 @@ from .. import color_group
 
 
 class ColorType(Enum):
-    GRAYSCALE = 0
+    GRAY = 0
     RGB = 1
     RGBA = 2
 
@@ -22,8 +22,8 @@ class ColorType(Enum):
     description="Create a new color value from individual channels.",
     icon="MdColorLens",
     inputs=[
-        EnumInput(ColorType, "Color Type", ColorType.RGBA),
-        if_enum_group(0, ColorType.GRAYSCALE)(
+        EnumInput(ColorType, "Color Type", ColorType.RGBA, preferred_style="tabs"),
+        if_enum_group(0, ColorType.GRAY)(
             SliderInput(
                 "Luma",
                 minimum=0,
@@ -88,7 +88,7 @@ class ColorType(Enum):
         ColorOutput(
             color_type="""
                 let channels = match Input0 {
-                    ColorType::Grayscale => 1,
+                    ColorType::Gray => 1,
                     ColorType::Rgb => 3,
                     ColorType::Rgba => 4,
                 };
@@ -105,7 +105,7 @@ def color_from_node(
     blue: float,
     alpha: float,
 ) -> Color:
-    if color_type == ColorType.GRAYSCALE:
+    if color_type == ColorType.GRAY:
         return Color.gray(gray / 255)
     if color_type == ColorType.RGB:
         return Color.bgr([blue / 255, green / 255, red / 255])

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -66,7 +66,7 @@ export interface InputOption {
     type?: ExpressionJson;
 }
 export type FileInputKind = 'image' | 'pth' | 'pt' | 'video' | 'bin' | 'param' | 'onnx';
-export type DropDownStyle = 'dropdown' | 'checkbox';
+export type DropDownStyle = 'dropdown' | 'checkbox' | 'tabs';
 
 export interface GenericInput extends InputBase {
     readonly kind: 'generic';

--- a/src/renderer/components/inputs/DropDownInput.tsx
+++ b/src/renderer/components/inputs/DropDownInput.tsx
@@ -1,6 +1,7 @@
 import { memo, useCallback } from 'react';
 import { Checkbox } from './elements/Checkbox';
 import { DropDown } from './elements/Dropdown';
+import { TabList } from './elements/TabList';
 import { WithLabel, WithoutLabel } from './InputContainer';
 import { InputProps } from './props';
 
@@ -16,11 +17,26 @@ export const DropDownInput = memo(({ value, setValue, input, isLocked }: DropDow
         return (
             <WithoutLabel>
                 <Checkbox
+                    isDisabled={isLocked}
                     label={label}
                     no={options[1]}
                     reset={reset}
                     value={value}
                     yes={options[0]}
+                    onChange={setValue}
+                />
+            </WithoutLabel>
+        );
+    }
+
+    if (preferredStyle === 'tabs') {
+        return (
+            <WithoutLabel>
+                <TabList
+                    isDisabled={isLocked}
+                    options={input.options}
+                    reset={reset}
+                    value={value}
                     onChange={setValue}
                 />
             </WithoutLabel>

--- a/src/renderer/components/inputs/elements/TabList.tsx
+++ b/src/renderer/components/inputs/elements/TabList.tsx
@@ -1,0 +1,72 @@
+import { TabList as ChakraTabList, Tab, TabIndicator, Tabs } from '@chakra-ui/react';
+import { memo, useEffect } from 'react';
+import { DropDownInput, InputSchemaValue } from '../../../../common/common-types';
+
+export interface TabListProps {
+    value: InputSchemaValue | undefined;
+    onChange: (value: InputSchemaValue) => void;
+    reset: () => void;
+    isDisabled?: boolean;
+    options: DropDownInput['options'];
+}
+
+export const TabList = memo(({ value, onChange, reset, isDisabled, options }: TabListProps) => {
+    // reset invalid values to default
+    useEffect(() => {
+        if (value === undefined || options.every((o) => o.value !== value)) {
+            reset();
+        }
+    }, [value, reset, options]);
+
+    let selection = options.findIndex((o) => o.value === value);
+    if (selection === -1) selection = 0;
+
+    const handleChange = (index: number) => {
+        const selectedValue = options[index]?.value as InputSchemaValue | undefined;
+        if (selectedValue === undefined) {
+            reset();
+        } else {
+            onChange(selectedValue);
+        }
+    };
+
+    return (
+        <Tabs
+            isFitted
+            className="nodrag"
+            index={selection}
+            mt="-0.25rem"
+            mx="-0.5rem"
+            pb={1}
+            position="relative"
+            size="sm"
+            variant="unstyled"
+            onChange={handleChange}
+        >
+            <ChakraTabList
+                borderBottom="1px solid"
+                borderColor="var(--chakra-colors-chakra-border-color)"
+            >
+                {options.map(({ option }, i) => {
+                    const selected = i === selection;
+
+                    return (
+                        <Tab
+                            isDisabled={isDisabled}
+                            key={option}
+                            opacity={selected ? 1 : 0.8}
+                            px={2}
+                        >
+                            {option}
+                        </Tab>
+                    );
+                })}
+            </ChakraTabList>
+            <TabIndicator
+                bg="currentColor"
+                height="2px"
+                mt="-2px"
+            />
+        </Tabs>
+    );
+});


### PR DESCRIPTION
This adds a tab list style display for dropdowns. This style shows all options at once and allows users to quickly change between them. Just like checkboxes, tabs are implemented using `preferred_style`, so it's a purely visual change and doesn't affect the behavior of the input at all.

I used tabs in 3 nodes so far.
- Crop, for the Crop Mode dropdown.
- Stretch Contrast, for the Stretch Mode dropdown.
- Color From, for the Color Type dropdown.

I also renamed some enum variants to make the tabs look better. In particular, I renamed "Grayscale" to "Gray" in Color From, which makes it nicely consistent with regular color input.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/a850182a-28cc-4916-b6cd-575e4e8e816c)
