### PR TITLE
Add categories and dividers for dropdowns

### DIFF
--- a/backend/src/nodes/impl/resize.py
+++ b/backend/src/nodes/impl/resize.py
@@ -17,13 +17,13 @@ class ResizeFilter(Enum):
     CATROM = 3
     LANCZOS = 1
 
-    # HERMITE = 5
-    # MITCHELL = 6
-    # BSPLINE = 7
-    # HAMMING = 8
-    # HANN = 9
-    # LAGRANGE = 10
-    # GAUSS = 11
+    HERMITE = 5
+    MITCHELL = 6
+    BSPLINE = 7
+    HAMMING = 8
+    HANN = 9
+    LAGRANGE = 10
+    GAUSS = 11
 
 
 _FILTER_MAP: dict[ResizeFilter, NavtiveResizeFilter] = {
@@ -32,13 +32,13 @@ _FILTER_MAP: dict[ResizeFilter, NavtiveResizeFilter] = {
     ResizeFilter.LINEAR: NavtiveResizeFilter.Linear,
     ResizeFilter.CATROM: NavtiveResizeFilter.CubicCatrom,
     ResizeFilter.LANCZOS: NavtiveResizeFilter.Lanczos,
-    # ResizeFilter.HERMITE: NavtiveResizeFilter.Hermite,
-    # ResizeFilter.MITCHELL: NavtiveResizeFilter.CubicMitchell,
-    # ResizeFilter.BSPLINE: NavtiveResizeFilter.CubicBSpline,
-    # ResizeFilter.HAMMING: NavtiveResizeFilter.Hamming,
-    # ResizeFilter.HANN: NavtiveResizeFilter.Hann,
-    # ResizeFilter.LAGRANGE: NavtiveResizeFilter.Lagrange,
-    # ResizeFilter.GAUSS: NavtiveResizeFilter.Gauss,
+    ResizeFilter.HERMITE: NavtiveResizeFilter.Hermite,
+    ResizeFilter.MITCHELL: NavtiveResizeFilter.CubicMitchell,
+    ResizeFilter.BSPLINE: NavtiveResizeFilter.CubicBSpline,
+    ResizeFilter.HAMMING: NavtiveResizeFilter.Hamming,
+    ResizeFilter.HANN: NavtiveResizeFilter.Hann,
+    ResizeFilter.LAGRANGE: NavtiveResizeFilter.Lagrange,
+    ResizeFilter.GAUSS: NavtiveResizeFilter.Gauss,
 }
 
 

--- a/backend/src/nodes/properties/inputs/image_dropdown_inputs.py
+++ b/backend/src/nodes/properties/inputs/image_dropdown_inputs.py
@@ -11,7 +11,7 @@ from ...impl.color.convert_data import (
 from ...impl.image_utils import BorderType
 from ...impl.pil_utils import RotationInterpolationMethod
 from ...impl.resize import ResizeFilter
-from .generic_inputs import DropDownInput, EnumInput
+from .generic_inputs import DropDownGroup, DropDownInput, EnumInput
 
 
 def ColorSpaceDetectorInput(label: str = "Color Space") -> DropDownInput:
@@ -55,10 +55,15 @@ def ResizeFilterInput() -> DropDownInput:
     return EnumInput(
         ResizeFilter,
         label="Interpolation Method",
+        categories=[
+            DropDownGroup("Basic", start_at=ResizeFilter.AUTO),
+            DropDownGroup("Advanced", start_at=ResizeFilter.HERMITE),
+        ],
         option_labels={
             ResizeFilter.NEAREST: "Nearest Neighbor",
             ResizeFilter.BOX: "Area (Box)",
             ResizeFilter.CATROM: "Cubic",
+            ResizeFilter.BSPLINE: "B-Spline",
         },
     )
 

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -67,6 +67,10 @@ export interface InputOption {
 }
 export type FileInputKind = 'image' | 'pth' | 'pt' | 'video' | 'bin' | 'param' | 'onnx';
 export type DropDownStyle = 'dropdown' | 'checkbox' | 'tabs';
+export interface DropdownGroup {
+    readonly label?: string | null;
+    readonly startAt: InputSchemaValue;
+}
 
 export interface GenericInput extends InputBase {
     readonly kind: 'generic';
@@ -76,6 +80,7 @@ export interface DropDownInput extends InputBase {
     readonly def: string | number;
     readonly options: readonly InputOption[];
     readonly preferredStyle: DropDownStyle;
+    readonly groups: readonly DropdownGroup[];
 }
 export interface FileInput extends InputBase {
     readonly kind: 'file';

--- a/src/renderer/components/inputs/DropDownInput.tsx
+++ b/src/renderer/components/inputs/DropDownInput.tsx
@@ -8,7 +8,7 @@ import { InputProps } from './props';
 type DropDownInputProps = InputProps<'dropdown', string | number>;
 
 export const DropDownInput = memo(({ value, setValue, input, isLocked }: DropDownInputProps) => {
-    const { options, def, label, preferredStyle } = input;
+    const { options, def, label, preferredStyle, groups } = input;
 
     const reset = useCallback(() => setValue(def), [setValue, def]);
 
@@ -46,6 +46,7 @@ export const DropDownInput = memo(({ value, setValue, input, isLocked }: DropDow
     return (
         <WithLabel input={input}>
             <DropDown
+                groups={groups}
                 isDisabled={isLocked}
                 options={input.options}
                 reset={reset}

--- a/src/renderer/components/inputs/elements/Dropdown.tsx
+++ b/src/renderer/components/inputs/elements/Dropdown.tsx
@@ -1,6 +1,6 @@
 import { Select } from '@chakra-ui/react';
 import { ChangeEvent, memo, useEffect } from 'react';
-import { DropDownInput, InputSchemaValue } from '../../../../common/common-types';
+import { DropDownInput, DropdownGroup, InputSchemaValue } from '../../../../common/common-types';
 
 export interface DropDownProps {
     value: InputSchemaValue | undefined;
@@ -8,49 +8,102 @@ export interface DropDownProps {
     reset: () => void;
     isDisabled?: boolean;
     options: DropDownInput['options'];
+    groups?: readonly DropdownGroup[];
 }
 
-export const DropDown = memo(({ value, onChange, reset, isDisabled, options }: DropDownProps) => {
-    // reset invalid values to default
-    useEffect(() => {
-        if (value === undefined || options.every((o) => o.value !== value)) {
-            reset();
-        }
-    }, [value, reset, options]);
+export const DropDown = memo(
+    ({ value, onChange, reset, isDisabled, options, groups }: DropDownProps) => {
+        // reset invalid values to default
+        useEffect(() => {
+            if (value === undefined || options.every((o) => o.value !== value)) {
+                reset();
+            }
+        }, [value, reset, options]);
 
-    let selection = options.findIndex((o) => o.value === value);
-    if (selection === -1) selection = 0;
+        let selection = options.findIndex((o) => o.value === value);
+        if (selection === -1) selection = 0;
 
-    const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
-        const selectedIndex = Number(event.target.value);
-        const selectedValue = options[selectedIndex]?.value as InputSchemaValue | undefined;
-        if (selectedValue === undefined) {
-            reset();
-        } else {
-            onChange(selectedValue);
-        }
-    };
+        const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+            const selectedIndex = Number(event.target.value);
+            const selectedValue = options[selectedIndex]?.value as InputSchemaValue | undefined;
+            if (selectedValue === undefined) {
+                reset();
+            } else {
+                onChange(selectedValue);
+            }
+        };
 
-    return (
-        <Select
-            borderRadius="lg"
-            className="nodrag"
-            disabled={isDisabled}
-            draggable={false}
-            size="sm"
-            style={{ contain: 'size' }}
-            value={selection}
-            onChange={handleChange}
-        >
-            {options.map(({ option }, index) => (
+        const optionElements: JSX.Element[] = [];
+        // eslint-disable-next-line @typescript-eslint/no-shadow
+        for (const [o, index] of options.map((o, i) => [o, i] as const)) {
+            const group = groups?.find((c) => c.startAt === o.value);
+            if (group) {
+                const pseudoValue = `--category-${index}-${group.label ?? ''}`;
+
+                if (group.label) {
+                    optionElements.push(
+                        <option
+                            disabled
+                            key={optionElements.length}
+                            style={{ fontSize: '30%' }}
+                            value={`--pad-${pseudoValue}`}
+                        >
+                            {' '}
+                        </option>,
+                        <option
+                            disabled
+                            key={optionElements.length + 1}
+                            style={{
+                                fontSize: '110%',
+                                fontWeight: 'bold',
+                                textAlign: 'center',
+                            }}
+                            value={pseudoValue}
+                        >
+                            {group.label}
+                        </option>
+                    );
+                } else {
+                    optionElements.push(
+                        <option
+                            disabled
+                            key={optionElements.length}
+                            style={{
+                                fontSize: '85%',
+                                color: 'rgba(128 128 128 / 70%)',
+                            }}
+                            value={`--hr-${pseudoValue}`}
+                        >
+                            {'\u23AF'.repeat(30)}
+                        </option>
+                    );
+                }
+            }
+
+            optionElements.push(
                 <option
-                    key={option}
+                    key={optionElements.length}
                     style={{ fontSize: '120%' }}
                     value={index}
                 >
-                    {option}
+                    {o.option}
                 </option>
-            ))}
-        </Select>
-    );
-});
+            );
+        }
+
+        return (
+            <Select
+                borderRadius="lg"
+                className="nodrag"
+                disabled={isDisabled}
+                draggable={false}
+                size="sm"
+                style={{ contain: 'size' }}
+                value={selection}
+                onChange={handleChange}
+            >
+                {optionElements}
+            </Select>
+        );
+    }
+);


### PR DESCRIPTION
Changes:
- Added support for dropdown groups and dividers. They are implemented as disabled options. This is kinda hacky, but it works.
- Added previously disabled interpolation filters for Resize and Resize to Side.
- Added categories for DDS formats.
- Added dividers for blend modes.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/cdbcdf03-fac9-4e0b-bd9f-11afebaecdcd)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/0a07f221-9138-476e-89ad-8d67f1dffadd)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/da47ac65-fad0-4cbb-b174-d10e77681ab2)
