### PR TITLE
Add "Manual/Copy" install mode to dependency manager

### DIFF
--- a/src/common/pip.ts
+++ b/src/common/pip.ts
@@ -57,7 +57,7 @@ export const runPip = async (
     });
 };
 
-const getFindLinks = (dependencies: readonly PyPiPackage[]): string[] => {
+export const getFindLinks = (dependencies: readonly PyPiPackage[]): string[] => {
     const links = new Set<string>();
     for (const p of dependencies) {
         if (p.findLink) {

--- a/src/renderer/contexts/DependencyContext.tsx
+++ b/src/renderer/contexts/DependencyContext.tsx
@@ -600,9 +600,9 @@ export const DependencyProvider = memo(({ children }: React.PropsWithChildren<un
                                                 label={
                                                     <Markdown nonInteractive>
                                                         {'The dependency install mode. ChaiNNer supports 3 ways of installing packages:\n\n' +
-                                                            '- Normal: This is the default installation mode. If you are having issues, you can try using the Direct Pip mode.\n' +
-                                                            '- Direct Pip: This will invoke pip more directly, which can fix some issues, but also makes it impossible to show installation progress.\n' +
-                                                            '- Manual/Copy: Copy the pip install command to your clipboard for you to run in your own terminal. You have to manually restart chaiNner afterwards.'}
+                                                            '- Normal: This is the default installation mode. This mode manually downloads packages in order to display download progress.\n' +
+                                                            '- Direct Pip: This will invoke pip more directly, like installing python packages normally. Use this setting when having issues with Normal. Note: this makes it impossible to show installation progress.\n' +
+                                                            '- Manual/Copy: Copy the pip install command to your clipboard for you to run in your own terminal. You will have to manually restart chaiNner afterwards.'}
                                                     </Markdown>
                                                 }
                                                 openDelay={500}

--- a/src/renderer/contexts/DependencyContext.tsx
+++ b/src/renderer/contexts/DependencyContext.tsx
@@ -59,7 +59,7 @@ import { GlobalContext } from './GlobalNodeState';
 import { SettingsContext } from './SettingsContext';
 
 const installModes = {
-    NORMAL: 'Normal Install',
+    NORMAL: 'Normal',
     DIRECT_PIP: 'Direct Pip',
     MANUAL_COPY: 'Manual/Copy',
 };

--- a/src/renderer/contexts/DependencyContext.tsx
+++ b/src/renderer/contexts/DependencyContext.tsx
@@ -459,7 +459,7 @@ export const DependencyProvider = memo(({ children }: React.PropsWithChildren<un
         toast({
             title: 'Command copied to clipboard.',
             description:
-                'Open up anm external terminal, paste the command, and run it. When it is done running, manually restart chaiNNer.',
+                'Open up an external terminal, paste the command, and run it. When it is done running, manually restart chaiNNer.',
             status: 'success',
             duration: 9000,
             isClosable: true,

--- a/src/renderer/contexts/DependencyContext.tsx
+++ b/src/renderer/contexts/DependencyContext.tsx
@@ -20,6 +20,13 @@ import {
     ModalFooter,
     ModalHeader,
     ModalOverlay,
+    Popover,
+    PopoverArrow,
+    PopoverBody,
+    PopoverCloseButton,
+    PopoverContent,
+    PopoverHeader,
+    PopoverTrigger,
     Progress,
     Select,
     Spacer,
@@ -30,7 +37,6 @@ import {
     Tooltip,
     VStack,
     useDisclosure,
-    useToast,
 } from '@chakra-ui/react';
 import { clipboard } from 'electron';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -423,8 +429,6 @@ export const DependencyProvider = memo(({ children }: React.PropsWithChildren<un
     );
     const onStdio: OnStdio = { onStderr: appendToOutput, onStdout: appendToOutput };
 
-    const toast = useToast();
-
     const changePackages = (supplier: () => Promise<void>) => {
         if (isRunningShell) throw new Error('Cannot run two pip commands at once');
 
@@ -454,16 +458,17 @@ export const DependencyProvider = memo(({ children }: React.PropsWithChildren<un
             });
     };
 
+    const {
+        isOpen: isPopoverOpen,
+        onToggle: onPopoverToggle,
+        onClose: onPopoverClose,
+    } = useDisclosure();
     const copyCommandToClipboard = (command: string) => {
         clipboard.writeText(command);
-        toast({
-            title: 'Command copied to clipboard.',
-            description:
-                'Open up an external terminal, paste the command, and run it. When it is done running, manually restart chaiNNer.',
-            status: 'success',
-            duration: 9000,
-            isClosable: true,
-        });
+        onPopoverToggle();
+        setTimeout(() => {
+            onPopoverClose();
+        }, 5000);
     };
 
     const installPackage = (pkg: Package) => {
@@ -582,18 +587,42 @@ export const DependencyProvider = memo(({ children }: React.PropsWithChildren<un
                                 <HStack gap={2}>
                                     <HStack>
                                         <HStack>
-                                            <Select
-                                                isDisabled={isRunningShell}
-                                                size="md"
-                                                value={installMode}
-                                                onChange={(e) => {
-                                                    setInstallMode(e.target.value);
-                                                }}
+                                            <Popover
+                                                closeOnBlur={false}
+                                                colorScheme="green"
+                                                isOpen={isPopoverOpen}
+                                                placement="top"
+                                                returnFocusOnClose={false}
+                                                onClose={onPopoverClose}
                                             >
-                                                <option>{installModes.NORMAL}</option>
-                                                <option>{installModes.DIRECT_PIP}</option>
-                                                <option>{installModes.MANUAL_COPY}</option>
-                                            </Select>
+                                                <PopoverTrigger>
+                                                    <Select
+                                                        isDisabled={isRunningShell}
+                                                        size="md"
+                                                        value={installMode}
+                                                        onChange={(e) => {
+                                                            setInstallMode(e.target.value);
+                                                        }}
+                                                    >
+                                                        <option>{installModes.NORMAL}</option>
+                                                        <option>{installModes.DIRECT_PIP}</option>
+                                                        <option>{installModes.MANUAL_COPY}</option>
+                                                    </Select>
+                                                </PopoverTrigger>
+                                                <PopoverContent>
+                                                    <PopoverHeader fontWeight="semibold">
+                                                        Command copied to clipboard.
+                                                    </PopoverHeader>
+                                                    <PopoverArrow />
+                                                    <PopoverCloseButton />
+                                                    <PopoverBody>
+                                                        Open up an external terminal, paste the
+                                                        command, and run it. When it is done
+                                                        running, manually restart chaiNNer.
+                                                    </PopoverBody>
+                                                </PopoverContent>
+                                            </Popover>
+
                                             <Tooltip
                                                 hasArrow
                                                 borderRadius={8}

--- a/src/renderer/contexts/DependencyContext.tsx
+++ b/src/renderer/contexts/DependencyContext.tsx
@@ -599,7 +599,7 @@ export const DependencyProvider = memo(({ children }: React.PropsWithChildren<un
                                             <Tooltip
                                                 hasArrow
                                                 borderRadius={8}
-                                                label="Change the dependency install mode. Normal Install is recommended, but if you are having issues, you can try using the Direct Pip mode (which will not show progress), or Manual/Copy mode, which will copy the correct install command to your clipboard for you to run in your own terminal."
+                                                label="Change the dependency install mode. Normal Install is recommended, but if you are having issues, you can try using the Direct Pip mode (which will not show progress), or Manual/Copy mode, which will copy the correct install command to your clipboard for you to run in your own terminal (restart chaiNNer manually after)."
                                                 openDelay={500}
                                                 px={2}
                                                 py={0}

--- a/src/renderer/contexts/DependencyContext.tsx
+++ b/src/renderer/contexts/DependencyContext.tsx
@@ -481,8 +481,6 @@ export const DependencyProvider = memo(({ children }: React.PropsWithChildren<un
                 '--upgrade',
                 ...deps,
                 ...findLinks,
-                '--no-cache-dir',
-                '--disable-pip-version-check',
             ];
             const cmd = args.join(' ');
             copyCommandToClipboard(cmd);

--- a/src/renderer/contexts/DependencyContext.tsx
+++ b/src/renderer/contexts/DependencyContext.tsx
@@ -599,7 +599,14 @@ export const DependencyProvider = memo(({ children }: React.PropsWithChildren<un
                                             <Tooltip
                                                 hasArrow
                                                 borderRadius={8}
-                                                label="Change the dependency install mode. Normal Install is recommended, but if you are having issues, you can try using the Direct Pip mode (which will not show progress), or Manual/Copy mode, which will copy the correct install command to your clipboard for you to run in your own terminal (restart chaiNNer manually after)."
+                                                label={
+                                                    <Markdown nonInteractive>
+                                                        {'The dependency install mode. ChaiNNer supports 3 ways of installing packages:\n\n' +
+                                                            '- Normal: This is the default installation mode. If you are having issues, you can try using the Direct Pip mode.\n' +
+                                                            '- Direct Pip: This will invoke pip more directly, which can fix some issues, but also makes it impossible to show installation progress.\n' +
+                                                            '- Manual/Copy: Copy the pip install command to your clipboard for you to run in your own terminal. You have to manually restart chaiNner afterwards.'}
+                                                    </Markdown>
+                                                }
                                                 openDelay={500}
                                                 px={2}
                                                 py={0}


### PR DESCRIPTION
Closes #2447. I am apparently not able to open a terminal with pre-written text, so instead I added the ability to switch between different install modes.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/34788790/da8339be-bfdc-4ccf-950d-cb047de1be3b)

Normal Install is the regular mode, Direct Pip is the former "use pip directly" toggle, and Manual/Copy will now copy the command to your clipboard for you to run yourself.

With this, I will no longer have to tell people how to do this themselves, they can just use this to copy the command and all they have to do is paste it in and press enter.