### PR TITLE
Allow glob negation in image iterator

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/load_images.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/load_images.py
@@ -31,7 +31,7 @@ def extension_filter(lst: list[str]) -> str:
 def list_glob(directory: str, globexpr: str, ext_filter: list[str]) -> list[str]:
     extension_expr = extension_filter(ext_filter)
 
-    flags = glob.EXTGLOB | glob.BRACE | glob.GLOBSTAR
+    flags = glob.EXTGLOB | glob.BRACE | glob.GLOBSTAR | glob.NEGATE
 
     filtered = glob.globfilter(
         glob.iglob(globexpr, root_dir=directory, flags=flags),


### PR DESCRIPTION
Realized that without this flag, you could not do negative globs