### PR TITLE
Optimize `resize`

### DIFF
--- a/backend/src/nodes/impl/resize.py
+++ b/backend/src/nodes/impl/resize.py
@@ -72,6 +72,10 @@ def resize(
         # no resize needed
         return img.copy()
 
+    if filter == ResizeFilter.NEAREST:
+        # we don't need premultiplied alpha for NN
+        separate_alpha = True
+
     native_filter = _FILTER_MAP[filter]
 
     if not separate_alpha and c == 4:

--- a/backend/src/packages/chaiNNer_standard/__init__.py
+++ b/backend/src/packages/chaiNNer_standard/__init__.py
@@ -83,7 +83,7 @@ package = add_package(
         Dependency(
             display_name="ChaiNNer Extensions",
             pypi_name="chainner_ext",
-            version="0.3.7",
+            version="0.3.8",
             size_estimate=2.0 * MB,
         ),
     ],


### PR DESCRIPTION
This improves the performance of `resize`. I implemented numerous performance improvements for `chainner_ext` and a small one in `resize` itself. Performance should now be mostly on par with OpenCV.