### PR TITLE
Fixed upscaling with transparency

### DIFF
--- a/backend/src/nodes/impl/upscale/convenient_upscale.py
+++ b/backend/src/nodes/impl/upscale/convenient_upscale.py
@@ -25,7 +25,7 @@ def denoise_and_flatten_alpha(img: np.ndarray) -> np.ndarray:
     alpha_max = np.max(img, axis=2)
     alpha_mean = np.mean(img, axis=2)
     alpha = alpha_max * alpha_mean + alpha_min * (1 - alpha_mean)
-    return alpha
+    return alpha.clip(0, 1)
 
 
 def convenient_upscale(


### PR DESCRIPTION
Fixes #2455.

The issue was the alpha we get from black & white images is not guaranteed to be normalized (it can be >1). Since #2407 removed normalization for performance reasons, those non-normalized values could be observed by other nodes.

The fix is to clip those alpha values in range.