### PR TITLE
Fixed accent color for `any` outputs

### DIFF
--- a/src/renderer/helpers/accentColors.ts
+++ b/src/renderer/helpers/accentColors.ts
@@ -29,17 +29,16 @@ const colorList = lazy(() => {
 const defaultColorList = [defaultColor] as const;
 
 export const getTypeAccentColors = (inputType: Type): readonly [string, ...string[]] => {
-    if (inputType.type === 'any') {
-        return defaultColorList;
-    }
-
     const colors: string[] = [];
-    for (const { type, color } of colorList()) {
+    const allColors = colorList();
+    for (const { type, color } of allColors) {
         if (!isDisjointWith(type, inputType)) {
             colors.push(color);
         }
     }
-    return colors.length > 0 ? (colors as [string, ...string[]]) : defaultColorList;
+    return colors.length > 0 && colors.length < allColors.length
+        ? (colors as [string, ...string[]])
+        : defaultColorList;
 };
 
 export const getCategoryAccentColor = (categories: CategoryMap, category: CategoryId) => {


### PR DESCRIPTION
In #2445, I failed to consider that the type system now removes the `Error` struct from `any` outputs, which led to Pass Through looking like this:

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/e7ccc844-44f6-4012-a794-b7f3d5606c7d)

So I fixed this issue.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/70dc978a-f900-477d-bbfd-fb956d7da620)
