### PR TITLE
Rename "Strengthen Normals" to "Scale Normals"

### DIFF
--- a/backend/src/packages/chaiNNer_standard/material_textures/normal_map/scale_normals.py
+++ b/backend/src/packages/chaiNNer_standard/material_textures/normal_map/scale_normals.py
@@ -13,9 +13,9 @@ from .. import normal_map_group
 
 @normal_map_group.register(
     schema_id="chainner:image:strengthen_normals",
-    name="Strengthen Normals",
+    name="Scale Normals",
     description=[
-        "Strengths and weakens the normals in the given normal map. Only the R and G channels of the input image will be used. The output normal map is guaranteed to be normalized.",
+        "Strengths or weakens the normals in the given normal map. Only the R and G channels of the input image will be used. The output normal map is guaranteed to be normalized.",
         "Conceptually, this node is equivalent to `chainner:image:add_normals` with the strength of the second normal map set to 0.",
     ],
     icon="MdExpand",
@@ -36,7 +36,7 @@ from .. import normal_map_group
         ),
     ],
 )
-def strengthen_normals_node(
+def scale_normals_node(
     n: np.ndarray, strength: int, method: AdditionMethod
 ) -> np.ndarray:
     return xyz_to_bgr(strengthen_normals(method, n, strength / 100))


### PR DESCRIPTION
I renamed the node because I wanted it to be as wide as other nodes. I didn't like the wise aesthetic.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/a06522a7-ca92-47ef-b36b-f81d1847c051)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/7dd5e369-f039-439a-b195-85d575d9d1d2)
