### PR TITLE
Fix lineage checks in UI

### DIFF
--- a/src/common/nodes/checkNodeValidity.ts
+++ b/src/common/nodes/checkNodeValidity.ts
@@ -159,7 +159,7 @@ export const checkAssignedLineage = (
     const input = schema.inputs.find((i) => i.id === inputId)!;
 
     const differentLineage = () =>
-        invalid('Cannot connect node to 2 different sequences of different origin.');
+        invalid("Cannot connect node to 2 sequences that don't share the same source node.");
     const nonIteratorInput = () =>
         invalid(`Input ${input.label} cannot be connected to a sequence.`);
 

--- a/src/common/nodes/checkNodeValidity.ts
+++ b/src/common/nodes/checkNodeValidity.ts
@@ -160,7 +160,8 @@ export const checkAssignedLineage = (
 
     const differentLineage = () =>
         invalid('Cannot connect node to 2 different sequences of different origin.');
-    const nonIteratorInput = () => invalid(`Input ${input.label} cannot be connected to a sequence.`);
+    const nonIteratorInput = () =>
+        invalid(`Input ${input.label} cannot be connected to a sequence.`);
 
     switch (schema.kind) {
         case 'regularNode': {

--- a/src/common/nodes/checkNodeValidity.ts
+++ b/src/common/nodes/checkNodeValidity.ts
@@ -17,8 +17,8 @@ export interface CheckNodeValidityOptions {
     inputData: InputData;
     connectedInputs: ReadonlySet<InputId>;
     functionInstance: FunctionInstance | undefined;
-    chainLineage?: ChainLineage;
-    nodeId?: string;
+    chainLineage: ChainLineage;
+    nodeId: string;
 }
 export const checkNodeValidity = ({
     schema,
@@ -97,24 +97,22 @@ export const checkNodeValidity = ({
     }
 
     // Lineage check
-    if (chainLineage && nodeId) {
-        for (const input of schema.inputs) {
-            const sourceLineage = chainLineage.getConnectedOutputLineage({
+    for (const input of schema.inputs) {
+        const sourceLineage = chainLineage.getConnectedOutputLineage({
+            nodeId,
+            inputId: input.id,
+        });
+        if (sourceLineage !== undefined) {
+            // eslint-disable-next-line @typescript-eslint/no-use-before-define
+            const lineageValid = checkAssignedLineage(
+                sourceLineage,
                 nodeId,
-                inputId: input.id,
-            });
-            if (sourceLineage !== undefined) {
-                // eslint-disable-next-line @typescript-eslint/no-use-before-define
-                const lineageValid = checkAssignedLineage(
-                    sourceLineage,
-                    nodeId,
-                    input.id,
-                    schema,
-                    chainLineage
-                );
-                if (!lineageValid.isValid) {
-                    return lineageValid;
-                }
+                input.id,
+                schema,
+                chainLineage
+            );
+            if (!lineageValid.isValid) {
+                return lineageValid;
             }
         }
     }

--- a/src/common/nodes/checkNodeValidity.ts
+++ b/src/common/nodes/checkNodeValidity.ts
@@ -160,7 +160,7 @@ export const checkAssignedLineage = (
 
     const differentLineage = () =>
         invalid('Cannot connect node to 2 different sequence of different origin.');
-    const nonIteratorInput = () => invalid(`Input ${input.label} cannot be connect to a sequence.`);
+    const nonIteratorInput = () => invalid(`Input ${input.label} cannot be connected to a sequence.`);
 
     switch (schema.kind) {
         case 'regularNode': {

--- a/src/common/nodes/checkNodeValidity.ts
+++ b/src/common/nodes/checkNodeValidity.ts
@@ -2,8 +2,10 @@ import { Input, InputData, InputId, NodeSchema } from '../common-types';
 import { FunctionInstance } from '../types/function';
 import { generateAssignmentErrorTrace, printErrorTrace, simpleError } from '../types/mismatch';
 import { withoutNull } from '../types/util';
+import { assertNever } from '../util';
 import { VALID, Validity, invalid } from '../Validity';
 import { testInputCondition } from './condition';
+import { ChainLineage, Lineage } from './lineage';
 import { getRequireConditions } from './required';
 
 const formatMissingInputs = (missingInputs: Input[]) => {
@@ -15,12 +17,16 @@ export interface CheckNodeValidityOptions {
     inputData: InputData;
     connectedInputs: ReadonlySet<InputId>;
     functionInstance: FunctionInstance | undefined;
+    chainLineage?: ChainLineage;
+    nodeId?: string;
 }
 export const checkNodeValidity = ({
     schema,
     inputData,
     connectedInputs,
     functionInstance,
+    chainLineage,
+    nodeId,
 }: CheckNodeValidityOptions): Validity => {
     const isOptional = (input: Input): boolean => {
         if (input.kind !== 'generic' || !input.optional) {
@@ -60,6 +66,7 @@ export const checkNodeValidity = ({
         return invalid(formatMissingInputs(missingInputs));
     }
 
+    // Type check
     if (functionInstance) {
         for (const { inputId, assignedType, inputType } of functionInstance.inputErrors) {
             const input = schema.inputs.find((i) => i.id === inputId)!;
@@ -86,6 +93,29 @@ export const checkNodeValidity = ({
         // eslint-disable-next-line no-unreachable-loop
         for (const { message } of functionInstance.outputErrors) {
             return invalid(`Some inputs are incompatible with each other. ${message ?? ''}`);
+        }
+    }
+
+    // Lineage check
+    if (chainLineage && nodeId) {
+        for (const input of schema.inputs) {
+            const sourceLineage = chainLineage.getConnectedOutputLineage({
+                nodeId,
+                inputId: input.id,
+            });
+            if (sourceLineage !== undefined) {
+                // eslint-disable-next-line @typescript-eslint/no-use-before-define
+                const lineageValid = checkAssignedLineage(
+                    sourceLineage,
+                    nodeId,
+                    input.id,
+                    schema,
+                    chainLineage
+                );
+                if (!lineageValid.isValid) {
+                    return lineageValid;
+                }
+            }
         }
     }
 
@@ -117,4 +147,59 @@ export const checkRequiredInputs = (schema: NodeSchema, inputData: InputData): V
         isValid: false,
         reason: formatMissingInputs(missingInputs),
     };
+};
+
+export const checkAssignedLineage = (
+    sourceLineage: Lineage | null,
+    nodeId: string,
+    inputId: InputId,
+    schema: NodeSchema,
+    chainLineage: ChainLineage
+): Validity => {
+    const input = schema.inputs.find((i) => i.id === inputId)!;
+
+    switch (schema.kind) {
+        case 'regularNode': {
+            // regular is auto-iterated, so it has to be treated separately
+            if (sourceLineage) {
+                const targetLineage = chainLineage.getInputLineage(nodeId, {
+                    exclude: new Set([inputId]),
+                });
+                if (targetLineage && !targetLineage.equals(sourceLineage)) {
+                    return invalid('Cannot connect node to 2 different iterators.');
+                }
+            } else {
+                // it's always valid connect a node with no lineage
+            }
+            break;
+        }
+        case 'newIterator': {
+            if (sourceLineage) {
+                return invalid(`Input ${input.label} cannot be connect to an iterator.`);
+            }
+            break;
+        }
+        case 'collector': {
+            const isIterated = schema.iteratorInputs[0].inputs.includes(inputId);
+            if (isIterated) {
+                if (!sourceLineage) {
+                    return invalid(`Input ${input.label} expects an iterator.`);
+                }
+
+                const targetLineage = chainLineage.getInputLineage(nodeId, {
+                    exclude: new Set([inputId]),
+                });
+                if (targetLineage && !targetLineage.equals(sourceLineage)) {
+                    return invalid('Cannot connect node to 2 different iterators.');
+                }
+            } else if (sourceLineage) {
+                return invalid(`Input ${input.label} cannot be connect to an iterator.`);
+            }
+            break;
+        }
+        default:
+            return assertNever(schema.kind);
+    }
+
+    return VALID;
 };

--- a/src/common/nodes/checkNodeValidity.ts
+++ b/src/common/nodes/checkNodeValidity.ts
@@ -159,7 +159,7 @@ export const checkAssignedLineage = (
     const input = schema.inputs.find((i) => i.id === inputId)!;
 
     const differentLineage = () =>
-        invalid('Cannot connect node to 2 different sequence of different origin.');
+        invalid('Cannot connect node to 2 different sequences of different origin.');
     const nonIteratorInput = () => invalid(`Input ${input.label} cannot be connected to a sequence.`);
 
     switch (schema.kind) {

--- a/src/common/nodes/checkNodeValidity.ts
+++ b/src/common/nodes/checkNodeValidity.ts
@@ -17,7 +17,7 @@ export interface CheckNodeValidityOptions {
     inputData: InputData;
     connectedInputs: ReadonlySet<InputId>;
     functionInstance: FunctionInstance | undefined;
-    chainLineage: ChainLineage;
+    chainLineage: ChainLineage | undefined;
     nodeId: string;
 }
 export const checkNodeValidity = ({
@@ -97,22 +97,24 @@ export const checkNodeValidity = ({
     }
 
     // Lineage check
-    for (const input of schema.inputs) {
-        const sourceLineage = chainLineage.getConnectedOutputLineage({
-            nodeId,
-            inputId: input.id,
-        });
-        if (sourceLineage !== undefined) {
-            // eslint-disable-next-line @typescript-eslint/no-use-before-define
-            const lineageValid = checkAssignedLineage(
-                sourceLineage,
+    if (chainLineage) {
+        for (const input of schema.inputs) {
+            const sourceLineage = chainLineage.getConnectedOutputLineage({
                 nodeId,
-                input.id,
-                schema,
-                chainLineage
-            );
-            if (!lineageValid.isValid) {
-                return lineageValid;
+                inputId: input.id,
+            });
+            if (sourceLineage !== undefined) {
+                // eslint-disable-next-line @typescript-eslint/no-use-before-define
+                const lineageValid = checkAssignedLineage(
+                    sourceLineage,
+                    nodeId,
+                    input.id,
+                    schema,
+                    chainLineage
+                );
+                if (!lineageValid.isValid) {
+                    return lineageValid;
+                }
             }
         }
     }

--- a/src/main/cli/run.ts
+++ b/src/main/cli/run.ts
@@ -14,6 +14,7 @@ import { log } from '../../common/log';
 import { checkNodeValidity } from '../../common/nodes/checkNodeValidity';
 import { getConnectedInputs } from '../../common/nodes/connectedInputs';
 import { getEffectivelyDisabledNodes } from '../../common/nodes/disabled';
+import { ChainLineage } from '../../common/nodes/lineage';
 import { parseFunctionDefinitions } from '../../common/nodes/parseFunctionDefinitions';
 import { getNodesWithSideEffects } from '../../common/nodes/sideEffect';
 import { toBackendJson } from '../../common/nodes/toBackendJson';
@@ -154,6 +155,7 @@ const ensureStaticCorrectness = (
 
     const byId = new Map(nodes.map((n) => [n.id, n]));
     const typeState = TypeState.create(byId, edges, new Map(), functionDefinitions);
+    const chainLineage = new ChainLineage(schemata, nodes, edges);
 
     const invalidNodes = nodes.flatMap((node) => {
         const functionInstance = typeState.functions.get(node.data.id);
@@ -164,6 +166,8 @@ const ensureStaticCorrectness = (
             connectedInputs: getConnectedInputs(node.id, edges),
             schema,
             functionInstance,
+            chainLineage,
+            nodeId: node.id,
         });
         if (validity.isValid) return [];
 

--- a/src/renderer/components/NodeDocumentation/NodeExample.tsx
+++ b/src/renderer/components/NodeDocumentation/NodeExample.tsx
@@ -140,6 +140,8 @@ export const NodeExample = memo(({ accentColor, selectedSchema }: NodeExamplePro
         connectedInputs: requiredGenericInputs,
         inputData,
         functionInstance: typeInfo.instance,
+        chainLineage: undefined,
+        nodeId,
     });
 
     const { iteratedInputs, iteratedOutputs } = useMemo(() => {

--- a/src/renderer/contexts/ExecutionContext.tsx
+++ b/src/renderer/contexts/ExecutionContext.tsx
@@ -133,6 +133,7 @@ const useRegisterNodeEvents = (
 export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>) => {
     const {
         typeStateRef,
+        chainLineageRef,
         outputDataActions,
         getInputHash,
         setManualOutputType,
@@ -384,6 +385,8 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
                     connectedInputs: getConnectedInputs(node.id, edges),
                     schema,
                     functionInstance,
+                    chainLineage: chainLineageRef.current,
+                    nodeId: node.id,
                 })
             );
             if (validity.isValid) return [];
@@ -448,6 +451,7 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
         schemata,
         sendAlert,
         typeStateRef,
+        chainLineageRef,
         features,
         featureStates,
         backend,

--- a/src/renderer/helpers/canConnect.ts
+++ b/src/renderer/helpers/canConnect.ts
@@ -1,0 +1,103 @@
+import { checkAssignedLineage } from '../../common/nodes/checkNodeValidity';
+import { EdgeState } from '../../common/nodes/EdgeState';
+import { ChainLineage } from '../../common/nodes/lineage';
+import { TypeState } from '../../common/nodes/TypeState';
+import {
+    generateAssignmentErrorTrace,
+    printErrorTrace,
+    simpleError,
+} from '../../common/types/mismatch';
+import { withoutNull } from '../../common/types/util';
+import { EMPTY_ARRAY, ParsedSourceHandle, ParsedTargetHandle } from '../../common/util';
+import { VALID, Validity, invalid } from '../../common/Validity';
+
+const canReach = (from: string, to: string, edges: EdgeState): boolean => {
+    // DFS
+    const visited = new Set<string>();
+    const stack = [from];
+
+    let current;
+    // eslint-disable-next-line no-cond-assign
+    while ((current = stack.pop())) {
+        if (current === to) return true;
+        if (!visited.has(current)) {
+            visited.add(current);
+
+            for (const edge of edges.byTarget.get(current) ?? EMPTY_ARRAY) {
+                stack.push(edge.source);
+            }
+        }
+    }
+    return false;
+};
+
+/**
+ * Returns whether the connection made between the two handles is valid,
+ * assuming that it replaces any connections to the target handle.
+ */
+export const canConnect = (
+    sourceHandle: ParsedSourceHandle,
+    targetHandle: ParsedTargetHandle,
+    typeState: TypeState,
+    chainLineage: ChainLineage
+): Validity => {
+    const sourceOutputId = sourceHandle.outputId;
+    const targetInputId = targetHandle.inputId;
+
+    // Cycle check
+    if (sourceHandle.nodeId === targetHandle.nodeId) {
+        return invalid('Cannot connect a node to itself.');
+    }
+    if (canReach(sourceHandle.nodeId, targetHandle.nodeId, typeState.edges)) {
+        return invalid('Connection would create an infinite loop.');
+    }
+
+    // Type check
+    const sourceFn = typeState.functions.get(sourceHandle.nodeId);
+    const targetFn = typeState.functions.get(targetHandle.nodeId);
+
+    if (!sourceFn || !targetFn) {
+        return invalid('Invalid connection data.');
+    }
+
+    const targetSchema = targetFn.definition.schema;
+
+    const outputType = sourceFn.outputs.get(sourceOutputId);
+    if (outputType !== undefined && !targetFn.canAssign(targetInputId, outputType)) {
+        const schema = targetSchema;
+        const input = schema.inputs.find((i) => i.id === targetInputId)!;
+        const inputType = withoutNull(targetFn.definition.inputDefaults.get(targetInputId)!);
+
+        const error = simpleError(outputType, inputType);
+        if (error) {
+            return invalid(
+                `Input ${input.label} requires ${error.definition} but would be connected with ${error.assigned}.`
+            );
+        }
+
+        const traceTree = generateAssignmentErrorTrace(outputType, inputType);
+        if (!traceTree) throw new Error('Cannot determine assignment error');
+        const trace = printErrorTrace(traceTree);
+        return invalid(
+            `Input ${input.label} cannot be connected with an incompatible value. ${trace.join(
+                ' '
+            )}`
+        );
+    }
+
+    // Iterator lineage check
+    const sourceLineage = chainLineage.getOutputLineage(sourceHandle);
+    const lineageValid = checkAssignedLineage(
+        sourceLineage,
+        targetHandle.nodeId,
+        targetHandle.inputId,
+        targetSchema,
+        chainLineage
+    );
+    if (!lineageValid.isValid) {
+        return lineageValid;
+    }
+
+    // all checks passed
+    return VALID;
+};

--- a/src/renderer/helpers/nodeState.ts
+++ b/src/renderer/helpers/nodeState.ts
@@ -15,7 +15,7 @@ import {
 import { IdSet } from '../../common/IdSet';
 import { testInputCondition } from '../../common/nodes/condition';
 import { FunctionInstance } from '../../common/types/function';
-import { EMPTY_ARRAY, EMPTY_SET, parseSourceHandle } from '../../common/util';
+import { EMPTY_ARRAY, EMPTY_SET } from '../../common/util';
 import { BackendContext } from '../contexts/BackendContext';
 import { GlobalContext, GlobalVolatileContext } from '../contexts/GlobalNodeState';
 import { useMemoObject } from '../hooks/useMemo';
@@ -119,14 +119,11 @@ export const useNodeStateFromData = (data: NodeData): NodeState => {
             // eslint-disable-next-line @typescript-eslint/no-shadow
             const iteratedInputs = new Set<InputId>();
             for (const input of schema.inputs) {
-                const edge = chainLineage.getEdgeByTarget({ nodeId: id, inputId: input.id });
-                // eslint-disable-next-line no-continue
-                if (!edge) continue;
-
-                const inputLineage = chainLineage.getOutputLineage(
-                    parseSourceHandle(edge.sourceHandle!)
-                );
-                if (inputLineage !== null) {
+                const inputLineage = chainLineage.getConnectedOutputLineage({
+                    nodeId: id,
+                    inputId: input.id,
+                });
+                if (inputLineage != null) {
                     iteratedInputs.add(input.id);
                 }
             }

--- a/src/renderer/hooks/useValidity.ts
+++ b/src/renderer/hooks/useValidity.ts
@@ -20,6 +20,7 @@ export const useValidity = (id: string, schema: NodeSchema, inputData: InputData
     const functionInstance = useContextSelector(GlobalVolatileContext, (c) =>
         c.typeState.functions.get(id)
     );
+    const chainLineage = useContextSelector(GlobalVolatileContext, (c) => c.chainLineage);
     const { getEdges } = useReactFlow<NodeData, EdgeData>();
 
     const alwaysValid = schema.inputs.length === 0;
@@ -40,10 +41,12 @@ export const useValidity = (id: string, schema: NodeSchema, inputData: InputData
                     inputData,
                     connectedInputs: getConnectedInputs(id, getEdges()),
                     functionInstance,
+                    chainLineage,
+                    nodeId: id,
                 })
             );
         }
-    }, [alwaysValid, id, schema, inputData, edgeChanges, getEdges, functionInstance]);
+    }, [alwaysValid, id, schema, inputData, edgeChanges, getEdges, functionInstance, chainLineage]);
 
     // The problem with `checkNodeValidity` is that is must be computed with a delay due to
     // `getEdges`. This means that the full validity we return here might be outdated. This is a


### PR DESCRIPTION
Fixes #2266.

This PR fixes the lineage checks for nodes. They should just work now, even in more difficult cases. I also added lineage checks to `checkNodeValidity` which ensures that a chain with invalid lineage never makes it to the backend. This also means that we now see lineage errors in the footer.

Note: It is still possible to create invalid connections using the context node selector. I haven't touched that part of the code yet. However, invalid connections will be correctly detected as such. I'll fix the context selector in a follow-up PR.

Examples:
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/26a03d36-3b13-4fa7-8051-85d006780814)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/269a7e62-6d1f-4586-8d97-b3753531b12c)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/081f0033-fb31-4276-8f6e-9fda845d47f3)
