### PR TITLE
Reworked backend events

### DIFF
--- a/backend/src/events.py
+++ b/backend/src/events.py
@@ -7,11 +7,29 @@ from typing import Dict, Literal, TypedDict, Union
 
 from api import ErrorValue, InputId, NodeId, OutputId
 
-# Data of events
+# General events
 
 
-class FinishData(TypedDict):
+class BackendStatusData(TypedDict):
     message: str
+    progress: float
+    statusProgress: float | None
+
+
+class BackendStatusEvent(TypedDict):
+    event: Literal["backend-status"]
+    data: BackendStatusData
+
+
+class BackendStateEvent(TypedDict):
+    event: Literal["backend-ready"] | Literal["backend-started"]
+    data: None
+
+
+BackendEvent = Union[BackendStatusEvent, BackendStateEvent]
+
+
+# Execution events
 
 
 InputsDict = Dict[InputId, ErrorValue]
@@ -29,48 +47,22 @@ class ExecutionErrorData(TypedDict):
     source: ExecutionErrorSource | None
 
 
-class NodeFinishData(TypedDict):
-    nodeId: NodeId
-    executionTime: float | None
-    data: dict[OutputId, object] | None
-    types: dict[OutputId, object] | None
-    progressPercent: float | None
-
-
-class NodeStartData(TypedDict):
-    nodeId: NodeId
-
-
-class NodeProgressUpdateData(TypedDict):
-    percent: float
-    index: int
-    total: int
-    eta: float
-    nodeId: NodeId
-
-
-class BackendStatusData(TypedDict):
-    message: str
-    progress: float
-    statusProgress: float | None
-
-
-# Events
-
-
-class FinishEvent(TypedDict):
-    event: Literal["finish"]
-    data: FinishData
-
-
 class ExecutionErrorEvent(TypedDict):
     event: Literal["execution-error"]
     data: ExecutionErrorData
 
 
-class NodeFinishEvent(TypedDict):
-    event: Literal["node-finish"]
-    data: NodeFinishData
+class ChainStartData(TypedDict):
+    nodes: list[str]
+
+
+class ChainStartEvent(TypedDict):
+    event: Literal["chain-start"]
+    data: ChainStartData
+
+
+class NodeStartData(TypedDict):
+    nodeId: NodeId
 
 
 class NodeStartEvent(TypedDict):
@@ -78,30 +70,52 @@ class NodeStartEvent(TypedDict):
     data: NodeStartData
 
 
+class NodeProgressData(TypedDict):
+    nodeId: NodeId
+    progress: float
+    """A number between 0 and 1"""
+    index: int
+    total: int
+    eta: float
+
+
 class NodeProgressUpdateEvent(TypedDict):
-    event: Literal["node-progress-update"]
-    data: NodeProgressUpdateData
+    event: Literal["node-progress"]
+    data: NodeProgressData
 
 
-class BackendStatusEvent(TypedDict):
-    event: Literal["backend-status"]
-    data: BackendStatusData
+class NodeBroadcastData(TypedDict):
+    nodeId: NodeId
+    data: dict[OutputId, object]
+    types: dict[OutputId, object]
 
 
-class BackendStateEvent(TypedDict):
-    event: Literal["backend-ready"] | Literal["backend-started"]
-    data: None
+class NodeBroadcastEvent(TypedDict):
+    event: Literal["node-broadcast"]
+    data: NodeBroadcastData
 
 
-Event = Union[
-    FinishEvent,
+class NodeFinishData(TypedDict):
+    nodeId: NodeId
+    executionTime: float
+
+
+class NodeFinishEvent(TypedDict):
+    event: Literal["node-finish"]
+    data: NodeFinishData
+
+
+ExecutionEvent = Union[
     ExecutionErrorEvent,
-    NodeFinishEvent,
+    ChainStartEvent,
     NodeStartEvent,
     NodeProgressUpdateEvent,
-    BackendStatusEvent,
-    BackendStateEvent,
+    NodeBroadcastEvent,
+    NodeFinishEvent,
 ]
+
+
+Event = Union[ExecutionEvent, BackendEvent]
 
 
 class EventConsumer(ABC):

--- a/backend/src/response.py
+++ b/backend/src/response.py
@@ -8,7 +8,6 @@ from process import NodeExecutionError
 
 class SuccessResponse(TypedDict):
     type: Literal["success"]
-    message: str
 
 
 class ErrorResponse(TypedDict):
@@ -20,7 +19,6 @@ class ErrorResponse(TypedDict):
 
 class NoExecutorResponse(TypedDict):
     type: Literal["no-executor"]
-    message: str
 
 
 class AlreadyRunningResponse(TypedDict):
@@ -28,8 +26,8 @@ class AlreadyRunningResponse(TypedDict):
     message: str
 
 
-def success_response(message: str) -> SuccessResponse:
-    return {"type": "success", "message": message}
+def success_response() -> SuccessResponse:
+    return {"type": "success"}
 
 
 def error_response(
@@ -51,8 +49,8 @@ def error_response(
     }
 
 
-def no_executor_response(message: str) -> NoExecutorResponse:
-    return {"type": "no-executor", "message": message}
+def no_executor_response() -> NoExecutorResponse:
+    return {"type": "no-executor"}
 
 
 def already_running_response(message: str) -> AlreadyRunningResponse:

--- a/src/common/Backend.ts
+++ b/src/common/Backend.ts
@@ -20,7 +20,6 @@ import { isRenderer } from './env';
 
 export interface BackendSuccessResponse {
     type: 'success';
-    message: string;
 }
 
 export interface BackendLiteralErrorValue {
@@ -54,7 +53,6 @@ export interface BackendExceptionResponse {
 }
 export interface BackendNoExecutorResponse {
     type: 'no-executor';
-    message: string;
 }
 export interface BackendAlreadyRunningResponse {
     type: 'already-running';
@@ -261,30 +259,32 @@ export const getBackend = (url: string): Backend => {
  * All possible events emitted by backend SSE along with the data layout of the event data.
  */
 export interface BackendEventMap {
-    finish: {
-        message: string;
-    };
     'execution-error': {
         message: string;
         source?: BackendExceptionSource | null;
         exception: string;
     };
-    'node-finish': {
-        nodeId: string;
-        executionTime?: number | null;
-        data?: OutputData | null;
-        types?: OutputTypes | null;
-        progressPercent?: number | null;
+    'chain-start': {
+        nodes: string[];
     };
     'node-start': {
         nodeId: string;
     };
-    'node-progress-update': {
+    'node-progress': {
         nodeId: string;
-        percent: number;
+        progress: number;
         index: number;
         total: number;
         eta: number;
+    };
+    'node-finish': {
+        nodeId: string;
+        executionTime: number;
+    };
+    'node-broadcast': {
+        nodeId: string;
+        data: OutputData;
+        types: OutputTypes;
     };
     'backend-status': {
         message: string;

--- a/src/renderer/components/CustomEdge/CustomEdge.tsx
+++ b/src/renderer/components/CustomEdge/CustomEdge.tsx
@@ -8,7 +8,7 @@ import { useDebouncedCallback } from 'use-debounce';
 import { EdgeData, NodeData } from '../../../common/common-types';
 import { parseSourceHandle } from '../../../common/util';
 import { BackendContext } from '../../contexts/BackendContext';
-import { ExecutionStatusContext } from '../../contexts/ExecutionContext';
+import { ExecutionContext, NodeExecutionStatus } from '../../contexts/ExecutionContext';
 import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { SettingsContext } from '../../contexts/SettingsContext';
 import { getTypeAccentColors } from '../../helpers/accentColors';
@@ -20,6 +20,7 @@ export const CustomEdge = memo(
     ({
         id,
         source,
+        target,
         sourceX: _sourceX,
         sourceY,
         targetX: _targetX,
@@ -38,10 +39,16 @@ export const CustomEdge = memo(
             GlobalVolatileContext,
             (c) => c.effectivelyDisabledNodes
         );
-        const animated = useContextSelector(GlobalVolatileContext, (c) => c.isAnimated(source));
+        const { paused, getNodeStatus } = useContext(ExecutionContext);
         const { useAnimateChain } = useContext(SettingsContext);
-        const { paused } = useContext(ExecutionStatusContext);
         const [animateChain] = useAnimateChain;
+
+        const sourceStatus = getNodeStatus(source);
+        const targetStatus = getNodeStatus(target);
+        const animated =
+            (sourceStatus === NodeExecutionStatus.RUNNING ||
+                sourceStatus === NodeExecutionStatus.YET_TO_RUN) &&
+            targetStatus !== NodeExecutionStatus.NOT_EXECUTING;
 
         const [edgePath, edgeCenterX, edgeCenterY] = useMemo(
             () =>

--- a/src/renderer/components/CustomEdge/CustomEdge.tsx
+++ b/src/renderer/components/CustomEdge/CustomEdge.tsx
@@ -28,7 +28,6 @@ export const CustomEdge = memo(
         targetPosition,
         selected,
         sourceHandleId,
-        animated,
         data = {},
         style,
     }: EdgeProps<EdgeData>) => {
@@ -39,6 +38,7 @@ export const CustomEdge = memo(
             GlobalVolatileContext,
             (c) => c.effectivelyDisabledNodes
         );
+        const animated = useContextSelector(GlobalVolatileContext, (c) => c.isAnimated(source));
         const { useAnimateChain } = useContext(SettingsContext);
         const { paused } = useContext(ExecutionStatusContext);
         const [animateChain] = useAnimateChain;

--- a/src/renderer/components/node/Node.tsx
+++ b/src/renderer/components/node/Node.tsx
@@ -13,7 +13,7 @@ import {
 } from '../../../common/util';
 import { AlertBoxContext } from '../../contexts/AlertBoxContext';
 import { BackendContext } from '../../contexts/BackendContext';
-import { ExecutionContext } from '../../contexts/ExecutionContext';
+import { ExecutionContext, NodeExecutionStatus } from '../../contexts/ExecutionContext';
 import { GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { getCategoryAccentColor, getTypeAccentColors } from '../../helpers/accentColors';
 import { shadeColor } from '../../helpers/colorTools';
@@ -63,15 +63,19 @@ const NodeInner = memo(({ data, selected }: NodeProps) => {
 
     const { sendToast } = useContext(AlertBoxContext);
     const { categories } = useContext(BackendContext);
-    const { getNodeProgress } = useContext(ExecutionContext);
+    const { getNodeProgress, getNodeStatus } = useContext(ExecutionContext);
 
     const { id, inputData } = data;
     const nodeProgress = getNodeProgress(id);
 
-    const animated = useContextSelector(
-        GlobalVolatileContext,
-        (c) => c.isAnimated(id) || c.isIndividuallyRunning(id)
+    const individuallyRunning = useContextSelector(GlobalVolatileContext, (c) =>
+        c.isIndividuallyRunning(id)
     );
+    const executionStatus = getNodeStatus(id);
+    const animated =
+        executionStatus === NodeExecutionStatus.RUNNING ||
+        executionStatus === NodeExecutionStatus.YET_TO_RUN ||
+        individuallyRunning;
 
     const { getEdge } = useReactFlow();
 

--- a/src/renderer/components/node/Node.tsx
+++ b/src/renderer/components/node/Node.tsx
@@ -68,7 +68,10 @@ const NodeInner = memo(({ data, selected }: NodeProps) => {
     const { id, inputData } = data;
     const nodeProgress = getNodeProgress(id);
 
-    const animated = useContextSelector(GlobalVolatileContext, (c) => c.isAnimated(id));
+    const animated = useContextSelector(
+        GlobalVolatileContext,
+        (c) => c.isAnimated(id) || c.isIndividuallyRunning(id)
+    );
 
     const { getEdge } = useReactFlow();
 

--- a/src/renderer/components/node/NodeFooter/NodeFooter.tsx
+++ b/src/renderer/components/node/NodeFooter/NodeFooter.tsx
@@ -17,8 +17,9 @@ interface NodeFooterProps {
 
 export const NodeFooter = memo(({ id, validity, useDisable, animated }: NodeFooterProps) => {
     const { canDisable } = useDisable ?? { canDisable: false };
-    const outputDataEntry = useContextSelector(GlobalVolatileContext, (c) =>
-        c.outputDataMap.get(id)
+    const lastExecutionTime = useContextSelector(
+        GlobalVolatileContext,
+        (c) => c.outputDataMap.get(id)?.lastExecutionTime
     );
 
     return (
@@ -45,9 +46,7 @@ export const NodeFooter = memo(({ id, validity, useDisable, animated }: NodeFoot
                 </Center>
 
                 <Center marginLeft="auto">
-                    {outputDataEntry?.lastExecutionTime !== undefined && (
-                        <Timer time={outputDataEntry.lastExecutionTime} />
-                    )}
+                    {lastExecutionTime !== undefined && <Timer time={lastExecutionTime} />}
                 </Center>
             </SimpleGrid>
         </Center>

--- a/src/renderer/components/node/NodeHeader.tsx
+++ b/src/renderer/components/node/NodeHeader.tsx
@@ -1,4 +1,4 @@
-import { Box, Center, HStack, Heading, LayoutProps, Text, VStack } from '@chakra-ui/react';
+import { Box, Center, HStack, Heading, Text, VStack } from '@chakra-ui/react';
 import { memo } from 'react';
 import ReactTimeAgo from 'react-time-ago';
 import { DisabledStatus } from '../../../common/nodes/disabled';
@@ -12,34 +12,80 @@ interface NodeHeaderProps {
     icon: string;
     accentColor: string;
     selected: boolean;
-    width?: LayoutProps['width'];
     disabledStatus: DisabledStatus;
     nodeProgress?: NodeProgress;
 }
 
 export const NodeHeader = memo(
-    ({
-        name,
-        width,
-        icon,
-        accentColor,
-        selected,
-        disabledStatus,
-        nodeProgress,
-    }: NodeHeaderProps) => {
-        const { percent, eta, index, total } = nodeProgress ?? {};
-        const etaDate = new Date();
-        etaDate.setSeconds(etaDate.getSeconds() + (eta ?? 0));
-
+    ({ name, icon, accentColor, selected, disabledStatus, nodeProgress }: NodeHeaderProps) => {
         const bgColor = useThemeColor('--bg-700');
         const gradL = interpolateColor(accentColor, bgColor, 0.9);
         const gradR = bgColor;
 
         const progColor = interpolateColor(accentColor, bgColor, 0.5);
+
+        let iteratorProcess = null;
+        if (nodeProgress) {
+            const { progress, eta, index, total } = nodeProgress;
+            const etaDate = new Date();
+            etaDate.setSeconds(etaDate.getSeconds() + eta);
+
+            iteratorProcess = (
+                <Box
+                    h={6}
+                    w="full"
+                >
+                    <Center w="full">
+                        <HStack
+                            mb="-6"
+                            position="relative"
+                        >
+                            <Text
+                                fontSize="sm"
+                                fontWeight="medium"
+                            >
+                                {index}/{total} ({(progress * 100).toFixed(0)}
+                                %)
+                            </Text>
+                            <Text
+                                fontSize="sm"
+                                fontWeight="medium"
+                            >
+                                ETA:{' '}
+                                {progress === 1 ? (
+                                    'Finished'
+                                ) : (
+                                    <ReactTimeAgo
+                                        future
+                                        date={etaDate}
+                                        locale="en-US"
+                                        timeStyle="round"
+                                        tooltip={false}
+                                    />
+                                )}
+                            </Text>
+                        </HStack>
+                    </Center>
+                    <Box
+                        bgColor="var(--node-bg-color)"
+                        h={6}
+                        w="full"
+                    >
+                        <Box
+                            bgColor={progColor}
+                            h={6}
+                            transition="all 0.15s ease-in-out"
+                            w={`${progress * 100}%`}
+                        />
+                    </Box>
+                </Box>
+            );
+        }
+
         return (
             <VStack
                 spacing={0}
-                w={width || 'full'}
+                w="full"
             >
                 <Center
                     bgGradient={`linear(to-r, ${gradL}, ${gradR})`}
@@ -48,7 +94,7 @@ export const NodeHeader = memo(
                     h="auto"
                     pt={2}
                     verticalAlign="middle"
-                    w={width || 'full'}
+                    w="full"
                 >
                     <HStack
                         mb={-1}
@@ -90,55 +136,7 @@ export const NodeHeader = memo(
                         </Center>
                     </HStack>
                 </Center>
-                {percent !== undefined && (
-                    <Box
-                        h={6}
-                        w="full"
-                    >
-                        <Center w="full">
-                            <HStack
-                                mb="-6"
-                                position="relative"
-                            >
-                                <Text
-                                    fontSize="sm"
-                                    fontWeight="medium"
-                                >{`${Number(index)}/${Number(total)} (${Number(
-                                    percent * 100
-                                ).toFixed(0)}%)`}</Text>
-                                <Text
-                                    fontSize="sm"
-                                    fontWeight="medium"
-                                >
-                                    ETA:{' '}
-                                    {percent === 1 ? (
-                                        'Finished'
-                                    ) : (
-                                        <ReactTimeAgo
-                                            future
-                                            date={etaDate}
-                                            locale="en-US"
-                                            timeStyle="round"
-                                            tooltip={false}
-                                        />
-                                    )}
-                                </Text>
-                            </HStack>
-                        </Center>
-                        <Box
-                            bgColor="var(--node-bg-color)"
-                            h={6}
-                            w="full"
-                        >
-                            <Box
-                                bgColor={progColor}
-                                h={6}
-                                transition="all 0.15s ease-in-out"
-                                w={`${percent * 100}%`}
-                            />
-                        </Box>
-                    </Box>
-                )}
+                {iteratorProcess}
             </VStack>
         );
     }

--- a/src/renderer/contexts/GlobalNodeState.tsx
+++ b/src/renderer/contexts/GlobalNodeState.tsx
@@ -105,7 +105,6 @@ interface GlobalVolatile {
     zoom: number;
     collidingEdge: string | undefined;
     collidingNode: string | undefined;
-    isAnimated: (nodeId: string) => boolean;
     isIndividuallyRunning: (node: string) => boolean;
     inputHashes: ReadonlyMap<string, string>;
     outputDataMap: ReadonlyMap<string, OutputDataEntry>;
@@ -120,8 +119,6 @@ interface Global {
     changeNodes: SetState<Node<NodeData>[]>;
     changeEdges: SetState<Edge<EdgeData>[]>;
     selectNode: (nodeId: string) => void;
-    animate: (nodeIdsToAnimate: Iterable<string>) => void;
-    unAnimate: (nodeIdsToAnimate?: Iterable<string>) => void;
     addIndividuallyRunning: (node: string) => void;
     removeIndividuallyRunning: (node: string) => void;
     createNode: (proto: NodeProto) => void;
@@ -1031,38 +1028,6 @@ export const GlobalProvider = memo(
             [modifyNode]
         );
 
-        const [animatedNodes, setAnimatedNodes] = useState<ReadonlySet<string>>(EMPTY_SET);
-        const animate = useCallback(
-            (nodes: Iterable<string>): void => {
-                const ids = new Set(nodes);
-                setAnimatedNodes((prev) => {
-                    const newSet = new Set(prev);
-                    for (const id of ids) {
-                        newSet.add(id);
-                    }
-                    return newSet;
-                });
-            },
-            [setAnimatedNodes]
-        );
-        const unAnimate = useCallback(
-            (nodes?: Iterable<string>): void => {
-                if (nodes) {
-                    const ids = new Set(nodes);
-                    setAnimatedNodes((prev) => {
-                        const newSet = new Set(prev);
-                        for (const id of ids) {
-                            newSet.delete(id);
-                        }
-                        return newSet;
-                    });
-                } else {
-                    setAnimatedNodes(EMPTY_SET);
-                }
-            },
-            [setAnimatedNodes]
-        );
-
         const [individuallyRunning, setIndividuallyRunning] =
             useState<ReadonlySet<string>>(EMPTY_SET);
         const addIndividuallyRunning = useCallback((node: string): void => {
@@ -1334,7 +1299,6 @@ export const GlobalProvider = memo(
             zoom,
             collidingEdge,
             collidingNode,
-            isAnimated: useCallback((nodeId) => animatedNodes.has(nodeId), [animatedNodes]),
             isIndividuallyRunning,
             inputHashes: inputHashesRef.current,
             outputDataMap,
@@ -1350,8 +1314,6 @@ export const GlobalProvider = memo(
             changeNodes,
             changeEdges,
             selectNode,
-            animate,
-            unAnimate,
             addIndividuallyRunning,
             removeIndividuallyRunning,
             createNode,

--- a/src/renderer/helpers/chainProgress.ts
+++ b/src/renderer/helpers/chainProgress.ts
@@ -1,0 +1,54 @@
+import { Edge, Node } from 'reactflow';
+import { EdgeData, NodeData } from '../../common/common-types';
+import { SchemaMap } from '../../common/SchemaMap';
+
+export type ChainProgress = ReadonlyMap<string, ChainNodeProgress>;
+
+export interface ChainNodeProgress {
+    readonly progress: number;
+    readonly weight: number;
+}
+
+export const getTotalProgress = (chainProgress: ChainProgress): number => {
+    if (chainProgress.size === 0) return 0;
+    let totalProgress = 0;
+    let totalWeight = 0;
+    for (const { progress, weight } of chainProgress.values()) {
+        totalProgress += progress * weight;
+        totalWeight += weight;
+    }
+    return totalProgress / totalWeight;
+};
+
+export const withNodeProgress = (
+    chainProgress: ChainProgress,
+    nodeId: string,
+    progress: number
+): ChainProgress => {
+    const node = chainProgress.get(nodeId);
+    if (!node) return chainProgress;
+    return new Map(chainProgress).set(nodeId, { progress, weight: node.weight });
+};
+
+export const getInitialChainProgress = (
+    nodes: readonly Node<NodeData>[],
+
+    _edges: readonly Edge<EdgeData>[],
+
+    schemata: SchemaMap
+): ChainProgress => {
+    const progress = new Map<string, ChainNodeProgress>();
+
+    // TODO: implement proper weights based on iterated nodes
+
+    for (const node of nodes) {
+        let weight = 1;
+        if (schemata.get(node.data.schemaId).nodeType === 'newIterator') {
+            // more weight for iterators
+            weight = 4;
+        }
+        progress.set(node.id, { progress: 0, weight });
+    }
+
+    return progress;
+};

--- a/src/renderer/hooks/useEventBacklog.ts
+++ b/src/renderer/hooks/useEventBacklog.ts
@@ -1,0 +1,38 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+
+export interface EventBacklog<T> {
+    readonly push: (event: T) => void;
+    readonly processAll: () => void;
+}
+
+export interface BacklogOption<T> {
+    process: (event: T[]) => void;
+    interval: number;
+}
+
+export const useEventBacklog = <T>({ process, interval }: BacklogOption<T>): EventBacklog<T> => {
+    const backlogRef = useRef<T[]>([]);
+    const push = useCallback((event: T): void => {
+        backlogRef.current.push(event);
+    }, []);
+
+    const processRef = useRef(process);
+    useEffect(() => {
+        processRef.current = process;
+    }, [process]);
+
+    const processAll = useCallback(() => {
+        if (backlogRef.current.length > 0) {
+            const backlog = backlogRef.current;
+            backlogRef.current = [];
+            processRef.current(backlog);
+        }
+    }, []);
+
+    useEffect(() => {
+        const timeout = setInterval(processAll, interval);
+        return () => clearInterval(timeout);
+    }, [processAll, interval]);
+
+    return useMemo(() => ({ push, processAll }), [push, processAll]);
+};

--- a/src/renderer/hooks/useRunNode.ts
+++ b/src/renderer/hooks/useRunNode.ts
@@ -19,7 +19,7 @@ export const useRunNode = (
     shouldRun: boolean
 ): (() => void) => {
     const { sendToast } = useContext(AlertBoxContext);
-    const { animate, unAnimate } = useContext(GlobalContext);
+    const { addIndividuallyRunning, removeIndividuallyRunning } = useContext(GlobalContext);
     const { schemata, backend } = useContext(BackendContext);
     const { useBackendSettings } = useContext(SettingsContext);
 
@@ -54,17 +54,17 @@ export const useRunNode = (
 
             if (shouldRun) {
                 didEverRun.current = true;
-                animate([id], false);
 
+                addIndividuallyRunning(id);
                 const result = await backend.runIndividual({
                     schemaId,
                     id,
                     inputs,
                     options,
                 });
+                removeIndividuallyRunning(id);
 
                 if (!result.success) {
-                    unAnimate([id]);
                     sendToast({
                         status: 'error',
                         title: 'Error',


### PR DESCRIPTION
Fixes #2319

This PR reworks the events the executor sends to the frontend. I changed both, what events are send, how they are sent, the data the events contains, and how and in which order the events are processed by the frontend. The frontend now also keeps track of the overall progress of the chain instead of the backend like before. 

Let's start with the backend changes:
- Added `chain-start` event. This event contains the list of nodes that will actually be executed. Due to caching and optimizations, this list is often different from the list of nodes the frontend sent to the backend. This list will be used for animations and progress by the frontend.
- Moved broadcasts into its own event. This is important for iterators where we do one broadcast for each iteration.
- Move all event code in the executor into `__send_*` methods. This makes the code pretty clean.
- Fixed a bug in the executor whether broadcasts would be sent out even after the execution as aborted.
- Other minor improvements to the executor.
- Removed useless `message` field in some responses of the backend API.

Frontend changes:
- Running individual nodes no longer uses the `animate`/`unAnimate` methods like regular executions. They now have their own state to make sure these two systems don't interfere with each other.
- Edges now derive their animation state from their connected source node. This is not completely correct yet (discussion on discord), but will be soon.
- Iterators now do type narrowing for the current iteration. This means that they display e.g. the image name of the current iteration. I was careful not to re-introduce #838 here. The type narrowing is always removed after the execution complete (successfully or otherwise).
- Overall chain progress is now tracked entirely by the frontend. I implemented the weighted node progress idea I proposed some time ago, but weights aren't assigned in a clever way yet. This should be easy to improve in follow-up PRs. That being said, it's still better that what we had before because it takes iterator progress into account.
- All node events are now processed sequentially. We previously batched events to process them more efficiently. However, the batching was done per event type, which caused some events to be executed out of order (e.g. a `node-finish` might be run *before* a `node-start`). This was the cause of #2319, and I fixed it by batching all node events together. I made the batch queue explicit and called it a backlog. It's necessary for the backlog to be explicit because we have to wait for all events to be fully processed before we can declare a run to be truly finished, or else some nasty race conditions occur. \
    The backlog also has the advantage that we can process the whole queue at once instead of individual events, which allows for some nice optimizations when there are many events (e.g. a fast iterator).