### PR TITLE
Update load_video node for more accurate color conversion and chroma reconstruction

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image/video_frames/load_video.py
+++ b/backend/src/packages/chaiNNer_standard/image/video_frames/load_video.py
@@ -68,7 +68,7 @@ def load_video_node(
 
     ffmpeg_reader = (
         ffmpeg.input(path)
-        .output("pipe:", format="rawvideo", pix_fmt="rgb24")
+        .output("pipe:", format="rawvideo", pix_fmt="bgr24", sws_flags="lanczos+accurate_rnd+full_chroma_int+full_chroma_inp+bitexact")
         .run_async(pipe_stdout=True, cmd=ffmpeg_path)
     )
 
@@ -123,7 +123,6 @@ def load_video_node(
                 print("Can't receive frame (stream end?). Exiting ...")
                 break
             in_frame = np.frombuffer(in_bytes, np.uint8).reshape([height, width, 3])
-            in_frame = cv2.cvtColor(in_frame, cv2.COLOR_RGB2BGR)
             yield in_frame, index
             index += 1
 

--- a/backend/src/packages/chaiNNer_standard/image/video_frames/load_video.py
+++ b/backend/src/packages/chaiNNer_standard/image/video_frames/load_video.py
@@ -67,7 +67,12 @@ def load_video_node(
 
     ffmpeg_reader = (
         ffmpeg.input(path)
-        .output("pipe:", format="rawvideo", pix_fmt="bgr24", sws_flags="lanczos+accurate_rnd+full_chroma_int+full_chroma_inp+bitexact")
+        .output(
+            "pipe:",
+            format="rawvideo",
+            pix_fmt="bgr24",
+            sws_flags="lanczos+accurate_rnd+full_chroma_int+full_chroma_inp+bitexact",
+        )
         .run_async(pipe_stdout=True, cmd=ffmpeg_path)
     )
 

--- a/backend/src/packages/chaiNNer_standard/image/video_frames/load_video.py
+++ b/backend/src/packages/chaiNNer_standard/image/video_frames/load_video.py
@@ -4,7 +4,6 @@ import os
 from pathlib import Path
 from typing import Any
 
-import cv2
 import ffmpeg
 import numpy as np
 


### PR DESCRIPTION
This PR updates the ffmpeg based load_video node to use a more accurate color decoding and chroma reconstruction path.  

This node now uses lanczos filtering by default and also skips the previously present extra conversion from rgb24 to bgr24 by having ffmpeg send a bgr24 rawvideo pipe natively to chaiNNer