### PR TITLE
Remove TODO comment

### DIFF
--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
@@ -157,7 +157,6 @@ def upscale_image_node(
 
     logger.debug("Upscaling image...")
 
-    # TODO: Have all super resolution models inherit from something that forces them to use in_nc and out_nc
     in_nc = model.input_channels
     out_nc = model.output_channels
     scale = model.scale


### PR DESCRIPTION
Since we have Spandrel now, this TODO is no longer to do, and is actually finished. 

(that comment was because at the time, models just arbitrarily had whatever properties were set on them, and thus having in_nc and out_nc was not a given. Now we have input_channels and output_channels guaranteed on the descriptor)