### PR TITLE
Add a toast message on start for dependency updates

### DIFF
--- a/src/common/locales/en/translation.json
+++ b/src/common/locales/en/translation.json
@@ -5,7 +5,9 @@
     }
   },
   "dependencyManager": {
-    "manageDependencies": "Manage Dependencies"
+    "manageDependencies": "Manage Dependencies",
+    "updatesAvailable": "Updates Available",
+    "updatesAvailableDescription": "There are {{count}} updates available for your dependencies."
   },
   "error": {
     "error": "Error",

--- a/src/renderer/components/DependencyManagerButton.tsx
+++ b/src/renderer/components/DependencyManagerButton.tsx
@@ -1,6 +1,6 @@
 import { DownloadIcon } from '@chakra-ui/icons';
-import { IconButton, Tag, TagLabel, Tooltip, VStack } from '@chakra-ui/react';
-import { memo } from 'react';
+import { IconButton, Tag, TagLabel, Tooltip, VStack, useToast } from '@chakra-ui/react';
+import { memo, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useContext } from 'use-context-selector';
 import { DependencyContext } from '../contexts/DependencyContext';
@@ -9,6 +9,34 @@ export const DependencyManagerButton = memo(() => {
     const { t } = useTranslation();
 
     const { openDependencyManager, availableUpdates } = useContext(DependencyContext);
+
+    const toast = useToast();
+
+    const shownOnce = useRef(false);
+    useEffect(() => {
+        if (shownOnce.current) {
+            return;
+        }
+
+        if (availableUpdates > 0) {
+            toast({
+                title: t('dependencyManager.updatesAvailable', 'Updates Available'),
+                description: t(
+                    'dependencyManager.updatesAvailableDescription',
+                    'There are {{count}} packages with available dependency updates.',
+                    { count: availableUpdates }
+                ),
+                status: 'info',
+                duration: 5000,
+                isClosable: true,
+                position: 'top-right',
+                onCloseComplete: () => {
+                    shownOnce.current = false;
+                },
+            });
+            shownOnce.current = true;
+        }
+    }, [availableUpdates, t, toast]);
 
     return (
         <Tooltip
@@ -26,7 +54,7 @@ export const DependencyManagerButton = memo(() => {
                 {availableUpdates > 0 ? (
                     <Tag
                         borderRadius="full"
-                        colorScheme="red"
+                        colorScheme="blue"
                         ml={-7}
                         mt={-1}
                         position="fixed"


### PR DESCRIPTION
Closes #2448 

![image](https://github.com/chaiNNer-org/chaiNNer/assets/34788790/1f67754a-9456-448b-91a2-8b5035e97f82)


I also changed the color of the bubble to be consistent with the toast and the update button in the dep manager, all of which are blue.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/34788790/23caf9ef-aad2-415d-8e22-e06ab83d42eb)
