### PR TITLE
Remove unnecessary node doc strings

### DIFF
--- a/backend/src/packages/chaiNNer_onnx/onnx/io/load_model.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/io/load_model.py
@@ -34,9 +34,6 @@ from .. import io_group
     ],
 )
 def load_model_node(path: Path) -> tuple[OnnxModel, Path, str]:
-    """Read a pth file from the specified path and return it as a state dict
-    and loaded model after finding arch config"""
-
     assert os.path.exists(path), f"Model file at location {path} does not exist"
 
     assert os.path.isfile(path), f"Path {path} is not a file"

--- a/backend/src/packages/chaiNNer_onnx/onnx/processing/remove_background.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/processing/remove_background.py
@@ -66,8 +66,6 @@ def remove_background_node(
     background_threshold: int,
     kernel_size: int,
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Removes background from image"""
-
     settings = get_settings(context)
     session = get_onnx_session(
         model,

--- a/backend/src/packages/chaiNNer_onnx/onnx/processing/upscale_image.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/processing/upscale_image.py
@@ -99,7 +99,6 @@ def upscale_image_node(
     tile_size: TileSize,
     separate_alpha: bool,
 ) -> np.ndarray:
-    """Upscales an image with a pretrained model"""
     settings = get_settings(context)
     session = get_onnx_session(
         model,

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/io/load_model.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/io/load_model.py
@@ -66,9 +66,6 @@ def parse_ckpt_state_dict(checkpoint: dict):
 def load_model_node(
     context: NodeContext, path: Path
 ) -> tuple[ModelDescriptor, Path, str]:
-    """Read a pth file from the specified path and return it as a state dict
-    and loaded model after finding arch config"""
-
     assert os.path.exists(path), f"Model file at location {path} does not exist"
 
     assert os.path.isfile(path), f"Path {path} is not a file"

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
@@ -169,8 +169,6 @@ def upscale_image_node(
     tile_size: TileSize,
     separate_alpha: bool,
 ) -> np.ndarray:
-    """Upscales an image with a pretrained model"""
-
     exec_options = get_settings(context)
 
     logger.debug("Upscaling image...")

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/restoration/upscale_face.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/restoration/upscale_face.py
@@ -157,8 +157,6 @@ def upscale_face_node(
     scale: int,
     weight: float,
 ) -> np.ndarray:
-    """Upscales an image with a face model"""
-
     face_helper = None
     try:
         img = denormalize(img)

--- a/backend/src/packages/chaiNNer_standard/image/io/load_image.py
+++ b/backend/src/packages/chaiNNer_standard/image/io/load_image.py
@@ -161,8 +161,6 @@ valid_formats = get_available_image_formats()
     ],
 )
 def load_image_node(path: Path) -> tuple[np.ndarray, Path, str]:
-    """Reads an image from the specified path and return it as a numpy array"""
-
     logger.debug(f"Reading image from path: {path}")
 
     dirname, basename, _ = split_file_path(path)

--- a/backend/src/packages/chaiNNer_standard/image/io/save_image.py
+++ b/backend/src/packages/chaiNNer_standard/image/io/save_image.py
@@ -233,8 +233,6 @@ def save_image_node(
     dds_mipmap_levels: int,
     dds_separate_alpha: bool,
 ) -> None:
-    """Write an image to the specified path and return write status"""
-
     full_path = get_full_path(base_directory, relative_path, filename, image_format)
     logger.debug(f"Writing image to path: {full_path}")
 

--- a/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/brightness_and_contrast.py
+++ b/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/brightness_and_contrast.py
@@ -38,8 +38,6 @@ from .. import adjustments_group
 def brightness_and_contrast_node(
     img: np.ndarray, brightness: float, contrast: float
 ) -> np.ndarray:
-    """Adjusts the brightness and contrast of an image"""
-
     brightness /= 100
     contrast /= 100
 

--- a/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/color_levels.py
+++ b/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/color_levels.py
@@ -13,7 +13,7 @@ from .. import adjustments_group
 @adjustments_group.register(
     schema_id="chainner:image:color_levels",
     name="Color Levels",
-    description="Adjust color levels",
+    description="Color Levels can be used to make an image lighter or darker, to change contrast or to correct a predominant color cast.",
     icon="MdOutlineColorLens",
     inputs=[
         ImageInput(channels=[1, 3, 4]),
@@ -77,13 +77,9 @@ def color_levels_node(
     out_black: float,
     out_white: float,
 ) -> np.ndarray:
-    """
-    Color Levels can be used to make an image lighter or darker,
-    to change contrast or to correct a predominant color cast.
+    # This code was adapted from a Stack-Overflow answer by Iperov,
+    # can found at: https://stackoverflow.com/a/60339950
 
-    This code was adapted from a Stack-Overflow answer by Iperov,
-    can found at: https://stackoverflow.com/a/60339950
-    """
     _, _, c = get_h_w_c(img)
 
     if c == 1:

--- a/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/hue_and_saturation.py
+++ b/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/hue_and_saturation.py
@@ -71,8 +71,6 @@ def hue_and_saturation_node(
     saturation: float,
     lightness: float,
 ) -> np.ndarray:
-    """Adjust the hue and saturation of an image"""
-
     saturation /= 100
     lightness /= 100
 

--- a/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/opacity.py
+++ b/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/opacity.py
@@ -36,8 +36,6 @@ from .. import adjustments_group
     ],
 )
 def opacity_node(img: np.ndarray, opacity: float) -> np.ndarray:
-    """Apply opacity adjustment to alpha channel"""
-
     # Convert inputs
     c = get_h_w_c(img)[2]
     if opacity == 100 and c == 4:

--- a/backend/src/packages/chaiNNer_standard/image_channel/all/merge_channels.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/all/merge_channels.py
@@ -52,8 +52,6 @@ def merge_channels_node(
     im3: np.ndarray | None,
     im4: np.ndarray | None,
 ) -> np.ndarray:
-    """Combine separate channels into a multi-chanel image"""
-
     start_shape = im1.shape[:2]
 
     for im in im2, im3, im4:

--- a/backend/src/packages/chaiNNer_standard/image_channel/misc/fill_alpha.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/misc/fill_alpha.py
@@ -47,8 +47,6 @@ class AlphaFillMethod(Enum):
 def fill_alpha_node(
     img: np.ndarray, method: AlphaFillMethod
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Fills transparent holes in the given image"""
-
     alpha = img[:, :, 3]
 
     if method == AlphaFillMethod.EXTEND_TEXTURE:

--- a/backend/src/packages/chaiNNer_standard/image_channel/transparency/merge_transparency.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/transparency/merge_transparency.py
@@ -46,8 +46,6 @@ def merge_transparency_node(
     rgb: np.ndarray | Color,
     a: np.ndarray | Color,
 ) -> np.ndarray:
-    """Combine separate channels into a multi-chanel image"""
-
     start_shape = None
 
     # determine shape

--- a/backend/src/packages/chaiNNer_standard/image_channel/transparency/split_transparency.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/transparency/split_transparency.py
@@ -14,7 +14,7 @@ from . import node_group
 @node_group.register(
     schema_id="chainner:image:split_transparency",
     name="Split Transparency",
-    description=("Split image channels into RGB and Alpha (transparency) channels."),
+    description="Split image channels into RGB and Alpha (transparency) channels.",
     icon="MdCallSplit",
     inputs=[ImageInput(channels=[1, 3, 4])],
     outputs=[
@@ -33,8 +33,6 @@ from . import node_group
     ],
 )
 def split_transparency_node(img: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-    """Split a multi-channel image into separate channels"""
-
     c = get_h_w_c(img)[2]
     if c == 3:
         # Performance optimization:

--- a/backend/src/packages/chaiNNer_standard/image_filter/correction/average_color_fix.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/correction/average_color_fix.py
@@ -38,8 +38,6 @@ from .. import correction_group
 def average_color_fix_node(
     input_img: np.ndarray, ref_img: np.ndarray, scale_factor: float
 ) -> np.ndarray:
-    """Fixes the average color of the input image"""
-
     if scale_factor != 100.0:
         # Make sure reference image dims are not resized to 0
         h, w, _ = get_h_w_c(ref_img)

--- a/backend/src/packages/chaiNNer_standard/image_filter/correction/color_transfer.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/correction/color_transfer.py
@@ -69,9 +69,6 @@ def color_transfer_node(
     overflow_method: OverflowMethod,
     reciprocal_scale: bool,
 ) -> np.ndarray:
-    """
-    Transfers the color distribution from source image to target image.
-    """
     _, _, img_c = get_h_w_c(img)
 
     # Preserve alpha

--- a/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/dilate.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/dilate.py
@@ -57,8 +57,6 @@ def dilate_node(
     radius: int,
     iterations: int,
 ) -> np.ndarray:
-    """Dilate an image"""
-
     if radius == 0 or iterations == 0:
         return img
 

--- a/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/erode.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/erode.py
@@ -57,8 +57,6 @@ def erode_node(
     radius: int,
     iterations: int,
 ) -> np.ndarray:
-    """Erode an image"""
-
     if radius == 0 or iterations == 0:
         return img
 

--- a/backend/src/packages/chaiNNer_standard/image_utility/compositing/add_caption.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/compositing/add_caption.py
@@ -39,6 +39,4 @@ from .. import compositing_group
 def add_caption_node(
     img: np.ndarray, caption: str, size: int, position: CaptionPosition
 ) -> np.ndarray:
-    """Add caption an image"""
-
     return add_caption(img, caption, size, position)

--- a/backend/src/packages/chaiNNer_standard/image_utility/compositing/blend_images.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/compositing/blend_images.py
@@ -202,8 +202,6 @@ def blend_images_node(
     y_px: int,
     crop_to_fit: bool,
 ) -> np.ndarray:
-    """Blend images together"""
-
     # Convert colors to images
     do_crop_to_fit = crop_to_fit
     if isinstance(base, Color):

--- a/backend/src/packages/chaiNNer_standard/image_utility/compositing/z_stack_images.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/compositing/z_stack_images.py
@@ -63,8 +63,6 @@ def z_stack_images_node(
     expression: Expression,
     *inputs: np.ndarray | None,
 ) -> np.ndarray:
-    """Align and evaluate images"""
-
     images = [x for x in inputs if x is not None]
     assert (
         2 <= len(images) <= 15

--- a/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/change_colorspace.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/change_colorspace.py
@@ -62,8 +62,6 @@ COLOR_SPACES_WITH_ALPHA_PARTNER = [
 def change_colorspace_node(
     img: np.ndarray, input_: int, output: int, alpha: bool
 ) -> np.ndarray:
-    """Takes an image and changes the color mode it"""
-
     from_cs = color_space_or_detector_from_id(input_)
     to_cs = color_space_from_id(output)
 

--- a/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/generate_hash.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/generate_hash.py
@@ -26,6 +26,8 @@ from .. import miscellaneous_group
             default=8,
             precision=0,
             controls_step=1,
+        ).with_docs(
+            "The digest size determines the length of the hash that is returned."
         ),
     ],
     outputs=[
@@ -34,7 +36,6 @@ from .. import miscellaneous_group
     ],
 )
 def generate_hash_node(img: np.ndarray, size: int) -> tuple[str, str]:
-    """Generate a hash from the input image. The digest size determines the length of the hash that is output."""
     img = np.ascontiguousarray(to_uint8(img))
     h = hashlib.blake2b(img, digest_size=size)  # type: ignore
     return h.hexdigest(), base64.urlsafe_b64encode(h.digest()).decode("utf-8")

--- a/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/image_metrics.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/image_metrics.py
@@ -33,8 +33,6 @@ from .. import miscellaneous_group
 def image_metrics_node(
     orig_img: np.ndarray, comp_img: np.ndarray
 ) -> tuple[float, float, float]:
-    """Compute MSE, PSNR, and SSIM"""
-
     assert (
         orig_img.shape == comp_img.shape
     ), "Images must have same dimensions and color depth"

--- a/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/inpaint.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/inpaint.py
@@ -65,8 +65,6 @@ def inpaint_node(
     inpaint_method: InpaintAlgorithm,
     radius: float,
 ) -> np.ndarray:
-    """Inpaint an image"""
-
     assert (
         img.shape[:2] == mask.shape[:2]
     ), "Input image and mask must have the same resolution"


### PR DESCRIPTION
Since doc strings are generally not updated and not visible to users, they are easily wrong and out of date. This PR removes all doc strings from nodes. No information is lost, since the same (or a more detailed) description of the node is already present with the node description.