### PR TITLE
Fix alert box closing delay

### DIFF
--- a/src/renderer/contexts/AlertBoxContext.tsx
+++ b/src/renderer/contexts/AlertBoxContext.tsx
@@ -323,7 +323,7 @@ export const AlertBoxProvider = memo(({ children }: React.PropsWithChildren<unkn
         <AlertBoxContext.Provider value={value}>
             <AlertDialog
                 isCentered
-                isOpen={isOpen}
+                isOpen={isOpen && current !== undefined}
                 leastDestructiveRef={cancelRef}
                 scrollBehavior="inside"
                 onClose={() => cancelRef.current?.click()}


### PR DESCRIPTION
I noticed that there was a small delay between clicking the close button on alerts and the alert actually being closed. This delay was very obvious, because we have a message queue that updates instantly. So when there's one alert and the alert gets closed, this delay causes an *empty alert* to be displayed for a few frames.

The fix is to simple try the open state to the message queue. If there is no message, don't have the alert open.