### PR TITLE
PyTorch upscale optimizations

### DIFF
--- a/backend/src/nodes/impl/pytorch/auto_split.py
+++ b/backend/src/nodes/impl/pytorch/auto_split.py
@@ -7,13 +7,49 @@ import torch
 from spandrel import ImageModelDescriptor
 
 from ..upscale.auto_split import Split, Tiler, auto_split
-from .utils import np2tensor, safe_cuda_cache_empty, tensor2np
+from .utils import safe_cuda_cache_empty
+
+
+def _into_standard_image_form(t: torch.Tensor) -> torch.Tensor:
+    if len(t.shape) == 2:
+        # (H, W)
+        return t
+    elif len(t.shape) == 3:
+        # (C, H, W) -> (H, W, C)
+        return t.permute(1, 2, 0)
+    elif len(t.shape) == 4:
+        # (1, C, H, W) -> (H, W, C)
+        return t.squeeze(0).permute(1, 2, 0)
+    else:
+        raise ValueError("Unsupported output tensor shape")
+
+
+def _into_batched_form(t: torch.Tensor) -> torch.Tensor:
+    if len(t.shape) == 2:
+        # (H, W) -> (1, 1, H, W)
+        return t.unsqueeze(0).unsqueeze(0)
+    elif len(t.shape) == 3:
+        # (H, W, C) -> (1, C, H, W)
+        return t.permute(2, 0, 1).unsqueeze(0)
+    else:
+        raise ValueError("Unsupported input tensor shape")
+
+
+def _rgb_to_bgr(t: torch.Tensor) -> torch.Tensor:
+    if len(t.shape) == 3 and t.shape[2] == 3:
+        # (H, W, C) RGB -> BGR
+        return t.flip(2)
+    elif len(t.shape) == 3 and t.shape[2] == 4:
+        # (H, W, C) RGBA -> BGRA
+        return torch.cat((t[:, :, 2:3], t[:, :, 1:2], t[:, :, 0:1], t[:, :, 3:4]), 2)
+    else:
+        return t
 
 
 @torch.inference_mode()
 def pytorch_auto_split(
     img: np.ndarray,
-    model: ImageModelDescriptor,
+    model: ImageModelDescriptor[torch.nn.Module],
     device: torch.device,
     use_fp16: bool,
     tiler: Tiler,
@@ -25,32 +61,34 @@ def pytorch_auto_split(
         model.model.float()
 
     def upscale(img: np.ndarray, _: object):
-        img_tensor = np2tensor(img, change_range=True)
-
-        d_img = None
+        input_tensor = None
         try:
-            d_img = img_tensor.to(device)
-            d_img = d_img.half() if use_fp16 else d_img.float()
+            # convert to tensor
+            input_tensor = torch.from_numpy(np.ascontiguousarray(img)).to(device)
+            input_tensor = input_tensor.half() if use_fp16 else input_tensor.float()
+            input_tensor = _rgb_to_bgr(input_tensor)
+            input_tensor = _into_batched_form(input_tensor)
 
-            result = model(d_img)
-            result = tensor2np(
-                result.detach().cpu().detach(),
-                change_range=False,
-                imtype=np.float32,
-            )
+            # inference
+            output_tensor = model(input_tensor)
 
-            del d_img
+            # convert back to numpy
+            output_tensor = _into_standard_image_form(output_tensor)
+            output_tensor = _rgb_to_bgr(output_tensor)
+            output_tensor = output_tensor.clip_(0, 1)
+            result = output_tensor.detach().cpu().detach().float().numpy()
+
             return result
         except RuntimeError as e:
             # Check to see if its actually the CUDA out of memory error
             if "allocate" in str(e) or "CUDA" in str(e):
                 # Collect garbage (clear VRAM)
-                if d_img is not None:
+                if input_tensor is not None:
                     try:
-                        d_img.detach().cpu()
+                        input_tensor.detach().cpu()
                     except Exception:
                         pass
-                    del d_img
+                    del input_tensor
                 gc.collect()
                 safe_cuda_cache_empty()
                 return Split()
@@ -61,7 +99,4 @@ def pytorch_auto_split(
     try:
         return auto_split(img, upscale, tiler)
     finally:
-        del model
-        del device
-        gc.collect()
         safe_cuda_cache_empty()

--- a/backend/src/nodes/impl/upscale/convenient_upscale.py
+++ b/backend/src/nodes/impl/upscale/convenient_upscale.py
@@ -34,6 +34,7 @@ def convenient_upscale(
     model_out_nc: int,
     upscale: ImageOp,
     separate_alpha: bool = False,
+    clip: bool = True,
 ) -> np.ndarray:
     """
     Upscales the given image in an intuitive/convenient way.
@@ -47,7 +48,8 @@ def convenient_upscale(
     """
     in_img_c = get_h_w_c(img)[2]
 
-    upscale = clipped(upscale)
+    if clip:
+        upscale = clipped(upscale)
 
     if model_in_nc != model_out_nc:
         return upscale(as_target_channels(img, model_in_nc, True))

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
@@ -125,6 +125,7 @@ def upscale(
         ImageOutput(
             "Image",
             image_type="""convenientUpscale(Input0, Input1)""",
+            assume_normalized=True,  # pytorch_auto_split already does clipping internally
         )
     ],
 )
@@ -156,4 +157,5 @@ def upscale_image_node(
         out_nc,
         lambda i: upscale(i, model, tile_size, exec_options),
         separate_alpha,
+        clip=False,  # pytorch_auto_split already does clipping internally
     )


### PR DESCRIPTION
Optimizations for pytorch upscaling:
- Do the RGB<->BGR, transpositions, and clipping on the GPU.
- Removed useless `gc.collect()`. At the very least, it didn't do anything in my testing.
- Turn off clipping inside `convenient_upscale`.
- Add `assume_normalized=True` to turn off clipping by `ImageOutput`.