### PR TITLE
Enabled Ruff S101 and replace all asserts with proper ifs + errors

### DIFF
--- a/backend/src/api/api.py
+++ b/backend/src/api/api.py
@@ -462,7 +462,6 @@ class PackageRegistry:
         return self.nodes[schema_id][1].category.package
 
     def add(self, package: Package) -> Package:
-        # assert package.where not in self.packages
         self.packages[package.where] = package
         return package
 

--- a/backend/src/api/api.py
+++ b/backend/src/api/api.py
@@ -213,22 +213,22 @@ class NodeGroup:
         iterator_inputs = to_list(iterator_inputs)
         iterator_outputs = to_list(iterator_outputs)
 
-        if node_type == "collector" and not (
-            len(iterator_inputs) == 1 and len(iterator_outputs) == 0
-        ):
-            raise ValueError(
-                "Collector nodes must have exactly one iterator input and zero iterator outputs"
-            )
-        elif node_type == "newIterator" and not (
-            len(iterator_inputs) == 0 and len(iterator_outputs) == 1
-        ):
-            raise ValueError(
-                "Iterator nodes must have exactly zero iterator inputs and one iterator output"
-            )
-        elif not (len(iterator_inputs) == 0 and len(iterator_outputs) == 0):
-            raise ValueError(
-                "Regular nodes must have exactly zero iterator inputs and zero iterator outputs"
-            )
+        if node_type == "collector":
+            if not (len(iterator_inputs) == 1 and len(iterator_outputs) == 0):
+                raise ValueError(
+                    "Collector nodes must have exactly one iterator input and zero iterator outputs"
+                )
+        elif node_type == "newIterator":
+            if not (len(iterator_inputs) == 0 and len(iterator_outputs) == 1):
+                raise ValueError(
+                    "Iterator nodes must have exactly zero iterator inputs and one iterator output"
+                )
+        else:  # noqa: PLR5501
+            if not (len(iterator_inputs) == 0 and len(iterator_outputs) == 0):
+                raise ValueError(
+                    "Regular nodes must have exactly zero iterator inputs and zero iterator outputs",
+                    f"Got {len(iterator_inputs)} iterator inputs and {len(iterator_outputs)} iterator outputs",
+                )
 
         def run_check(level: CheckLevel, run: Callable[[bool], None]):
             if level == CheckLevel.NONE:

--- a/backend/src/api/api.py
+++ b/backend/src/api/api.py
@@ -129,12 +129,18 @@ class NodeData:
 
     @property
     def single_iterator_input(self) -> IteratorInputInfo:
-        assert len(self.iterator_inputs) == 1
+        if len(self.iterator_inputs[0].inputs) != 1:
+            raise ValueError(
+                "Expected exactly one input for single iterator input node"
+            )
         return self.iterator_inputs[0]
 
     @property
     def single_iterator_output(self) -> IteratorOutputInfo:
-        assert len(self.iterator_outputs) == 1
+        if len(self.iterator_outputs[0].outputs) != 1:
+            raise ValueError(
+                "Expected exactly one output for single iterator output node"
+            )
         return self.iterator_outputs[0]
 
 
@@ -207,12 +213,22 @@ class NodeGroup:
         iterator_inputs = to_list(iterator_inputs)
         iterator_outputs = to_list(iterator_outputs)
 
-        if node_type == "collector":
-            assert len(iterator_inputs) == 1 and len(iterator_outputs) == 0
-        elif node_type == "newIterator":
-            assert len(iterator_inputs) == 0 and len(iterator_outputs) == 1
-        else:
-            assert len(iterator_inputs) == 0 and len(iterator_outputs) == 0
+        if node_type == "collector" and not (
+            len(iterator_inputs) == 1 and len(iterator_outputs) == 0
+        ):
+            raise ValueError(
+                "Collector nodes must have exactly one iterator input and zero iterator outputs"
+            )
+        elif node_type == "newIterator" and not (
+            len(iterator_inputs) == 0 and len(iterator_outputs) == 1
+        ):
+            raise ValueError(
+                "Iterator nodes must have exactly zero iterator inputs and one iterator output"
+            )
+        elif not (len(iterator_inputs) == 0 and len(iterator_outputs) == 0):
+            raise ValueError(
+                "Regular nodes must have exactly zero iterator inputs and zero iterator outputs"
+            )
 
         def run_check(level: CheckLevel, run: Callable[[bool], None]):
             if level == CheckLevel.NONE:

--- a/backend/src/api/api.py
+++ b/backend/src/api/api.py
@@ -576,7 +576,8 @@ class Iterator(Generic[I]):
         Creates a new iterator the given number of items where each item is
         lazily evaluated. The iterable will be equivalent to `map(map_fn, range(count))`.
         """
-        assert count >= 0
+        if count < 0:
+            raise ValueError("count must be >= 0")
 
         def supplier():
             for i in range(count):

--- a/backend/src/api/input.py
+++ b/backend/src/api/input.py
@@ -108,10 +108,11 @@ class BaseInput:
     def enforce_(self, value: object | None):
         if self.optional and value is None:
             return None
-        assert value is not None, (
-            f"Expected value to exist, "
-            f"but does not exist for {self.kind} input with type {self.input_type} and label {self.label}"
-        )
+        if value is None:
+            raise ValueError(
+                f"Expected value to exist, "
+                f"but does not exist for {self.kind} input with type {self.input_type} and label {self.label}"
+            )
         return self.enforce(value)
 
     def get_error_value(self, value: object) -> ErrorValue:

--- a/backend/src/api/node_check.py
+++ b/backend/src/api/node_check.py
@@ -106,7 +106,8 @@ def eval_type(t: str | _Ty, __globals: dict[str, Any]):
 
 
 def union_types(types: list[_Ty]) -> _Ty:
-    assert len(types) > 0
+    if len(types) == 0:
+        raise ValueError("Cannot union zero types")
     t: Any = types[0]
     for t2 in types[1:]:
         t = Union[t, cast(Any, t2)]

--- a/backend/src/api/output.py
+++ b/backend/src/api/output.py
@@ -66,5 +66,6 @@ class BaseOutput:
         return None
 
     def enforce(self, value: object) -> object:
-        assert value is not None
+        if value is None:
+            raise ValueError("Value cannot be None")
         return value

--- a/backend/src/chain/cache.py
+++ b/backend/src/chain/cache.py
@@ -14,7 +14,8 @@ class CacheStrategy:
     STATIC_HITS_TO_LIVE = 1_000_000_000
 
     def __init__(self, hits_to_live: int) -> None:
-        assert hits_to_live >= 0
+        if hits_to_live <= 0:
+            raise ValueError("hits_to_live must be greater than 0")
         self.hits_to_live = hits_to_live
 
     @property
@@ -79,7 +80,8 @@ T = TypeVar("T")
 
 class _CacheEntry(Generic[T]):
     def __init__(self, value: T, hits_to_live: int):
-        assert hits_to_live > 0
+        if hits_to_live <= 0:
+            raise ValueError("hits_to_live must be greater than 0")
         self.value: T = value
         self.hits_to_live: int = hits_to_live
 

--- a/backend/src/chain/chain.py
+++ b/backend/src/chain/chain.py
@@ -21,7 +21,10 @@ class FunctionNode:
         self.id: NodeId = node_id
         self.schema_id: str = schema_id
         self.data: NodeData = registry.get_node(schema_id)
-        assert self.data.type == "regularNode"
+        if self.data.type != "regularNode":
+            raise ValueError(
+                f"Invalid node type {self.data.type}. Expected regularNode."
+            )
 
     def has_side_effects(self) -> bool:
         return self.data.side_effects
@@ -32,7 +35,10 @@ class NewIteratorNode:
         self.id: NodeId = node_id
         self.schema_id: str = schema_id
         self.data: NodeData = registry.get_node(schema_id)
-        assert self.data.type == "newIterator"
+        if self.data.type != "newIterator":
+            raise ValueError(
+                f"Invalid node type {self.data.type}. Expected newIterator."
+            )
 
     def has_side_effects(self) -> bool:
         return self.data.side_effects
@@ -43,7 +49,8 @@ class CollectorNode:
         self.id: NodeId = node_id
         self.schema_id: str = schema_id
         self.data: NodeData = registry.get_node(schema_id)
-        assert self.data.type == "collector"
+        if self.data.type != "collector":
+            raise ValueError(f"Invalid node type {self.data.type}. Expected collector.")
 
     def has_side_effects(self) -> bool:
         return self.data.side_effects
@@ -77,7 +84,8 @@ class Chain:
         self.__edges_by_target: dict[NodeId, list[Edge]] = {}
 
     def add_node(self, node: Node):
-        assert node.id not in self.nodes, f"Duplicate node id {node.id}"
+        if node.id in self.nodes:
+            raise ValueError(f"Duplicate node id {node.id}")
         self.nodes[node.id] = node
 
     def add_edge(self, edge: Edge):

--- a/backend/src/nodes/groups.py
+++ b/backend/src/nodes/groups.py
@@ -84,7 +84,10 @@ class Condition:
                 v.append(value)
             else:
                 enum_value = value.value
-                assert isinstance(enum_value, (int, str))
+                if not isinstance(enum_value, (int, str)):
+                    raise ValueError(
+                        f"Enum value {value} has invalid value {enum_value} of type {type(enum_value)}."
+                    )
                 v.append(enum_value)
 
         if isinstance(values, (int, str, Enum)):

--- a/backend/src/nodes/impl/blend.py
+++ b/backend/src/nodes/impl/blend.py
@@ -196,13 +196,13 @@ def blend_images(overlay: np.ndarray, base: np.ndarray, blend_mode: BlendMode):
     o_shape = get_h_w_c(overlay)
     b_shape = get_h_w_c(base)
 
-    assert (
-        o_shape[:2] == b_shape[:2]
-    ), "The overlay and the base image must have the same size"
+    if not (o_shape[:2] == b_shape[:2]):
+        raise ValueError("The overlay and the base image must have the same size")
 
     def assert_sane(c: int, name: str):
         sane = c in (1, 3, 4)
-        assert sane, f"The {name} has to be a grayscale, RGB, or RGBA image"
+        if not sane:
+            raise ValueError(f"The {name} has to be a grayscale, RGB, or RGBA image")
 
     o_channels = o_shape[2]
     b_channels = b_shape[2]

--- a/backend/src/nodes/impl/blend.py
+++ b/backend/src/nodes/impl/blend.py
@@ -196,7 +196,7 @@ def blend_images(overlay: np.ndarray, base: np.ndarray, blend_mode: BlendMode):
     o_shape = get_h_w_c(overlay)
     b_shape = get_h_w_c(base)
 
-    if not (o_shape[:2] == b_shape[:2]):
+    if o_shape[:2] != b_shape[:2]:
         raise ValueError("The overlay and the base image must have the same size")
 
     def assert_sane(c: int, name: str):

--- a/backend/src/nodes/impl/cas.py
+++ b/backend/src/nodes/impl/cas.py
@@ -32,7 +32,7 @@ def create_cas_mask(img: np.ndarray, kernel: np.ndarray, bias: float = 2) -> np.
     https://www.shadertoy.com/view/wtlSWB#
     """
     if bias <= 0:
-        raise ValueError("Bias must be greater than or equal to 0.")
+        raise ValueError("Bias must be >0.")
 
     l = _luminance(img)
     min_l = cv2.erode(l, kernel)

--- a/backend/src/nodes/impl/cas.py
+++ b/backend/src/nodes/impl/cas.py
@@ -31,7 +31,8 @@ def create_cas_mask(img: np.ndarray, kernel: np.ndarray, bias: float = 2) -> np.
     Lou Kramer, FidelityFX CAS, AMD Developer Day 2019, https://gpuopen.com/wp-content/uploads/2019/07/FidelityFX-CAS.pptx
     https://www.shadertoy.com/view/wtlSWB#
     """
-    assert bias > 0, "Bias must be greater than or equal to 0."
+    if bias <= 0:
+        raise ValueError("Bias must be greater than or equal to 0.")
 
     l = _luminance(img)
     min_l = cv2.erode(l, kernel)

--- a/backend/src/nodes/impl/color/color.py
+++ b/backend/src/nodes/impl/color/color.py
@@ -24,7 +24,8 @@ class ColorJson(TypedDict):
 
 class Color:
     def __init__(self, value: tuple[float, ...]) -> None:
-        assert len(value) >= 1
+        if len(value) == 0:
+            raise ValueError("Colors must have at least one channel.")
         self.value: tuple[float, ...] = value
 
     @property
@@ -38,19 +39,22 @@ class Color:
     @staticmethod
     def bgr(value: Iterable[FloatLike]) -> Color:
         t = tuple(map(_norm, value))
-        assert len(t) == 3
+        if len(t) != 3:
+            raise ValueError("RGB colors must have 3 channels.")
         return Color(t)
 
     @staticmethod
     def bgra(value: Iterable[FloatLike]) -> Color:
         t = tuple(map(_norm, value))
-        assert len(t) == 4
+        if len(t) != 4:
+            raise ValueError("RGBA colors must have 4 channels.")
         return Color(t)
 
     @staticmethod
     def from_1x1_image(img: np.ndarray) -> Color:
         h, w, c = get_h_w_c(img)
-        assert h == w == 1
+        if not (h == w == 1):
+            raise ValueError("The image must be 1x1.")
 
         if c == 1:
             return Color.gray(img.flat[0])
@@ -69,13 +73,16 @@ class Color:
         values = color_json["values"]
 
         if kind == "grayscale":
-            assert len(values) == 1
+            if len(values) != 1:
+                raise ValueError("Grayscale colors must have 1 channel.")
             return Color.gray(values[0])
         elif kind == "rgb":
-            assert len(values) == 3
+            if len(values) != 3:
+                raise ValueError("RGB colors must have 3 channels.")
             return Color.bgr([values[2], values[1], values[0]])
         elif kind == "rgba":
-            assert len(values) == 4
+            if len(values) != 4:
+                raise ValueError("RGBA colors must have 4 channels.")
             return Color.bgra([values[2], values[1], values[0], values[3]])
         else:
             raise AssertionError(f"Unknown color kind {kind}")

--- a/backend/src/nodes/impl/color/convert.py
+++ b/backend/src/nodes/impl/color/convert.py
@@ -58,7 +58,8 @@ def get_shortest_path(
                 best = x
             elif x.cost < best.cost:
                 best = x
-        assert best is not None
+        if best is None:
+            raise ValueError("Could not find best item in front.")
 
         current = best.path[-1]
         del front[current]
@@ -123,7 +124,8 @@ def convert(
             if c.output == curr_out:
                 conv = c
                 break
-        assert conv is not None
+        if conv is None:
+            raise ValueError("Could not find conversion.")
 
         img = conv.convert(img)
 

--- a/backend/src/nodes/impl/color/convert_data.py
+++ b/backend/src/nodes/impl/color/convert_data.py
@@ -86,7 +86,8 @@ color_spaces_or_detectors: list[ColorSpace | ColorSpaceDetector] = [
 
 def __rev3(image: np.ndarray) -> np.ndarray:
     c = get_h_w_c(image)[2]
-    assert c == 3, "Expected a 3-channel image"
+    if c != 3:
+        raise ValueError("Expected a 3-channel image")
     return np.stack([image[:, :, 2], image[:, :, 1], image[:, :, 0]], axis=2)
 
 
@@ -320,8 +321,10 @@ conversions: list[Conversion] = [
 
 # Add conversions that can be generated because only alpha is different
 for dir_3, dir_4 in ALPHA_PAIRS.items():
-    assert dir_3.channels == 3
-    assert dir_4.channels == 4
+    if dir_3.channels != 3:
+        raise ValueError(f"Expected a 3-channel color space, got {dir_3}")
+    if dir_4.channels != 4:
+        raise ValueError(f"Expected a 4-channel color space, got {dir_4}")
 
     # Add and remove the alpha channel
     conversions.append(

--- a/backend/src/nodes/impl/color/convert_model.py
+++ b/backend/src/nodes/impl/color/convert_model.py
@@ -10,7 +10,8 @@ from ...utils.utils import get_h_w_c
 
 class ColorSpace:
     def __init__(self, id_: int, name: str, channels: int):
-        assert 0 <= id_ and id_ < 256
+        if not (0 <= id_ and id_ < 256):
+            raise ValueError(f"Invalid color space id {id_}.")
         self.id = id_
         self.name = name
         self.channels = channels
@@ -18,12 +19,16 @@ class ColorSpace:
 
 class ColorSpaceDetector:
     def __init__(self, id_: int, name: str, color_spaces: Iterable[ColorSpace]) -> None:
-        assert 1000 <= id_ and id_ < 2000
+        if not (1000 <= id_ and id_ < 2000):
+            raise ValueError(f"Invalid color space detector id {id_}.")
         self.id = id_
         self.name = name
         self.channel_map: dict[int, ColorSpace] = {}
         for cs in color_spaces:
-            assert cs.channels not in self.channel_map
+            if cs.channels in self.channel_map:
+                raise ValueError(
+                    f"Duplicate color space {cs.name} with {cs.channels} channels."
+                )
             self.channel_map[cs.channels] = cs
         self.channels = list(self.channel_map.keys())
 
@@ -73,11 +78,18 @@ class Conversion:
         cost: int = 1,
     ):
         input_, output = direction
-        assert input_ != output
+        if input_ == output:
+            raise ValueError(
+                f"Invalid conversion from {input_.name} to {output.name}."
+                f" The input and output color spaces must be different."
+            )
         self.input: ColorSpace = input_
         self.output: ColorSpace = output
         self.__convert = convert
-        assert cost >= 1
+        if cost < 1:
+            raise ValueError(
+                f"Invalid conversion cost {cost}. The cost must be at least 1."
+            )
         self.cost: int = cost
 
     def convert(self, img: np.ndarray) -> np.ndarray:

--- a/backend/src/nodes/impl/dds/texconv.py
+++ b/backend/src/nodes/impl/dds/texconv.py
@@ -109,7 +109,8 @@ def save_as_dds(
     """
     target_dir, name, ext = split_file_path(path)
 
-    assert ext == ".dds", "The file to save must end with '.dds'"
+    if ext != ".dds":
+        raise ValueError("The file to save must end with '.dds'")
 
     temp_dir = mkdtemp(prefix="chaiNNer-")
 

--- a/backend/src/nodes/impl/image_utils.py
+++ b/backend/src/nodes/impl/image_utils.py
@@ -74,7 +74,8 @@ class NormalMapType(Enum):
 
 
 def convert_to_bgra(img: np.ndarray, in_c: int) -> np.ndarray:
-    assert in_c in (1, 3, 4), f"Number of channels ({in_c}) unexpected"
+    if in_c not in (1, 3, 4):
+        raise ValueError(f"Number of channels ({in_c}) unexpected")
     if in_c == 1:
         img = cv2.cvtColor(img, cv2.COLOR_GRAY2BGRA)
     elif in_c == 3:
@@ -223,9 +224,10 @@ def as_target_channels(
         return img
 
     if not narrowing:
-        assert (
-            c < target_c
-        ), f"Narrowing is false, image channels ({c}) must be less than target channels ({target_c})"
+        if c >= target_c:
+            raise ValueError(
+                f"Narrowing is false, image channels ({c}) must be less than target channels ({target_c})"
+            )
 
     if c == 1:
         if target_c == 3:
@@ -276,9 +278,10 @@ def create_border(
         cv_border_type = cv2.BORDER_CONSTANT
         value = (1.0,) * c
     elif border_type == BorderType.CUSTOM_COLOR:
-        assert (
-            color is not None
-        ), "Creating a border with a custom color requires supplying a custom color."
+        if color is None:
+            raise ValueError(
+                "Creating a border with a custom color requires supplying a custom color."
+            )
 
         # widen image or color to make them compatible
         if color.channels > c:

--- a/backend/src/nodes/impl/ncnn/model.py
+++ b/backend/src/nodes/impl/ncnn/model.py
@@ -401,9 +401,10 @@ class NcnnModel:
         layer_bytes = b""
 
         if weights_a:
-            assert len(weights_a) == len(
-                weights_b
-            ), "All corresponding nodes must have same number of weights"
+            if len(weights_a) != len(weights_b):
+                raise ValueError(
+                    "All corresponding nodes must have same number of weights"
+                )
 
             layer_bytes_list = []
             for weight_name, weight_a in weights_a.items():
@@ -415,13 +416,15 @@ class NcnnModel:
                     )
                     raise
 
-                assert (
-                    weight_a.shape == weight_b.shape
-                ), "Corresponding weights must have the same size and shape"
+                if weight_a.shape != weight_b.shape:
+                    raise ValueError(
+                        "Corresponding weights must have the same size and shape"
+                    )
 
-                assert len(weight_a.quantize_tag) == len(
-                    weight_b.quantize_tag
-                ), "Weights must either both have or both not have a quantize tag"
+                if len(weight_a.quantize_tag) != len(weight_b.quantize_tag):
+                    raise ValueError(
+                        "Weights must either both have or both not have a quantize tag"
+                    )
 
                 if (
                     weight_a.quantize_tag == DTYPE_FP16

--- a/backend/src/nodes/impl/ncnn/model.py
+++ b/backend/src/nodes/impl/ncnn/model.py
@@ -471,7 +471,8 @@ class NcnnModel:
     def parse_param_layer(self, layer_str: str) -> tuple[str, NcnnLayer]:
         param_list = layer_str.strip().split()
         op_type, name = param_list[:2]
-        assert op_type != "MemoryData", "This NCNN param file contains invalid layers"
+        if op_type == "MemoryData":
+            raise ValueError("This NCNN param file contains invalid layers")
 
         num_inputs = int(param_list[2])
         num_outputs = int(param_list[3])
@@ -598,7 +599,8 @@ class NcnnModel:
             quantize_tag = binf.read(4)
             dtype = DTYPE_DICT[quantize_tag]
             weight_data_length = layer.params[2].value
-            assert isinstance(weight_data_length, int), "Weight data size must be int"
+            if not isinstance(weight_data_length, int):
+                raise TypeError("Weight data size must be int")
             weight_data_size = (
                 weight_data_length * 2
                 if quantize_tag == DTYPE_FP16
@@ -606,7 +608,8 @@ class NcnnModel:
             )
             weight_data = np.frombuffer(binf.read(weight_data_size), dtype)
             num_output = layer.params[0].value
-            assert isinstance(num_output, int), "Num output must be int"
+            if not isinstance(num_output, int):
+                raise TypeError("Num output must be int")
             num_input = weight_data_length // num_output
             weight_data = weight_data.reshape((num_input, num_output))
             weight_dict["weight"] = NcnnWeight(weight_data, quantize_tag)
@@ -618,13 +621,15 @@ class NcnnModel:
                 weight_dict["bias"] = NcnnWeight(bias_data)
         elif op_type == "PReLU":
             num_slope = layer.params[0].value
-            assert isinstance(num_slope, int), "Num slopes must be int"
+            if not isinstance(num_slope, int):
+                raise TypeError("Num slopes must be int")
             slope_data_size = num_slope * 4
             slope_data = np.frombuffer(binf.read(slope_data_size), np.float32)
             weight_dict["slope"] = NcnnWeight(slope_data)
         elif op_type == "Scale":
             scale_data_length = layer.params[0].value
-            assert isinstance(scale_data_length, int), "Scale data size must be int"
+            if not isinstance(scale_data_length, int):
+                raise TypeError("Scale data size must be int")
             if scale_data_length != -233:
                 quantize_tag = binf.read(4)
                 dtype = DTYPE_DICT[quantize_tag]
@@ -701,9 +706,10 @@ class NcnnModel:
             (i, l) for i, l in enumerate(model_b.layers) if l.weight_data
         ]
 
-        assert len(layer_a_weights) == len(
-            layer_b_weights
-        ), "Models must have same number of layers containing weights"
+        if len(layer_a_weights) != len(layer_b_weights):
+            raise ValueError(
+                "Models must have same number of layers containing weights"
+            )
 
         weight_bytes_list = []
         for layer_a, layer_b in zip(layer_a_weights, layer_b_weights):
@@ -775,14 +781,15 @@ class NcnnModelWrapper:
                 scale *= checked_cast(int, layer.params[3].value)
                 current_conv = layer
 
-        assert (
-            current_conv is not None
-        ), "Cannot broadcast; model has no Convolution layers"
+        if current_conv is None:
+            raise ValueError("Cannot broadcast; model has no Convolution layers")
 
         out_nc = checked_cast(int, current_conv.params[0].value) // pixel_shuffle**2
 
-        assert scale >= 1, "Models with scale less than 1x not supported"
-        assert scale % 1 == 0, f"Model not supported, scale {scale} is not an integer"
+        if scale < 1:
+            raise ValueError("Models with scale less than 1x not supported")
+        if scale % 1 != 0:
+            raise ValueError(f"Model not supported, scale {scale} is not an integer")
 
         return int(scale), in_nc, out_nc, nf, fp
 
@@ -796,12 +803,15 @@ class NcnnModelWrapper:
             kernel_h = kernel_w
         weight_data_size = layer.params[6].value
 
-        assert (
+        if not (
             isinstance(nf, int)
             and isinstance(kernel_w, int)
             and isinstance(kernel_h, int)
             and isinstance(weight_data_size, int)
-        ), "Out nc, kernel width and height, and weight data size must all be ints"
+        ):
+            raise TypeError(
+                "Out nc, kernel width and height, and weight data size must all be ints"
+            )
         in_nc = weight_data_size // nf // kernel_w // kernel_h
 
         return nf, in_nc

--- a/backend/src/nodes/impl/noise.py
+++ b/backend/src/nodes/impl/noise.py
@@ -16,19 +16,22 @@ def __add_noises(
 ) -> np.ndarray:
     img = image
     h, w, c = get_h_w_c(img)
-    assert c != 2, "Noise cannot be added to 2-channel images."
+    if c == 2:
+        raise ValueError("Noise cannot be added to 2-channel images.")
 
     if c > 3:
         img = img[:, :, :3]
 
     noises = noise_gen(h, w)
 
-    assert len(noises) > 0
+    if len(noises) == 0:
+        raise RuntimeError("No noise was generated.")
 
     max_channels = min(c, 3)
     for n in noises:
         noise_channels = get_h_w_c(n)[2]
-        assert noise_channels in (1, 3), "Noise must be a grayscale or RGB image."
+        if noise_channels not in (1, 3):
+            raise ValueError("Noise must be a grayscale or RGB image.")
         max_channels = max(max_channels, noise_channels)
 
     noises = [as_target_channels(n, max_channels) for n in noises]

--- a/backend/src/nodes/impl/noise_functions/simplex.py
+++ b/backend/src/nodes/impl/noise_functions/simplex.py
@@ -93,7 +93,8 @@ class SimplexNoise:
 
     def evaluate(self, points: np.ndarray):
         n_points = points.shape[0]
-        assert points.shape == (n_points, self.dimensions)
+        if points.shape != (n_points, self.dimensions):
+            raise ValueError("points.shape must be equal to (n_points, dimensions)")
 
         skewed_points = points + (points.sum(axis=1) * self.F).reshape((n_points, 1))
         skewed_bases, skewed_points_remainder = np.divmod(skewed_points, 1)

--- a/backend/src/nodes/impl/normals/edge_filter.py
+++ b/backend/src/nodes/impl/normals/edge_filter.py
@@ -160,7 +160,8 @@ def get_filter_kernels(
     filter_x = FILTERS_X.get(edge_filter, None)
     if edge_filter == EdgeFilter.MULTI_GAUSS:
         filter_x = create_gauss_kernel(gauss_parameter)
-    assert filter_x is not None, f"Unknown filter '{edge_filter}'"
+    if filter_x is None:
+        raise ValueError(f"Unknown filter '{edge_filter}'")
 
     if edge_filter != EdgeFilter.MULTI_GAUSS:
         # normalize filter

--- a/backend/src/nodes/impl/normals/height.py
+++ b/backend/src/nodes/impl/normals/height.py
@@ -22,7 +22,8 @@ def get_height_map(img: np.ndarray, source: HeightSource) -> np.ndarray:
     """
     h, w, c = get_h_w_c(img)
 
-    assert c in (1, 3, 4), "Only grayscale, RGB, and RGBA images are supported"
+    if c not in (1, 3, 4):
+        raise ValueError("Only grayscale, RGB, and RGBA images are supported")
 
     if source == HeightSource.ALPHA:
         if c < 4:

--- a/backend/src/nodes/impl/onnx/onnx_to_ncnn.py
+++ b/backend/src/nodes/impl/onnx/onnx_to_ncnn.py
@@ -3726,7 +3726,8 @@ class Onnx2NcnnConverter:
                     else:
                         steps = np.empty(0, np.int32)
 
-                assert np.all(steps != 1), f"Unsupported Slice step {steps}"
+                if not np.all(steps != 1):
+                    raise ValueError(f"Unsupported Slice step {steps}")
 
                 # Filter out N-dim axis
                 if axes.size:
@@ -3740,9 +3741,8 @@ class Onnx2NcnnConverter:
                 layer.add_param(9, [starts.size, *list(starts)])
                 layer.add_param(10, [ends.size, *list(ends)])
                 if axes.size:
-                    assert np.all(
-                        axes != 0 and axes <= 3 and axes >= -3
-                    ), f"Unsupported Slice axes {axes}"
+                    if not np.all(axes != 0 and axes <= 3 and axes >= -3):
+                        raise ValueError(f"Unsupported Slice axes {axes}")
                     layer.add_param(
                         11, [axes.size, *[a - 1 if a > 0 else a for a in axes]]
                     )
@@ -3754,7 +3754,8 @@ class Onnx2NcnnConverter:
                 axis = get_node_attr_i(node, "axis", 0)
                 splits = get_node_attr_ai(node, "split")
 
-                assert axis >= 1, f"Unsupported axis {axis} in Split"
+                if axis < 1:
+                    raise ValueError(f"Unsupported axis {axis} in Split")
 
                 if splits.size:
                     layer.add_param(0, [output_size, *list(splits[:-1]), -233])
@@ -3769,9 +3770,8 @@ class Onnx2NcnnConverter:
                 axes = get_node_attr_ai(node, "axes")
 
                 if axes.size:
-                    assert np.all(
-                        axes != 0 and axes <= 4 and axes >= -3
-                    ), f"Unsupported Squeeze axes {axes}"
+                    if not np.all(axes != 0 and axes <= 4 and axes >= -3):
+                        raise ValueError(f"Unsupported Squeeze axes {axes}")
 
                     layer.add_param(
                         3, [axes.size, *[a - 1 if a > 0 else a for a in axes]]
@@ -3880,9 +3880,8 @@ class Onnx2NcnnConverter:
             elif op == "Unsqueeze":
                 axes = get_node_attr_ai(node, "axes")
 
-                assert (
-                    np.all(axes != 0) and np.all(axes <= 4) and np.all(axes >= -4)
-                ), f"Unsupported axes {axes} in Unsqueeze"
+                if not (np.all(axes != 0) and np.all(axes <= 4) and np.all(axes >= -4)):
+                    raise ValueError(f"Unsupported axes {axes} in Unsqueeze")
 
                 layer.add_param(
                     3, [axes.size, *[axis - 1 if axis > 0 else axis for axis in axes]]

--- a/backend/src/nodes/impl/pytorch/pix_transform/auto_split.py
+++ b/backend/src/nodes/impl/pytorch/pix_transform/auto_split.py
@@ -56,12 +56,12 @@ def pix_transform_auto_split(
     s_w, s_h, _ = get_h_w_c(source)
     g_w, g_h, _ = get_h_w_c(guide)
 
-    assert (
-        g_h > s_h and g_w > s_w
-    ), "The guide image mus be larger than the source image."
-    assert (
-        g_w / s_w == g_w // s_w and g_w / s_w == g_h / s_h
-    ), "The size of the guide image must be an integer multiple of the size of the source image (e.g. 2x, 3x, 4x, ...)."
+    if not (g_h > s_h and g_w > s_w):
+        raise ValueError("The guide image must be larger than the source image.")
+    if not (g_w / s_w == g_w // s_w and g_w / s_w == g_h / s_h):
+        raise ValueError(
+            "The size of the guide image must be an integer multiple of the size of the source image (e.g. 2x, 3x, 4x, ...)."
+        )
 
     tiler = _PixTiler()
     scale = g_w // s_w

--- a/backend/src/nodes/impl/pytorch/pix_transform/pix_transform.py
+++ b/backend/src/nodes/impl/pytorch/pix_transform/pix_transform.py
@@ -36,9 +36,12 @@ def pix_transform(
     source_img = source_img.squeeze()
     lr_height, lr_width = source_img.shape
 
-    assert hr_height == hr_width
-    assert lr_height == lr_width
-    assert hr_height % lr_height == 0
+    if hr_height != hr_width:
+        raise ValueError("Guide image must be square")
+    if lr_height != lr_width:
+        raise ValueError("Source image must be square")
+    if hr_height % lr_height != 0:
+        raise ValueError("Guide image must be a multiple of source image")
 
     d = hr_height // lr_height
     m = lr_height

--- a/backend/src/nodes/impl/rembg/bg.py
+++ b/backend/src/nodes/impl/rembg/bg.py
@@ -126,7 +126,8 @@ def remove_bg(
     masks = session.predict(pimg)
     cutouts = []
 
-    assert len(masks) > 0, "Model failed to generate masks"
+    if len(masks) == 0:
+        raise RuntimeError("Model failed to generate masks")
 
     for mask in masks:
         if post_process_mask:

--- a/backend/src/nodes/impl/upscale/auto_split_tiles.py
+++ b/backend/src/nodes/impl/upscale/auto_split_tiles.py
@@ -48,5 +48,8 @@ def parse_tile_size_input(tile_size: TileSize, estimate: Callable[[], Tiler]) ->
     if tile_size == -2:
         return MaxTileSize()
 
-    assert tile_size > 0
+    if tile_size <= 0:
+        raise ValueError(
+            "Invalid tile size. Tile size must be positive and greater than zero."
+        )
     return MaxTileSize(tile_size)

--- a/backend/src/nodes/impl/upscale/convenient_upscale.py
+++ b/backend/src/nodes/impl/upscale/convenient_upscale.py
@@ -9,7 +9,8 @@ from ..image_utils import as_target_channels
 
 def with_black_and_white_backgrounds(img: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     c = get_h_w_c(img)[2]
-    assert c == 4
+    if c != 4:
+        raise ValueError("Image must be RGBA")
 
     black = np.copy(img[:, :, :3])
     white = np.copy(img[:, :, :3])

--- a/backend/src/nodes/impl/upscale/exact_split.py
+++ b/backend/src/nodes/impl/upscale/exact_split.py
@@ -49,13 +49,16 @@ def _exact_split_into_segments(length: int, exact: int, overlap: int) -> list[_S
         # trivial
         return [_Segment(0, exact, 0, 0)]
 
-    assert length > exact
-    assert exact > overlap * 2
+    if length <= exact:
+        raise ValueError("Length must be greater than exact size.")
+    if exact <= overlap * 2:
+        raise ValueError("Exact size must be greater than overlap * 2.")
 
     result: list[_Segment] = []
 
     def add(s: _Segment):
-        assert s.padded_length == exact
+        if s.padded_length != exact:
+            raise ValueError("Segment must have exact size.")
         result.append(s)
 
     # The current strategy is to go from left to right and to align segments
@@ -130,7 +133,8 @@ def _exact_split_without_padding(
 ) -> np.ndarray:
     h, w, _ = get_h_w_c(img)
     exact_w, exact_h = exact_size
-    assert w >= exact_w and h >= exact_h
+    if not (w >= exact_w and h >= exact_h):
+        raise ValueError("Image must be larger than the exact size.")
 
     if (w, h) == exact_size:
         return upscale(img, Region(0, 0, w, h))
@@ -148,16 +152,22 @@ def _exact_split_without_padding(
 
         for tile, pad in row:
             padded_tile = tile.add_padding(pad)
-            assert padded_tile.size == exact_size
+            if padded_tile.size != exact_size:
+                raise RuntimeError("Padded tile size must be exactly the given size.")
 
             upscale_result = upscale(padded_tile.read_from(img), padded_tile)
 
             # figure out by how much the image was upscaled by
             up_h, up_w, up_c = get_h_w_c(upscale_result)
             current_scale = up_h // exact_h
-            assert current_scale > 0
-            assert exact_h * current_scale == up_h
-            assert exact_w * current_scale == up_w
+            if current_scale <= 0:
+                raise ValueError(
+                    "Upscale factor must be positive and greater than zero."
+                )
+            if exact_h * current_scale != up_h:
+                raise ValueError("Result height did not match expected dimensions.")
+            if exact_w * current_scale != up_w:
+                raise ValueError("Result width did not match expected dimensions.")
 
             if row_result is None:
                 # allocate the result image
@@ -172,14 +182,20 @@ def _exact_split_without_padding(
                 )
                 row_overlap = TileOverlap(pad.top * scale, pad.bottom * scale)
 
-            assert current_scale == scale
+            if current_scale != scale:
+                raise ValueError(
+                    "Upscale factor must be the same for all tiles in a row."
+                )
 
             row_result.add_tile(
                 upscale_result, TileOverlap(pad.left * scale, pad.right * scale)
             )
 
-        assert row_result is not None
-        assert row_overlap is not None
+        if row_result is None:
+            raise RuntimeError("No row result was created.")
+        if row_overlap is None:
+            raise RuntimeError("No row overlap was created.")
+
         if result is None:
             result = TileBlender(
                 width=w * scale,
@@ -191,7 +207,8 @@ def _exact_split_without_padding(
 
         result.add_tile(row_result.get_result(), row_overlap)
 
-    assert result is not None
+    if result is None:
+        raise RuntimeError("No result was created.")
 
     # remove initially added padding
     return result.get_result()

--- a/backend/src/nodes/impl/upscale/grayscale.py
+++ b/backend/src/nodes/impl/upscale/grayscale.py
@@ -17,7 +17,9 @@ class SplitMode(Enum):
         if img.ndim == 2:
             return [img]
 
-        assert img.ndim == 3
+        if img.ndim != 3:
+            raise ValueError("Image must be 2D or 3D in order to be split.")
+
         c = img.shape[2]
 
         if c == 1:
@@ -41,7 +43,8 @@ class SplitMode(Enum):
 
     def combine(self, channels: list[np.ndarray]) -> np.ndarray:
         l = len(channels)
-        assert l > 0
+        if l == 0:
+            raise ValueError("Cannot combine 0 channels")
 
         if l == 1:
             return channels[0]

--- a/backend/src/nodes/impl/upscale/tiler.py
+++ b/backend/src/nodes/impl/upscale/tiler.py
@@ -23,7 +23,8 @@ class Tiler(ABC):
 
     def split(self, tile_size: Size) -> Size:
         w, h = tile_size
-        assert w >= 16 and h >= 16
+        if not (w >= 16 and h >= 16):
+            raise ValueError("Tile size must be at least 16x16px.")
         return max(16, w // 2), max(16, h // 2)
 
 

--- a/backend/src/nodes/properties/inputs/file_inputs.py
+++ b/backend/src/nodes/properties/inputs/file_inputs.py
@@ -54,9 +54,12 @@ class FileInput(BaseInput):
         }
 
     def enforce(self, value: object) -> str:
-        assert isinstance(value, str)
-        assert os.path.exists(value), f"File {value} does not exist"
-        assert os.path.isfile(value), f"The path {value} is not a file"
+        if not isinstance(value, str):
+            raise TypeError("value must be a string")
+        if not os.path.exists(value):
+            raise FileNotFoundError(f"File {value} does not exist")
+        if not os.path.isfile(value):
+            raise ValueError(f"The path {value} is not a file")
         return value
 
 
@@ -138,9 +141,10 @@ class DirectoryInput(BaseInput):
         }
 
     def enforce(self, value: object):
-        assert isinstance(value, str)
-        if self.must_exist:
-            assert os.path.exists(value), f"Directory {value} does not exist"
+        if not isinstance(value, str):
+            raise TypeError("value must be a string")
+        if self.must_exist and not os.path.exists(value):
+            raise FileNotFoundError(f"Directory {value} does not exist")
         return value
 
 

--- a/backend/src/nodes/properties/inputs/numeric_inputs.py
+++ b/backend/src/nodes/properties/inputs/numeric_inputs.py
@@ -103,7 +103,8 @@ class NumberInput(BaseInput):
         raise ValueError("NumberInput and SliderInput cannot be made optional")
 
     def enforce(self, value: object):
-        assert isinstance(value, (int, float))
+        if not isinstance(value, (int, float)):
+            raise TypeError(f"Expected a number, but got {type(value)}")
 
         if math.isnan(value):
             raise ValueError("NaN is not a valid number")

--- a/backend/src/nodes/properties/inputs/numpy_inputs.py
+++ b/backend/src/nodes/properties/inputs/numpy_inputs.py
@@ -62,7 +62,8 @@ class ImageInput(BaseInput):
 
             return value
 
-        assert isinstance(value, np.ndarray)
+        if not isinstance(value, np.ndarray):
+            raise TypeError(f"Expected a np.ndarray, but got {type(value)}")
         _, _, c = get_h_w_c(value)
 
         if self.channels is not None and c not in self.channels:
@@ -72,7 +73,8 @@ class ImageInput(BaseInput):
                 f"The input {self.label} only supports {expected} but was given {actual}."
             )
 
-        assert value.dtype == np.float32, "Expected the input image to be normalized."
+        if value.dtype != np.float32:
+            raise ValueError("Expected the input image to be normalized.")
 
         if c == 1 and value.ndim == 3:
             value = value[:, :, 0]

--- a/backend/src/nodes/properties/inputs/onnx_inputs.py
+++ b/backend/src/nodes/properties/inputs/onnx_inputs.py
@@ -24,8 +24,10 @@ class OnnxGenericModelInput(OnnxModelInput):
         super().__init__(label, navi.intersect(input_type, "OnnxGenericModel"))
 
     def enforce(self, value: object):
-        assert isinstance(value, OnnxModels)
-        assert not is_rembg_model(value.bytes), "Expected a non-rembg model"
+        if not isinstance(value, OnnxModels):
+            raise TypeError("Expected an Onnx Model")
+        if is_rembg_model(value.bytes):
+            raise ValueError("Expected a non-rembg model")
         return value
 
 
@@ -39,8 +41,10 @@ class OnnxRemBgModelInput(OnnxModelInput):
         self.associated_type = OnnxRemBg
 
     def enforce(self, value: object):
-        assert isinstance(value, OnnxModels)
-        assert is_rembg_model(value.bytes), "Expected a rembg model"
+        if not isinstance(value, OnnxModels):
+            raise TypeError("Expected an Onnx Model")
+        if not is_rembg_model(value.bytes):
+            raise ValueError("Expected a rembg model")
         return value
 
 

--- a/backend/src/nodes/properties/inputs/pytorch_inputs.py
+++ b/backend/src/nodes/properties/inputs/pytorch_inputs.py
@@ -29,10 +29,11 @@ class ModelInput(BaseInput):
 
     def enforce(self, value: object):
         if spandrel is not None:
-            assert isinstance(
+            if not isinstance(
                 value,
                 (spandrel.ImageModelDescriptor, spandrel.MaskedImageModelDescriptor),
-            ), "Expected a supported PyTorch model."
+            ):
+                raise TypeError("Expected a supported PyTorch model.")
         return value
 
 
@@ -53,12 +54,10 @@ class SrModelInput(ModelInput):
 
     def enforce(self, value: object):
         if spandrel is not None:
-            assert isinstance(
-                value, spandrel.ImageModelDescriptor
-            ), "Expected a supported single image PyTorch model."
-            assert (
-                value.purpose in self.purpose
-            ), "Expected a Super-Resolution or Restoration model."
+            if not isinstance(value, spandrel.ImageModelDescriptor):
+                raise TypeError("Expected a supported single image PyTorch model.")
+            if value.purpose not in self.purpose:
+                raise ValueError("Expected a Super-Resolution or Restoration model.")
         return value
 
 
@@ -77,12 +76,10 @@ class FaceModelInput(ModelInput):
 
     def enforce(self, value: object):
         if spandrel is not None:
-            assert isinstance(
-                value, spandrel.ImageModelDescriptor
-            ), "Expected a supported single image PyTorch model."
-            assert (
-                value.purpose in self.purpose
-            ), "Expected a Face Super-Resolution model."
+            if not isinstance(value, spandrel.ImageModelDescriptor):
+                raise TypeError("Expected a supported single image PyTorch model.")
+            if value.purpose not in self.purpose:
+                raise ValueError("Expected a Face Super-Resolution model.")
         return value
 
 
@@ -101,10 +98,10 @@ class InpaintModelInput(ModelInput):
 
     def enforce(self, value: object):
         if spandrel is not None:
-            assert isinstance(
-                value, spandrel.MaskedImageModelDescriptor
-            ), "Expected a supported masked-image PyTorch model."
-            assert value.purpose in self.purpose, "Expected an Inpainting model."
+            if not isinstance(value, spandrel.MaskedImageModelDescriptor):
+                raise TypeError("Expected a supported masked-image PyTorch model.")
+            if value.purpose not in self.purpose:
+                raise ValueError("Expected an Inpainting model.")
         return value
 
 

--- a/backend/src/nodes/properties/outputs/file_outputs.py
+++ b/backend/src/nodes/properties/outputs/file_outputs.py
@@ -25,5 +25,6 @@ class DirectoryOutput(BaseOutput):
         return navi.named("Directory", {"path": navi.literal(value)})
 
     def enforce(self, value: object) -> str:
-        assert isinstance(value, str)
+        if not isinstance(value, str):
+            raise TypeError(f"Expected a string, but got {type(value)}")
         return value

--- a/backend/src/nodes/properties/outputs/generic_outputs.py
+++ b/backend/src/nodes/properties/outputs/generic_outputs.py
@@ -26,7 +26,8 @@ class NumberOutput(BaseOutput):
         return navi.literal(value)
 
     def enforce(self, value: object) -> int | float:
-        assert isinstance(value, (int, float))
+        if not isinstance(value, (int, float)):
+            raise TypeError(f"Expected a number, but got {type(value)}")
         return value
 
 
@@ -42,7 +43,8 @@ class TextOutput(BaseOutput):
         return navi.literal(value)
 
     def enforce(self, value: object) -> str:
-        assert isinstance(value, str)
+        if not isinstance(value, str):
+            raise TypeError(f"Expected a string, but got {type(value)}")
         return value
 
 
@@ -61,7 +63,8 @@ class SeedOutput(BaseOutput):
         super().__init__(output_type="Seed", label=label, kind="generic")
 
     def enforce(self, value: object) -> Seed:
-        assert isinstance(value, Seed)
+        if not isinstance(value, Seed):
+            raise TypeError(f"Expected a Seed, but got {type(value)}")
         return value
 
 
@@ -83,7 +86,8 @@ class ColorOutput(BaseOutput):
         self.channels = channels
 
     def enforce(self, value: object) -> Color:
-        assert isinstance(value, Color)
+        if not isinstance(value, Color):
+            raise TypeError(f"Expected a Color, but got {type(value)}")
 
         if self.channels is not None and value.channels != self.channels:
             expected = format_color_with_channels([self.channels])

--- a/backend/src/nodes/properties/outputs/numpy_outputs.py
+++ b/backend/src/nodes/properties/outputs/numpy_outputs.py
@@ -33,7 +33,8 @@ class NumPyOutput(BaseOutput):
         )
 
     def enforce(self, value: object) -> np.ndarray:
-        assert isinstance(value, np.ndarray)
+        if not isinstance(value, np.ndarray):
+            raise TypeError(f"Expected a np.ndarray, but got {type(value)}")
         return value
 
 
@@ -75,7 +76,8 @@ class ImageOutput(NumPyOutput):
         return navi.Image(width=w, height=h, channels=c)
 
     def enforce(self, value: object) -> np.ndarray:
-        assert isinstance(value, np.ndarray)
+        if not isinstance(value, np.ndarray):
+            raise TypeError(f"Expected a np.ndarray, but got {type(value)}")
 
         h, w, c = get_h_w_c(value)
 
@@ -102,12 +104,13 @@ class ImageOutput(NumPyOutput):
         if not self.assume_normalized:
             value = normalize(value)
 
-        assert value.dtype == np.float32, (
-            f"The output {self.label} did not return a normalized image."
-            f" This is a bug in the implementation of the node."
-            f" Please report this bug."
-            f"\n\nTo the author of this node: Either use `normalize` or remove `assume_normalized=True` from this output."
-        )
+        if value.dtype != np.float32:
+            raise RuntimeError(
+                f"The output {self.label} did not return a normalized image."
+                f" This is a bug in the implementation of the node."
+                f" Please report this bug."
+                f"\n\nTo the author of this node: Either use `normalize` or remove `assume_normalized=True` from this output."
+            )
 
         # make image readonly
         value.setflags(write=False)

--- a/backend/src/nodes/utils/checked_cast.py
+++ b/backend/src/nodes/utils/checked_cast.py
@@ -6,5 +6,6 @@ T = TypeVar("T")
 
 
 def checked_cast(t: type[T], value: object) -> T:
-    assert isinstance(value, t), f"Value is {type(value)}, must be type {t}"
+    if not isinstance(value, t):
+        raise ValueError(f"Value is {type(value)}, must be type {t}")
     return value

--- a/backend/src/nodes/utils/format.py
+++ b/backend/src/nodes/utils/format.py
@@ -14,7 +14,8 @@ def join_english(
     s = list(map(to_str, items))
 
     l = len(s)
-    assert l > 0
+    if l == 0:
+        raise ValueError("Must have at least one item")
 
     if l == 1:
         return s[0]
@@ -28,7 +29,8 @@ def format_image_with_channels(
     conj: Conj = "and",
     plural: bool = False,
 ) -> str:
-    assert len(channels) > 0
+    if len(channels) == 0:
+        raise ValueError("Must have at least one channel")
 
     named = {1: "grayscale", 3: "RGB", 4: "RGBA"}
     if all(x in named for x in channels):
@@ -50,7 +52,8 @@ def format_color_with_channels(
     conj: Conj = "and",
     plural: bool = False,
 ) -> str:
-    assert len(channels) > 0
+    if len(channels) == 0:
+        raise ValueError("Must have at least one channel")
 
     named = {1: "grayscale", 3: "RGB", 4: "RGBA"}
     if all(x in named for x in channels):

--- a/backend/src/nodes/utils/utils.py
+++ b/backend/src/nodes/utils/utils.py
@@ -231,8 +231,16 @@ class Region:
 
     def write_into(self, lhs: np.ndarray, rhs: np.ndarray):
         h, w, c = get_h_w_c(rhs)
-        assert (w, h) == self.size
-        assert c == get_h_w_c(lhs)[2]
+        if (w, h) != self.size:
+            raise ValueError(
+                f"The image to write into must have the same size as the region. "
+                f"Expected {self.size}, got {(w, h)}"
+            )
+        if c != get_h_w_c(lhs)[2]:
+            raise ValueError(
+                f"The image to write into must have the same number of channels as the region. "
+                f"Expected {get_h_w_c(lhs)[2]}, got {c}"
+            )
 
         if c == 1:
             if lhs.ndim == 2 and rhs.ndim == 3:

--- a/backend/src/packages/chaiNNer_external/external_stable_diffusion/automatic1111/image_to_image.py
+++ b/backend/src/packages/chaiNNer_external/external_stable_diffusion/automatic1111/image_to_image.py
@@ -136,7 +136,8 @@ def image_to_image_node(
     )
     result = decode_base64_image(response["images"][0])
     h, w, _ = get_h_w_c(result)
-    assert (
-        (w, h) == (width, height)
-    ), f"Expected the returned image to be {width}x{height}px but found {w}x{h}px instead "
+    if (w, h) != (width, height):
+        raise RuntimeError(
+            f"Expected the returned image to be {width}x{height}px but found {w}x{h}px instead "
+        )
     return result

--- a/backend/src/packages/chaiNNer_external/external_stable_diffusion/automatic1111/inpaint.py
+++ b/backend/src/packages/chaiNNer_external/external_stable_diffusion/automatic1111/inpaint.py
@@ -178,11 +178,12 @@ def inpaint_node(
     h, w, _ = get_h_w_c(result)
     if inpaint_area == InpaintArea.ONLY_MASKED:
         in_h, in_w, _ = get_h_w_c(image)
-        assert (
-            (w, h) == (in_w, in_h)
-        ), f"Expected the returned image to be {in_w}x{in_h}px but found {w}x{h}px instead "
-    else:
-        assert (
-            (w, h) == (width, height)
-        ), f"Expected the returned image to be {width}x{height}px but found {w}x{h}px instead "
+        if (w, h) != (in_w, in_h):
+            raise RuntimeError(
+                f"Expected the returned image to be {in_w}x{in_h}px but found {w}x{h}px instead "
+            )
+    elif (w, h) != (width, height):
+        raise RuntimeError(
+            f"Expected the returned image to be {width}x{height}px but found {w}x{h}px instead "
+        )
     return result

--- a/backend/src/packages/chaiNNer_external/external_stable_diffusion/automatic1111/outpaint.py
+++ b/backend/src/packages/chaiNNer_external/external_stable_diffusion/automatic1111/outpaint.py
@@ -256,7 +256,8 @@ def outpaint_node(
     )
     result = decode_base64_image(response["images"][0])
     h, w, _ = get_h_w_c(result)
-    assert (
-        (w, h) == (expected_output_width, expected_output_height)
-    ), f"Expected the returned image to be {expected_output_width}x{expected_output_height}px but found {w}x{h}px instead "
+    if (w, h) != (expected_output_width, expected_output_height):
+        raise RuntimeError(
+            f"Expected the returned image to be {expected_output_width}x{expected_output_height}px but found {w}x{h}px instead "
+        )
     return result

--- a/backend/src/packages/chaiNNer_external/external_stable_diffusion/automatic1111/text_to_image.py
+++ b/backend/src/packages/chaiNNer_external/external_stable_diffusion/automatic1111/text_to_image.py
@@ -110,7 +110,8 @@ def text_to_image_node(
     )
     result = decode_base64_image(response["images"][0])
     h, w, _ = get_h_w_c(result)
-    assert (
-        (w, h) == (width, height)
-    ), f"Expected the returned image to be {width}x{height}px but found {w}x{h}px instead "
+    if (w, h) != (width, height):
+        raise RuntimeError(
+            f"Expected the returned image to be {width}x{height}px but found {w}x{h}px instead "
+        )
     return result

--- a/backend/src/packages/chaiNNer_external/external_stable_diffusion/automatic1111/upscale.py
+++ b/backend/src/packages/chaiNNer_external/external_stable_diffusion/automatic1111/upscale.py
@@ -183,16 +183,17 @@ def upscale_node(
 
     if mode == UpscalerMode.SCALE_TO:
         if crop:
-            assert (
-                (rw, rh) == (width, height)
-            ), f"Expected the returned image to be {width}x{height}px but found {rw}x{rh}px instead "
-        else:
-            assert (
-                (rw, rh) == (int(iw * larger_ratio), int(ih * larger_ratio))
-            ), f"Expected the returned image to be {width}x{height}px but found {rw}x{rh}px instead "
-    else:
-        assert (
-            (rw, rh) == (int(iw * upscaling_resize), int(ih * upscaling_resize))
-        ), f"Expected the returned image to be {width}x{height}px but found {rw}x{rh}px instead "
+            if (rw, rh) != (width, height):
+                raise RuntimeError(
+                    f"Expected the returned image to be {width}x{height}px but found {rw}x{rh}px instead "
+                )
+        elif (rw, rh) != (int(iw * larger_ratio), int(ih * larger_ratio)):
+            raise RuntimeError(
+                f"Expected the returned image to be {width}x{height}px but found {rw}x{rh}px instead "
+            )
+    elif (rw, rh) != (int(iw * upscaling_resize), int(ih * upscaling_resize)):
+        raise RuntimeError(
+            f"Expected the returned image to be {width}x{height}px but found {rw}x{rh}px instead "
+        )
 
     return result

--- a/backend/src/packages/chaiNNer_external/web_ui.py
+++ b/backend/src/packages/chaiNNer_external/web_ui.py
@@ -132,7 +132,8 @@ async def get_verified_api() -> Api | None:
 
     # check all apis in parallel
     apis = ApiConfig.from_env().list_apis()
-    assert len(apis) > 0
+    if len(apis) == 0:
+        raise RuntimeError("No stable diffusion API found")
     tasks = [
         api.get_async(STABLE_DIFFUSION_OPTIONS_PATH, timeout=timeout) for api in apis
     ]

--- a/backend/src/packages/chaiNNer_onnx/onnx/io/load_model.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/io/load_model.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import os
-
 import onnx
 from sanic.log import logger
 
@@ -35,12 +33,6 @@ from .. import io_group
 def load_model_node(path: str) -> tuple[OnnxModel, str, str]:
     """Read a pth file from the specified path and return it as a state dict
     and loaded model after finding arch config"""
-
-    if not os.path.exists(path):
-        raise FileNotFoundError(f"Model file at location {path} does not exist")
-
-    if not os.path.isfile(path):
-        raise ValueError(f"Path {path} is not a file")
 
     logger.debug(f"Reading onnx model from path: {path}")
     model = onnx.load_model(path)

--- a/backend/src/packages/chaiNNer_onnx/onnx/io/load_model.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/io/load_model.py
@@ -36,9 +36,11 @@ def load_model_node(path: str) -> tuple[OnnxModel, str, str]:
     """Read a pth file from the specified path and return it as a state dict
     and loaded model after finding arch config"""
 
-    assert os.path.exists(path), f"Model file at location {path} does not exist"
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"Model file at location {path} does not exist")
 
-    assert os.path.isfile(path), f"Path {path} is not a file"
+    if not os.path.isfile(path):
+        raise ValueError(f"Path {path} is not a file")
 
     logger.debug(f"Reading onnx model from path: {path}")
     model = onnx.load_model(path)

--- a/backend/src/packages/chaiNNer_onnx/onnx/utility/interpolate_models.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/utility/interpolate_models.py
@@ -34,9 +34,8 @@ def perform_interp(
         weight_array_a = onph.to_array(weight_a)
         weight_array_b = onph.to_array(weight_b)
 
-        assert (
-            weight_array_a.shape == weight_array_b.shape
-        ), "Weights must have same size and shape"
+        if weight_array_a.shape != weight_array_b.shape:
+            raise ValueError("Weights must have same size and shape")
 
         weight_array_interp = (
             weight_array_a * amount_a + weight_array_b * amount_b
@@ -104,9 +103,8 @@ def interpolate_models_node(
     model_proto_b = safely_optimize_onnx_model(model_proto_b)
     model_b_weights = model_proto_b.graph.initializer
 
-    assert len(model_a_weights) == len(
-        model_b_weights
-    ), "Models must have same number of weights"
+    if len(model_a_weights) != len(model_b_weights):
+        raise ValueError("Models must have same number of weights")
 
     logger.debug("Interpolating models...")
     interp_weights_list = perform_interp(model_a_weights, model_b_weights, amount)

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/io/load_model.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/io/load_model.py
@@ -68,12 +68,6 @@ def load_model_node(
     """Read a pth file from the specified path and return it as a state dict
     and loaded model after finding arch config"""
 
-    if not os.path.exists(path):
-        raise FileNotFoundError(f"Model file at location {path} does not exist")
-
-    if not os.path.isfile(path):
-        raise ValueError(f"Path {path} is not a file")
-
     exec_options = get_settings(context)
     pytorch_device = exec_options.device
 

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/io/load_model.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/io/load_model.py
@@ -68,9 +68,11 @@ def load_model_node(
     """Read a pth file from the specified path and return it as a state dict
     and loaded model after finding arch config"""
 
-    assert os.path.exists(path), f"Model file at location {path} does not exist"
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"Model file at location {path} does not exist")
 
-    assert os.path.isfile(path), f"Path {path} is not a file"
+    if not os.path.isfile(path):
+        raise ValueError(f"Path {path} is not a file")
 
     exec_options = get_settings(context)
     pytorch_device = exec_options.device

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/inpaint.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/inpaint.py
@@ -152,9 +152,8 @@ def inpaint_node(
     mask: np.ndarray,
     model: MaskedImageModelDescriptor,
 ) -> np.ndarray:
-    assert (
-        img.shape[:2] == mask.shape[:2]
-    ), "Input image and mask must have the same resolution"
+    if img.shape[:2] != mask.shape[:2]:
+        raise ValueError("Input image and mask must have the same resolution")
 
     exec_options = get_settings(context)
 

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/utility/convert_to_ncnn.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/utility/convert_to_ncnn.py
@@ -56,9 +56,10 @@ def convert_to_ncnn_node(
                 manager to use this node."
         )
 
-    assert not isinstance(
-        model.model, (HAT, DAT, OmniSR, SwinIR, Swin2SR, SCUNet, SRFormer)
-    ), f"{model.architecture} is not supported for NCNN conversions at this time."
+    if isinstance(model.model, (HAT, DAT, OmniSR, SwinIR, Swin2SR, SCUNet, SRFormer)):
+        raise ValueError(
+            f"{model.architecture} is not supported for NCNN conversions at this time."
+        )
 
     exec_options = get_settings(context)
     device = exec_options.device

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/utility/convert_to_onnx.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/utility/convert_to_onnx.py
@@ -70,15 +70,17 @@ OPSET_LABELS: dict[Opset, str] = {
 def convert_to_onnx_node(
     context: NodeContext, model: ImageModelDescriptor, is_fp16: int, opset: Opset
 ) -> tuple[OnnxGeneric, str, str]:
-    assert not isinstance(
-        model.model, SCUNet
-    ), "SCUNet is not supported for ONNX conversion at this time."
+    if isinstance(model.model, SCUNet):
+        raise ValueError("SCUNet is not supported for ONNX conversion at this time.")
 
     fp16 = bool(is_fp16)
     exec_options = get_settings(context)
     device = exec_options.device
     if fp16:
-        assert exec_options.use_fp16, "PyTorch fp16 mode must be supported and turned on in settings to convert model as fp16."
+        if not exec_options.use_fp16:
+            raise RuntimeError(
+                "PyTorch fp16 mode must be supported and turned on in settings to convert model as fp16."
+            )
 
     model.model.eval()
     model = model.to(device)

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/utility/interpolate_models.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/utility/interpolate_models.py
@@ -44,7 +44,6 @@ def check_can_interp(model_a: dict, model_b: dict):
     model_descriptor = ModelLoader(torch.device("cpu")).load_from_state_dict(interp_50)
     size = max(model_descriptor.size_requirements.minimum, 3)
     size = size + (size % model_descriptor.size_requirements.multiple_of)
-    assert isinstance(size, int), "min_size_restriction must be an int"
     fake_img = np.ones((size, size, model_descriptor.input_channels), dtype=np.float32)
     del interp_50
     with torch.no_grad():

--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/load_image_pairs.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/load_image_pairs.py
@@ -77,11 +77,12 @@ def load_image_pairs_node(
     image_files_a: list[str] = list_all_files_sorted(directory_a, supported_filetypes)
     image_files_b: list[str] = list_all_files_sorted(directory_b, supported_filetypes)
 
-    assert len(image_files_a) == len(image_files_b), (
-        "Number of images in directories A and B must be equal. "
-        f"Directory A: {directory_a} has {len(image_files_a)} images. "
-        f"Directory B: {directory_b} has {len(image_files_b)} images."
-    )
+    if len(image_files_a) != len(image_files_b):
+        raise ValueError(
+            "Number of images in directories A and B must be equal. "
+            f"Directory A: {directory_a} has {len(image_files_a)} images. "
+            f"Directory B: {directory_b} has {len(image_files_b)} images."
+        )
 
     if use_limit:
         image_files_a = image_files_a[:limit]

--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/split_spritesheet.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/split_spritesheet.py
@@ -59,12 +59,14 @@ def split_spritesheet_node(
     columns: int,
 ) -> Iterator[tuple[np.ndarray, int]]:
     h, w, _ = get_h_w_c(sprite_sheet)
-    assert (
-        h % rows == 0
-    ), "Height of sprite sheet must be a multiple of the number of rows"
-    assert (
-        w % columns == 0
-    ), "Width of sprite sheet must be a multiple of the number of columns"
+    if h % rows != 0:
+        raise ValueError(
+            "Height of sprite sheet must be a multiple of the number of rows"
+        )
+    if w % columns != 0:
+        raise ValueError(
+            "Width of sprite sheet must be a multiple of the number of columns"
+        )
 
     individual_h = h // rows
     individual_w = w // columns

--- a/backend/src/packages/chaiNNer_standard/image/video_frames/save_video.py
+++ b/backend/src/packages/chaiNNer_standard/image/video_frames/save_video.py
@@ -267,9 +267,10 @@ def save_video_node(
 
             # Verify some parameters
             if encoder in [VideoEncoder.H264, VideoEncoder.H265]:
-                assert (
-                    h % 2 == 0 and w % 2 == 0
-                ), f'The "{encoder.value}" encoder requires an even-number frame resolution.'
+                if not (h % 2 == 0 and w % 2 == 0):
+                    raise ValueError(
+                        f'The "{encoder.value}" encoder requires an even-number frame resolution.'
+                    )
 
             try:
                 writer.out = (

--- a/backend/src/packages/chaiNNer_standard/image_channel/all/combine_rgba.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/all/combine_rgba.py
@@ -80,9 +80,8 @@ def combine_rgba_node(
     # check same size
     for i in inputs:
         if isinstance(i, np.ndarray):
-            assert (
-                i.shape[:2] == start_shape
-            ), "All channel images must have the same resolution"
+            if i.shape[:2] != start_shape:
+                raise ValueError("All channel images must have the same resolution")
 
     channels = [
         (

--- a/backend/src/packages/chaiNNer_standard/image_channel/all/merge_channels.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/all/merge_channels.py
@@ -58,9 +58,8 @@ def merge_channels_node(
 
     for im in im2, im3, im4:
         if im is not None:
-            assert (
-                im.shape[:2] == start_shape
-            ), "All images to be merged must be the same resolution"
+            if im.shape[:2] != start_shape:
+                raise ValueError("All images to be merged must be the same resolution")
 
     imgs = []
     for img in im1, im2, im3, im4:

--- a/backend/src/packages/chaiNNer_standard/image_channel/misc/alpha_matting.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/misc/alpha_matting.py
@@ -65,12 +65,14 @@ def alpha_matting_node(
     fg_threshold: int,
     bg_threshold: int,
 ) -> np.ndarray:
-    assert (
-        fg_threshold > bg_threshold
-    ), "The foreground threshold must be greater than the background threshold."
+    if fg_threshold <= bg_threshold:
+        raise ValueError(
+            "The foreground threshold must be greater than the background threshold."
+        )
 
     h, w, c = get_h_w_c(img)
-    assert (h, w) == trimap.shape[:2], "The image and trimap must have the same size."
+    if (h, w) != trimap.shape[:2]:
+        raise ValueError("The image and trimap must have the same size.")
 
     # apply thresholding to trimap
     trimap = np.where(trimap > fg_threshold / 255, 1, trimap)
@@ -84,11 +86,14 @@ def alpha_matting_node(
         img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
     img = img.astype(np.float64)
 
-    assert img.dtype == np.float64
-    assert trimap.dtype == np.float64
+    if img.dtype != np.float64:
+        raise ValueError(f"Image must be float64, got {img.dtype}")
+    if trimap.dtype != np.float64:
+        raise ValueError(f"Trimap must be float64, got {trimap.dtype}")
     alpha = pymatting.estimate_alpha_cf(img, trimap)
     foreground = pymatting.estimate_foreground_ml(img, alpha)
-    assert isinstance(foreground, np.ndarray)
+    if not isinstance(foreground, np.ndarray):
+        raise AssertionError(f"Foreground must be np.ndarray, got {type(foreground)}")
 
     # convert to bgr
     foreground = cv2.cvtColor(foreground, cv2.COLOR_RGB2BGR)

--- a/backend/src/packages/chaiNNer_standard/image_channel/misc/chroma_key.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/misc/chroma_key.py
@@ -151,11 +151,14 @@ def trimap_matting_keying(
     img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
     img = img.astype(np.float64)
 
-    assert img.dtype == np.float64
-    assert trimap.dtype == np.float64
+    if img.dtype != np.float64:
+        raise ValueError(f"Image must be float64, got {img.dtype}")
+    if trimap.dtype != np.float64:
+        raise ValueError(f"Trimap must be float64, got {trimap.dtype}")
     alpha = pymatting.estimate_alpha_cf(img, trimap)
     foreground = pymatting.estimate_foreground_ml(img, alpha)
-    assert isinstance(foreground, np.ndarray)
+    if not isinstance(foreground, np.ndarray):
+        raise AssertionError(f"Foreground must be np.ndarray, got {type(foreground)}")
 
     # convert to bgr
     foreground = cv2.cvtColor(foreground, cv2.COLOR_RGB2BGR)

--- a/backend/src/packages/chaiNNer_standard/image_channel/transparency/merge_transparency.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/transparency/merge_transparency.py
@@ -64,9 +64,8 @@ def merge_transparency_node(
     # check same size
     for i in rgb, a:
         if isinstance(i, np.ndarray):
-            assert (
-                i.shape[:2] == start_shape
-            ), "All channel images must have the same resolution"
+            if i.shape[:2] != start_shape:
+                raise ValueError("All channel images must have the same resolution")
 
     def to_image(i: np.ndarray | Color) -> np.ndarray:
         if isinstance(i, np.ndarray):

--- a/backend/src/packages/chaiNNer_standard/image_dimension/crop/crop.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/crop/crop.py
@@ -95,20 +95,26 @@ def crop_node(
         if amount == 0:
             return img
 
-        assert 2 * amount < h, "Cropped area would result in an image with no height"
-        assert 2 * amount < w, "Cropped area would result in an image with no width"
+        if 2 * amount >= h:
+            raise ValueError("Cropped area would result in an image with no height")
+        if 2 * amount >= w:
+            raise ValueError("Cropped area would result in an image with no width")
 
         return img[amount : h - amount, amount : w - amount]
     elif mode == CropMode.EDGES:
         if top == bottom == left == right == 0:
             return img
 
-        assert top + bottom < h, "Cropped area would result in an image with no height"
-        assert left + right < w, "Cropped area would result in an image with no width"
+        if top + bottom >= h:
+            raise ValueError("Cropped area would result in an image with no height")
+        if left + right >= w:
+            raise ValueError("Cropped area would result in an image with no width")
 
         return img[top : h - bottom, left : w - right]
     elif mode == CropMode.OFFSETS:
-        assert top < h, "Cropped area would result in an image with no height"
-        assert left < w, "Cropped area would result in an image with no width"
+        if top <= h:
+            raise ValueError("Cropped area would result in an image with no height")
+        if left <= w:
+            raise ValueError("Cropped area would result in an image with no width")
 
         return img[top : top + height, left : left + width]

--- a/backend/src/packages/chaiNNer_standard/image_filter/correction/average_color_fix.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/correction/average_color_fix.py
@@ -53,9 +53,8 @@ def average_color_fix_node(
     input_h, input_w, input_c = get_h_w_c(input_img)
     ref_h, ref_w, ref_c = get_h_w_c(ref_img)
 
-    assert (
-        ref_w < input_w and ref_h < input_h
-    ), "Image must be larger than Reference Image"
+    if not (ref_w < input_w and ref_h < input_h):
+        raise ValueError("Image must be larger than Reference Image")
 
     # Find the diff of both images
 

--- a/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/high_pass.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/high_pass.py
@@ -97,11 +97,13 @@ def high_pass_node(
     if mode == BlurMode.GAUSSIAN:
         blurred = fast_gaussian_blur(img, radius)
     elif mode == BlurMode.CUSTOM:
-        assert blurred is not None, "Expected a blurred image to be given."
+        if blurred is None:
+            raise ValueError("Expected a blurred image to be given.")
 
-    assert (
-        blurred.shape == img.shape
-    ), "Expected blurred image to have same shape as the input image."
+    if blurred.shape != img.shape:
+        raise ValueError(
+            "Expected blurred image to have same shape as the input image."
+        )
 
     img = contrast * (img - blurred) + 0.5
 

--- a/backend/src/packages/chaiNNer_standard/image_filter/quantize/dither_palette.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/quantize/dither_palette.py
@@ -75,9 +75,8 @@ def dither_palette_node(
     error_diffusion_map: ErrorDiffusionMap,
     history_length: int,
 ) -> np.ndarray:
-    assert (
-        get_h_w_c(img)[2] == get_h_w_c(palette)[2]
-    ), "Image and palette must have the same number of channels."
+    if get_h_w_c(img)[2] != get_h_w_c(palette)[2]:
+        raise ValueError("Image and palette must have the same number of channels.")
 
     palette = palette[:1, ...]
     quant = PaletteQuantization(palette)

--- a/backend/src/packages/chaiNNer_standard/image_filter/quantize/quantize_to_reference.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/quantize/quantize_to_reference.py
@@ -100,11 +100,18 @@ def quantize_to_reference_node(
 ) -> np.ndarray:
     i_h, i_w, i_c = get_h_w_c(img)
     r_h, r_w, r_c = get_h_w_c(reference_img)
-    assert i_c == r_c, "Image and reference image must have the same number of channels"
-    assert i_h >= r_h, "Image height must be larger than reference image height"
-    assert i_h % r_h == 0, "Image height must be a multiple of reference image height"
-    assert i_w >= r_w, "Image width must be larger than reference image width"
-    assert i_w % r_w == 0, "Image width must be a multiple of reference image width"
+    if i_c != r_c:
+        raise ValueError(
+            "Image and reference image must have the same number of channels"
+        )
+    if i_h < r_h:
+        raise ValueError("Image height must be larger than reference image height")
+    if i_h % r_h != 0:
+        raise ValueError("Image height must be a multiple of reference image height")
+    if i_w < r_w:
+        raise ValueError("Image width must be larger than reference image width")
+    if i_w % r_w != 0:
+        raise ValueError("Image width must be a multiple of reference image width")
 
     spatial_scale = spatial_scale / 100
     spatial_scale = spatial_scale * spatial_scale

--- a/backend/src/packages/chaiNNer_standard/image_utility/compositing/blend_images.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/compositing/blend_images.py
@@ -248,7 +248,7 @@ def blend_images_node(
         base = cv2.copyMakeBorder(
             base, top, bottom, left, right, cv2.BORDER_CONSTANT, value=(0.0,)
         )
-        assert isinstance(base, np.ndarray)
+        assert isinstance(base, np.ndarray)  # noqa: S101
     else:  # Make sure cached image not being worked on regardless
         base = base.copy()
 

--- a/backend/src/packages/chaiNNer_standard/image_utility/compositing/stack_images.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/compositing/stack_images.py
@@ -207,19 +207,23 @@ def stack_images_node(
 
     if orientation == Orientation.HORIZONTAL:
         for i in range(len(fixed_imgs)):
-            assert (
-                fixed_imgs[i].shape[0] == fixed_imgs[0].shape[0]
-            ), "Inputted heights are not the same and could not be auto-fixed"
-            assert (
-                fixed_imgs[i].dtype == fixed_imgs[0].dtype
-            ), "The image types are not the same and could not be auto-fixed"
+            if fixed_imgs[i].shape[0] != fixed_imgs[0].shape[0]:
+                raise ValueError(
+                    "Inputted heights are not the same and could not be auto-fixed"
+                )
+            if fixed_imgs[i].dtype != fixed_imgs[0].dtype:
+                raise ValueError(
+                    "The image types are not the same and could not be auto-fixed"
+                )
         return cv2.hconcat(fixed_imgs)
     elif orientation == Orientation.VERTICAL:
         for i in range(len(fixed_imgs)):
-            assert (
-                fixed_imgs[i].shape[1] == fixed_imgs[0].shape[1]
-            ), "Inputted widths are not the same and could not be auto-fixed"
-            assert (
-                fixed_imgs[i].dtype == fixed_imgs[0].dtype
-            ), "The image types are not the same and could not be auto-fixed"
+            if fixed_imgs[i].shape[1] != fixed_imgs[0].shape[1]:
+                raise ValueError(
+                    "Inputted widths are not the same and could not be auto-fixed"
+                )
+            if fixed_imgs[i].dtype != fixed_imgs[0].dtype:
+                raise ValueError(
+                    "The image types are not the same and could not be auto-fixed"
+                )
         return cv2.vconcat(fixed_imgs)

--- a/backend/src/packages/chaiNNer_standard/image_utility/compositing/z_stack_images.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/compositing/z_stack_images.py
@@ -66,13 +66,11 @@ def z_stack_images_node(
     """Align and evaluate images"""
 
     images = [x for x in inputs if x is not None]
-    assert (
-        2 <= len(images) <= 15
-    ), f"Number of images must be between 2 and 15 ({len(images)})"
+    if not (2 <= len(images) <= 15):
+        raise ValueError(f"Number of images must be between 2 and 15 ({len(images)})")
 
-    assert all(
-        get_h_w_c(image) == get_h_w_c(images[0]) for image in images
-    ), "All images must have the same dimensions and channels"
+    if not all(get_h_w_c(image) == get_h_w_c(images[0]) for image in images):
+        raise ValueError("All images must have the same dimensions and channels")
 
     if expression == Expression.MEAN:
         result = np.mean(images, axis=0)

--- a/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/apply_palette.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/apply_palette.py
@@ -16,10 +16,12 @@ def quantize(img: np.ndarray, levels: int) -> np.ndarray:
 
     The type of the integers in the returned array will be the smallest unsigned integer type that can fit `levels` many values. E.g. uint8 is used for 256, and uint16 is used for 257 levels.
     """
-    assert levels >= 1
-    assert (
-        levels <= 2**24
-    ), "Quantizing float32 values with more than 2**24 levels doesn't make sense, because only integers up to 2**24 can be represented exactly using float32."
+    if levels < 1:
+        raise ValueError("levels must be at least 1")
+    if levels > 2**24:
+        raise ValueError(
+            "Quantizing float32 values with more than 2**24 levels doesn't make sense, because only integers up to 2**24 can be represented exactly using float32."
+        )
 
     q: np.ndarray = np.round(img * (levels - 1))
 

--- a/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/change_colorspace.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/change_colorspace.py
@@ -69,7 +69,8 @@ def change_colorspace_node(
 
     alpha_cs = get_alpha_partner(to_cs)
     if alpha and alpha_cs is not None:
-        assert alpha_cs.channels == 4
+        if alpha_cs.channels != 4:
+            raise ValueError("Image must have 4 channels to convert with alpha")
         to_cs = alpha_cs
 
     return convert(img, from_cs, to_cs)

--- a/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/image_metrics.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/image_metrics.py
@@ -35,9 +35,8 @@ def image_metrics_node(
 ) -> tuple[float, float, float]:
     """Compute MSE, PSNR, and SSIM"""
 
-    assert (
-        orig_img.shape == comp_img.shape
-    ), "Images must have same dimensions and color depth"
+    if orig_img.shape != comp_img.shape:
+        raise ValueError("Images must have same dimensions and color depth")
 
     # If an image is not grayscale, convert to YCrCb and compute metrics
     # on luma channel only

--- a/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/inpaint.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/inpaint.py
@@ -67,9 +67,8 @@ def inpaint_node(
 ) -> np.ndarray:
     """Inpaint an image"""
 
-    assert (
-        img.shape[:2] == mask.shape[:2]
-    ), "Input image and mask must have the same resolution"
+    if img.shape[:2] != mask.shape[:2]:
+        raise ValueError("Input image and mask must have the same resolution")
 
     img = to_uint8(img, normalized=True)
     mask = to_uint8(mask, normalized=True)

--- a/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/pick_color.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/pick_color.py
@@ -109,10 +109,11 @@ def pick_color_node(
         x = round_half_up((w - 1) * x_rel / 100)
         y = round_half_up((h - 1) * y_rel / 100)
 
-    assert x < w and y < h, (
-        "The given coordinates (X, Y) are outside the image."
-        f" Expect X={x} to be to 0 to {w-1} and Y={y} to be to 0 to {h-1}."
-    )
+    if not (x < w and y < h):
+        raise ValueError(
+            "The given coordinates (X, Y) are outside the image."
+            f" Expect X={x} to be to 0 to {w-1} and Y={y} to be to 0 to {h-1}."
+        )
 
     if c == 1:
         return Color.gray(orig_img[y, x])

--- a/backend/src/packages/chaiNNer_standard/material_textures/conversion/metal_to_specular.py
+++ b/backend/src/packages/chaiNNer_standard/material_textures/conversion/metal_to_specular.py
@@ -21,7 +21,8 @@ def metal_to_spec(
     metal: np.ndarray,
     roughness: np.ndarray | None,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    assert get_h_w_c(albedo)[2] == 3, "Expected the albedo map to be an RGB image"
+    if get_h_w_c(albedo)[2] != 3:
+        raise ValueError("Expected the albedo map to be an RGB image")
 
     # This uses the conversion method described here:
     # https://marmoset.co/posts/pbr-texture-conversion/

--- a/backend/src/packages/chaiNNer_standard/material_textures/conversion/specular_to_metal.py
+++ b/backend/src/packages/chaiNNer_standard/material_textures/conversion/specular_to_metal.py
@@ -23,8 +23,10 @@ def spec_to_metal(
     metallic_min: float,
     metallic_max: float,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    assert get_h_w_c(diff)[2] == 3, "Expected the diffuse map to be an RGB image"
-    assert get_h_w_c(spec)[2] == 3, "Expected the specular map to be an RGB image"
+    if get_h_w_c(diff)[2] != 3:
+        raise ValueError("Expected the diffuse map to be an RGB image")
+    if get_h_w_c(spec)[2] != 3:
+        raise ValueError("Expected the specular map to be an RGB image")
 
     metallic_diff = (
         0.0001 if metallic_min == metallic_max else metallic_max - metallic_min

--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -177,7 +177,9 @@ def run_node(
         if node.type == "newIterator":
             return enforce_iterator_output(raw_output, node)
 
-        assert node.type == "regularNode"  # noqa: S101
+        if node.type != "regularNode":
+            raise ValueError(f"Unknown node type: {node.type}. Expected regularNode.")
+
         return enforce_output(raw_output, node)
     except Aborted:
         raise
@@ -430,6 +432,7 @@ class Executor:
         assert isinstance(  # noqa: S101
             output, RegularOutput
         ), "Expected output to be a regular output"
+
         return output.output[output_index]
 
     async def __resolve_node_input(self, node_input: Input) -> object:
@@ -563,7 +566,9 @@ class Executor:
             elif isinstance(n, NewIteratorNode):
                 raise ValueError("Nested iterators are not supported")
             else:
-                assert isinstance(n, FunctionNode)  # noqa: S101
+                assert isinstance(  # noqa: S101
+                    n, FunctionNode
+                ), "Expected n to be an instance of FunctionNode"
 
                 if n.has_side_effects():
                     output_nodes.add(n)

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -62,7 +62,8 @@ class AppContext:
 
     @staticmethod
     def get(app_instance: Sanic) -> AppContext:
-        assert isinstance(app_instance.ctx, AppContext)
+        if not isinstance(app_instance.ctx, AppContext):
+            raise ValueError("AppContext is not set!")
         return app_instance.ctx
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,8 @@ extend-select = [
     "SLF", # flake8-self
     # "SIM", # flake8-simplify
     # "TCH", # flake8-tidy-imports
-    "NPY", # NumPy-specific rules
+    "NPY",  # NumPy-specific rules
+    "S101", # flake8-bandit: assert
 ]
 ignore = [
     "E501",    # Line too long


### PR DESCRIPTION
> Assertions are removed when Python is run with optimization requested (i.e., when the -O flag is present), which is a common practice in production environments. As such, assertions should not be used for runtime validation of user input or to enforce interface constraints.

> Consider raising a meaningful error instead of using assert.

This PR removes (almost) all assertions and replaces them with equivalent checks + actual error messages where missing.

While there may not be a functional difference unless -O is used, it is still recommended to only use asserts for tests or debugging purposes and to use regular `raise` exceptions instead. 

This does leave 3 `assert isinstance(...` checks in place, because converting them to regular if statements gives me a nice pylance error about it being impossible for these to _not_ be an instance of that type. So, I just left them as is.

Note: While I was as careful as possible only manually flipping trivial checks like < into >= and just `if not (...)`ing the more complicated ones, there is still a chance that this introduces a bug from a flipped condition. However, I think this is unlikely.