### PR TITLE
Improved automatic chain formatting

### DIFF
--- a/src/renderer/components/ReactFlowBox.tsx
+++ b/src/renderer/components/ReactFlowBox.tsx
@@ -431,7 +431,7 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
     );
 
     const onLayout = useCallback(() => {
-        getLayoutedPositionMap(nodes, edges)
+        getLayoutedPositionMap(nodes, edges, isSnapToGrid ? snapToGridAmount : undefined)
             .then((positionMap) => {
                 changeNodes((nds) => {
                     return nds.map((node) => {
@@ -446,7 +446,7 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
             .catch((error) => {
                 log.error(error);
             });
-    }, [nodes, edges, changeNodes]);
+    }, [nodes, edges, isSnapToGrid, snapToGridAmount, changeNodes]);
 
     useHotkeys('ctrl+shift+f, cmd+shift+f', onLayout);
     useIpcRendererListener('format-chain', onLayout);


### PR DESCRIPTION
Changes:
- Less space between connected nodes.
- Less vertical space between nodes within a connected component.
- More space between components (unconnected sub graphs).
- Better handling of edges. Edges were previously approximated as straight lines, now they are curves just like in chainner.
- More refinement iterations to get better results for complex chains.
- Account for snap to grid.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/9627ce93-bd5c-40f2-8393-910422feaafe)
