### PR TITLE
Add "Copy" to context menus

### DIFF
--- a/src/renderer/hooks/useNodeMenu.tsx
+++ b/src/renderer/hooks/useNodeMenu.tsx
@@ -9,10 +9,12 @@ import {
 import { MenuDivider, MenuItem, MenuList } from '@chakra-ui/react';
 import { BsFillJournalBookmarkFill } from 'react-icons/bs';
 import { MdPlayArrow, MdPlayDisabled } from 'react-icons/md';
+import { useReactFlow } from 'reactflow';
 import { useContext } from 'use-context-selector';
-import { NodeData } from '../../common/common-types';
+import { EdgeData, NodeData } from '../../common/common-types';
 import { GlobalContext } from '../contexts/GlobalNodeState';
 import { NodeDocumentationContext } from '../contexts/NodeDocumentationContext';
+import { copyToClipboard } from '../helpers/copyAndPaste';
 import { UseContextMenu, useContextMenu } from './useContextMenu';
 import { UseDisabled } from './useDisabled';
 
@@ -33,8 +35,24 @@ export const useNodeMenu = (
         useContext(GlobalContext);
     const { isDirectlyDisabled, canDisable, toggleDirectlyDisabled } = useDisabled;
 
+    const { getNode, getNodes, getEdges } = useReactFlow<NodeData, EdgeData>();
+
     return useContextMenu(() => (
         <MenuList className="nodrag">
+            <MenuItem
+                icon={<CopyIcon />}
+                onClick={() => {
+                    const node = getNode(id);
+                    if (node && !node.selected) {
+                        const nodeCopy = { ...node, selected: true };
+                        copyToClipboard([nodeCopy], []);
+                    } else {
+                        copyToClipboard(getNodes(), getEdges());
+                    }
+                }}
+            >
+                Copy
+            </MenuItem>
             <MenuItem
                 icon={<CopyIcon />}
                 onClick={() => {
@@ -43,6 +61,7 @@ export const useNodeMenu = (
             >
                 Duplicate
             </MenuItem>
+            <MenuDivider />
             <MenuItem
                 icon={<CloseIcon />}
                 onClick={() => {

--- a/src/renderer/hooks/useNodesMenu.tsx
+++ b/src/renderer/hooks/useNodesMenu.tsx
@@ -1,9 +1,10 @@
 import { CloseIcon, CopyIcon, DeleteIcon } from '@chakra-ui/icons';
-import { MenuItem, MenuList } from '@chakra-ui/react';
-import { Node } from 'reactflow';
+import { MenuDivider, MenuItem, MenuList } from '@chakra-ui/react';
+import { Node, useReactFlow } from 'reactflow';
 import { useContext } from 'use-context-selector';
-import { NodeData } from '../../common/common-types';
+import { EdgeData, NodeData } from '../../common/common-types';
 import { GlobalContext } from '../contexts/GlobalNodeState';
+import { copyToClipboard } from '../helpers/copyAndPaste';
 import { UseContextMenu, useContextMenu } from './useContextMenu';
 
 export const useNodesMenu = (nodes: Node<NodeData>[]): UseContextMenu => {
@@ -11,8 +12,18 @@ export const useNodesMenu = (nodes: Node<NodeData>[]): UseContextMenu => {
 
     const nodeIds = nodes.map((n) => n.id);
 
+    const { getNodes, getEdges } = useReactFlow<NodeData, EdgeData>();
+
     return useContextMenu(() => (
         <MenuList className="nodrag">
+            <MenuItem
+                icon={<CopyIcon />}
+                onClick={() => {
+                    copyToClipboard(getNodes(), getEdges());
+                }}
+            >
+                Copy
+            </MenuItem>
             <MenuItem
                 icon={<CopyIcon />}
                 onClick={() => {
@@ -21,6 +32,7 @@ export const useNodesMenu = (nodes: Node<NodeData>[]): UseContextMenu => {
             >
                 Duplicate
             </MenuItem>
+            <MenuDivider />
             <MenuItem
                 icon={<CloseIcon />}
                 onClick={() => {


### PR DESCRIPTION
We've had duplicate in these menus before, but not copy.

I will add a paste button to the node selector menu (probably above the search bar) in a separate pr