### PR TITLE
Migrate VSCode `settings.json`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -108,8 +108,8 @@
     "editor.defaultFormatter": "charliermarsh.ruff",
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-        "source.organizeImports": true,
-        "source.fixAll": "always"
+      "source.organizeImports": "explicit",
+      "source.fixAll": "always"
     }
   }
 }


### PR DESCRIPTION
After the last VSCode update, VSCode will now **always** migrate workspace `settings.json` files automatically. If you discard those changes, it will do it again the next time you open the repo. There is no setting to turn this off. I already did this for spandrel and will go through our other repos too.

I fucking hate this. This is about as annoying as the `debug.log` fiasco some time ago. Who in their right mind thought that it was a good idea for an IDE to automatically change project files? They should have just kept supporting old settings with an option to migrate settings (e.g. via a button click). Yes, this is more work on their part, but making settings incompatible was also their fault, so they should just take the L.