### PR TITLE
Yield in iterator to process events

### DIFF
--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -657,6 +657,9 @@ class Executor:
 
                 await self.progress.suspend()
                 await update_progress()
+                # cooperative yield so the event loop can run
+                # https://stackoverflow.com/questions/36647825/cooperative-yield-in-asyncio
+                await asyncio.sleep(0)
                 await self.progress.suspend()
             except Aborted:
                 raise


### PR DESCRIPTION
This fixes the bug that iterator progress would not show up in the UI if the iterator was not connected to any regular nodes.

Discussion [here](https://discord.com/channels/930865462852591648/1078534152464384152/1201559012806770708).