### PR TITLE
Relative coordinates and tile fill for Shift node

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image_utility/modification/shift.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/modification/shift.py
@@ -1,13 +1,26 @@
 from __future__ import annotations
 
+from enum import Enum
+
 import numpy as np
 
-import navi
-from nodes.impl.image_utils import FillColor, shift
-from nodes.properties.inputs import FillColorDropdown, ImageInput, NumberInput
+from nodes.groups import if_enum_group
+from nodes.impl.image_utils import ShiftFill, shift
+from nodes.properties.inputs import (
+    EnumInput,
+    ImageInput,
+    NumberInput,
+    SliderInput,
+)
 from nodes.properties.outputs import ImageOutput
+from nodes.utils.utils import get_h_w_c, round_half_up
 
 from .. import modification_group
+
+
+class ShiftCoordMode(Enum):
+    RELATIVE = 0
+    ABSOLUTE = 1
 
 
 @modification_group.register(
@@ -16,26 +29,54 @@ from .. import modification_group
     description="Shift an image by an x, y amount.",
     icon="BsGraphDown",
     inputs=[
-        ImageInput(),
-        NumberInput("Amount X", minimum=None, unit="px"),
-        NumberInput("Amount Y", minimum=None, unit="px"),
-        FillColorDropdown(),
+        ImageInput().with_id(0),
+        EnumInput(
+            ShiftCoordMode, default=ShiftCoordMode.ABSOLUTE, preferred_style="tabs"
+        ).with_id(4),
+        if_enum_group(4, ShiftCoordMode.RELATIVE)(
+            SliderInput("X", minimum=-100, maximum=100, default=0, unit="%").with_id(5),
+            SliderInput("Y", minimum=-100, maximum=100, default=0, unit="%").with_id(6),
+        ),
+        if_enum_group(4, ShiftCoordMode.ABSOLUTE)(
+            NumberInput("X", minimum=None, unit="px").with_id(1),
+            NumberInput("Y", minimum=None, unit="px").with_id(2),
+        ),
+        EnumInput(
+            ShiftFill,
+            label="Negative Space Fill",
+            default=ShiftFill.AUTO,
+            option_labels={
+                ShiftFill.WRAP: "Wrap (Tile)",
+            },
+        ).with_id(3),
     ],
     outputs=[
         ImageOutput(
-            image_type=navi.Image(
-                width="Input0.width",
-                height="Input0.height",
-                channels="FillColor::getOutputChannels(Input3, Input0.channels)",
-            ),
+            image_type="""
+                let i = Input0;
+                let fill = Input3;
+                match fill {
+                    ShiftFill::Transparent => Image { width: i.width, height: i.height, channels: 4 },
+                    _ => i,
+                }
+            """,
             assume_normalized=True,
         )
     ],
 )
 def shift_node(
     img: np.ndarray,
-    amount_x: int,
-    amount_y: int,
-    fill: FillColor,
+    mode: ShiftCoordMode,
+    rel_x: int,
+    rel_y: int,
+    abs_x: int,
+    abs_y: int,
+    fill: ShiftFill,
 ) -> np.ndarray:
-    return shift(img, amount_x, amount_y, fill)
+    h, w, _ = get_h_w_c(img)
+
+    if mode == ShiftCoordMode.RELATIVE:
+        abs_x = round_half_up(w * rel_x / 100)
+        abs_y = round_half_up(h * rel_y / 100)
+
+    return shift(img, abs_x, abs_y, fill)


### PR DESCRIPTION
Since I needed it, I added relative coordinates and a Wrap (Tile) fill mode to the Shift node.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/24c05522-4943-47eb-8eda-7914d89e86d8)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/de063136-a0b1-43c8-a5ac-7d1bd756128d)
