### PR TITLE
Fix resize for non-C-style arrays

### DIFF
--- a/backend/src/packages/chaiNNer_standard/__init__.py
+++ b/backend/src/packages/chaiNNer_standard/__init__.py
@@ -83,7 +83,7 @@ package = add_package(
         Dependency(
             display_name="ChaiNNer Extensions",
             pypi_name="chainner_ext",
-            version="0.3.8",
+            version="0.3.9",
             size_estimate=2.0 * MB,
         ),
     ],


### PR DESCRIPTION
Fixes the issue with View Image reported to us by adegerard. The cause of the issue was that a recent optimization to `resize` caused a bug for ndarrays that aren't in C memory layout. I fixed this in https://github.com/chaiNNer-org/chaiNNer-rs/pull/26. This Pr simply bumps the `chainner_ext` version to include the fix.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/c542c777-bf1e-4b8e-b8f6-20d735ea516b)
