### PR TITLE
Fix load error messages not having a stack trace

### DIFF
--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -572,8 +572,9 @@ async def import_packages(
         import_errors: list[api.LoadErrorInfo] = []
         for e in load_errors:
             if not isinstance(e.error, ModuleNotFoundError):
-                logger.warning(f"Failed to load {e.module} ({e.file}):")
-                logger.warning(e.error)
+                logger.warning(
+                    f"Failed to load {e.module} ({e.file}):", exc_info=e.error
+                )
             else:
                 import_errors.append(e)
 


### PR DESCRIPTION
While implementing #2507, I forgot the `iterator_inputs=IteratorInputInfo(inputs=0)` which prevented the node from loading. Those were the errors messages that were logged:

```
[2024-01-24 16:10:11 +0100] [8492] [WARNING] Failed to load packages.chaiNNer_standard.utility.math.accumulate (C:\Users\micha\Git\chaiNNer\backend\src\packages\chaiNNer_standard\utility\math\accumulate.py):
[2024-01-24 16:10:11 +0100] [8492] [WARNING]
```

Pretty useless. No message, not even a stack trace. Turns out that `logger.warning(e.error)` only logs the error message but never the stack trace. So I used `exc_info=e.error` to get the stack trace. 

The full error with stack trace was this btw:

```
[2024-01-24 16:12:59 +0100] [1608] [WARNING] Failed to load packages.chaiNNer_standard.utility.math.accumulate (C:\Users\micha\Git\chaiNNer\backend\src\packages\chaiNNer_standard\utility\math\accumulate.py):
Traceback (most recent call last):
  File "C:\Users\micha\Git\chaiNNer\backend\src\api\api.py", line 477, in load_nodes
    importlib.import_module(module, package=None)
  File "C:\Python38\lib\importlib\__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "C:\Users\micha\Git\chaiNNer\backend\src\packages\chaiNNer_standard\utility\math\accumulate.py", line 44, in <module>
    @math_group.register(
  File "C:\Users\micha\Git\chaiNNer\backend\src\api\api.py", line 223, in register
    assert len(iterator_inputs) == 1 and len(iterator_outputs) == 0
AssertionError
```