### PR TITLE
Function to determine whether a node is auto iterable

### DIFF
--- a/src/common/nodes/connectedInputs.ts
+++ b/src/common/nodes/connectedInputs.ts
@@ -2,6 +2,7 @@ import { Type } from '@chainner/navi';
 import { EdgeData, InputId, OutputId } from '../common-types';
 import { FunctionDefinition } from '../types/function';
 import { parseTargetHandle } from '../util';
+import { isAutoIterable } from './lineage';
 import type { Edge } from 'reactflow';
 
 export const getConnectedInputs = (
@@ -27,7 +28,7 @@ export const getFirstPossibleInput = (
         // check if the input has a handle
         if (!i.hasHandle) return false;
 
-        if (fn.schema.kind !== 'regularNode') {
+        if (!isAutoIterable(fn.schema)) {
             const inputIterated = fn.schema.iteratorInputs.some((info) =>
                 info.inputs.includes(i.id)
             );
@@ -46,7 +47,7 @@ export const getFirstPossibleOutput = (
 
     let allowIterated = false;
     let allowNonIterated = false;
-    if (inputFn.schema.kind === 'regularNode') {
+    if (isAutoIterable(inputFn.schema)) {
         allowIterated = true;
         allowNonIterated = true;
     } else {
@@ -64,8 +65,7 @@ export const getFirstPossibleOutput = (
             info.outputs.includes(o.id)
         );
         if (!allowIterated && outputIterated) return false;
-        if (!allowNonIterated && outputFn.schema.kind !== 'regularNode' && !outputIterated)
-            return false;
+        if (!allowNonIterated && !isAutoIterable(outputFn.schema) && !outputIterated) return false;
 
         // type check
         const type = outputFn.outputDefaults.get(o.id);

--- a/src/common/nodes/lineage.ts
+++ b/src/common/nodes/lineage.ts
@@ -14,6 +14,13 @@ import {
 } from '../util';
 
 /**
+ * Returns whether a node of this schema can be auto iterated.
+ */
+export const isAutoIterable = (schema: NodeSchema): boolean => {
+    return schema.kind === 'regularNode' && schema.inputs.some((i) => i.hasHandle);
+};
+
+/**
  * Represents the iterator lineage of an output.
  *
  * Note: this class only provides a minimal interface to enable future extensions.

--- a/src/renderer/helpers/nodeState.ts
+++ b/src/renderer/helpers/nodeState.ts
@@ -13,6 +13,7 @@ import {
 } from '../../common/common-types';
 import { IdSet } from '../../common/IdSet';
 import { TestFn, testForInputCondition } from '../../common/nodes/condition';
+import { isAutoIterable } from '../../common/nodes/lineage';
 import { FunctionInstance } from '../../common/types/function';
 import { EMPTY_ARRAY, EMPTY_SET } from '../../common/util';
 import { BackendContext } from '../contexts/BackendContext';
@@ -114,7 +115,7 @@ export const useNodeStateFromData = (data: NodeData): NodeState => {
 
     const chainLineage = useContextSelector(GlobalVolatileContext, (c) => c.chainLineage);
     const [iteratedInputs, iteratedOutputs] = useMemo(() => {
-        if (schema.kind === 'regularNode') {
+        if (isAutoIterable(schema)) {
             // eslint-disable-next-line @typescript-eslint/no-shadow
             const iteratedInputs = new Set<InputId>();
             for (const input of schema.inputs) {


### PR DESCRIPTION
Instead of checking `schema.kind === 'regularNode'`, I added a function that determines whether a node is auto iterable. I then used this function where it made sense.

I have to note that this function uses a slightly different definition of "auto iterable". It not only considers the node type, but also its inputs. E.g. Load Image can't actually be iterated because it doesn't have any input handles. 

This new definition is there to fix a minor issue with the node context selector. Previously, if you started the connection at the Frames input of Save Video, it would suggest Load Image as compatible. This has now been fixed.