### PR TITLE
Update pytorch to 2.1.2 + fix CI/linux CPU pytorch

### DIFF
--- a/backend/src/packages/chaiNNer_pytorch/__init__.py
+++ b/backend/src/packages/chaiNNer_pytorch/__init__.py
@@ -50,7 +50,7 @@ def get_pytorch():
                 extra_index_url=(
                     "https://download.pytorch.org/whl/cu121"
                     if nvidia_is_available
-                    else None
+                    else "https://download.pytorch.org/whl/cpu"
                 ),
             ),
             Dependency(
@@ -61,7 +61,7 @@ def get_pytorch():
                 extra_index_url=(
                     "https://download.pytorch.org/whl/cu121"
                     if nvidia_is_available
-                    else None
+                    else "https://download.pytorch.org/whl/cpu"
                 ),
             ),
         ]

--- a/backend/src/packages/chaiNNer_pytorch/__init__.py
+++ b/backend/src/packages/chaiNNer_pytorch/__init__.py
@@ -30,13 +30,13 @@ def get_pytorch():
             Dependency(
                 display_name="PyTorch",
                 pypi_name="torch",
-                version="2.1.1",
+                version="2.1.2",
                 size_estimate=55.8 * MB,
             ),
             Dependency(
                 display_name="TorchVision",
                 pypi_name="torchvision",
-                version="0.16.1",
+                version="0.16.2",
                 size_estimate=1.3 * MB,
             ),
         ]
@@ -45,7 +45,7 @@ def get_pytorch():
             Dependency(
                 display_name="PyTorch",
                 pypi_name="torch",
-                version="2.1.1+cu121" if nvidia_is_available else "2.1.1",
+                version="2.1.2+cu121" if nvidia_is_available else "2.1.2",
                 size_estimate=2 * GB if nvidia_is_available else 140 * MB,
                 extra_index_url=(
                     "https://download.pytorch.org/whl/cu121"
@@ -56,7 +56,7 @@ def get_pytorch():
             Dependency(
                 display_name="TorchVision",
                 pypi_name="torchvision",
-                version="0.16.1+cu121" if nvidia_is_available else "0.16.1",
+                version="0.16.2+cu121" if nvidia_is_available else "0.16.2",
                 size_estimate=2 * MB if nvidia_is_available else 800 * KB,
                 extra_index_url=(
                     "https://download.pytorch.org/whl/cu121"


### PR DESCRIPTION
I guess one benefit to taking so long for a major release is that we can stay up to date with pytorch and not feel bad about it.

Also, I realized after looking at https://pytorch.org/get-started/locally/ that the reason our CI was installing the cuda version of pytorch was because for some odd reason, linux uses the cuda version by default and the cpu is the one you have to specify the extra index url for. So I just was explicit for both and tada now it works and it takes 1/4 of the time to run our CI.

This also means that linux users were previously unable to install the cpu version of torch. Oops. What an odd choice...