### PR TITLE
Optimize Split Transparency output for subsequent operations

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image_channel/transparency/split_transparency.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/transparency/split_transparency.py
@@ -6,6 +6,7 @@ import navi
 from nodes.impl.image_utils import as_target_channels
 from nodes.properties.inputs import ImageInput
 from nodes.properties.outputs import ImageOutput
+from nodes.utils.utils import get_h_w_c
 
 from . import node_group
 
@@ -33,6 +34,14 @@ from . import node_group
 )
 def split_transparency_node(img: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     """Split a multi-channel image into separate channels"""
+
+    c = get_h_w_c(img)[2]
+    if c == 3:
+        # Performance optimization:
+        # Subsequent operations will be faster since the underlying array will
+        # be contiguous in memory. The speed up can anything from nothing to
+        # 5x faster depending on the operation.
+        return img, np.ones(img.shape[:2], dtype=img.dtype)
 
     img = as_target_channels(img, 4)
 


### PR DESCRIPTION
While optimizing `resize`, I learned that creating an RGB image by returning the first 3 channels of an RGBA image can cause very significant slow downs in subsequent operations. This is because iterating over array slices is a lot slower than iterating over contiguous memory. Slices also might require a copy to make them contiguous (some image operations are implemented in such a way that they require contiguous memory).

I also want to say that we generally don't need to worry about slices being bad for performance. They are only bad if they can be trivially avoided, like in Split Transparency. For RGB images, this node was creating a new RGBA image and then returned 2 slices to that RGBA image. So I added some code to return the RGB image and new image instead. This not only improves performance for subsequent operations, it also allocates less memory.