### PR TITLE
Allow handles for Merge Spritesheet number inputs

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/merge_spritesheet.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/merge_spritesheet.py
@@ -23,7 +23,6 @@ from .. import batch_processing_group
             controls_step=1,
             minimum=1,
             default=1,
-            has_handle=False,
         ).with_docs(
             "The number of rows to split the image into. The height of the image must be a multiple of this number."
         ),
@@ -32,7 +31,6 @@ from .. import batch_processing_group
             controls_step=1,
             minimum=1,
             default=1,
-            has_handle=False,
         ).with_docs(
             "The number of columns to split the image into. The width of the image must be a multiple of this number."
         ),


### PR DESCRIPTION
They were likely disabled due to bugs in the old simplified lineage code, but this is no longer a concern.

Example of why this is useful:
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/42397d33-ee66-4567-8884-9d763a66309b)
