### PR TITLE
Better node errors using error messages in output types

### DIFF
--- a/backend/src/navi.py
+++ b/backend/src/navi.py
@@ -150,6 +150,10 @@ def intersect(*items: ExpressionJson) -> ExpressionJson:
     return {"type": "intersection", "items": list(items)}
 
 
+def intersect_with_error(*items: ExpressionJson) -> ExpressionJson:
+    return union(intersect(*items), *[intersect("Error", item) for item in items])
+
+
 def named(name: str, fields: dict[str, ExpressionJson] | None = None) -> ExpressionJson:
     return {"type": "named", "name": name, "fields": fields}
 

--- a/backend/src/nodes/properties/outputs/file_outputs.py
+++ b/backend/src/nodes/properties/outputs/file_outputs.py
@@ -18,7 +18,7 @@ class DirectoryOutput(BaseOutput):
             if of_input is None
             else f"splitFilePath(Input{of_input}.path).dir"
         )
-        directory_type = navi.intersect(directory_type, output_type)
+        directory_type = navi.intersect_with_error(directory_type, output_type)
         super().__init__(directory_type, label, associated_type=str)
 
     def get_broadcast_type(self, value: str):

--- a/backend/src/nodes/properties/outputs/generic_outputs.py
+++ b/backend/src/nodes/properties/outputs/generic_outputs.py
@@ -17,7 +17,7 @@ class NumberOutput(BaseOutput):
         output_type: navi.ExpressionJson = "number",
     ):
         super().__init__(
-            navi.intersect("number", output_type),
+            navi.intersect_with_error("number", output_type),
             label,
             associated_type=Union[int, float],
         )
@@ -36,7 +36,7 @@ class TextOutput(BaseOutput):
         label: str,
         output_type: navi.ExpressionJson = "string",
     ):
-        super().__init__(navi.intersect("string", output_type), label)
+        super().__init__(navi.intersect_with_error("string", output_type), label)
 
     def get_broadcast_type(self, value: str):
         return navi.literal(value)
@@ -73,7 +73,9 @@ class ColorOutput(BaseOutput):
         channels: int | None = None,
     ):
         super().__init__(
-            output_type=navi.intersect(color_type, navi.Color(channels=channels)),
+            output_type=navi.intersect_with_error(
+                color_type, navi.Color(channels=channels)
+            ),
             label=label,
             kind="generic",
         )

--- a/backend/src/nodes/properties/outputs/numpy_outputs.py
+++ b/backend/src/nodes/properties/outputs/numpy_outputs.py
@@ -53,7 +53,7 @@ class ImageOutput(NumPyOutput):
         assume_normalized: bool = False,
     ):
         super().__init__(
-            navi.intersect(image_type, navi.Image(channels=channels)),
+            navi.intersect_with_error(image_type, navi.Image(channels=channels)),
             label,
             kind=kind,
             has_handle=has_handle,

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/guided_upscale.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/guided_upscale.py
@@ -48,22 +48,24 @@ from .. import processing_group
                 let source = Input0;
                 let guide = Input1;
 
-                let valid = bool::and(
-                    // guide image must be larger than source image
-                    guide.width > source.width,
+                let kScale = bool::and(
                     // guide image's size must be `k * source.size` for `k>1`
                     guide.width / source.width == int,
                     guide.width / source.width == guide.height / source.height
                 );
 
-                Image {
-                    width: guide.width,
-                    height: guide.height,
-                    channels: source.channels,
-                } & if valid { any } else { never }
+                if guide.width <= source.width {
+                    error("The guide image must be larger than the source image.")
+                } else if bool::not(kScale) {
+                    error("The size of the guide image must be an integer multiple of the size of the source image (e.g. 2x, 3x, 4x, ...).")
+                } else {
+                    Image {
+                        width: guide.width,
+                        height: guide.height,
+                        channels: source.channels,
+                    }
+                }
                 """
-        ).with_never_reason(
-            "The guide image must be larger than the source image, and the size of the guide image must be an integer multiple of the size of the source image (e.g. 2x, 3x, 4x, ...)."
         ),
     ],
 )

--- a/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/stretch_contrast.py
+++ b/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/stretch_contrast.py
@@ -52,14 +52,18 @@ class StretchMode(Enum):
     outputs=[
         ImageOutput(
             image_type="""
-                let valid: bool = match Input1 {
+                let minMaxRangeValid: bool = match Input1 {
                     StretchMode::Manual => Input4 < Input5,
                     _ => true,
                 };
 
-                if valid { Input0 } else { never }
+                if minMaxRangeValid {
+                    Input0
+                } else {
+                    error("Minimum must be less than Maximum.")
+                }
             """,
-        ).with_never_reason("Minimum must be less than the Maximum."),
+        ),
     ],
 )
 def stretch_contrast_node(

--- a/backend/src/packages/chaiNNer_standard/image_channel/all/combine_rgba.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/all/combine_rgba.py
@@ -34,23 +34,24 @@ from . import node_group
     outputs=[
         ImageOutput(
             image_type="""
-                let anyImages = bool::or(Input0 == Image, Input1 == Image, Input2 == Image, Input3 == Image);
+                def isImage(i: any) = match i { Image => true, _ => false };
+                let anyImages = bool::or(isImage(Input0), isImage(Input1), isImage(Input2), isImage(Input3));
 
-                def getWidth(i: any) = match i { Image => i.width, _ => Image.width };
-                def getHeight(i: any) = match i { Image => i.height, _ => Image.height };
+                if bool::not(anyImages) {
+                    error("At least one channel must be an image.")
+                } else {
+                    def getWidth(i: any) = match i { Image => i.width, _ => Image.width };
+                    def getHeight(i: any) = match i { Image => i.height, _ => Image.height };
 
-                let valid = if anyImages { any } else { never };
-
-                valid & Image {
-                    width: getWidth(Input0) & getWidth(Input1) & getWidth(Input2) & getWidth(Input3),
-                    height: getHeight(Input0) & getHeight(Input1) & getHeight(Input2) & getHeight(Input3),
+                    Image {
+                        width: getWidth(Input0) & getWidth(Input1) & getWidth(Input2) & getWidth(Input3),
+                        height: getHeight(Input0) & getHeight(Input1) & getHeight(Input2) & getHeight(Input3),
+                    }
                 }
             """,
             channels=4,
             assume_normalized=True,
-        ).with_never_reason(
-            "All input channels must have the same size, and at least one input channel must be an image."
-        )
+        ).with_never_reason("All input channels must have the same size.")
     ],
 )
 def combine_rgba_node(

--- a/backend/src/packages/chaiNNer_standard/image_channel/misc/alpha_matting.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/misc/alpha_matting.py
@@ -47,22 +47,15 @@ from . import node_group
                 let fg = Input2;
                 let bg = Input3;
 
-                let valid = bool::and(
-                    fg > bg,
-                    image.width == trimap.width,
-                    image.height == trimap.height,
-                );
-
-                if valid {
-                    Image { width: image.width, height: image.height }
+                if fg <= bg {
+                    error("The foreground threshold must be greater than the background threshold.")
+                } else if bool::or(image.width != trimap.width, image.height != trimap.height) {
+                    error("The image and trimap must have the same size.")
                 } else {
-                    never
+                    Image { width: image.width, height: image.height }
                 }
             """,
             channels=4,
-        ).with_never_reason(
-            "The image and trimap must have the same size,"
-            " and the foreground threshold must be greater than the background threshold."
         ),
     ],
 )

--- a/backend/src/packages/chaiNNer_standard/image_filter/quantize/quantize_to_reference.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/quantize/quantize_to_reference.py
@@ -74,22 +74,21 @@ def quantize_image(image: np.ndarray, palette: np.ndarray):
     outputs=[
         ImageOutput(
             image_type="""
-            let valid = bool::and(
-                Input0.width >= Input1.width,
-                number::mod(Input0.width, Input1.width) == 0,
-                Input0.height >= Input1.height,
-                number::mod(Input0.height, Input1.height) == 0,
-                Input0.channels == Input1.channels,
-            );
-
-            Image {
-                width: max(Input0.width, Input1.width),
-                height: max(Input0.height, Input1.height),
-                channels: Input0.channels,
-            } & if valid { any } else { never }""",
+            if Input0.channels != Input1.channels {
+                error("The target image and reference image must have the same number of channels.")
+            } else if bool::or(Input0.width < Input1.width, Input0.height < Input1.height) {
+                error("The target image must be larger than the reference image.")
+            } else if bool::or(number::mod(Input0.width, Input1.width) != 0, number::mod(Input0.height, Input1.height) != 0) {
+                error("The size of the target image must be an integer multiple of the size of the reference image (e.g. 2x, 3x, 4x, 8x).")
+            } else {
+                Image {
+                    width: max(Input0.width, Input1.width),
+                    height: max(Input0.height, Input1.height),
+                    channels: Input0.channels,
+                }
+            }
+            """,
             assume_normalized=True,
-        ).with_never_reason(
-            "Target image must be larger than reference image in both dimensions, must have dimensions that are a multiple of each other, and must have the same number of channels."
         )
     ],
 )

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "GPLv3",
       "dependencies": {
         "@babel/plugin-transform-react-jsx": "^7.17.12",
-        "@chainner/navi": "^0.6.2",
+        "@chainner/navi": "^0.7.0",
         "@chakra-ui/icons": "^2.1.1",
         "@chakra-ui/react": "^2.8.2",
         "@emotion/react": "^11.9.0",
@@ -964,9 +964,9 @@
       "dev": true
     },
     "node_modules/@chainner/navi": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@chainner/navi/-/navi-0.6.2.tgz",
-      "integrity": "sha512-udqqqOjRrBs7AZ6+aW8oOVl2SPqmH1jhF8tHubyeV8QUUeKS0meMqbmbEtlXmwtc4QDN85/UQjzmaIjNR+NYig==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@chainner/navi/-/navi-0.7.0.tgz",
+      "integrity": "sha512-2pfd+gWXCAU0xMZ1FDoRsVfiIEdtfdbBsHFSAQme+NQISuI6VsGh4T+m7vj63DdCbH4iRP6DpbF8xKMH0qhB5A==",
       "engines": {
         "node": ">=16.0.0"
       }
@@ -25821,9 +25821,9 @@
       "dev": true
     },
     "@chainner/navi": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@chainner/navi/-/navi-0.6.2.tgz",
-      "integrity": "sha512-udqqqOjRrBs7AZ6+aW8oOVl2SPqmH1jhF8tHubyeV8QUUeKS0meMqbmbEtlXmwtc4QDN85/UQjzmaIjNR+NYig=="
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@chainner/navi/-/navi-0.7.0.tgz",
+      "integrity": "sha512-2pfd+gWXCAU0xMZ1FDoRsVfiIEdtfdbBsHFSAQme+NQISuI6VsGh4T+m7vj63DdCbH4iRP6DpbF8xKMH0qhB5A=="
     },
     "@chakra-ui/accordion": {
       "version": "2.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "GPLv3",
       "dependencies": {
         "@babel/plugin-transform-react-jsx": "^7.17.12",
-        "@chainner/navi": "^0.7.0",
+        "@chainner/navi": "^0.7.1",
         "@chakra-ui/icons": "^2.1.1",
         "@chakra-ui/react": "^2.8.2",
         "@emotion/react": "^11.9.0",
@@ -964,9 +964,9 @@
       "dev": true
     },
     "node_modules/@chainner/navi": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@chainner/navi/-/navi-0.7.0.tgz",
-      "integrity": "sha512-2pfd+gWXCAU0xMZ1FDoRsVfiIEdtfdbBsHFSAQme+NQISuI6VsGh4T+m7vj63DdCbH4iRP6DpbF8xKMH0qhB5A==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@chainner/navi/-/navi-0.7.1.tgz",
+      "integrity": "sha512-YQZngMQ28U6I5NONuKufUQPtWO6pPgztQ5Y6oDP+75oaH2aPDCI5A6AKVSH8fAgfCl/IOeff81RlhvfYvryvUQ==",
       "engines": {
         "node": ">=16.0.0"
       }
@@ -25821,9 +25821,9 @@
       "dev": true
     },
     "@chainner/navi": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@chainner/navi/-/navi-0.7.0.tgz",
-      "integrity": "sha512-2pfd+gWXCAU0xMZ1FDoRsVfiIEdtfdbBsHFSAQme+NQISuI6VsGh4T+m7vj63DdCbH4iRP6DpbF8xKMH0qhB5A=="
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@chainner/navi/-/navi-0.7.1.tgz",
+      "integrity": "sha512-YQZngMQ28U6I5NONuKufUQPtWO6pPgztQ5Y6oDP+75oaH2aPDCI5A6AKVSH8fAgfCl/IOeff81RlhvfYvryvUQ=="
     },
     "@chakra-ui/accordion": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
   },
   "dependencies": {
     "@babel/plugin-transform-react-jsx": "^7.17.12",
-    "@chainner/navi": "^0.7.0",
+    "@chainner/navi": "^0.7.1",
     "@chakra-ui/icons": "^2.1.1",
     "@chakra-ui/react": "^2.8.2",
     "@emotion/react": "^11.9.0",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
   },
   "dependencies": {
     "@babel/plugin-transform-react-jsx": "^7.17.12",
-    "@chainner/navi": "^0.6.2",
+    "@chainner/navi": "^0.7.0",
     "@chakra-ui/icons": "^2.1.1",
     "@chakra-ui/react": "^2.8.2",
     "@emotion/react": "^11.9.0",

--- a/src/common/nodes/checkNodeValidity.ts
+++ b/src/common/nodes/checkNodeValidity.ts
@@ -84,12 +84,8 @@ export const checkNodeValidity = ({
         }
 
         // eslint-disable-next-line no-unreachable-loop
-        for (const { outputId } of functionInstance.outputErrors) {
-            const output = schema.outputs.find((o) => o.id === outputId)!;
-
-            return invalid(
-                `Some inputs are incompatible with each other. ${output.neverReason ?? ''}`
-            );
+        for (const { message } of functionInstance.outputErrors) {
+            return invalid(`Some inputs are incompatible with each other. ${message ?? ''}`);
         }
     }
 

--- a/src/common/types/chainner-scope.ts
+++ b/src/common/types/chainner-scope.ts
@@ -23,6 +23,11 @@ import {
 const code = `
 struct null;
 
+struct Error { message: string }
+def error(message: invStrSet("")): Error {
+    Error { message: message }
+}
+
 struct Seed;
 
 struct Directory { path: string }

--- a/src/common/types/json.ts
+++ b/src/common/types/json.ts
@@ -136,6 +136,7 @@ export const fromJson = (e: ExpressionJson): Expression => {
             }
             return new StructExpression(
                 e.name,
+                undefined,
                 Object.entries(e.fields ?? {}).map(
                     ([name, type]) => new StructExpressionField(name, fromJson(type))
                 )


### PR DESCRIPTION
This PR adds the ability for output types to return error messages. This is useful for complex types where `never_reason` alone isn't enough. Since `never_reason` is only one message, we previously weren't able to communicate the precise reason for the error, even though the type system knows the reason. I fixed this by allowing output types to return not only their type, but also an optional `Error { message: string }` type. This allows us to define relevant error messages, instead of just listing reasons why the node could be invalid.

In actual output type code, this looks like this (Alpha Matting node):
```
if fg <= bg {
    error("The foreground threshold must be greater than the background threshold.")
} else if bool::or(image.width != trimap.width, image.height != trimap.height) {
    error("The image and trimap must have the same size.")
} else {
    Image { width: image.width, height: image.height }
}
```

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/8c3f10ea-f7b9-483a-9ab1-2751af6b5b37)

Note that this PR doesn't remove `never_reason`. `never_reason` is just simpler to use in many cases, and it still provides a useful fallback/default for error messages. I think of the new `error("...")` as an addition, not as a replacement.