### PR TITLE
Add strengthen normals node

### DIFF
--- a/backend/src/packages/chaiNNer_standard/material_textures/normal_map/strengthen_normals.py
+++ b/backend/src/packages/chaiNNer_standard/material_textures/normal_map/strengthen_normals.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import numpy as np
+
+import navi
+from nodes.impl.normals.addition import AdditionMethod, strengthen_normals
+from nodes.impl.normals.util import xyz_to_bgr
+from nodes.properties.inputs import EnumInput, ImageInput, SliderInput
+from nodes.properties.outputs import ImageOutput
+
+from .. import normal_map_group
+
+
+@normal_map_group.register(
+    schema_id="chainner:image:strengthen_normals",
+    name="Strengthen Normals",
+    description=[
+        "Strengths and weakens the normals in the given normal map. Only the R and G channels of the input image will be used. The output normal map is guaranteed to be normalized.",
+        "Conceptually, this node is equivalent to `chainner:image:add_normals` with the strength of the second normal map set to 0.",
+    ],
+    icon="MdExpand",
+    inputs=[
+        ImageInput("Normal Map", channels=[3, 4]),
+        SliderInput("Strength", maximum=400, default=100),
+        EnumInput(
+            AdditionMethod,
+            label="Method",
+            default=AdditionMethod.PARTIAL_DERIVATIVES,
+        ),
+    ],
+    outputs=[
+        ImageOutput(
+            "Normal Map",
+            image_type=navi.Image(size_as="Input0"),
+            channels=3,
+        ),
+    ],
+)
+def strengthen_normals_node(
+    n: np.ndarray, strength: int, method: AdditionMethod
+) -> np.ndarray:
+    return xyz_to_bgr(strengthen_normals(method, n, strength / 100))


### PR DESCRIPTION
This adds a node to strengthen/scale the normals of a normal map. This node is especially useful for making detail normal maps more or less strong.

I previously used the Add Normals node for this, but this was a bit annoying and limited since I sometimes needed a strength factor > 200. So I made this functionality its own node. As an added benefit, the Stengthen Normals is also about 2x faster than the old way I did it via Add Normals.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/e6cddc21-e8b6-4e60-9f77-8dd03e0e92be)
