### PR TITLE
Auto-layouting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -46,6 +46,7 @@
     "imwrite",
     "jit",
     "Lanczos",
+    "layouted",
     "leakyrelu",
     "localstorage",
     "Luma",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "decompress": "^4.2.1",
         "electron-log": "^4.4.8",
         "electron-squirrel-startup": "^1.0.0",
+        "elkjs": "^0.8.2",
         "eventsource": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "framer-motion": "^6.3.6",
@@ -58,6 +59,7 @@
         "use-debounce": "^8.0.1",
         "uuid": "^8.3.2",
         "wcag-contrast": "^3.0.0",
+        "web-worker": "^1.2.0",
         "yargs": "^17.5.1"
       },
       "devDependencies": {
@@ -10831,6 +10833,11 @@
       "engines": {
         "node": ">= 4.0.0"
       }
+    },
+    "node_modules/elkjs": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.8.2.tgz",
+      "integrity": "sha512-L6uRgvZTH+4OF5NE/MBbzQx/WYpru1xCBE9respNj6qznEewGUIfhzmm7horWWxbNO2M0WckQypGctR8lH79xQ=="
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -24503,6 +24510,11 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/web-worker": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz",
+      "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA=="
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -33529,6 +33541,11 @@
           "optional": true
         }
       }
+    },
+    "elkjs": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.8.2.tgz",
+      "integrity": "sha512-L6uRgvZTH+4OF5NE/MBbzQx/WYpru1xCBE9respNj6qznEewGUIfhzmm7horWWxbNO2M0WckQypGctR8lH79xQ=="
     },
     "emittery": {
       "version": "0.13.1",
@@ -43607,6 +43624,11 @@
       "requires": {
         "defaults": "^1.0.3"
       }
+    },
+    "web-worker": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz",
+      "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA=="
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "decompress": "^4.2.1",
     "electron-log": "^4.4.8",
     "electron-squirrel-startup": "^1.0.0",
+    "elkjs": "^0.8.2",
     "eventsource": "^2.0.2",
     "fast-deep-equal": "^3.1.3",
     "framer-motion": "^6.3.6",
@@ -155,6 +156,7 @@
     "use-debounce": "^8.0.1",
     "uuid": "^8.3.2",
     "wcag-contrast": "^3.0.0",
+    "web-worker": "^1.2.0",
     "yargs": "^17.5.1"
   },
   "optionalDependencies": {

--- a/src/common/safeIpc.ts
+++ b/src/common/safeIpc.ts
@@ -84,6 +84,7 @@ export interface SendChannels {
     paste: SendChannelInfo;
     duplicate: SendChannelInfo;
     'duplicate-with-input-edges': SendChannelInfo;
+    'format-chain': SendChannelInfo;
 }
 export type ChannelArgs<C extends keyof (InvokeChannels & SendChannels)> = (InvokeChannels &
     SendChannels)[C]['args'];

--- a/src/main/gui/menu.ts
+++ b/src/main/gui/menu.ts
@@ -288,6 +288,15 @@ export const setMainMenu = ({ mainWindow, menuData, enabled = false }: MainMenuA
                               },
                               enabled,
                           },
+                          { type: 'separator' },
+                          {
+                              label: 'Format Chain',
+                              accelerator: 'CmdOrCtrl+Shift+F',
+                              click: () => {
+                                  mainWindow.webContents.send('format-chain');
+                              },
+                              enabled,
+                          },
                       ],
                   },
                   { role: 'windowMenu' },
@@ -358,6 +367,16 @@ export const setMainMenu = ({ mainWindow, menuData, enabled = false }: MainMenuA
                               registerAccelerator: false,
                               click: () => {
                                   mainWindow.webContents.send('duplicate-with-input-edges');
+                              },
+                              enabled,
+                          },
+                          { type: 'separator' },
+                          {
+                              label: 'Format Chain',
+                              accelerator: 'CmdOrCtrl+Shift+F',
+                              registerAccelerator: false,
+                              click: () => {
+                                  mainWindow.webContents.send('format-chain');
                               },
                               enabled,
                           },

--- a/src/renderer/components/ReactFlowBox.tsx
+++ b/src/renderer/components/ReactFlowBox.tsx
@@ -475,29 +475,29 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
         getLayoutedElements(nodes, edges)
             .then((response) => {
                 const { nodes: layoutedNodes } = response;
-
                 if (layoutedNodes) {
-                    const nodesWithTheirPositionsModified = layoutedNodes.map((node) => {
-                        const originalNode = nodes.find((n) => n.id === node.id);
-                        if (!originalNode) {
-                            return undefined;
-                        }
-                        return {
-                            ...originalNode,
-                            position: node.position,
-                        };
+                    changeNodes((nds) => {
+                        const nodesWithTheirPositionsModified = layoutedNodes.map((node) => {
+                            const originalNode = nds.find((n) => n.id === node.id);
+                            if (!originalNode) {
+                                return undefined;
+                            }
+                            return {
+                                ...originalNode,
+                                position: node.position,
+                            };
+                        });
+                        const notUndefined = nodesWithTheirPositionsModified.filter(
+                            (n) => n !== undefined
+                        ) as Node<NodeData>[];
+                        return notUndefined;
                     });
-                    const notUndefined = nodesWithTheirPositionsModified.filter(
-                        (n) => n !== undefined
-                    ) as Node<NodeData>[];
-
-                    setNodes(notUndefined);
                 }
             })
             .catch((error) => {
                 log.error(error);
             });
-    }, [nodes, edges, setNodes]);
+    }, [nodes, edges, changeNodes]);
 
     useHotkeys('ctrl+f, cmd+f', onLayout);
 

--- a/src/renderer/components/ReactFlowBox.tsx
+++ b/src/renderer/components/ReactFlowBox.tsx
@@ -44,6 +44,7 @@ import { DataTransferProcessorOptions, dataTransferProcessors } from '../helpers
 import { AABB, Point, getBezierPathValues, pointDist } from '../helpers/graphUtils';
 import { isSnappedToGrid, snapToGrid } from '../helpers/reactFlowUtil';
 import { useHotkeys } from '../hooks/useHotkeys';
+import { useIpcRendererListener } from '../hooks/useIpcRendererListener';
 import { useMemoArray } from '../hooks/useMemo';
 import { useNodesMenu } from '../hooks/useNodesMenu';
 import { usePaneNodeSearchMenu } from '../hooks/usePaneNodeSearchMenu';
@@ -499,7 +500,8 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
             });
     }, [nodes, edges, changeNodes]);
 
-    useHotkeys('ctrl+f, cmd+f', onLayout);
+    useHotkeys('ctrl+shift+f, cmd+shift+f', onLayout);
+    useIpcRendererListener('format-chain', onLayout);
 
     return (
         <Box

--- a/src/renderer/components/ReactFlowBox.tsx
+++ b/src/renderer/components/ReactFlowBox.tsx
@@ -44,7 +44,7 @@ import {
     AABB,
     Point,
     getBezierPathValues,
-    getLayoutedElements,
+    getLayoutedPositionMap,
     pointDist,
 } from '../helpers/graphUtils';
 import { isSnappedToGrid, snapToGrid } from '../helpers/reactFlowUtil';
@@ -431,7 +431,7 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
     );
 
     const onLayout = useCallback(() => {
-        getLayoutedElements(nodes, edges)
+        getLayoutedPositionMap(nodes, edges)
             .then((positionMap) => {
                 changeNodes((nds) => {
                     return nds.map((node) => {

--- a/src/renderer/components/ReactFlowBox.tsx
+++ b/src/renderer/components/ReactFlowBox.tsx
@@ -493,12 +493,20 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
                         ) as Node<NodeData>[];
                         return notUndefined;
                     });
+                    const minX = Math.min(...layoutedNodes.map((n) => n.position.x || Infinity));
+                    const minY = Math.min(...layoutedNodes.map((n) => n.position.y || Infinity));
+
+                    reactFlowInstance.setViewport({
+                        x: minX,
+                        y: minY,
+                        zoom: reactFlowInstance.getZoom(),
+                    });
                 }
             })
             .catch((error) => {
                 log.error(error);
             });
-    }, [nodes, edges, changeNodes]);
+    }, [nodes, edges, changeNodes, reactFlowInstance]);
 
     useHotkeys('ctrl+shift+f, cmd+shift+f', onLayout);
     useIpcRendererListener('format-chain', onLayout);

--- a/src/renderer/helpers/graphUtils.ts
+++ b/src/renderer/helpers/graphUtils.ts
@@ -179,7 +179,7 @@ const elkOptions = {
     'elk.direction': 'RIGHT',
 };
 
-export const getLayoutedElements = async (nodes: Node<NodeData>[], edges: Edge<EdgeData>[]) => {
+export const getLayoutedPositionMap = async (nodes: Node<NodeData>[], edges: Edge<EdgeData>[]) => {
     const isHorizontal = elkOptions['elk.direction'] === 'RIGHT';
     const graph: ElkNode = {
         id: 'root',


### PR DESCRIPTION
I realized as I was using chaiNNer for cleaning up a family photo that it would be really nice to auto-layout my messy chain, so I implemented it real quick.

This implementation is based on the [elkjs react-flow example](https://reactflow.dev/examples/layout/elkjs). The resulting code isn't the greatest, but it works.

I'd like this to also be a button somewhere or a menu item, but for now it's just ctrl+f (for format) as a proof of concept. I don't know if there would be a better hotkey to set it to if we want to keep a hotkey, otherwise it should be a button trigger.

The original implementation ran FitView after setting the nodes, but that doesn't really work since you can't set the nodes and do a .then after, so I just excluded it. I'd love to do that, but only if we can get it to actually work.
