### PR TITLE
Make Resize To Side input order consistent with Resize

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize_to_side.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize_to_side.py
@@ -98,7 +98,6 @@ def resize_to_side_conditional(
             unit="px",
         ),
         EnumInput(SideSelection, label="Resize To"),
-        ResizeFilterInput(),
         EnumInput(
             ResizeCondition,
             option_labels={
@@ -106,7 +105,8 @@ def resize_to_side_conditional(
                 ResizeCondition.UPSCALE: "Upscale Only",
                 ResizeCondition.DOWNSCALE: "Downscale Only",
             },
-        ),
+        ).with_id(4),
+        ResizeFilterInput().with_id(3),
     ],
     outputs=[
         ImageOutput(

--- a/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize_to_side.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize_to_side.py
@@ -170,8 +170,8 @@ def resize_to_side_node(
     img: np.ndarray,
     target: int,
     side: SideSelection,
-    filter: ResizeFilter,
     condition: ResizeCondition,
+    filter: ResizeFilter,
 ) -> np.ndarray:
     h, w, _ = get_h_w_c(img)
     out_dims = resize_to_side_conditional(w, h, target, side, condition)


### PR DESCRIPTION
Very minor change. I swapped Resize Condition and Interpolation Method. This makes the order consistent with Resize (last), and it also groups together the 3 inputs responsible for determining the output size.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/b58b4947-f74c-48b1-9b85-8a6932fd3172)
