### PR TITLE
Update to spandrel 0.1.5 and enforce model tiling hint

### DIFF
--- a/backend/src/nodes/properties/outputs/pytorch_outputs.py
+++ b/backend/src/nodes/properties/outputs/pytorch_outputs.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from spandrel import (
-    ModelDescriptor,
-)
+from spandrel import ModelDescriptor, ModelTiling
 
 import navi
 from api import BaseOutput, OutputKind
@@ -29,6 +27,12 @@ class ModelOutput(BaseOutput):
         }
 
     def get_broadcast_type(self, value: ModelDescriptor):
+        tiling_map: dict[ModelTiling, str] = {
+            ModelTiling.SUPPORTED: "ModelTiling::Supported",
+            ModelTiling.DISCOURAGED: "ModelTiling::Discouraged",
+            ModelTiling.INTERNAL: "ModelTiling::Internal",
+        }
+
         return navi.named(
             "PyTorchModel",
             {
@@ -38,6 +42,7 @@ class ModelOutput(BaseOutput):
                 "arch": navi.literal(value.architecture),
                 "subType": navi.literal(value.purpose),
                 "size": navi.literal("x".join(value.tags)),
+                "tiling": tiling_map[value.tiling],
             },
         )
 

--- a/backend/src/packages/chaiNNer_pytorch/__init__.py
+++ b/backend/src/packages/chaiNNer_pytorch/__init__.py
@@ -95,7 +95,7 @@ package = add_package(
         Dependency(
             display_name="Spandrel",
             pypi_name="spandrel",
-            version="0.1.3",
+            version="0.1.5",
             size_estimate=250 * KB,
         ),
     ],

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import numpy as np
 import torch
 from sanic.log import logger
-from spandrel import ImageModelDescriptor
+from spandrel import ImageModelDescriptor, ModelTiling
 
 from nodes.groups import Condition, if_group
 from nodes.impl.pytorch.auto_split import pytorch_auto_split
 from nodes.impl.upscale.auto_split_tiles import (
+    NO_TILING,
     TileSize,
     estimate_tile_size,
     parse_tile_size_input,
@@ -40,6 +41,10 @@ def upscale(
         # TODO: use bfloat16 if RTX
         use_fp16 = options.use_fp16 and model.supports_half
         device = options.device
+
+        if model.tiling == ModelTiling.INTERNAL:
+            # disable tiling if the model already does it internally
+            tile_size = NO_TILING
 
         def estimate():
             if "cuda" in device.type:

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
@@ -89,20 +89,28 @@ def upscale(
     inputs=[
         ImageInput().with_id(1),
         SrModelInput().with_id(0),
-        TileSizeDropdown()
-        .with_id(2)
-        .with_docs(
-            "Tiled upscaling is used to allow large images to be upscaled without"
-            " hitting memory limits.",
-            "This works by splitting the image into tiles (with overlap), upscaling"
-            " each tile individually, and seamlessly recombining them.",
-            "Generally it's recommended to use the largest tile size possible for"
-            " best performance (with the ideal scenario being no tiling at all),"
-            " but depending on the model and image size, this may not be possible.",
-            "If you are having issues with the automatic mode, you can manually"
-            " select a tile size. Sometimes, a manually selected tile size may be"
-            " faster than what the automatic mode picks.",
-            hint=True,
+        if_group(
+            Condition.type(
+                0,
+                "PyTorchModel { tiling: ModelTiling::Supported | ModelTiling::Discouraged } ",
+                if_not_connected=True,
+            )
+        )(
+            TileSizeDropdown()
+            .with_id(2)
+            .with_docs(
+                "Tiled upscaling is used to allow large images to be upscaled without"
+                " hitting memory limits.",
+                "This works by splitting the image into tiles (with overlap), upscaling"
+                " each tile individually, and seamlessly recombining them.",
+                "Generally it's recommended to use the largest tile size possible for"
+                " best performance (with the ideal scenario being no tiling at all),"
+                " but depending on the model and image size, this may not be possible.",
+                "If you are having issues with the automatic mode, you can manually"
+                " select a tile size. Sometimes, a manually selected tile size may be"
+                " faster than what the automatic mode picks.",
+                hint=True,
+            ),
         ),
         if_group(
             Condition.type(1, "Image { channels: 4 } ")

--- a/src/common/types/chainner-scope.ts
+++ b/src/common/types/chainner-scope.ts
@@ -51,7 +51,9 @@ struct PyTorchModel {
     arch: string,
     size: string,
     subType: string,
+    tiling: ModelTiling,
 }
+enum ModelTiling { Supported, Discouraged, Internal }
 
 struct NcnnBinFile { path: string }
 struct NcnnParamFile { path: string }


### PR DESCRIPTION
Changes:
- Update to spandrel 0.1.5.
- Always use no tiling mode if the model does tiling internally no matter what the user selects.