### PR TITLE
Add edge detection node

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/edge_detection.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/edge_detection.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+from enum import Enum
+
+import cv2
+import numpy as np
+
+from nodes.groups import if_enum_group
+from nodes.impl.image_utils import fast_gaussian_blur
+from nodes.properties.inputs import EnumInput, ImageInput, SliderInput
+from nodes.properties.outputs import ImageOutput
+from nodes.utils.utils import get_h_w_c
+
+from .. import miscellaneous_group
+
+
+class Algorithm(Enum):
+    SOBEL = 1
+    SCHARR = 2
+    GRADIENT = 3
+    DIFFERENTIAL = 4
+    ROBERTS = 5
+    PREWITT_COMPASS = 6
+    LAPLACIAN = 7
+    LAPLACIAN_DENOISE = 8
+    DIFFERENCE_OF_GAUSSIAN = 9
+
+
+class GradientComponent(Enum):
+    MAGNITUDE = 1
+    X = 2
+    Y = 3
+
+
+FILTER_X: dict[Algorithm, np.ndarray] = {
+    Algorithm.SOBEL: (
+        0.25
+        * np.array(
+            [
+                [-1, 0, +1],
+                [-2, 0, +2],
+                [-1, 0, +1],
+            ]
+        ).astype(np.float32)
+    ),
+    Algorithm.SCHARR: (
+        (1 / 256)
+        * np.array(
+            [
+                [-47, 0, +47],
+                [-162, 0, +162],
+                [-47, 0, +47],
+            ]
+        ).astype(np.float32)
+    ),
+    Algorithm.GRADIENT: (
+        np.array(
+            [
+                [0, 0, 0],
+                [-1, 1, 0],
+                [0, 0, 0],
+            ]
+        ).astype(np.float32)
+    ),
+    Algorithm.DIFFERENTIAL: (
+        0.5
+        * np.array(
+            [
+                [0, 0, 0],
+                [0, -1, +1],
+                [0, -1, +1],
+            ]
+        ).astype(np.float32)
+    ),
+    Algorithm.ROBERTS: (
+        np.array(
+            [
+                [0, 0, 0],
+                [0, +1, 0],
+                [0, 0, -1],
+            ]
+        ).astype(np.float32)
+    ),
+}
+
+FILTER_Y: dict[Algorithm, np.ndarray] = {
+    Algorithm.DIFFERENTIAL: (
+        0.5
+        * np.array(
+            [
+                [0, 0, 0],
+                [0, +1, +1],
+                [0, -1, -1],
+            ]
+        ).astype(np.float32)
+    ),
+    Algorithm.ROBERTS: (
+        np.array(
+            [
+                [0, 0, 0],
+                [0, 0, +1],
+                [0, -1, 0],
+            ]
+        ).astype(np.float32)
+    ),
+}
+
+LAPLACE_KERNEL = 0.25 * np.array(
+    [
+        [1, 1, 1],
+        [1, -8, 1],
+        [1, 1, 1],
+    ]
+).astype(np.float32)
+
+
+@miscellaneous_group.register(
+    schema_id="chainner:image:edge_detection",
+    name="Edge Detection",
+    description=(
+        "Detect the edges of the input image with a variety of algorithms. The output will be the magnitude of the gradient per channel. The alpha channel will be copied from the input image."
+    ),
+    icon="MdAutoFixHigh",
+    inputs=[
+        ImageInput(),
+        EnumInput(Algorithm).with_id(1),
+        if_enum_group(
+            1,
+            (
+                Algorithm.SOBEL,
+                Algorithm.SCHARR,
+                Algorithm.GRADIENT,
+                Algorithm.DIFFERENTIAL,
+            ),
+        )(
+            EnumInput(GradientComponent),
+        ),
+        if_enum_group(1, Algorithm.DIFFERENCE_OF_GAUSSIAN)(
+            SliderInput("Radius 1", minimum=0, default=1, maximum=10, precision=3),
+            SliderInput("Radius 2", minimum=0, default=2, maximum=20, precision=3),
+        ),
+        SliderInput(
+            "Amount", minimum=0, default=1, maximum=10, precision=2, scale="log"
+        ),
+    ],
+    outputs=[ImageOutput(image_type="Input0")],
+)
+def edge_detection_node(
+    img: np.ndarray,
+    algorithm: Algorithm,
+    gradient_component: GradientComponent,
+    radius_1: float,
+    radius_2: float,
+    amount: float,
+) -> np.ndarray:
+    c = get_h_w_c(img)[2]
+    alpha = None
+    if c >= 4:
+        alpha = img[:, :, 3:]
+        img = img[:, :, :3]
+
+    if algorithm in (
+        Algorithm.SOBEL,
+        Algorithm.SCHARR,
+        Algorithm.GRADIENT,
+        Algorithm.DIFFERENTIAL,
+        Algorithm.ROBERTS,
+    ):
+        filter_x = FILTER_X[algorithm]
+        filter_y = FILTER_Y.get(algorithm)
+
+        def g_x():
+            return cv2.filter2D(img, -1, filter_x)
+
+        def g_y():
+            filter = filter_y or np.rot90(filter_x, 1)
+            return cv2.filter2D(img, -1, filter)
+
+        if algorithm == Algorithm.ROBERTS:
+            gradient_component = GradientComponent.MAGNITUDE
+
+        if gradient_component == GradientComponent.MAGNITUDE:
+            img = np.hypot(g_x(), g_y()) * (amount / 2)
+        elif gradient_component == GradientComponent.X:
+            img = g_x() * (amount / 2) + 0.5
+        elif gradient_component == GradientComponent.Y:
+            img = g_y() * (amount / 2) + 0.5
+        else:
+            raise ValueError(f"Invalid gradient component: {gradient_component}")
+
+    elif algorithm == Algorithm.PREWITT_COMPASS:
+        img = prewitt_compass(img) * (amount / 2)
+
+    elif algorithm == Algorithm.LAPLACIAN:
+        img = cv2.filter2D(img, -1, LAPLACE_KERNEL) * amount
+
+    elif algorithm == Algorithm.LAPLACIAN_DENOISE:
+        img = laplacian_denoise(img) * amount
+
+    elif algorithm == Algorithm.DIFFERENCE_OF_GAUSSIAN:
+        g1 = fast_gaussian_blur(img, radius_1)
+        g2 = fast_gaussian_blur(img, radius_2)
+        img = (g1 - g2) * amount
+
+    img = img.clip(0, 1)
+
+    if alpha is not None:
+        img = np.dstack((img, alpha))
+    return img
+
+
+def prewitt_compass(img: np.ndarray) -> np.ndarray:
+    filter_0 = 0.25 * np.array(
+        [
+            [-1, +1, +1],
+            [-1, -2, +1],
+            [-1, +1, +1],
+        ]
+    ).astype(np.float32)
+    filter_45 = 0.25 * np.array(
+        [
+            [+1, +1, +1],
+            [-1, -2, +1],
+            [-1, -1, +1],
+        ]
+    ).astype(np.float32)
+
+    g = np.abs(cv2.filter2D(img, -1, filter_0))
+    for i in range(1, 4):
+        g = np.maximum(g, np.abs(cv2.filter2D(img, -1, np.rot90(filter_0, i))))
+    for i in range(4):
+        g = np.maximum(g, np.abs(cv2.filter2D(img, -1, np.rot90(filter_45, i))))
+
+    return g
+
+
+def laplacian_denoise(img: np.ndarray) -> np.ndarray:
+    # Modified version of Gimp's Laplace filter.
+    # https://gitlab.gnome.org/GNOME/gegl/-/blob/master/opencl/edge-laplace.cl
+    # Changes: Instead of using the laplacian to get the sign of the magnitude,
+    # we use it as a clipped factor. This eliminates abrupt changes in the
+    # output image and has an even stronger denoising effect.
+    max_val = cv2.dilate(img, cv2.getStructuringElement(cv2.MORPH_CROSS, (3, 3)))
+    min_val = cv2.erode(img, cv2.getStructuringElement(cv2.MORPH_CROSS, (3, 3)))
+    laplace = cv2.filter2D(img, -1, LAPLACE_KERNEL)
+    return np.maximum(max_val - img, img - min_val) * np.clip(laplace * 10, -0.75, 0.75)


### PR DESCRIPTION
Fixes #2497.

This adds an edge detection node that implements common methods such as Sobel, Scharr, Laplacian, and DoG.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/7edc39f3-9556-4d59-ad7f-c97576e0e269)

Example: 

Sobel:
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/2fdfdffd-df84-43b3-b534-209e39d56a63)

Laplacian Denoise:
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/bc70fe74-9bec-4588-86a5-b681a2b79bcc)

DoG:
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/639b2de2-3b7e-4750-b776-2290e5f2e179)

Sobel X component:
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/08c3a899-8084-4918-ba74-1378afe4b694)
