### PR TITLE
Fixed iterator limit and improved output types

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/load_image_pairs.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/load_image_pairs.py
@@ -30,7 +30,7 @@ from ..io.load_image import load_image_node
         DirectoryInput("Directory B"),
         BoolInput("Use limit", default=False),
         if_group(Condition.bool(2, True))(
-            NumberInput("Limit", default=10).with_docs(
+            NumberInput("Limit", default=10, minimum=1).with_docs(
                 "Limit the number of images to iterate over. This can be useful for testing the iterator without having to iterate over all images."
             )
         ),
@@ -42,15 +42,16 @@ from ..io.load_image import load_image_node
     outputs=[
         ImageOutput("Image A"),
         ImageOutput("Image B"),
-        DirectoryOutput("Directory A"),
-        DirectoryOutput("Directory B"),
+        DirectoryOutput("Directory A", output_type="Input0"),
+        DirectoryOutput("Directory B", output_type="Input1"),
         TextOutput("Subdirectory Path A"),
         TextOutput("Subdirectory Path B"),
         TextOutput("Image Name A"),
         TextOutput("Image Name B"),
-        NumberOutput("Index", output_type="uint").with_docs(
-            "A counter that starts at 0 and increments by 1 for each image."
-        ),
+        NumberOutput(
+            "Index",
+            output_type="if Input2 { min(uint, Input3 - 1) } else { uint }",
+        ).with_docs("A counter that starts at 0 and increments by 1 for each image."),
     ],
     iterator_outputs=IteratorOutputInfo(outputs=[0, 1, 4, 5, 6, 7, 8]),
     kind="newIterator",

--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/load_images.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/load_images.py
@@ -66,7 +66,7 @@ def list_glob(directory: str, globexpr: str, ext_filter: list[str]) -> list[str]
         ),
         BoolInput("Use limit", default=False),
         if_group(Condition.bool(4, True))(
-            NumberInput("Limit", default=10).with_docs(
+            NumberInput("Limit", default=10, minimum=1).with_docs(
                 "Limit the number of images to iterate over. This can be useful for testing the iterator without having to iterate over all images."
             )
         ),

--- a/backend/src/packages/chaiNNer_standard/image/video_frames/load_video.py
+++ b/backend/src/packages/chaiNNer_standard/image/video_frames/load_video.py
@@ -38,7 +38,7 @@ ffprobe_path = os.environ.get("STATIC_FFPROBE_PATH", "ffprobe")
         VideoFileInput(primary_input=True),
         BoolInput("Use limit", default=False),
         if_group(Condition.bool(1, True))(
-            NumberInput("Limit", default=10).with_docs(
+            NumberInput("Limit", default=10, minimum=1).with_docs(
                 "Limit the number of frames to iterate over. This can be useful for testing the iterator without having to iterate over all frames of the video."
                 " Will not copy audio if limit is used."
             )


### PR DESCRIPTION
I fixed the iteration limit of all iterator source nodes with limits and improved the output types of Load Image Pairs.