### PR TITLE
Removed forced `textSize` in Markdown components

### DIFF
--- a/src/renderer/components/Markdown.tsx
+++ b/src/renderer/components/Markdown.tsx
@@ -15,7 +15,6 @@ const getDocsMarkdownComponents = (interactive: boolean): Components => {
             return (
                 <SupportHighlighting>
                     <Text
-                        fontSize="md"
                         my={2}
                         userSelect="text"
                     >


### PR DESCRIPTION
This removes the `fontSize="md"` which forced this size on all MD paragraphs. Font size is now inherited as it should.

This PR is necessary for [this change](https://github.com/chaiNNer-org/chaiNNer/pull/2462#discussion_r1459693658) to look right.