### PR TITLE
New inline label design for number, text, and dropdown inputs

### DIFF
--- a/backend/src/nodes/properties/inputs/file_inputs.py
+++ b/backend/src/nodes/properties/inputs/file_inputs.py
@@ -7,6 +7,7 @@ from api import BaseInput
 
 # pylint: disable=relative-beyond-top-level
 from ...impl.image_formats import get_available_image_formats
+from .label import LabelStyle
 
 FileInputKind = Union[
     Literal["bin"],
@@ -115,7 +116,7 @@ class DirectoryInput(BaseInput):
         label: str = "Directory",
         has_handle: bool = True,
         must_exist: bool = True,
-        hide_label: bool = False,
+        label_style: LabelStyle = "default",
     ):
         super().__init__("Directory", label, kind="directory", has_handle=has_handle)
 
@@ -127,14 +128,14 @@ class DirectoryInput(BaseInput):
         """
 
         self.must_exist: bool = must_exist
-        self.hide_label: bool = hide_label
+        self.label_style: LabelStyle = label_style
 
         self.associated_type = str
 
     def to_dict(self):
         return {
             **super().to_dict(),
-            "hideLabel": self.hide_label,
+            "labelStyle": self.label_style,
         }
 
     def enforce(self, value: object):

--- a/backend/src/nodes/properties/inputs/generic_inputs.py
+++ b/backend/src/nodes/properties/inputs/generic_inputs.py
@@ -25,6 +25,7 @@ from ...utils.utils import (
     split_pascal_case,
     split_snake_case,
 )
+from .label import LabelStyle
 from .numeric_inputs import NumberInput
 
 
@@ -78,6 +79,7 @@ class DropDownInput(BaseInput):
         options: list[DropDownOption],
         default_value: str | int | None = None,
         preferred_style: DropDownStyle = "dropdown",
+        label_style: LabelStyle = "default",
         groups: list[DropDownGroup] | None = None,
         associated_type: Any = None,
     ):
@@ -88,6 +90,7 @@ class DropDownInput(BaseInput):
             default_value if default_value is not None else options[0]["value"]
         )
         self.preferred_style: DropDownStyle = preferred_style
+        self.label_style: LabelStyle = label_style
         self.groups: list[DropDownGroup] = groups or []
 
         if self.default not in self.accepted_values:
@@ -106,6 +109,7 @@ class DropDownInput(BaseInput):
             "options": self.options,
             "def": self.default,
             "preferredStyle": self.preferred_style,
+            "labelStyle": self.label_style,
             "groups": [c.to_dict() for c in self.groups],
         }
 
@@ -177,6 +181,7 @@ class EnumInput(Generic[T], DropDownInput):
         option_labels: dict[T, str] | None = None,
         extra_definitions: str | None = None,
         preferred_style: DropDownStyle = "dropdown",
+        label_style: LabelStyle = "default",
         categories: list[DropDownGroup] | None = None,
     ):
         if type_name is None:
@@ -210,6 +215,7 @@ class EnumInput(Generic[T], DropDownInput):
             options=options,
             default_value=default.value if default is not None else None,
             preferred_style=preferred_style,
+            label_style=label_style,
             groups=categories,
         )
 
@@ -241,7 +247,7 @@ class TextInput(BaseInput):
         multiline: bool = False,
         allow_numbers: bool = True,
         default: str | None = None,
-        hide_label: bool = False,
+        label_style: LabelStyle = "default",
         allow_empty_string: bool = False,
     ):
         super().__init__(
@@ -255,7 +261,7 @@ class TextInput(BaseInput):
         self.placeholder = placeholder
         self.default = default
         self.multiline = multiline
-        self.hide_label = hide_label
+        self.label_style: LabelStyle = label_style
         self.allow_empty_string = allow_empty_string
 
         if default is not None:
@@ -294,7 +300,7 @@ class TextInput(BaseInput):
             "placeholder": self.placeholder,
             "multiline": self.multiline,
             "def": self.default,
-            "hideLabel": self.hide_label,
+            "labelStyle": self.label_style,
             "allowEmptyString": self.allow_empty_string,
         }
 
@@ -335,6 +341,7 @@ class SeedInput(NumberInput):
             maximum=None,
             precision=0,
             default=0,
+            label_style="default",
         )
         self.has_handle = has_handle
 
@@ -461,6 +468,7 @@ def VideoFfv1ContainerDropdown() -> DropDownInput:
     return DropDownInput(
         input_type="VideoContainer",
         label="Container",
+        label_style="inline",
         options=[
             {"option": VIDEO_CONTAINERS[vc], "value": vc.value}
             for vc in VIDEO_FFV1_CONTAINERS
@@ -480,6 +488,7 @@ def VideoVp9ContainerDropdown() -> DropDownInput:
     return DropDownInput(
         input_type="VideoContainer",
         label="Container",
+        label_style="inline",
         options=[
             {"option": VIDEO_CONTAINERS[vc], "value": vc.value}
             for vc in VIDEO_VP9_CONTAINERS
@@ -500,6 +509,7 @@ def VideoH264ContainerDropdown() -> DropDownInput:
     return DropDownInput(
         input_type="VideoContainer",
         label="Container",
+        label_style="inline",
         options=[
             {"option": VIDEO_CONTAINERS[vc], "value": vc.value}
             for vc in VIDEO_H264_CONTAINERS
@@ -519,6 +529,7 @@ def VideoH265ContainerDropdown() -> DropDownInput:
     return DropDownInput(
         input_type="VideoContainer",
         label="Container",
+        label_style="inline",
         options=[
             {"option": VIDEO_CONTAINERS[vc], "value": vc.value}
             for vc in VIDEO_H265_CONTAINERS
@@ -546,6 +557,7 @@ def VideoEncoderDropdown() -> DropDownInput:
     return DropDownInput(
         input_type="VideoEncoder",
         label="Encoder",
+        label_style="inline",
         options=[
             {"option": label, "value": vc.value}
             for vc, label in VIDEO_ENCODER_LABELS.items()
@@ -560,6 +572,7 @@ def VideoPresetDropdown() -> DropDownInput:
     return DropDownInput(
         input_type="VideoPreset",
         label="Preset",
+        label_style="inline",
         options=[
             {"option": "ultrafast", "value": "ultrafast"},
             {"option": "superfast", "value": "superfast"},

--- a/backend/src/nodes/properties/inputs/label.py
+++ b/backend/src/nodes/properties/inputs/label.py
@@ -1,0 +1,7 @@
+from typing import Literal
+
+LabelStyle = Literal["default", "hidden", "inline"]
+
+
+def get_default_label_style(label: str) -> LabelStyle:
+    return "inline" if len(label) <= 8 else "default"

--- a/backend/src/nodes/properties/inputs/numeric_inputs.py
+++ b/backend/src/nodes/properties/inputs/numeric_inputs.py
@@ -7,6 +7,7 @@ import navi
 from api import BaseInput, InputConversion, InputKind
 
 from ...utils.utils import round_half_up
+from .label import LabelStyle, get_default_label_style
 
 
 def clamp_number(
@@ -57,7 +58,7 @@ class NumberInput(BaseInput):
         note_expression: str | None = None,
         kind: InputKind = "number",
         hide_trailing_zeros: bool = True,
-        hide_label: bool = False,
+        label_style: LabelStyle | None = None,
         has_handle: bool = True,
     ):
         super().__init__("number", label, kind=kind, has_handle=has_handle)
@@ -72,7 +73,7 @@ class NumberInput(BaseInput):
         self.unit = unit
         self.note_expression = note_expression
         self.hide_trailing_zeros = hide_trailing_zeros
-        self.hide_label = hide_label
+        self.label_style: LabelStyle = label_style or get_default_label_style(label)
 
         self.associated_type = float if precision > 0 else int
 
@@ -95,7 +96,7 @@ class NumberInput(BaseInput):
             "controlsStep": self.controls_step,
             "unit": self.unit,
             "hideTrailingZeros": self.hide_trailing_zeros,
-            "hideLabel": self.hide_label,
+            "labelStyle": self.label_style,
             "hasHandle": self.has_handle,
         }
 

--- a/backend/src/packages/chaiNNer_standard/image/video_frames/save_video.py
+++ b/backend/src/packages/chaiNNer_standard/image/video_frames/save_video.py
@@ -134,7 +134,7 @@ class Writer:
             TextInput(
                 "Additional parameters",
                 multiline=True,
-                hide_label=True,
+                label_style="hidden",
                 allow_empty_string=True,
                 has_handle=False,
             )

--- a/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize.py
@@ -44,7 +44,7 @@ class ImageResizeMode(Enum):
                 controls_step=25.0,
                 default=100.0,
                 unit="%",
-                hide_label=True,
+                label_style="hidden",
             ).with_id(2),
         ),
         if_enum_group(1, ImageResizeMode.ABSOLUTE)(

--- a/backend/src/packages/chaiNNer_standard/material_textures/normal_map/convert_normals.py
+++ b/backend/src/packages/chaiNNer_standard/material_textures/normal_map/convert_normals.py
@@ -32,6 +32,7 @@ from .. import normal_map_group
         EnumInput(
             NormalMapType,
             label="From",
+            label_style="inline",
             default=NormalMapType.DIRECTX,
             option_labels={
                 NormalMapType.DIRECTX: "DirectX",
@@ -41,6 +42,7 @@ from .. import normal_map_group
         EnumInput(
             NormalMapType,
             label="To",
+            label_style="inline",
             default=NormalMapType.OPENGL,
             option_labels={
                 NormalMapType.DIRECTX: "DirectX",

--- a/backend/src/packages/chaiNNer_standard/material_textures/normal_map/normalize_normals.py
+++ b/backend/src/packages/chaiNNer_standard/material_textures/normal_map/normalize_normals.py
@@ -30,7 +30,9 @@ class BChannel(Enum):
     icon="MdOutlineAutoFixHigh",
     inputs=[
         ImageInput("Normal Map", channels=[3, 4]),
-        EnumInput(BChannel, "Output B", default=BChannel.Z).with_docs(
+        EnumInput(
+            BChannel, "Output B", label_style="inline", default=BChannel.Z
+        ).with_docs(
             "Determines the content of the B channel of the output normal map.",
             "- `Z`: Unlike the X and Y components which are in range [-1, 1], the Z component is guaranteed to be in the range [0, 1]. This allows us to directly use the Z component as the B channel.",
             "- `Z Mapped`: Just like the X and Y components, the Z component will be mapped to [0, 1] and stored as the B channel. Since the Z component is always >= 0, the B channel will be in the range [0.5, 1] ([128, 255])",

--- a/backend/src/packages/chaiNNer_standard/utility/random/random_number.py
+++ b/backend/src/packages/chaiNNer_standard/utility/random/random_number.py
@@ -15,12 +15,12 @@ from .. import random_group
     icon="MdCalculate",
     inputs=[
         NumberInput(
-            "Minimum Value",
+            "Min",
             minimum=None,
             maximum=None,
         ),
         NumberInput(
-            "Maximum Value",
+            "Max",
             minimum=None,
             maximum=None,
             default=100,

--- a/backend/src/packages/chaiNNer_standard/utility/text/note.py
+++ b/backend/src/packages/chaiNNer_standard/utility/text/note.py
@@ -15,7 +15,7 @@ from .. import text_group
             label="Note Text",
             multiline=True,
             has_handle=False,
-            hide_label=True,
+            label_style="hidden",
         ).make_optional(),
     ],
     outputs=[],

--- a/backend/src/packages/chaiNNer_standard/utility/value/directory.py
+++ b/backend/src/packages/chaiNNer_standard/utility/value/directory.py
@@ -13,7 +13,7 @@ from .. import value_group
     icon="BsFolder",
     inputs=[
         DirectoryInput(
-            "Directory", must_exist=False, hide_label=True, has_handle=True
+            "Directory", must_exist=False, label_style="hidden", has_handle=True
         ).make_fused(),
     ],
     outputs=[

--- a/backend/src/packages/chaiNNer_standard/utility/value/number.py
+++ b/backend/src/packages/chaiNNer_standard/utility/value/number.py
@@ -18,7 +18,7 @@ from .. import value_group
             maximum=None,
             precision=100,
             controls_step=1,
-            hide_label=True,
+            label_style="hidden",
         ).make_fused(),
     ],
     outputs=[

--- a/backend/src/packages/chaiNNer_standard/utility/value/parse_number.py
+++ b/backend/src/packages/chaiNNer_standard/utility/value/parse_number.py
@@ -12,7 +12,7 @@ from .. import value_group
     description="Parses text to base-10.",
     icon="MdCalculate",
     inputs=[
-        TextInput("Text"),
+        TextInput("Text", label_style="inline"),
         NumberInput("Base", default=10, minimum=2, maximum=36),
     ],
     outputs=[

--- a/backend/src/packages/chaiNNer_standard/utility/value/text.py
+++ b/backend/src/packages/chaiNNer_standard/utility/value/text.py
@@ -13,7 +13,7 @@ from .. import value_group
     icon="MdTextFields",
     inputs=[
         TextInput(
-            "Text", min_length=0, hide_label=True, allow_empty_string=True
+            "Text", min_length=0, label_style="hidden", allow_empty_string=True
         ).make_fused(),
     ],
     outputs=[

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -71,6 +71,7 @@ export interface DropdownGroup {
     readonly label?: string | null;
     readonly startAt: InputSchemaValue;
 }
+export type LabelStyle = 'default' | 'inline' | 'hidden';
 
 export interface GenericInput extends InputBase {
     readonly kind: 'generic';
@@ -80,6 +81,7 @@ export interface DropDownInput extends InputBase {
     readonly def: string | number;
     readonly options: readonly InputOption[];
     readonly preferredStyle: DropDownStyle;
+    readonly labelStyle: LabelStyle;
     readonly groups: readonly DropdownGroup[];
 }
 export interface FileInput extends InputBase {
@@ -90,7 +92,7 @@ export interface FileInput extends InputBase {
 }
 export interface DirectoryInput extends InputBase {
     readonly kind: 'directory';
-    readonly hideLabel: boolean;
+    readonly labelStyle: LabelStyle;
 }
 export interface TextInput extends InputBase {
     readonly kind: 'text';
@@ -100,7 +102,7 @@ export interface TextInput extends InputBase {
     readonly placeholder?: string | null;
     readonly def?: string | null;
     readonly allowEmptyString?: boolean;
-    readonly hideLabel: boolean;
+    readonly labelStyle: LabelStyle | undefined;
 }
 export interface NumberInput extends InputBase {
     readonly kind: 'number';
@@ -112,7 +114,7 @@ export interface NumberInput extends InputBase {
     readonly unit?: string | null;
     readonly noteExpression?: string | null;
     readonly hideTrailingZeros: boolean;
-    readonly hideLabel: boolean;
+    readonly labelStyle: LabelStyle;
 }
 export interface SliderInput extends InputBase {
     readonly kind: 'slider';

--- a/src/renderer/components/inputs/DirectoryInput.tsx
+++ b/src/renderer/components/inputs/DirectoryInput.tsx
@@ -19,7 +19,7 @@ import { getFields, isDirectory } from '../../../common/types/util';
 import { useContextMenu } from '../../hooks/useContextMenu';
 import { useInputRefactor } from '../../hooks/useInputRefactor';
 import { useLastDirectory } from '../../hooks/useLastDirectory';
-import { MaybeLabel } from './InputContainer';
+import { AutoLabel } from './InputContainer';
 import { InputProps } from './props';
 
 const getDirectoryPath = (type: Type): string | undefined => {
@@ -101,7 +101,7 @@ export const DirectoryInput = memo(
         ));
 
         return (
-            <MaybeLabel input={input}>
+            <AutoLabel input={input}>
                 <Tooltip
                     borderRadius={8}
                     label={displayDirectory}
@@ -126,6 +126,7 @@ export const DirectoryInput = memo(
                             cursor="pointer"
                             disabled={isLocked || isConnected}
                             draggable={false}
+                            htmlSize={1}
                             placeholder="Click to select..."
                             size="sm"
                             textOverflow="ellipsis"
@@ -135,7 +136,7 @@ export const DirectoryInput = memo(
                         />
                     </InputGroup>
                 </Tooltip>
-            </MaybeLabel>
+            </AutoLabel>
         );
     }
 );

--- a/src/renderer/components/inputs/DropDownInput.tsx
+++ b/src/renderer/components/inputs/DropDownInput.tsx
@@ -5,7 +5,7 @@ import { Markdown } from '../Markdown';
 import { Checkbox } from './elements/Checkbox';
 import { DropDown } from './elements/Dropdown';
 import { TabList } from './elements/TabList';
-import { WithLabel, WithoutLabel } from './InputContainer';
+import { AutoLabel, WithoutLabel } from './InputContainer';
 import { InputProps } from './props';
 
 type DropDownInputProps = InputProps<'dropdown', string | number>;
@@ -68,7 +68,7 @@ export const DropDownInput = memo(({ value, setValue, input, isLocked }: DropDow
     }
 
     return (
-        <WithLabel input={input}>
+        <AutoLabel input={input}>
             <DropDown
                 groups={groups}
                 isDisabled={isLocked}
@@ -77,6 +77,6 @@ export const DropDownInput = memo(({ value, setValue, input, isLocked }: DropDow
                 value={value}
                 onChange={setValue}
             />
-        </WithLabel>
+        </AutoLabel>
     );
 });

--- a/src/renderer/components/inputs/NumberInput.tsx
+++ b/src/renderer/components/inputs/NumberInput.tsx
@@ -8,7 +8,7 @@ import { areApproximatelyEqual } from '../../../common/util';
 import { useContextMenu } from '../../hooks/useContextMenu';
 import { useInputRefactor } from '../../hooks/useInputRefactor';
 import { AdvancedNumberInput } from './elements/AdvanceNumberInput';
-import { MaybeLabel } from './InputContainer';
+import { AutoLabel } from './InputContainer';
 import { InputProps } from './props';
 
 export const NumberInput = memo(
@@ -83,7 +83,7 @@ export const NumberInput = memo(
         ));
 
         return (
-            <MaybeLabel input={input}>
+            <AutoLabel input={input}>
                 <HStack w="full">
                     <AdvancedNumberInput
                         controlsStep={controlsStep}
@@ -100,7 +100,7 @@ export const NumberInput = memo(
                         onContextMenu={menu.onContextMenu}
                     />
                 </HStack>
-            </MaybeLabel>
+            </AutoLabel>
         );
     }
 );

--- a/src/renderer/components/inputs/TextInput.tsx
+++ b/src/renderer/components/inputs/TextInput.tsx
@@ -12,7 +12,7 @@ import { typeToString } from '../../helpers/naviHelpers';
 import { useContextMenu } from '../../hooks/useContextMenu';
 import { useInputRefactor } from '../../hooks/useInputRefactor';
 import { DragHandleSVG } from '../CustomIcons';
-import { MaybeLabel } from './InputContainer';
+import { AutoLabel } from './InputContainer';
 import { InputProps } from './props';
 
 const DEFAULT_SIZE = { width: 240, height: 80 };
@@ -200,6 +200,7 @@ export const TextInput = memo(
                     className="nodrag"
                     disabled={isLocked || isConnected}
                     draggable={false}
+                    htmlSize={1}
                     maxLength={maxLength ?? undefined}
                     placeholder={placeholder ?? label}
                     size="sm"
@@ -214,6 +215,6 @@ export const TextInput = memo(
             );
         }
 
-        return <MaybeLabel input={input}>{inputElement}</MaybeLabel>;
+        return <AutoLabel input={input}>{inputElement}</AutoLabel>;
     }
 );


### PR DESCRIPTION
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/faf3577c-f57f-4f2d-8a13-a50f16470266)

What we talked about on discord.

I replaced the `hide_label: bool` option many inputs had with a `label_style: "default" | "inline" | "hidden"`. This allows us to select how we want to display the label in the UI. The defaults for text and dropdown inputs are just as before. Number input will use "inline" when the label is short enough and "default" otherwise. 

I also changed a few nodes to take advantage of the new design.

**DO NOT MERGE** until after the next patch release. I'm sure that we'll find some bugs, so I would like to avoid having users find them.