### PR TITLE
Rename `node_type`/`nodeType` to `kind`

### DIFF
--- a/backend/src/api/api.py
+++ b/backend/src/api/api.py
@@ -28,7 +28,7 @@ from .node_check import (
 )
 from .output import BaseOutput
 from .settings import Setting
-from .types import FeatureId, InputId, NodeId, NodeType, OutputId, RunFn
+from .types import FeatureId, InputId, NodeId, NodeKind, OutputId, RunFn
 
 KB = 1024**1
 MB = 1024**2
@@ -123,7 +123,7 @@ class NodeData:
     see_also: list[str]
     name: str
     icon: str
-    type: NodeType
+    kind: NodeKind
 
     inputs: list[BaseInput]
     outputs: list[BaseOutput]
@@ -182,7 +182,7 @@ class NodeGroup:
         inputs: list[BaseInput | NestedGroup],
         outputs: list[BaseOutput],
         icon: str = "BsQuestionCircleFill",
-        node_type: NodeType = "regularNode",
+        kind: NodeKind = "regularNode",
         side_effects: bool = False,
         deprecated: bool = False,
         decorators: list[Callable] | None = None,
@@ -219,9 +219,9 @@ class NodeGroup:
         iterator_inputs = to_list(iterator_inputs)
         iterator_outputs = to_list(iterator_outputs)
 
-        if node_type == "collector":
+        if kind == "collector":
             assert len(iterator_inputs) == 1 and len(iterator_outputs) == 0
-        elif node_type == "newIterator":
+        elif kind == "newIterator":
             assert len(iterator_inputs) == 0 and len(iterator_outputs) == 1
         else:
             assert len(iterator_inputs) == 0 and len(iterator_outputs) == 0
@@ -242,7 +242,7 @@ class NodeGroup:
             p_inputs, group_layout = _process_inputs(inputs)
             p_outputs = _process_outputs(outputs)
 
-            if node_type == "regularNode":
+            if kind == "regularNode":
                 run_check(
                     TYPE_CHECK_LEVEL,
                     lambda _: check_schema_types(
@@ -264,7 +264,7 @@ class NodeGroup:
                 description=description,
                 see_also=see_also,
                 icon=icon,
-                type=node_type,
+                kind=kind,
                 inputs=p_inputs,
                 group_layout=group_layout,
                 outputs=p_outputs,

--- a/backend/src/api/types.py
+++ b/backend/src/api/types.py
@@ -10,4 +10,4 @@ FeatureId = NewType("FeatureId", str)
 
 RunFn = Callable[..., Any]
 
-NodeType = Literal["regularNode", "newIterator", "collector"]
+NodeKind = Literal["regularNode", "newIterator", "collector"]

--- a/backend/src/chain/chain.py
+++ b/backend/src/chain/chain.py
@@ -22,7 +22,7 @@ class FunctionNode:
         self.id: NodeId = node_id
         self.schema_id: str = schema_id
         self.data: NodeData = registry.get_node(schema_id)
-        assert self.data.type == "regularNode"
+        assert self.data.kind == "regularNode"
 
     def has_side_effects(self) -> bool:
         return self.data.side_effects
@@ -33,7 +33,7 @@ class NewIteratorNode:
         self.id: NodeId = node_id
         self.schema_id: str = schema_id
         self.data: NodeData = registry.get_node(schema_id)
-        assert self.data.type == "newIterator"
+        assert self.data.kind == "newIterator"
 
     def has_side_effects(self) -> bool:
         return self.data.side_effects
@@ -44,7 +44,7 @@ class CollectorNode:
         self.id: NodeId = node_id
         self.schema_id: str = schema_id
         self.data: NodeData = registry.get_node(schema_id)
-        assert self.data.type == "collector"
+        assert self.data.kind == "collector"
 
     def has_side_effects(self) -> bool:
         return self.data.side_effects

--- a/backend/src/packages/chaiNNer_ncnn/ncnn/batch_processing/load_models.py
+++ b/backend/src/packages/chaiNNer_ncnn/ncnn/batch_processing/load_models.py
@@ -45,7 +45,7 @@ from ..io.load_model import load_model_node
         ),
     ],
     iterator_outputs=IteratorOutputInfo(outputs=[0, 2, 3, 4]),
-    node_type="newIterator",
+    kind="newIterator",
 )
 def load_models_node(
     directory: str,

--- a/backend/src/packages/chaiNNer_onnx/onnx/batch_processing/load_models.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/batch_processing/load_models.py
@@ -45,7 +45,7 @@ from ..io.load_model import load_model_node
         ),
     ],
     iterator_outputs=IteratorOutputInfo(outputs=[0, 2, 3, 4]),
-    node_type="newIterator",
+    kind="newIterator",
 )
 def load_models_node(
     directory: str,

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/iteration/load_models.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/iteration/load_models.py
@@ -42,7 +42,7 @@ from ..io.load_model import load_model_node
         ),
     ],
     iterator_outputs=IteratorOutputInfo(outputs=[0, 2, 3, 4]),
-    node_type="newIterator",
+    kind="newIterator",
     node_context=True,
 )
 def load_models_node(

--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/load_image_pairs.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/load_image_pairs.py
@@ -53,7 +53,7 @@ from ..io.load_image import load_image_node
         ),
     ],
     iterator_outputs=IteratorOutputInfo(outputs=[0, 1, 4, 5, 6, 7, 8]),
-    node_type="newIterator",
+    kind="newIterator",
 )
 def load_image_pairs_node(
     directory_a: str,

--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/load_images.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/load_images.py
@@ -86,7 +86,7 @@ def list_glob(directory: str, globexpr: str, ext_filter: list[str]) -> list[str]
         ),
     ],
     iterator_outputs=IteratorOutputInfo(outputs=[0, 2, 3, 4]),
-    node_type="newIterator",
+    kind="newIterator",
 )
 def load_images_node(
     directory: str,

--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/merge_spritesheet.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/merge_spritesheet.py
@@ -48,7 +48,7 @@ from .. import batch_processing_group
             }"""
         )
     ],
-    node_type="collector",
+    kind="collector",
 )
 def merge_spritesheet_node(
     _: None,

--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/split_spritesheet.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/split_spritesheet.py
@@ -51,7 +51,7 @@ from .. import batch_processing_group
         ),
     ],
     iterator_outputs=IteratorOutputInfo(outputs=[0, 1], length_type="Input1 * Input2"),
-    node_type="newIterator",
+    kind="newIterator",
 )
 def split_spritesheet_node(
     sprite_sheet: np.ndarray,

--- a/backend/src/packages/chaiNNer_standard/image/video_frames/load_video.py
+++ b/backend/src/packages/chaiNNer_standard/image/video_frames/load_video.py
@@ -56,7 +56,7 @@ ffprobe_path = os.environ.get("STATIC_FFPROBE_PATH", "ffprobe")
         AudioStreamOutput(),
     ],
     iterator_outputs=IteratorOutputInfo(outputs=[0, 1]),
-    node_type="newIterator",
+    kind="newIterator",
 )
 def load_video_node(
     path: str,

--- a/backend/src/packages/chaiNNer_standard/image/video_frames/save_video.py
+++ b/backend/src/packages/chaiNNer_standard/image/video_frames/save_video.py
@@ -172,7 +172,7 @@ class Writer:
     ],
     iterator_inputs=IteratorInputInfo(inputs=0),
     outputs=[],
-    node_type="collector",
+    kind="collector",
     side_effects=True,
 )
 def save_video_node(

--- a/backend/src/packages/chaiNNer_standard/utility/value/range.py
+++ b/backend/src/packages/chaiNNer_standard/utility/value/range.py
@@ -30,7 +30,7 @@ from .. import value_group
         ).with_never_reason("The range is empty."),
     ],
     iterator_outputs=IteratorOutputInfo(outputs=0),
-    node_type="newIterator",
+    kind="newIterator",
 )
 def range_node(
     start: int,

--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -143,7 +143,7 @@ def enforce_iterator_output(raw_output: object, node: NodeData) -> IteratorOutpu
 def run_node(
     node: NodeData, context: NodeContext, inputs: list[object], node_id: NodeId
 ) -> NodeOutput | CollectorOutput:
-    if node.type == "collector":
+    if node.kind == "collector":
         ignored_inputs = node.single_iterator_input.inputs
     else:
         ignored_inputs = []
@@ -156,13 +156,13 @@ def run_node(
         else:
             raw_output = node.run(*enforced_inputs)
 
-        if node.type == "collector":
+        if node.kind == "collector":
             assert isinstance(raw_output, Collector)
             return CollectorOutput(raw_output)
-        if node.type == "newIterator":
+        if node.kind == "newIterator":
             return enforce_iterator_output(raw_output, node)
 
-        assert node.type == "regularNode"
+        assert node.kind == "regularNode"
         return enforce_output(raw_output, node)
     except Aborted:
         raise

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -130,7 +130,7 @@ async def nodes(_request: Request):
             "description": node.description,
             "seeAlso": node.see_also,
             "icon": node.icon,
-            "nodeType": node.type,
+            "kind": node.kind,
             "hasSideEffects": node.side_effects,
             "deprecated": node.deprecated,
             "features": node.features,

--- a/src/common/SchemaMap.ts
+++ b/src/common/SchemaMap.ts
@@ -21,7 +21,7 @@ const BLANK_SCHEMA: NodeSchema = {
     name: '',
     description: '',
     seeAlso: [],
-    nodeType: 'regularNode',
+    kind: 'regularNode',
     schemaId: '' as SchemaId,
     hasSideEffects: false,
     deprecated: false,

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -250,7 +250,7 @@ export type OfKind<T extends { readonly kind: string }, Kind extends T['kind']> 
     ? T
     : never;
 
-export type NodeType = 'regularNode' | 'newIterator' | 'collector';
+export type NodeKind = 'regularNode' | 'newIterator' | 'collector';
 
 export type InputData = Readonly<Record<InputId, InputValue>>;
 export type InputHeight = Readonly<Record<InputId, number>>;
@@ -275,7 +275,7 @@ export interface NodeSchema {
     readonly description: string;
     readonly seeAlso: readonly SchemaId[];
     readonly icon: string;
-    readonly nodeType: NodeType;
+    readonly kind: NodeKind;
     readonly inputs: readonly Input[];
     readonly outputs: readonly Output[];
     readonly groupLayout: readonly (InputId | Group)[];

--- a/src/common/nodes/lineage.ts
+++ b/src/common/nodes/lineage.ts
@@ -72,7 +72,7 @@ export class ChainLineage {
         const schema = this.nodeSchemata.get(nodeId);
         if (!schema) return null;
 
-        switch (schema.nodeType) {
+        switch (schema.kind) {
             case 'newIterator': {
                 // iterator source nodes do not support iterated inputs
                 return null;
@@ -129,7 +129,7 @@ export class ChainLineage {
                 return lineage;
             }
             default:
-                return assertNever(schema.nodeType);
+                return assertNever(schema.kind);
         }
     }
 
@@ -140,7 +140,7 @@ export class ChainLineage {
         const schema = this.nodeSchemata.get(nodeId);
         if (!schema) return null;
 
-        switch (schema.nodeType) {
+        switch (schema.kind) {
             case 'regularNode': {
                 // for regular nodes, the lineage of all outputs is equal to
                 // the lineage of the first iterated input (if any).
@@ -161,7 +161,7 @@ export class ChainLineage {
                 return null;
             }
             default:
-                return assertNever(schema.nodeType);
+                return assertNever(schema.kind);
         }
     }
 }

--- a/src/renderer/components/NodeSelectorPanel/RepresentativeNode.tsx
+++ b/src/renderer/components/NodeSelectorPanel/RepresentativeNode.tsx
@@ -2,7 +2,7 @@ import { StarIcon } from '@chakra-ui/icons';
 import { Box, Center, Flex, HStack, Heading, Spacer } from '@chakra-ui/react';
 import { memo, useState } from 'react';
 import { useContext } from 'use-context-selector';
-import { CategoryId, NodeType, SchemaId } from '../../../common/common-types';
+import { CategoryId, SchemaId } from '../../../common/common-types';
 import { BackendContext } from '../../contexts/BackendContext';
 import { getCategoryAccentColor } from '../../helpers/accentColors';
 import { useNodeFavorites } from '../../hooks/useNodeFavorites';
@@ -14,21 +14,20 @@ interface RepresentativeNodeProps {
     name: string;
     collapsed?: boolean;
     schemaId: SchemaId;
-    nodeType: NodeType;
     createNodeFromSelector: () => void;
 }
 
 export const RepresentativeNode = memo(
     ({
         category,
-        nodeType,
         name,
         icon,
         schemaId,
         collapsed = false,
         createNodeFromSelector,
     }: RepresentativeNodeProps) => {
-        const { categories } = useContext(BackendContext);
+        const { categories, schemata } = useContext(BackendContext);
+        const schema = schemata.get(schemaId);
 
         const bgColor = 'var(--selector-node-bg)';
         const accentColor = getCategoryAccentColor(categories, category);
@@ -38,7 +37,7 @@ export const RepresentativeNode = memo(
         const { favorites, addFavorites, removeFavorite } = useNodeFavorites();
         const isFavorite = favorites.has(schemaId);
 
-        const isIterator = nodeType === 'newIterator' || nodeType === 'collector';
+        const isIterator = schema.kind === 'newIterator' || schema.kind === 'collector';
         let bgGradient = `linear-gradient(90deg, ${accentColor} 0%, ${accentColor} 100%)`;
         if (isIterator) {
             bgGradient = `repeating-linear(to right,${accentColor},${accentColor} 2px,${bgColor} 2px,${bgColor} 4px)`;

--- a/src/renderer/components/NodeSelectorPanel/RepresentativeNodeWrapper.tsx
+++ b/src/renderer/components/NodeSelectorPanel/RepresentativeNodeWrapper.tsx
@@ -116,13 +116,12 @@ export const RepresentativeNodeWrapper = memo(
             });
 
             createNode({
-                nodeType: node.nodeType,
                 position,
                 data: {
                     schemaId: node.schemaId,
                 },
             });
-        }, [createNode, node.schemaId, node.nodeType, reactFlowInstance, reactFlowWrapper]);
+        }, [createNode, node.schemaId, reactFlowInstance, reactFlowWrapper]);
 
         const featureDetails = node.features.map((feature) => {
             const featureState = featureStates.get(feature);
@@ -194,7 +193,6 @@ export const RepresentativeNodeWrapper = memo(
                                     createNodeFromSelector={createNodeFromSelector}
                                     icon={node.icon}
                                     name={node.name}
-                                    nodeType={node.nodeType}
                                     schemaId={node.schemaId}
                                 />
                             </Center>

--- a/src/renderer/components/node/Node.tsx
+++ b/src/renderer/components/node/Node.tsx
@@ -153,7 +153,7 @@ const NodeInner = memo(({ data, selected }: NodeProps) => {
     };
 
     const startingNode = isStartingNode(schema);
-    const isNewIterator = schema.nodeType === 'newIterator';
+    const isNewIterator = schema.kind === 'newIterator';
     const hasStaticValueInput = schema.inputs.some((i) => i.kind === 'static');
     const reload = useRunNode(
         data,

--- a/src/renderer/components/outputs/DefaultImageOutput.tsx
+++ b/src/renderer/components/outputs/DefaultImageOutput.tsx
@@ -78,7 +78,6 @@ export const DefaultImageOutput = memo(({ output, id, schema, type }: OutputProp
                             data: {
                                 schemaId: VIEW_SCHEMA_ID,
                             },
-                            nodeType: 'regularNode',
                         });
                         createEdge(
                             { nodeId: id, outputId: output.id },

--- a/src/renderer/contexts/ExecutionContext.tsx
+++ b/src/renderer/contexts/ExecutionContext.tsx
@@ -402,7 +402,7 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
         // find iterator nodes for later
         const iteratorNodeIds = new Set(
             nodes
-                .filter((n) => schemata.get(n.data.schemaId).nodeType === 'newIterator')
+                .filter((n) => schemata.get(n.data.schemaId).kind === 'newIterator')
                 .map((n) => n.data.id)
         );
         executingIteratorNodesRef.current = iteratorNodeIds;

--- a/src/renderer/helpers/chainProgress.ts
+++ b/src/renderer/helpers/chainProgress.ts
@@ -43,7 +43,7 @@ export const getInitialChainProgress = (
 
     for (const node of nodes) {
         let weight = 1;
-        if (schemata.get(node.data.schemaId).nodeType === 'newIterator') {
+        if (schemata.get(node.data.schemaId).kind === 'newIterator') {
             // more weight for iterators
             weight = 4;
         }

--- a/src/renderer/helpers/copyAndPaste.ts
+++ b/src/renderer/helpers/copyAndPaste.ts
@@ -120,7 +120,6 @@ export const pasteFromClipboard = (
                                 positionY = (height + y) / 2;
                             }
                             createNode({
-                                nodeType: 'regularNode',
                                 position: screenToFlowPosition({ x: positionX, y: positionY }),
                                 data: {
                                     schemaId: 'chainner:image:load' as SchemaId,

--- a/src/renderer/helpers/dataTransfer.ts
+++ b/src/renderer/helpers/dataTransfer.ts
@@ -54,7 +54,7 @@ export type DataTransferProcessor = (
 
 const chainnerSchemaProcessor: DataTransferProcessor = (
     dataTransfer,
-    { getNodePosition, createNode, schemata }
+    { getNodePosition, createNode }
 ) => {
     if (!dataTransfer.getData(TransferTypes.ChainnerSchema)) return false;
 
@@ -62,12 +62,9 @@ const chainnerSchemaProcessor: DataTransferProcessor = (
         dataTransfer.getData(TransferTypes.ChainnerSchema)
     ) as ChainnerDragData;
 
-    const nodeSchema = schemata.get(schemaId);
-
     createNode({
         position: getNodePosition(offsetX, offsetY),
         data: { schemaId },
-        nodeType: nodeSchema.nodeType,
     });
     return true;
 };
@@ -148,7 +145,6 @@ const openFileProcessor: DataTransferProcessor = (
                             schemaId: schema.schemaId,
                             inputData: { [input.id]: path },
                         },
-                        nodeType: schema.nodeType,
                     });
 
                     return true;

--- a/src/renderer/helpers/nodeState.ts
+++ b/src/renderer/helpers/nodeState.ts
@@ -115,7 +115,7 @@ export const useNodeStateFromData = (data: NodeData): NodeState => {
 
     const chainLineage = useContextSelector(GlobalVolatileContext, (c) => c.chainLineage);
     const [iteratedInputs, iteratedOutputs] = useMemo(() => {
-        if (schema.nodeType === 'regularNode') {
+        if (schema.kind === 'regularNode') {
             // eslint-disable-next-line @typescript-eslint/no-shadow
             const iteratedInputs = new Set<InputId>();
             for (const input of schema.inputs) {

--- a/src/renderer/helpers/reactFlowUtil.ts
+++ b/src/renderer/helpers/reactFlowUtil.ts
@@ -1,5 +1,5 @@
 import { Edge, Node, XYPosition } from 'reactflow';
-import { EdgeData, InputData, Mutable, NodeData, NodeType } from '../../common/common-types';
+import { EdgeData, InputData, Mutable, NodeData } from '../../common/common-types';
 import { SchemaMap } from '../../common/SchemaMap';
 import { createUniqueId, deepCopy } from '../../common/util';
 
@@ -7,16 +7,17 @@ export interface NodeProto {
     id?: string;
     position: Readonly<XYPosition>;
     data: Omit<NodeData, 'id' | 'inputData'> & { inputData?: InputData };
-    nodeType: NodeType;
 }
 
 export const createNode = (
-    { id = createUniqueId(), position, data, nodeType }: NodeProto,
+    { id = createUniqueId(), position, data }: NodeProto,
     schemata: SchemaMap,
     selected = false
 ): Node<NodeData> => {
+    const schema = schemata.get(data.schemaId);
+
     const newNode: Node<Mutable<NodeData>> = {
-        type: nodeType,
+        type: schema.kind,
         id,
         position: { ...position },
         data: {

--- a/src/renderer/hooks/useInputRefactor.tsx
+++ b/src/renderer/hooks/useInputRefactor.tsx
@@ -82,7 +82,6 @@ export const useInputRefactor = (
                             schemaId: valueNodeMap[specificInput.kind],
                             inputData: { [0 as InputId]: value },
                         },
-                        nodeType: 'regularNode',
                     });
                     createEdge(
                         { nodeId: valueNodeId, outputId: 0 as OutputId },

--- a/src/renderer/hooks/usePaneNodeSearchMenu.tsx
+++ b/src/renderer/hooks/usePaneNodeSearchMenu.tsx
@@ -317,7 +317,7 @@ const getConnectionTarget = (
                 downstreamIters.size > 0 ||
                 upstreamIters.size > 0 ||
                 sourceNode?.type === 'newIterator';
-            if (hasIteratorLineage && schema.nodeType === 'newIterator') {
+            if (hasIteratorLineage && schema.kind === 'newIterator') {
                 return undefined;
             }
 
@@ -354,7 +354,7 @@ const getConnectionTarget = (
                 downstreamIters.size > 0 ||
                 upstreamIters.size > 0 ||
                 sourceNode.type === 'newIterator';
-            if (hasIteratorLineage && schema.nodeType === 'newIterator') {
+            if (hasIteratorLineage && schema.kind === 'newIterator') {
                 return undefined;
             }
 
@@ -435,7 +435,6 @@ export const usePaneNodeSearchMenu = (): UsePaneNodeSearchMenuValue => {
                 data: {
                     schemaId: schema.schemaId,
                 },
-                nodeType: schema.nodeType,
             });
             const targetFn = functionDefinitions.get(schema.schemaId);
             if (connectingFrom && targetFn && target.type !== 'none') {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -3,7 +3,7 @@ import { memo, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { EdgeTypes, NodeTypes, ReactFlowProvider } from 'reactflow';
 import { useContext } from 'use-context-selector';
-import { NodeType } from '../common/common-types';
+import { NodeKind } from '../common/common-types';
 import { getLocalStorage, getStorageKeys } from '../common/util';
 import { ChaiNNerLogo } from './components/chaiNNerLogo';
 import { CustomEdge } from './components/CustomEdge/CustomEdge';
@@ -22,7 +22,7 @@ import { SettingsProvider } from './contexts/SettingsContext';
 import { useIpcRendererListener } from './hooks/useIpcRendererListener';
 import { useLastWindowSize } from './hooks/useLastWindowSize';
 
-const nodeTypes: NodeTypes & Record<NodeType, unknown> = {
+const nodeTypes: NodeTypes & Record<NodeKind, unknown> = {
     regularNode: Node,
     newIterator: Node,
     collector: Node,


### PR DESCRIPTION
This implements the renaming we talked about [on discord](https://discord.com/channels/930865462852591648/1078534152464384152/1197997538129739847).

Basically, we agreed that having a `nodeType` property on backend nodes is too easy to confused with the React Flow node type. While these 2 are currently the same (the frontend uses the backend node type to determine the type of RF node), they will not be in the future. To make this distinction more clear, I renamed our current `nodeType` properties to `kind`.

I already removed a few redundant `nodeType` properties on components and objects that also get a schema ID. Since the node kind is a property of the schema, the schema ID can be used to get it.