### PR TITLE
Use pathlib Path classes as the datatype for DirectoryInputs and FileInputs

### DIFF
--- a/backend/src/nodes/impl/dds/texconv.py
+++ b/backend/src/nodes/impl/dds/texconv.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import sys
 import uuid
+from pathlib import Path
 from tempfile import mkdtemp
 
 import numpy as np
@@ -62,7 +63,7 @@ def __run_texconv(args: list[str], error_message: str):
         raise ValueError(f"{error_message}: Code {result.returncode}: {output}")
 
 
-def dds_to_png_texconv(path: str) -> str:
+def dds_to_png_texconv(path: Path) -> Path:
     """
     Converts the given DDS file to PNG by creating a temporary PNG file.
     """
@@ -82,16 +83,16 @@ def dds_to_png_texconv(path: str) -> str:
             prefix,
             "-o",
             tempdir,
-            path,
+            str(path),
         ],
         "Unable to convert DDS",
     )
 
-    return os.path.join(tempdir, prefix + basename + ".png")
+    return (Path(tempdir) / (prefix + basename)).with_suffix(".png")
 
 
 def save_as_dds(
-    path: str,
+    path: Path,
     image: np.ndarray,
     dds_format: DxgiFormat,
     mipmap_levels: int = 0,

--- a/backend/src/nodes/impl/dds/texconv.py
+++ b/backend/src/nodes/impl/dds/texconv.py
@@ -127,7 +127,7 @@ def save_as_dds(
             str(mipmap_levels),
             # use texconv to directly produce the target file
             "-o",
-            target_dir,
+            str(target_dir),
         ]
 
         bc = ""

--- a/backend/src/nodes/impl/image_utils.py
+++ b/backend/src/nodes/impl/image_utils.py
@@ -6,6 +6,7 @@ import os
 import random
 import string
 from enum import Enum
+from pathlib import Path
 
 import cv2
 import numpy as np
@@ -329,15 +330,15 @@ def calculate_ssim(
     return float(np.mean(ssim_map))
 
 
-def cv_save_image(path: str, img: np.ndarray, params: list[int]):
+def cv_save_image(path: Path | str, img: np.ndarray, params: list[int]):
     """
     A light wrapper around `cv2.imwrite` to support non-ASCII paths.
     """
 
     # Write image with opencv if path is ascii, since imwrite doesn't support unicode
     # This saves us from having to keep the image buffer in memory, if possible
-    if path.isascii():
-        cv2.imwrite(path, img, params)
+    if str(path).isascii():
+        cv2.imwrite(str(path), img, params)
     else:
         dirname, _, extension = split_file_path(path)
         try:

--- a/backend/src/nodes/impl/ncnn/model.py
+++ b/backend/src/nodes/impl/ncnn/model.py
@@ -4,6 +4,7 @@ import os
 from copy import deepcopy
 from io import BufferedReader, StringIO
 from json import load as jload
+from pathlib import Path
 
 import numpy as np
 from sanic.log import logger
@@ -645,7 +646,7 @@ class NcnnModel:
 
         return weight_dict
 
-    def write_param(self, filename: str = "") -> str:
+    def write_param(self, filename: Path | str = "") -> str:
         with StringIO() as p:
             p.write(f"{self.magic}\n{self.node_count} {self.blob_count}\n")
 
@@ -686,7 +687,7 @@ class NcnnModel:
 
         return b"".join(layer_weights)
 
-    def write_bin(self, filename: str) -> None:
+    def write_bin(self, filename: Path | str) -> None:
         with open(filename, "wb") as f:
             f.write(self.serialize_weights())
 

--- a/backend/src/nodes/properties/inputs/file_inputs.py
+++ b/backend/src/nodes/properties/inputs/file_inputs.py
@@ -55,6 +55,8 @@ class FileInput(BaseInput):
         }
 
     def enforce(self, value: object) -> Path:
+        if isinstance(value, str):
+            value = Path(value)
         assert isinstance(value, Path)
         assert value.exists(), f"File {value} does not exist"
         assert value.is_file(), f"The path {value} is not a file"
@@ -139,6 +141,8 @@ class DirectoryInput(BaseInput):
         }
 
     def enforce(self, value: object):
+        if isinstance(value, str):
+            value = Path(value)
         assert isinstance(value, Path)
         if self.must_exist:
             assert value.exists(), f"Directory {value} does not exist"

--- a/backend/src/nodes/properties/inputs/file_inputs.py
+++ b/backend/src/nodes/properties/inputs/file_inputs.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from typing import Literal, Union
 
@@ -45,7 +44,7 @@ class FileInput(BaseInput):
             }}
         """
 
-        self.associated_type = str
+        self.associated_type = Path
 
     def to_dict(self):
         return {
@@ -55,10 +54,10 @@ class FileInput(BaseInput):
             "primaryInput": self.primary_input,
         }
 
-    def enforce(self, value: object) -> str:
-        assert isinstance(value, str)
-        assert os.path.exists(value), f"File {value} does not exist"
-        assert os.path.isfile(value), f"The path {value} is not a file"
+    def enforce(self, value: object) -> Path:
+        assert isinstance(value, Path)
+        assert value.exists(), f"File {value} does not exist"
+        assert value.is_file(), f"The path {value} is not a file"
         return value
 
 
@@ -142,7 +141,7 @@ class DirectoryInput(BaseInput):
     def enforce(self, value: object):
         assert isinstance(value, Path)
         if self.must_exist:
-            assert os.path.exists(value), f"Directory {value} does not exist"
+            assert value.exists(), f"Directory {value} does not exist"
         return value
 
 

--- a/backend/src/nodes/properties/inputs/file_inputs.py
+++ b/backend/src/nodes/properties/inputs/file_inputs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from typing import Literal, Union
 
 from api import BaseInput
@@ -130,7 +131,7 @@ class DirectoryInput(BaseInput):
         self.must_exist: bool = must_exist
         self.label_style: LabelStyle = label_style
 
-        self.associated_type = str
+        self.associated_type = Path
 
     def to_dict(self):
         return {
@@ -139,7 +140,7 @@ class DirectoryInput(BaseInput):
         }
 
     def enforce(self, value: object):
-        assert isinstance(value, str)
+        assert isinstance(value, Path)
         if self.must_exist:
             assert os.path.exists(value), f"Directory {value} does not exist"
         return value

--- a/backend/src/nodes/properties/outputs/file_outputs.py
+++ b/backend/src/nodes/properties/outputs/file_outputs.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import navi
 from api import BaseOutput
 
@@ -19,11 +21,11 @@ class DirectoryOutput(BaseOutput):
             else f"splitFilePath(Input{of_input}.path).dir"
         )
         directory_type = navi.intersect_with_error(directory_type, output_type)
-        super().__init__(directory_type, label, associated_type=str)
+        super().__init__(directory_type, label, associated_type=Path)
 
-    def get_broadcast_type(self, value: str):
-        return navi.named("Directory", {"path": navi.literal(value)})
+    def get_broadcast_type(self, value: Path):
+        return navi.named("Directory", {"path": navi.literal(str(value))})
 
-    def enforce(self, value: object) -> str:
-        assert isinstance(value, str)
+    def enforce(self, value: object) -> Path:
+        assert isinstance(value, Path)
         return value

--- a/backend/src/nodes/utils/utils.py
+++ b/backend/src/nodes/utils/utils.py
@@ -5,6 +5,7 @@ import math
 import os
 import re
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Tuple
 
 import numpy as np
@@ -84,13 +85,13 @@ def join_space_case(words: list[str]) -> str:
     return " ".join([smart_capitalize(x) for x in words])
 
 
-def split_file_path(path: str) -> tuple[str, str, str]:
+def split_file_path(path: Path | str) -> tuple[Path, str, str]:
     """
     Returns the base directory, file name, and extension of the given file path.
     """
     base, ext = os.path.splitext(path)
     dirname, basename = os.path.split(base)
-    return dirname, basename, ext
+    return Path(dirname), basename, ext
 
 
 def walk_error_handler(exception_instance: Exception):

--- a/backend/src/nodes/utils/utils.py
+++ b/backend/src/nodes/utils/utils.py
@@ -101,9 +101,9 @@ def walk_error_handler(exception_instance: Exception):
 
 
 def list_all_files_sorted(
-    directory: str, ext_filter: list[str] | None = None
-) -> list[str]:
-    just_files: list[str] = []
+    directory: Path, ext_filter: list[str] | None = None
+) -> list[Path]:
+    just_files: list[Path] = []
     for root, dirs, files in os.walk(
         directory, topdown=True, onerror=walk_error_handler
     ):
@@ -112,7 +112,7 @@ def list_all_files_sorted(
             filepath = os.path.join(root, name)
             _base, ext = os.path.splitext(filepath)
             if ext_filter is None or ext.lower() in ext_filter:
-                just_files.append(filepath)
+                just_files.append(Path(filepath))
     return just_files
 
 

--- a/backend/src/packages/chaiNNer_ncnn/ncnn/batch_processing/load_models.py
+++ b/backend/src/packages/chaiNNer_ncnn/ncnn/batch_processing/load_models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 from sanic.log import logger
 
@@ -48,19 +49,19 @@ from ..io.load_model import load_model_node
     kind="newIterator",
 )
 def load_models_node(
-    directory: str,
+    directory: Path,
     fail_fast: bool,
-) -> tuple[Iterator[tuple[NcnnModelWrapper, str, str, int]], str]:
+) -> tuple[Iterator[tuple[NcnnModelWrapper, str, str, int]], Path]:
     logger.debug(f"Iterating over models in directory: {directory}")
 
-    def load_model(filepath_pairs: tuple[str, str], index: int):
+    def load_model(filepath_pairs: tuple[Path, Path], index: int):
         model, dirname, basename = load_model_node(filepath_pairs[0], filepath_pairs[1])
         # Get relative path from root directory passed by Iterator directory input
         rel_path = os.path.relpath(dirname, directory)
         return model, rel_path, basename, index
 
-    param_files: list[str] = list_all_files_sorted(directory, [".param"])
-    bin_files: list[str] = list_all_files_sorted(directory, [".bin"])
+    param_files: list[Path] = list_all_files_sorted(directory, [".param"])
+    bin_files: list[Path] = list_all_files_sorted(directory, [".bin"])
 
     if len(param_files) != len(bin_files):
         raise ValueError(

--- a/backend/src/packages/chaiNNer_ncnn/ncnn/io/load_model.py
+++ b/backend/src/packages/chaiNNer_ncnn/ncnn/io/load_model.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from nodes.groups import ncnn_file_inputs_group
 from nodes.impl.ncnn.model import NcnnModel, NcnnModelWrapper
 from nodes.impl.ncnn.optimizer import NcnnOptimizer
@@ -35,7 +37,7 @@ from .. import io_group
 )
 def load_model_node(
     param_path: str, bin_path: str
-) -> tuple[NcnnModelWrapper, str, str]:
+) -> tuple[NcnnModelWrapper, Path, str]:
     model = NcnnModel.load_from_file(param_path, bin_path)
     NcnnOptimizer(model).optimize()
 

--- a/backend/src/packages/chaiNNer_ncnn/ncnn/io/load_model.py
+++ b/backend/src/packages/chaiNNer_ncnn/ncnn/io/load_model.py
@@ -36,9 +36,9 @@ from .. import io_group
     ],
 )
 def load_model_node(
-    param_path: str, bin_path: str
+    param_path: Path, bin_path: Path
 ) -> tuple[NcnnModelWrapper, Path, str]:
-    model = NcnnModel.load_from_file(param_path, bin_path)
+    model = NcnnModel.load_from_file(str(param_path), str(bin_path))
     NcnnOptimizer(model).optimize()
 
     model_dir, model_name, _ = split_file_path(param_path)

--- a/backend/src/packages/chaiNNer_ncnn/ncnn/io/save_model.py
+++ b/backend/src/packages/chaiNNer_ncnn/ncnn/io/save_model.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 from sanic.log import logger
 
@@ -21,11 +21,11 @@ from .. import io_group
     outputs=[],
     side_effects=True,
 )
-def save_model_node(model: NcnnModelWrapper, directory: str, name: str) -> None:
+def save_model_node(model: NcnnModelWrapper, directory: Path, name: str) -> None:
     full_bin = f"{name}.bin"
     full_param = f"{name}.param"
-    full_bin_path = os.path.join(directory, full_bin)
-    full_param_path = os.path.join(directory, full_param)
+    full_bin_path = directory / full_bin
+    full_param_path = directory / full_param
 
     logger.debug(f"Writing NCNN model to paths: {full_bin_path} {full_param_path}")
     model.model.write_bin(full_bin_path)

--- a/backend/src/packages/chaiNNer_onnx/onnx/batch_processing/load_models.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/batch_processing/load_models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 from sanic.log import logger
 
@@ -48,12 +49,12 @@ from ..io.load_model import load_model_node
     kind="newIterator",
 )
 def load_models_node(
-    directory: str,
+    directory: Path,
     fail_fast: bool,
-) -> tuple[Iterator[tuple[OnnxModel, str, str, int]], str]:
+) -> tuple[Iterator[tuple[OnnxModel, str, str, int]], Path]:
     logger.debug(f"Iterating over models in directory: {directory}")
 
-    def load_model(path: str, index: int):
+    def load_model(path: Path, index: int):
         model, dirname, basename = load_model_node(path)
         # Get relative path from root directory passed by Iterator directory input
         rel_path = os.path.relpath(dirname, directory)

--- a/backend/src/packages/chaiNNer_onnx/onnx/io/load_model.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/io/load_model.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import onnx
 from sanic.log import logger
@@ -32,7 +33,7 @@ from .. import io_group
         "chainner:onnx:load_models",
     ],
 )
-def load_model_node(path: str) -> tuple[OnnxModel, str, str]:
+def load_model_node(path: str) -> tuple[OnnxModel, Path, str]:
     """Read a pth file from the specified path and return it as a state dict
     and loaded model after finding arch config"""
 

--- a/backend/src/packages/chaiNNer_onnx/onnx/io/load_model.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/io/load_model.py
@@ -33,7 +33,7 @@ from .. import io_group
         "chainner:onnx:load_models",
     ],
 )
-def load_model_node(path: str) -> tuple[OnnxModel, Path, str]:
+def load_model_node(path: Path) -> tuple[OnnxModel, Path, str]:
     """Read a pth file from the specified path and return it as a state dict
     and loaded model after finding arch config"""
 
@@ -42,7 +42,7 @@ def load_model_node(path: str) -> tuple[OnnxModel, Path, str]:
     assert os.path.isfile(path), f"Path {path} is not a file"
 
     logger.debug(f"Reading onnx model from path: {path}")
-    model = onnx.load_model(path)
+    model = onnx.load_model(str(path))
 
     model_as_string = model.SerializeToString()
 

--- a/backend/src/packages/chaiNNer_onnx/onnx/io/save_model.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/io/save_model.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import os
+from pathlib import Path
 
 from sanic.log import logger
 
@@ -23,8 +23,8 @@ from .. import io_group
     outputs=[],
     side_effects=True,
 )
-def save_model_node(model: OnnxModel, directory: str, model_name: str) -> None:
-    full_path = f"{os.path.join(directory, model_name)}.onnx"
+def save_model_node(model: OnnxModel, directory: Path, model_name: str) -> None:
+    full_path = f"{directory / model_name}.onnx"
     logger.debug(f"Writing file to path: {full_path}")
     with open(full_path, "wb") as f:
         f.write(model.bytes)

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/io/load_model.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/io/load_model.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 from sanic.log import logger
 from spandrel import ModelDescriptor, ModelLoader
@@ -64,7 +65,7 @@ def parse_ckpt_state_dict(checkpoint: dict):
 )
 def load_model_node(
     context: NodeContext, path: str
-) -> tuple[ModelDescriptor, str, str]:
+) -> tuple[ModelDescriptor, Path, str]:
     """Read a pth file from the specified path and return it as a state dict
     and loaded model after finding arch config"""
 

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/io/load_model.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/io/load_model.py
@@ -64,7 +64,7 @@ def parse_ckpt_state_dict(checkpoint: dict):
     ],
 )
 def load_model_node(
-    context: NodeContext, path: str
+    context: NodeContext, path: Path
 ) -> tuple[ModelDescriptor, Path, str]:
     """Read a pth file from the specified path and return it as a state dict
     and loaded model after finding arch config"""

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/io/save_model.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/io/save_model.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import os
 from enum import Enum
+from pathlib import Path
 
 import torch
 from safetensors.torch import save_file
@@ -44,10 +44,10 @@ class WeightFormat(Enum):
     side_effects=True,
 )
 def save_model_node(
-    model: ModelDescriptor, directory: str, name: str, weight_format: WeightFormat
+    model: ModelDescriptor, directory: Path, name: str, weight_format: WeightFormat
 ) -> None:
     full_file = f"{name}.{weight_format.value}"
-    full_path = os.path.join(directory, full_file)
+    full_path = directory / full_file
     logger.debug(f"Writing model to path: {full_path}")
     if weight_format == WeightFormat.PTH:
         torch.save(model.model.state_dict(), full_path)

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/iteration/load_models.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/iteration/load_models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 from sanic.log import logger
 from spandrel import ModelDescriptor
@@ -47,18 +48,18 @@ from ..io.load_model import load_model_node
 )
 def load_models_node(
     context: NodeContext,
-    directory: str,
+    directory: Path,
     fail_fast: bool,
-) -> tuple[Iterator[tuple[ModelDescriptor, str, str, int]], str]:
+) -> tuple[Iterator[tuple[ModelDescriptor, str, str, int]], Path]:
     logger.debug(f"Iterating over models in directory: {directory}")
 
-    def load_model(path: str, index: int):
+    def load_model(path: Path, index: int):
         model, dirname, basename = load_model_node(context, path)
         # Get relative path from root directory passed by Iterator directory input
         rel_path = os.path.relpath(dirname, directory)
         return model, rel_path, basename, index
 
     supported_filetypes = [".pt", ".pth", ".ckpt", ".safetensors"]
-    model_files: list[str] = list_all_files_sorted(directory, supported_filetypes)
+    model_files: list[Path] = list_all_files_sorted(directory, supported_filetypes)
 
     return Iterator.from_list(model_files, load_model, fail_fast), directory

--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/load_image_pairs.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/load_image_pairs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import numpy as np
 
@@ -57,13 +58,15 @@ from ..io.load_image import load_image_node
     kind="newIterator",
 )
 def load_image_pairs_node(
-    directory_a: str,
-    directory_b: str,
+    directory_a: Path,
+    directory_b: Path,
     use_limit: bool,
     limit: int,
     fail_fast: bool,
-) -> tuple[Iterator[tuple[np.ndarray, np.ndarray, str, str, str, str, int]], str, str]:
-    def load_images(filepaths: tuple[str, str], index: int):
+) -> tuple[
+    Iterator[tuple[np.ndarray, np.ndarray, str, str, str, str, int]], Path, Path
+]:
+    def load_images(filepaths: tuple[Path, Path], index: int):
         path_a, path_b = filepaths
         img_a, img_dir_a, basename_a = load_image_node(path_a)
         img_b, img_dir_b, basename_b = load_image_node(path_b)
@@ -75,8 +78,8 @@ def load_image_pairs_node(
 
     supported_filetypes = get_available_image_formats()
 
-    image_files_a: list[str] = list_all_files_sorted(directory_a, supported_filetypes)
-    image_files_b: list[str] = list_all_files_sorted(directory_b, supported_filetypes)
+    image_files_a: list[Path] = list_all_files_sorted(directory_a, supported_filetypes)
+    image_files_b: list[Path] = list_all_files_sorted(directory_b, supported_filetypes)
 
     assert len(image_files_a) == len(image_files_b), (
         "Number of images in directories A and B must be equal. "

--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/load_images.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/load_images.py
@@ -28,7 +28,7 @@ def extension_filter(lst: list[str]) -> str:
     return "**/*@(" + "|".join(lst) + ")"
 
 
-def list_glob(directory: Path, globexpr: str, ext_filter: list[str]) -> list[str]:
+def list_glob(directory: Path, globexpr: str, ext_filter: list[str]) -> list[Path]:
     extension_expr = extension_filter(ext_filter)
 
     flags = glob.EXTGLOB | glob.BRACE | glob.GLOBSTAR | glob.NEGATE | glob.DOTGLOB
@@ -41,10 +41,13 @@ def list_glob(directory: Path, globexpr: str, ext_filter: list[str]) -> list[str
         flags=flags | glob.IGNORECASE,
     )
 
-    return sorted(
-        {str(directory / f) for f in filtered},
-        key=alphanumeric_sort,
-    )
+    return [
+        Path(x)
+        for x in sorted(
+            {str(directory / f) for f in filtered},
+            key=alphanumeric_sort,
+        )
+    ]
 
 
 @batch_processing_group.register(
@@ -99,7 +102,7 @@ def load_images_node(
     limit: int,
     fail_fast: bool,
 ) -> tuple[Iterator[tuple[np.ndarray, str, str, int]], Path]:
-    def load_image(path: str, index: int):
+    def load_image(path: Path, index: int):
         img, img_dir, basename = load_image_node(path)
         # Get relative path from root directory passed by Iterator directory input
         rel_path = os.path.relpath(img_dir, directory)
@@ -110,7 +113,7 @@ def load_images_node(
     if not use_glob:
         glob_str = "**/*" if is_recursive else "*"
 
-    just_image_files: list[str] = list_glob(directory, glob_str, supported_filetypes)
+    just_image_files = list_glob(directory, glob_str, supported_filetypes)
     if not len(just_image_files):
         raise FileNotFoundError(f"{directory} has no valid images.")
 

--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/load_images.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/load_images.py
@@ -28,7 +28,7 @@ def extension_filter(lst: list[str]) -> str:
     return "**/*@(" + "|".join(lst) + ")"
 
 
-def list_glob(directory: str, globexpr: str, ext_filter: list[str]) -> list[str]:
+def list_glob(directory: Path, globexpr: str, ext_filter: list[str]) -> list[str]:
     extension_expr = extension_filter(ext_filter)
 
     flags = glob.EXTGLOB | glob.BRACE | glob.GLOBSTAR | glob.NEGATE | glob.DOTGLOB
@@ -42,7 +42,7 @@ def list_glob(directory: str, globexpr: str, ext_filter: list[str]) -> list[str]
     )
 
     return sorted(
-        {str(Path(directory) / f) for f in filtered},
+        {str(directory / f) for f in filtered},
         key=alphanumeric_sort,
     )
 
@@ -91,14 +91,14 @@ def list_glob(directory: str, globexpr: str, ext_filter: list[str]) -> list[str]
     kind="newIterator",
 )
 def load_images_node(
-    directory: str,
+    directory: Path,
     use_glob: bool,
     is_recursive: bool,
     glob_str: str,
     use_limit: bool,
     limit: int,
     fail_fast: bool,
-) -> tuple[Iterator[tuple[np.ndarray, str, str, int]], str]:
+) -> tuple[Iterator[tuple[np.ndarray, str, str, int]], Path]:
     def load_image(path: str, index: int):
         img, img_dir, basename = load_image_node(path)
         # Get relative path from root directory passed by Iterator directory input

--- a/backend/src/packages/chaiNNer_standard/image/io/load_image.py
+++ b/backend/src/packages/chaiNNer_standard/image/io/load_image.py
@@ -160,7 +160,7 @@ valid_formats = get_available_image_formats()
         FileNameOutput("Name", of_input=0),
     ],
 )
-def load_image_node(path: str) -> tuple[np.ndarray, Path, str]:
+def load_image_node(path: Path) -> tuple[np.ndarray, Path, str]:
     """Reads an image from the specified path and return it as a numpy array"""
 
     logger.debug(f"Reading image from path: {path}")

--- a/backend/src/packages/chaiNNer_standard/image/io/load_image.py
+++ b/backend/src/packages/chaiNNer_standard/image/io/load_image.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import platform
+from pathlib import Path
 from typing import Callable, Iterable, Union
 
 import cv2
@@ -21,7 +22,7 @@ from nodes.utils.utils import get_h_w_c, split_file_path
 
 from .. import io_group
 
-_Decoder = Callable[[str], Union[np.ndarray, None]]
+_Decoder = Callable[[Path], Union[np.ndarray, None]]
 """
 An image decoder.
 
@@ -31,7 +32,7 @@ unsupported format.
 """
 
 
-def get_ext(path: str) -> str:
+def get_ext(path: Path | str) -> str:
     return split_file_path(path)[2].lower()
 
 
@@ -54,7 +55,7 @@ def remove_unnecessary_alpha(img: np.ndarray) -> np.ndarray:
     return img
 
 
-def _read_cv(path: str) -> np.ndarray | None:
+def _read_cv(path: Path) -> np.ndarray | None:
     if get_ext(path) not in get_opencv_formats():
         # not supported
         return None
@@ -67,7 +68,7 @@ def _read_cv(path: str) -> np.ndarray | None:
 
     if img is None:
         try:
-            img = cv2.imread(path, cv2.IMREAD_UNCHANGED)
+            img = cv2.imread(str(path), cv2.IMREAD_UNCHANGED)
         except Exception as e:
             raise RuntimeError(
                 f'Error reading image image from path "{path}". Image may be corrupt.'
@@ -81,7 +82,7 @@ def _read_cv(path: str) -> np.ndarray | None:
     return img
 
 
-def _read_pil(path: str) -> np.ndarray | None:
+def _read_pil(path: Path) -> np.ndarray | None:
     if get_ext(path) not in get_pil_formats():
         # not supported
         return None
@@ -96,7 +97,7 @@ def _read_pil(path: str) -> np.ndarray | None:
     return img
 
 
-def _read_dds(path: str) -> np.ndarray | None:
+def _read_dds(path: Path) -> np.ndarray | None:
     if get_ext(path) != ".dds":
         # not supported
         return None
@@ -159,7 +160,7 @@ valid_formats = get_available_image_formats()
         FileNameOutput("Name", of_input=0),
     ],
 )
-def load_image_node(path: str) -> tuple[np.ndarray, str, str]:
+def load_image_node(path: str) -> tuple[np.ndarray, Path, str]:
     """Reads an image from the specified path and return it as a numpy array"""
 
     logger.debug(f"Reading image from path: {path}")
@@ -170,7 +171,7 @@ def load_image_node(path: str) -> tuple[np.ndarray, str, str]:
     error = None
     for name, decoder in _decoders:
         try:
-            img = decoder(path)
+            img = decoder(Path(path))
         except Exception as e:
             error = e
             logger.warning(f"Decoder {name} failed")

--- a/backend/src/packages/chaiNNer_standard/image/io/save_image.py
+++ b/backend/src/packages/chaiNNer_standard/image/io/save_image.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from enum import Enum
+from pathlib import Path
 from typing import Literal
 
 import cv2
@@ -215,7 +216,7 @@ class TiffColorDepth(Enum):
 )
 def save_image_node(
     img: np.ndarray,
-    base_directory: str,
+    base_directory: Path,
     relative_path: str | None,
     filename: str,
     image_format: ImageFormat,
@@ -323,13 +324,13 @@ def save_image_node(
 
 
 def get_full_path(
-    base_directory: str,
+    base_directory: Path,
     relative_path: str | None,
     filename: str,
     image_format: ImageFormat,
-) -> str:
+) -> Path:
     file = f"{filename}.{image_format.extension}"
     if relative_path and relative_path != ".":
-        base_directory = os.path.join(base_directory, relative_path)
-    full_path = os.path.join(base_directory, file)
+        base_directory = base_directory / relative_path
+    full_path = base_directory / file
     return full_path

--- a/backend/src/packages/chaiNNer_standard/image/video_frames/load_video.py
+++ b/backend/src/packages/chaiNNer_standard/image/video_frames/load_video.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from typing import Any
 
 import cv2
@@ -59,10 +60,10 @@ ffprobe_path = os.environ.get("STATIC_FFPROBE_PATH", "ffprobe")
     kind="newIterator",
 )
 def load_video_node(
-    path: str,
+    path: Path,
     use_limit: bool,
     limit: int,
-) -> tuple[Iterator[tuple[np.ndarray, int]], str, str, float, Any]:
+) -> tuple[Iterator[tuple[np.ndarray, int]], Path, str, float, Any]:
     video_dir, video_name, _ = split_file_path(path)
 
     ffmpeg_reader = (

--- a/backend/src/packages/chaiNNer_standard/utility/value/directory.py
+++ b/backend/src/packages/chaiNNer_standard/utility/value/directory.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from nodes.properties.inputs import DirectoryInput
 from nodes.properties.outputs import DirectoryOutput
 
@@ -20,5 +22,5 @@ from .. import value_group
         DirectoryOutput("Directory", output_type="Input0"),
     ],
 )
-def directory_node(directory: str) -> str:
+def directory_node(directory: Path) -> Path:
     return directory


### PR DESCRIPTION
pathlib Paths are awesome. They have tons of helper methods directly on them so you don't have to import a bunch of stuff from os.path to do path operations. They also implicitly guarantee that the string isn't some random junk.

This PR is the first step to getting better path/directory-related nodes. working with Path objects will be far simpler than working with strings.