### PR TITLE
Disallow ONNX conversions for SAFMN

### DIFF
--- a/backend/src/nodes/impl/pytorch/convert_to_onnx_impl.py
+++ b/backend/src/nodes/impl/pytorch/convert_to_onnx_impl.py
@@ -2,6 +2,12 @@ from io import BytesIO
 
 import torch
 from spandrel import ImageModelDescriptor, ModelDescriptor
+from spandrel.architectures.SAFMN import SAFMN
+from spandrel.architectures.SCUNet import SCUNet
+
+
+def is_onnx_supported(model: ModelDescriptor) -> bool:
+    return not isinstance(model.model, (SCUNet, SAFMN))
 
 
 def convert_to_onnx_impl(

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/utility/convert_to_ncnn.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/utility/convert_to_ncnn.py
@@ -12,7 +12,10 @@ from spandrel.architectures.SwinIR import SwinIR
 from api import NodeContext
 from nodes.impl.ncnn.model import NcnnModelWrapper
 from nodes.impl.onnx.model import OnnxGeneric
-from nodes.impl.pytorch.convert_to_onnx_impl import convert_to_onnx_impl
+from nodes.impl.pytorch.convert_to_onnx_impl import (
+    convert_to_onnx_impl,
+    is_onnx_supported,
+)
 from nodes.properties.inputs import OnnxFpDropdown, SrModelInput
 from nodes.properties.outputs import NcnnModelOutput, TextOutput
 
@@ -56,7 +59,7 @@ def convert_to_ncnn_node(
                 manager to use this node."
         )
 
-    assert not isinstance(
+    assert is_onnx_supported(model) and not isinstance(
         model.model, (HAT, DAT, OmniSR, SwinIR, Swin2SR, SCUNet, SRFormer)
     ), f"{model.architecture} is not supported for NCNN conversions at this time."
 

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/utility/convert_to_onnx.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/utility/convert_to_onnx.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 from enum import Enum
 
 from spandrel import ImageModelDescriptor
-from spandrel.architectures.SCUNet import SCUNet
 
 from api import NodeContext
 from nodes.impl.onnx.model import OnnxGeneric
-from nodes.impl.pytorch.convert_to_onnx_impl import convert_to_onnx_impl
+from nodes.impl.pytorch.convert_to_onnx_impl import (
+    convert_to_onnx_impl,
+    is_onnx_supported,
+)
 from nodes.properties.inputs import EnumInput, OnnxFpDropdown, SrModelInput
 from nodes.properties.outputs import OnnxModelOutput, TextOutput
 
@@ -70,9 +72,9 @@ OPSET_LABELS: dict[Opset, str] = {
 def convert_to_onnx_node(
     context: NodeContext, model: ImageModelDescriptor, is_fp16: int, opset: Opset
 ) -> tuple[OnnxGeneric, str, str]:
-    assert not isinstance(
-        model.model, SCUNet
-    ), "SCUNet is not supported for ONNX conversion at this time."
+    assert is_onnx_supported(
+        model
+    ), f"{model.architecture} is not supported for ONNX conversion at this time."
 
     fp16 = bool(is_fp16)
     exec_options = get_settings(context)


### PR DESCRIPTION
Fixes #2504.

SAFMN only supports fixed-resolution ONNX models, which is not what we want. Since SAFMN ONNX models pretty useless for us, we might as well not support creating them.

I also added a new `is_onnx_supported` method so that the NCNN conversion node knows about it too.