### PR TITLE
List images starting with dot

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/load_images.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/load_images.py
@@ -31,10 +31,12 @@ def extension_filter(lst: list[str]) -> str:
 def list_glob(directory: str, globexpr: str, ext_filter: list[str]) -> list[str]:
     extension_expr = extension_filter(ext_filter)
 
-    flags = glob.EXTGLOB | glob.BRACE | glob.GLOBSTAR | glob.NEGATE
+    flags = glob.EXTGLOB | glob.BRACE | glob.GLOBSTAR | glob.NEGATE | glob.DOTGLOB
+
+    foo = list(glob.iglob(globexpr, root_dir=directory, flags=flags))
 
     filtered = glob.globfilter(
-        glob.iglob(globexpr, root_dir=directory, flags=flags),
+        foo,
         extension_expr,
         flags=flags | glob.IGNORECASE,
     )


### PR DESCRIPTION
Fixes #2506.

Dot files are ignored by default since it's Unix convention to have config/meta files start with dot. I added [the `DOTGLOB` flag](https://facelessuser.github.io/wcmatch/glob/#dotglob) to fix this. This is okay for us to do since we filter by extension anyway, so we won't accidentally load any weird files.