### PR TITLE
Add "Defer errors" option to applicable iterators

### DIFF
--- a/backend/src/api/api.py
+++ b/backend/src/api/api.py
@@ -605,13 +605,13 @@ L = TypeVar("L")
 
 @dataclass
 class Iterator(Generic[I]):
-    iter_supplier: Callable[[], Iterable[I]]
+    iter_supplier: Callable[[], Iterable[I | Exception]]
     expected_length: int
     defer_errors: bool = False
 
     @staticmethod
     def from_iter(
-        iter_supplier: Callable[[], Iterable[I]],
+        iter_supplier: Callable[[], Iterable[I | Exception]],
         expected_length: int,
         defer_errors: bool = False,
     ) -> Iterator[I]:
@@ -628,7 +628,10 @@ class Iterator(Generic[I]):
 
         def supplier():
             for i, x in enumerate(l):
-                yield map_fn(x, i)
+                try:
+                    yield map_fn(x, i)
+                except Exception as e:
+                    yield e
 
         return Iterator(supplier, len(l), defer_errors=defer_errors)
 
@@ -644,7 +647,10 @@ class Iterator(Generic[I]):
 
         def supplier():
             for i in range(count):
-                yield map_fn(i)
+                try:
+                    yield map_fn(i)
+                except Exception as e:
+                    yield e
 
         return Iterator(supplier, count, defer_errors=defer_errors)
 

--- a/backend/src/api/api.py
+++ b/backend/src/api/api.py
@@ -615,19 +615,7 @@ class Iterator(Generic[I]):
         expected_length: int,
         defer_errors: bool = False,
     ) -> Iterator[I]:
-        def wrapped_supplier():
-            errors = []
-            for x in iter_supplier():
-                try:
-                    yield x
-                except Exception as e:
-                    if defer_errors:
-                        errors.append(str(e))
-                    else:
-                        raise e
-            Iterator.__throw_errors(errors)
-
-        return Iterator(wrapped_supplier, expected_length, defer_errors=defer_errors)
+        return Iterator(iter_supplier, expected_length, defer_errors=defer_errors)
 
     @staticmethod
     def from_list(
@@ -638,18 +626,9 @@ class Iterator(Generic[I]):
         function. The iterable will be equivalent to `map(map_fn, l)`.
         """
 
-        errors = []
-
         def supplier():
             for i, x in enumerate(l):
-                try:
-                    yield map_fn(x, i)
-                except Exception as e:
-                    if defer_errors:
-                        errors.append(str(e))
-                    else:
-                        raise e
-            Iterator.__throw_errors(errors)
+                yield map_fn(x, i)
 
         return Iterator(supplier, len(l), defer_errors=defer_errors)
 
@@ -663,26 +642,11 @@ class Iterator(Generic[I]):
         """
         assert count >= 0
 
-        errors = []
-
         def supplier():
             for i in range(count):
-                try:
-                    yield map_fn(i)
-                except Exception as e:
-                    if defer_errors:
-                        errors.append(str(e))
-                    else:
-                        raise e
-            Iterator.__throw_errors(errors)
+                yield map_fn(i)
 
         return Iterator(supplier, count, defer_errors=defer_errors)
-
-    @staticmethod
-    def __throw_errors(errors: list[str]):
-        if len(errors) > 0:
-            error_string = "- " + "\n- ".join(errors)
-            raise Exception(f"Errors occurred during iteration:\n{error_string}")
 
 
 N = TypeVar("N")

--- a/backend/src/packages/chaiNNer_ncnn/ncnn/batch_processing/load_models.py
+++ b/backend/src/packages/chaiNNer_ncnn/ncnn/batch_processing/load_models.py
@@ -6,7 +6,7 @@ from sanic.log import logger
 
 from api import Iterator, IteratorOutputInfo
 from nodes.impl.ncnn.model import NcnnModelWrapper
-from nodes.properties.inputs import DirectoryInput
+from nodes.properties.inputs import BoolInput, DirectoryInput
 from nodes.properties.outputs import (
     DirectoryOutput,
     NcnnModelOutput,
@@ -30,6 +30,10 @@ from ..io.load_model import load_model_node
     icon="MdLoop",
     inputs=[
         DirectoryInput(),
+        BoolInput("Defer errors", default=True).with_docs(
+            "Ignore errors that occur during iteration and throw them after processing. Use this if you want to make sure one bad model doesn't interrupt your batch.",
+            hint=True,
+        ),
     ],
     outputs=[
         NcnnModelOutput(),
@@ -45,6 +49,7 @@ from ..io.load_model import load_model_node
 )
 def load_models_node(
     directory: str,
+    defer_errors: bool,
 ) -> tuple[Iterator[tuple[NcnnModelWrapper, str, str, int]], str]:
     logger.debug(f"Iterating over models in directory: {directory}")
 
@@ -76,4 +81,4 @@ def load_models_node(
 
     model_files = list(zip(param_files, bin_files))
 
-    return Iterator.from_list(model_files, load_model), directory
+    return Iterator.from_list(model_files, load_model, defer_errors), directory

--- a/backend/src/packages/chaiNNer_onnx/onnx/batch_processing/load_models.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/batch_processing/load_models.py
@@ -6,7 +6,7 @@ from sanic.log import logger
 
 from api import Iterator, IteratorOutputInfo
 from nodes.impl.onnx.model import OnnxModel
-from nodes.properties.inputs import DirectoryInput
+from nodes.properties.inputs import BoolInput, DirectoryInput
 from nodes.properties.outputs import (
     DirectoryOutput,
     NumberOutput,
@@ -30,6 +30,10 @@ from ..io.load_model import load_model_node
     icon="MdLoop",
     inputs=[
         DirectoryInput(),
+        BoolInput("Defer errors", default=True).with_docs(
+            "Ignore errors that occur during iteration and throw them after processing. Use this if you want to make sure one bad model doesn't interrupt your batch.",
+            hint=True,
+        ),
     ],
     outputs=[
         OnnxModelOutput(),
@@ -45,6 +49,7 @@ from ..io.load_model import load_model_node
 )
 def load_models_node(
     directory: str,
+    defer_errors: bool,
 ) -> tuple[Iterator[tuple[OnnxModel, str, str, int]], str]:
     logger.debug(f"Iterating over models in directory: {directory}")
 
@@ -57,4 +62,4 @@ def load_models_node(
     supported_filetypes = [".onnx"]
     model_files = list_all_files_sorted(directory, supported_filetypes)
 
-    return Iterator.from_list(model_files, load_model), directory
+    return Iterator.from_list(model_files, load_model, defer_errors), directory

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/iteration/load_models.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/iteration/load_models.py
@@ -7,6 +7,7 @@ from spandrel import ModelDescriptor
 
 from api import Iterator, IteratorOutputInfo
 from nodes.properties.inputs import DirectoryInput
+from nodes.properties.inputs.generic_inputs import BoolInput
 from nodes.properties.outputs import DirectoryOutput, NumberOutput, TextOutput
 from nodes.properties.outputs.pytorch_outputs import ModelOutput
 from nodes.utils.utils import list_all_files_sorted
@@ -26,6 +27,10 @@ from ..io.load_model import load_model_node
     icon="MdLoop",
     inputs=[
         DirectoryInput(),
+        BoolInput("Defer errors", default=True).with_docs(
+            "Ignore errors that occur during iteration and throw them after processing. Use this if you want to make sure one bad model doesn't interrupt your batch.",
+            hint=True,
+        ),
     ],
     outputs=[
         ModelOutput(),
@@ -41,6 +46,7 @@ from ..io.load_model import load_model_node
 )
 def load_models_node(
     directory: str,
+    defer_errors: bool,
 ) -> tuple[Iterator[tuple[ModelDescriptor, str, str, int]], str]:
     logger.debug(f"Iterating over models in directory: {directory}")
 
@@ -53,4 +59,4 @@ def load_models_node(
     supported_filetypes = [".pt", ".pth", ".ckpt"]
     model_files: list[str] = list_all_files_sorted(directory, supported_filetypes)
 
-    return Iterator.from_list(model_files, load_model), directory
+    return Iterator.from_list(model_files, load_model, defer_errors), directory

--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/load_image_pairs.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/load_image_pairs.py
@@ -34,6 +34,10 @@ from ..io.load_image import load_image_node
                 "Limit the number of images to iterate over. This can be useful for testing the iterator without having to iterate over all images."
             )
         ),
+        BoolInput("Defer errors", default=True).with_docs(
+            "Ignore errors that occur during iteration and throw them after processing. Use this if you want to make sure one bad image doesn't interrupt your batch.",
+            hint=True,
+        ),
     ],
     outputs=[
         ImageOutput("Image A"),
@@ -56,6 +60,7 @@ def load_image_pairs_node(
     directory_b: str,
     use_limit: bool,
     limit: int,
+    defer_errors: bool,
 ) -> tuple[Iterator[tuple[np.ndarray, np.ndarray, str, str, str, str, int]], str, str]:
     def load_images(filepaths: tuple[str, str], index: int):
         path_a, path_b = filepaths
@@ -84,4 +89,8 @@ def load_image_pairs_node(
 
     image_files = list(zip(image_files_a, image_files_b))
 
-    return Iterator.from_list(image_files, load_images), directory_a, directory_b
+    return (
+        Iterator.from_list(image_files, load_images, defer_errors),
+        directory_a,
+        directory_b,
+    )

--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/load_images.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/load_images.py
@@ -70,6 +70,10 @@ def list_glob(directory: str, globexpr: str, ext_filter: list[str]) -> list[str]
                 "Limit the number of images to iterate over. This can be useful for testing the iterator without having to iterate over all images."
             )
         ),
+        BoolInput("Defer errors", default=True).with_docs(
+            "Ignore errors that occur during iteration and throw them after processing. Use this if you want to make sure one bad image doesn't interrupt your batch.",
+            hint=True,
+        ),
     ],
     outputs=[
         ImageOutput(),
@@ -91,6 +95,7 @@ def load_images_node(
     glob_str: str,
     use_limit: bool,
     limit: int,
+    defer_errors: bool,
 ) -> tuple[Iterator[tuple[np.ndarray, str, str, int]], str]:
     def load_image(path: str, index: int):
         img, img_dir, basename = load_image_node(path)
@@ -110,4 +115,4 @@ def load_images_node(
     if use_limit:
         just_image_files = just_image_files[:limit]
 
-    return Iterator.from_list(just_image_files, load_image), directory
+    return Iterator.from_list(just_image_files, load_image, defer_errors), directory

--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -571,10 +571,10 @@ class Executor:
         await self.__send_node_progress(node, times, 0, expected_length)
 
         errors: list[str] = []
-        iterable = iterator_output.iterator.iter_supplier()
-        while True:
+        for values in iterator_output.iterator.iter_supplier():
             try:
-                values = next(iterable)  # type: ignore
+                if isinstance(values, Exception):
+                    raise values
 
                 # write current values to cache
                 iter_output = fill_partial_output(values)
@@ -603,10 +603,7 @@ class Executor:
                 await self.progress.suspend()
                 await update_progress()
                 await self.progress.suspend()
-            except StopIteration:
-                break
-            except StopAsyncIteration:
-                break
+
             except Exception as e:
                 if iterator_output.iterator.defer_errors:
                     errors.append(str(e))

--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -603,7 +603,8 @@ class Executor:
                 await self.progress.suspend()
                 await update_progress()
                 await self.progress.suspend()
-
+            except Aborted:
+                raise
             except Exception as e:
                 if iterator_output.iterator.defer_errors:
                     errors.append(str(e))

--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -570,7 +570,7 @@ class Executor:
         # iterate
         await self.__send_node_progress(node, times, 0, expected_length)
 
-        errors: list[str] = []
+        deferred_errors: list[str] = []
         for values in iterator_output.iterator.iter_supplier():
             try:
                 if isinstance(values, Exception):
@@ -607,7 +607,7 @@ class Executor:
                 raise
             except Exception as e:
                 if iterator_output.iterator.defer_errors:
-                    errors.append(str(e))
+                    deferred_errors.append(str(e))
                 else:
                     raise e
 
@@ -642,8 +642,8 @@ class Executor:
                 self.cache_strategy[collector_node.id],
             )
 
-        if iterator_output.iterator.defer_errors and len(errors) > 0:
-            error_string = "- " + "\n- ".join(errors)
+        if len(deferred_errors) > 0:
+            error_string = "- " + "\n- ".join(deferred_errors)
             raise Exception(f"Errors occurred during iteration:\n{error_string}")
 
     async def __process_nodes(self):


### PR DESCRIPTION
So it turns out the reason it wasn't working properly before was because of #2440... The models i was using just weren't being picked up by the node i was using to test. Therefore, I didn't actually need to do the manual iteration with the `while True` + `next()` nonsense.

This might not be the most glamorous solution, but it works and I'm happy enough with it.