### PR TITLE
Change edge running animation + behavior

### DIFF
--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -429,11 +429,10 @@ class Executor:
         logger.debug(f"node: {node}")
         logger.debug(f"Running node {node.id}")
 
-        await self.__send_node_start(node)
-        await self.progress.suspend()
-
         inputs = await self.__gather_inputs(node)
 
+        await self.progress.suspend()
+        await self.__send_node_start(node)
         await self.progress.suspend()
 
         output, execution_time = await self.loop.run_in_executor(

--- a/src/renderer/components/CustomEdge/CustomEdge.scss
+++ b/src/renderer/components/CustomEdge/CustomEdge.scss
@@ -2,7 +2,7 @@
 
 @keyframes dashdraw-chain {
     from {
-        stroke-dashoffset: 13;
+        stroke-dashoffset: 20;
     }
 }
 
@@ -14,50 +14,68 @@
     animation: none !important;
 }
 
-.edge-chain-links {
+// .edge-chain-links {
+//     stroke-width: 2px;
+//     transition-duration: 0.15s;
+//     transition-property: stroke-width, stroke;
+//     transition-timing-function: ease-in-out;
+//     cursor: pointer;
+//     stroke-dasharray: 0 !important;
+
+//     &.hovered {
+//         stroke-width: 4px;
+//     }
+
+//     &.animated {
+//         stroke-dasharray: 0 !important;
+//     }
+
+//     &.colliding {
+//         stroke-width: 8px;
+//     }
+// }
+
+.edge-chain-behind {
+    stroke-width: 2px;
+    transition-duration: 0.15s;
+    transition-property: stroke-width, stroke;
+    transition-timing-function: ease-in-out;
+    stroke: var(--bg-700);
+
+    &.hovered {
+        stroke-width: 4px;
+    }
+}
+
+.edge-chain {
     stroke-width: 2px;
     transition-duration: 0.15s;
     transition-property: stroke-width, stroke;
     transition-timing-function: ease-in-out;
     cursor: pointer;
     stroke-dasharray: 0 !important;
+    stroke-dashoffset: 0;
+    stroke-linecap: round;
+    animation: 'none';
+    opacity: 100%;
+
+    // &.animated {
+    //     stroke-dasharray: 5 10 !important;
+    //     animation: 'dashdraw-chain 0.5s linear infinite';
+    // }
 
     &.hovered {
         stroke-width: 4px;
     }
 
-    &.animated {
-        stroke-dasharray: 0 !important;
-    }
-
-    &.colliding {
-        stroke-width: 8px;
-    }
-}
-
-.edge-chain {
-    stroke-width: 6px;
-    transition-duration: 0.15s;
-    transition-property: stroke-width, stroke;
-    transition-timing-function: ease-in-out;
-    cursor: pointer;
-    stroke-dasharray: 1 10 !important;
-    stroke-dashoffset: 2;
-    stroke-linecap: round;
-    animation: 'none';
-    opacity: 0;
-
-    &.animated {
-        stroke-dasharray: 1 10 !important;
-    }
-
-    &.hovered {
-        stroke-width: 8px;
-    }
-
     &.running {
+        stroke-dasharray: 10 !important;
         animation: 'dashdraw-chain 0.5s linear infinite';
-        opacity: 1;
+    }
+
+    &.yet-to-run {
+        stroke: var(--fg-000);
+        opacity: 50%;
     }
 
     &.colliding {

--- a/src/renderer/components/CustomEdge/CustomEdge.scss
+++ b/src/renderer/components/CustomEdge/CustomEdge.scss
@@ -48,8 +48,8 @@
     }
 
     &.yet-to-run {
-        stroke: var(--fg-000);
-        opacity: 50%;
+        stroke-dasharray: 10 !important;
+        animation: none;
     }
 
     &.colliding {

--- a/src/renderer/components/CustomEdge/CustomEdge.scss
+++ b/src/renderer/components/CustomEdge/CustomEdge.scss
@@ -14,27 +14,6 @@
     animation: none !important;
 }
 
-// .edge-chain-links {
-//     stroke-width: 2px;
-//     transition-duration: 0.15s;
-//     transition-property: stroke-width, stroke;
-//     transition-timing-function: ease-in-out;
-//     cursor: pointer;
-//     stroke-dasharray: 0 !important;
-
-//     &.hovered {
-//         stroke-width: 4px;
-//     }
-
-//     &.animated {
-//         stroke-dasharray: 0 !important;
-//     }
-
-//     &.colliding {
-//         stroke-width: 8px;
-//     }
-// }
-
 .edge-chain-behind {
     stroke-width: 2px;
     transition-duration: 0.15s;
@@ -58,11 +37,6 @@
     stroke-linecap: round;
     animation: 'none';
     opacity: 100%;
-
-    // &.animated {
-    //     stroke-dasharray: 5 10 !important;
-    //     animation: 'dashdraw-chain 0.5s linear infinite';
-    // }
 
     &.hovered {
         stroke-width: 4px;

--- a/src/renderer/components/CustomEdge/CustomEdge.tsx
+++ b/src/renderer/components/CustomEdge/CustomEdge.tsx
@@ -55,9 +55,8 @@ const getRunningStateClass = (
         case NodeExecutionStatus.YET_TO_RUN:
             return EDGE_CLASS.YET_TO_RUN;
         default:
-            assertNever(sourceStatus);
+            return assertNever(sourceStatus);
     }
-    return EDGE_CLASS.NONE;
 };
 
 export const CustomEdge = memo(

--- a/src/renderer/components/CustomEdge/CustomEdge.tsx
+++ b/src/renderer/components/CustomEdge/CustomEdge.tsx
@@ -43,7 +43,7 @@ const getRunningStateClass = (
         case NodeExecutionStatus.FINISHED:
             return '';
         case NodeExecutionStatus.RUNNING:
-            return animateChain ? '' : 'running';
+            return animateChain ? 'running' : '';
         case NodeExecutionStatus.YET_TO_RUN:
             return 'yet-to-run';
         default:

--- a/src/renderer/components/CustomEdge/CustomEdge.tsx
+++ b/src/renderer/components/CustomEdge/CustomEdge.tsx
@@ -16,18 +16,26 @@ import { shadeColor } from '../../helpers/colorTools';
 import { useEdgeMenu } from '../../hooks/useEdgeMenu';
 import './CustomEdge.scss';
 
+const EDGE_CLASS = {
+    RUNNING: 'running',
+    YET_TO_RUN: 'yet-to-run',
+    HOVERED: 'hovered',
+    COLLIDING: 'colliding',
+    NONE: '',
+};
+
 const getHoveredClass = (isHovered: boolean) => {
     if (isHovered) {
-        return 'hovered';
+        return EDGE_CLASS.HOVERED;
     }
-    return '';
+    return EDGE_CLASS.NONE;
 };
 
 const getCollidingClass = (isColliding: boolean) => {
     if (isColliding) {
-        return 'colliding';
+        return EDGE_CLASS.COLLIDING;
     }
-    return '';
+    return EDGE_CLASS.NONE;
 };
 
 const getRunningStateClass = (
@@ -36,20 +44,20 @@ const getRunningStateClass = (
     animateChain?: boolean
 ) => {
     if (targetStatus === NodeExecutionStatus.NOT_EXECUTING) {
-        return '';
+        return EDGE_CLASS.NONE;
     }
     switch (sourceStatus) {
         case NodeExecutionStatus.NOT_EXECUTING:
         case NodeExecutionStatus.FINISHED:
-            return '';
+            return EDGE_CLASS.NONE;
         case NodeExecutionStatus.RUNNING:
-            return animateChain ? 'running' : '';
+            return animateChain ? EDGE_CLASS.RUNNING : EDGE_CLASS.NONE;
         case NodeExecutionStatus.YET_TO_RUN:
-            return 'yet-to-run';
+            return EDGE_CLASS.YET_TO_RUN;
         default:
             assertNever(sourceStatus);
     }
-    return '';
+    return EDGE_CLASS.NONE;
 };
 
 export const CustomEdge = memo(

--- a/src/renderer/components/CustomEdge/CustomEdge.tsx
+++ b/src/renderer/components/CustomEdge/CustomEdge.tsx
@@ -51,7 +51,7 @@ const getRunningStateClass = (
         case NodeExecutionStatus.FINISHED:
             return EDGE_CLASS.NONE;
         case NodeExecutionStatus.RUNNING:
-            return animateChain ? EDGE_CLASS.RUNNING : EDGE_CLASS.NONE;
+            return animateChain ? EDGE_CLASS.RUNNING : EDGE_CLASS.YET_TO_RUN;
         case NodeExecutionStatus.YET_TO_RUN:
             return EDGE_CLASS.YET_TO_RUN;
         default:

--- a/src/renderer/components/CustomEdge/CustomEdge.tsx
+++ b/src/renderer/components/CustomEdge/CustomEdge.tsx
@@ -32,7 +32,8 @@ const getCollidingClass = (isColliding: boolean) => {
 
 const getRunningStateClass = (
     sourceStatus: NodeExecutionStatus,
-    targetStatus: NodeExecutionStatus
+    targetStatus: NodeExecutionStatus,
+    animateChain?: boolean
 ) => {
     if (targetStatus === NodeExecutionStatus.NOT_EXECUTING) {
         return '';
@@ -42,7 +43,7 @@ const getRunningStateClass = (
         case NodeExecutionStatus.FINISHED:
             return '';
         case NodeExecutionStatus.RUNNING:
-            return 'running';
+            return animateChain ? '' : 'running';
         case NodeExecutionStatus.YET_TO_RUN:
             return 'yet-to-run';
         default:
@@ -136,9 +137,10 @@ export const CustomEdge = memo(
             () =>
                 `${getHoveredClass(isHovered)} ${getRunningStateClass(
                     sourceStatus,
-                    targetStatus
+                    targetStatus,
+                    animateChain
                 )} ${getCollidingClass(isColliding)}`,
-            [isHovered, sourceStatus, targetStatus, isColliding]
+            [isHovered, sourceStatus, targetStatus, isColliding, animateChain]
         );
 
         // NOTE: I know that technically speaking this is bad

--- a/src/renderer/components/CustomEdge/CustomEdge.tsx
+++ b/src/renderer/components/CustomEdge/CustomEdge.tsx
@@ -190,23 +190,7 @@ export const CustomEdge = memo(
                     fill="none"
                     id={id}
                     stroke={currentColor}
-                    // strokeDasharray={50}
-                    // strokeDashoffset={50} // percent
-                    // style={{ transition: 'stroke-dashoffset ease-in-out 0.25s' }}
                 />
-                {/* <path
-                    className={`edge-chain ${classModifier}`}
-                    d={edgePath}
-                    fill="none"
-                    id={id}
-                    stroke={currentColor}
-                />
-                <path
-                    className={`edge-chain dot ${classModifier}`}
-                    d={edgePath}
-                    fill="none"
-                    id={id}
-                /> */}
                 <path
                     d={edgePath}
                     style={{


### PR DESCRIPTION
This changes a few things:
- The running edge animation is now just a standard crawling ants animation, but with rounded caps and a solid gray edge behind it. Ideally IMO it would be kinda like a loading animation instead but I'm not sure that's possible.
- Edges will now only be animated when the source node is running. To accomplish this, I had to change when the node start event gets sent out. Now, it sends that out after all the inputs are computed. Honestly, this just makes more sense in general, since the node really isn't running until after its inputs are done.
- Yet-to-run edges are now 50% opacity white.

With this, I think it's a bit more obvious what's actually in the process of running. Ideally, this also should reduce CPU usage due to the fewer animations, but I haven't actually checked that.