### PR TITLE
Add PyTorch memory budget limit setting

### DIFF
--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
@@ -55,6 +55,8 @@ def upscale(
                 model_bytes = sum(
                     p.numel() * element_size for p in model.model.parameters()
                 )
+                if options.budget_limit > 0:
+                    free = min(int(options.budget_limit * 1024**3), free)
                 budget = int(free * 0.8)
 
                 return MaxTileSize(

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
@@ -70,9 +70,10 @@ def upscale(
                         element_size,
                     )
                 )
-            elif options.budget_limit > 0:
+            elif device.type == "cpu":
                 free = psutil.virtual_memory().available
-                free = min(options.budget_limit * 1024**3, free)
+                if options.budget_limit > 0:
+                    free = min(options.budget_limit * 1024**3, free)
                 budget = int(free * 0.8)
                 return MaxTileSize(
                     estimate_tile_size(

--- a/backend/src/packages/chaiNNer_pytorch/settings.py
+++ b/backend/src/packages/chaiNNer_pytorch/settings.py
@@ -70,7 +70,7 @@ package.add_setting(
     NumberSetting(
         label="Memory Budget Limit (GiB)",
         key="budget_limit",
-        description="Maximum memory to use for PyTorch inference. 0 means no limit. Memory usage measurement is not completely accurate yet; you may need to significantly adjust this budget limit via trial-and-error if it's not having the effect you want.",
+        description="Maximum memory (VRAM) to use for PyTorch inference. 0 means no limit. Memory usage measurement is not completely accurate yet; you may need to significantly adjust this budget limit via trial-and-error if it's not having the effect you want.",
         default=0,
         min=0,
         max=1024**2,

--- a/backend/src/packages/chaiNNer_pytorch/settings.py
+++ b/backend/src/packages/chaiNNer_pytorch/settings.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import torch
 from sanic.log import logger
 
-from api import DropdownSetting, NodeContext, ToggleSetting
+from api import DropdownSetting, NodeContext, NumberSetting, ToggleSetting
 from gpu import get_nvidia_helper
 from system import is_arm_mac
 
@@ -66,12 +66,24 @@ package.add_setting(
     ),
 )
 
+package.add_setting(
+    NumberSetting(
+        label="Memory Budget Limit (GiB)",
+        key="budget_limit",
+        description="Maximum memory to use for PyTorch inference. 0 means no limit. Memory usage measurement is not completely accurate yet; you may need to significantly adjust this budget limit via trial-and-error if it's not having the effect you want.",
+        default=0,
+        min=0,
+        max=1024**2,
+    )
+)
+
 
 @dataclass(frozen=True)
 class PyTorchSettings:
     use_cpu: bool
     use_fp16: bool
     gpu_index: int
+    budget_limit: int
 
     # PyTorch 2.0 does not support FP16 when using CPU
     def __post_init__(self):
@@ -111,4 +123,5 @@ def get_settings(context: NodeContext) -> PyTorchSettings:
         use_cpu=settings.get_bool("use_cpu", False),
         use_fp16=settings.get_bool("use_fp16", False),
         gpu_index=settings.get_int("gpu_index", 0, parse_str=True),
+        budget_limit=settings.get_int("budget_limit", 0, parse_str=True),
     )

--- a/backend/src/packages/chaiNNer_pytorch/settings.py
+++ b/backend/src/packages/chaiNNer_pytorch/settings.py
@@ -70,7 +70,7 @@ package.add_setting(
     NumberSetting(
         label="Memory Budget Limit (GiB)",
         key="budget_limit",
-        description="Maximum memory (VRAM) to use for PyTorch inference. 0 means no limit. Memory usage measurement is not completely accurate yet; you may need to significantly adjust this budget limit via trial-and-error if it's not having the effect you want.",
+        description="Maximum memory (VRAM if GPU, RAM if CPU) to use for PyTorch inference. 0 means no limit. Memory usage measurement is not completely accurate yet; you may need to significantly adjust this budget limit via trial-and-error if it's not having the effect you want.",
         default=0,
         min=0,
         max=1024**2,


### PR DESCRIPTION
Partially reimplements #2088. However, I don't understand what the Mac stuff is doing there, so someone else (@stonerl?) will have to finish that out. For just limiting VRAM, this works. This was mostly based on the existing NCNN setting.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/34788790/f47e5626-5b17-4f85-98bd-aac2898719ef)



closes #2450.