### PR TITLE
Fix scale of Hq2X in output type

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize_pixel_art.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize_pixel_art.py
@@ -88,10 +88,9 @@ ALGORITHM_LABEL: dict[ResizeAlgorithm, str] = {
                     ResizeAlgorithm::SuperEagle2X => 2,
                     ResizeAlgorithm::Sai2X => 2,
                     ResizeAlgorithm::SuperSai2X => 2,
-                    ResizeAlgorithm::AdvMane2X => 2,
+                    ResizeAlgorithm::Hq2X => 2,
                     ResizeAlgorithm::Hq3X => 3,
                     ResizeAlgorithm::Hq4X => 4,
-                    _ => 4
                 };
 
                 Image {


### PR DESCRIPTION
I messed up a copy paste. Since we have exhaustive `match`s now, I also removed the default case. If we forgot a case, we'll now get a type error.

Fixes #2464.