### PR TITLE
Add Chroma Key node

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image_channel/misc/chroma_key.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/misc/chroma_key.py
@@ -32,6 +32,7 @@ class KeyMethod(Enum):
     name="Chroma Key",
     description=[
         "Removes a color from an image and replaces it with transparency.",
+        "To set he key color, either define a constant color with the `chainner:utility:color` node or pick a color from the image with the `chainner:image:pick_color` node.",
         "This nodes offers multiple strategies to key the image:",
         "- **Binary**:",
         "    A simple binary thresholding method is used to determine the whether a pixel in the image is transparent or not. This method is mostly useful images *without anti-aliasing*.",

--- a/backend/src/packages/chaiNNer_standard/image_channel/misc/chroma_key.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/misc/chroma_key.py
@@ -32,7 +32,7 @@ class KeyMethod(Enum):
     name="Chroma Key",
     description=[
         "Removes a color from an image and replaces it with transparency.",
-        "To set he key color, either define a constant color with the `chainner:utility:color` node or pick a color from the image with the `chainner:image:pick_color` node.",
+        "To set the key color, either define a constant color with the `chainner:utility:color` node or pick a color from the image with the `chainner:image:pick_color` node.",
         "This nodes offers multiple strategies to key the image:",
         "- **Binary**:",
         "    A simple binary thresholding method is used to determine the whether a pixel in the image is transparent or not. This method is mostly useful images *without anti-aliasing*.",

--- a/backend/src/packages/chaiNNer_standard/image_channel/misc/chroma_key.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/misc/chroma_key.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from enum import Enum
+
+import cv2
+import numpy as np
+import pymatting
+
+import navi
+from nodes.groups import if_enum_group, linked_inputs_group
+from nodes.impl.color.color import Color
+from nodes.properties.inputs import (
+    BoolInput,
+    ColorInput,
+    EnumInput,
+    ImageInput,
+    SliderInput,
+)
+from nodes.properties.outputs import ImageOutput
+from nodes.utils.utils import get_h_w_c
+
+from . import node_group
+
+
+class KeyMethod(Enum):
+    BINARY = 1
+    TRIMAP_MATTING = 2
+
+
+@node_group.register(
+    schema_id="chainner:image:chroma_key",
+    name="Chroma Key",
+    description=[
+        "Removes a color from an image and replaces it with transparency.",
+        "This nodes offers multiple strategies to key the image:",
+        "- **Binary**:",
+        "    A simple binary thresholding method is used to determine the whether a pixel in the image is transparent or not. This method is mostly useful images *without anti-aliasing*.",
+        "- **Trimap matting**:",
+        "    This method uses a separate threshold for foreground (FG) and background (BG) to create a trimap. Alpha matting is then performed on the trimap to create the final alpha. For more information on alpha matting, see the `chainner:image:alpha_matting` node.",
+        "    The confusion sliders can be used to reduce the amount of pixels that are considered to be FG or BG. This is useful for anti-alised/blurred edges.",
+        "    Since alpha matting can be slow, it is recommended to use the **Output Trimap** option. This option will use the trimap for alpha directly, without performing alpha matting. Using the fast preview, you can tweak the other parameters to generate a good trimap. Once you are satisfied with the trimap, you can disable the **Output Trimap** option to perform alpha matting.",
+    ],
+    icon="MdOutlineFormatColorFill",
+    inputs=[
+        ImageInput(channels=3),
+        ColorInput(channels=3),
+        EnumInput(KeyMethod).with_id(2),
+        if_enum_group(2, KeyMethod.BINARY)(
+            SliderInput(
+                "Threshold", maximum=100, default=1, precision=1, controls_step=1
+            )
+        ),
+        if_enum_group(2, KeyMethod.TRIMAP_MATTING)(
+            SliderInput(
+                "Threshold BG", maximum=100, default=2, precision=1, controls_step=1
+            ),
+            SliderInput(
+                "Threshold FG", maximum=100, default=10, precision=1, controls_step=1
+            ),
+            linked_inputs_group(
+                SliderInput("Confusion BG", maximum=100, default=4, scale="log"),
+                SliderInput("Confusion FG", maximum=100, default=4, scale="log"),
+            ),
+            BoolInput("Output Trimap", default=False).with_docs(
+                "If enabled, the generated trimap will be used as alpha. No alpha matting will be performed."
+            ),
+        ),
+    ],
+    outputs=[
+        ImageOutput(
+            image_type=navi.Image(size_as="Input0"),
+            channels=4,
+        ),
+    ],
+)
+def chroma_key_node(
+    img: np.ndarray,
+    key_color: Color,
+    method: KeyMethod,
+    binary_threshold: float,
+    tm_threshold_bg: float,
+    tm_threshold_fg: float,
+    tm_confusion_bg: int,
+    tm_confusion_fg: int,
+    tm_output_trimap: bool,
+) -> np.ndarray:
+    if method == KeyMethod.BINARY:
+        return binary_keying(img, key_color, binary_threshold / 100)
+    elif method == KeyMethod.TRIMAP_MATTING:
+        return trimap_matting_keying(
+            img,
+            key_color,
+            tm_threshold_bg / 100,
+            tm_threshold_fg / 100,
+            tm_confusion_bg,
+            tm_confusion_fg,
+            tm_output_trimap,
+        )
+    else:
+        raise AssertionError(f"Invalid alpha fill method {method}")
+
+
+def binary_keying(img: np.ndarray, key_color: Color, threshold: float) -> np.ndarray:
+    h, w, _ = get_h_w_c(img)
+
+    diff = np.abs(img - key_color.to_image(w, h))
+    diff = np.sum(diff, axis=-1) / 3
+
+    alpha = np.where(diff > threshold, 1, 0).astype(np.float32)
+    return np.dstack([img, alpha])
+
+
+def trimap_matting_keying(
+    img: np.ndarray,
+    key_color: Color,
+    threshold_bg: float,
+    threshold_fg: float,
+    confusion_bg: int,
+    confusion_fg: int,
+    output_trimap: bool,
+) -> np.ndarray:
+    h, w, _ = get_h_w_c(img)
+
+    diff = np.abs(img - key_color.to_image(w, h))
+    diff = np.sum(diff, axis=-1) / 3
+
+    # determine in and out
+    bg_mask = np.where(diff <= threshold_bg, 255, 0).astype(np.uint8)
+    fg_mask = np.where(diff > threshold_fg, 255, 0).astype(np.uint8)
+    if confusion_bg > 0:
+        element = cv2.getStructuringElement(
+            cv2.MORPH_ELLIPSE, (2 * confusion_bg + 1,) * 2
+        )
+        cv2.erode(bg_mask, element, iterations=1, dst=bg_mask)
+    if confusion_fg > 0:
+        element = cv2.getStructuringElement(
+            cv2.MORPH_ELLIPSE, (2 * confusion_fg + 1,) * 2
+        )
+        cv2.erode(fg_mask, element, iterations=1, dst=fg_mask)
+
+    # must be float64
+    trimap = np.full((h, w), 0.5, dtype=np.float64)
+    trimap[bg_mask > 128] = 0
+    trimap[fg_mask > 128] = 1
+
+    if output_trimap:
+        return np.dstack((img, trimap.astype(np.float32)))
+
+    # convert to rgb
+    img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+    img = img.astype(np.float64)
+
+    assert img.dtype == np.float64
+    assert trimap.dtype == np.float64
+    alpha = pymatting.estimate_alpha_cf(img, trimap)
+    foreground = pymatting.estimate_foreground_ml(img, alpha)
+    assert isinstance(foreground, np.ndarray)
+
+    # convert to bgr
+    foreground = cv2.cvtColor(foreground, cv2.COLOR_RGB2BGR)
+    return np.dstack(
+        (
+            foreground.astype(np.float32),
+            alpha.astype(np.float32),
+        )
+    )


### PR DESCRIPTION
Fixes #1786
Fixes #2226

This adds a Chroma key node. 

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/015fed19-489a-40e2-ba3b-b53b9dd17c5e)


The node as 2 key modes: binary and trimap matting. While the binary method is just a threshold to decide a binary transparent yes/no, the trimap option will generate a trimap and then perform alpha matting. As such, the trimap option is substantially slower, but can produce pretty good results. Here are some examples:

| Before | After | Settings |
| --- | --- | --- |
|  ![green coco 5](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/0f938f52-29bb-41fb-863b-0dd8572f4970) | ![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/c321370b-4433-446a-b394-62cf7e4995a8) | ![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/eb96581d-4385-4d75-b465-ffa6f970019f)
| ![green stop](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/aacbfdfa-379e-4583-873f-251c319c4016) | ![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/6a8e7938-8460-4880-8eec-d7b323763247) | ![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/f16faa36-c4c2-4f01-9707-20ef24004495)
| ![green alice 1 clean](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/842d643f-8c9f-4211-a0fa-fe78d00ace79) |![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/033a7147-85f3-4753-a0a5-251c9bbf250b) |![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/b7b825e4-12da-4103-bc0b-8130b88306fb)
| ![white toki 1](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/423e8a34-bc7e-4c6c-b68d-aa7af34dfb2e) |![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/51c0e143-4bf4-49ec-be88-bc3784b3058f) |![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/a51519d4-f558-4f27-982e-83fec7d32be9)
| ![gray original 3](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/48085c6f-e06f-480e-912c-f12c9dc4f8da) |![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/9bc979c3-a8fa-47eb-a87c-f814214c907b) |![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/54a79d2b-0f94-4a23-a610-a21b3f6cf527)

Not perfect, but pretty good.