### PR TITLE
Switch to using pyav for video

### DIFF
--- a/backend/src/packages/chaiNNer_standard/__init__.py
+++ b/backend/src/packages/chaiNNer_standard/__init__.py
@@ -35,11 +35,11 @@ package = add_package(
             size_estimate=13.5 * KB,
         ),
         Dependency(
-            display_name="FFMPEG",
-            pypi_name="ffmpeg-python",
-            version="0.2.0",
-            size_estimate=25 * KB,
-            import_name="ffmpeg",
+            display_name="PyAV",
+            pypi_name="av",
+            version="11.0.0",
+            size_estimate=25 * MB,
+            import_name="av",
         ),
         Dependency(
             display_name="Requests",

--- a/backend/src/packages/chaiNNer_standard/image/video_frames/load_video.py
+++ b/backend/src/packages/chaiNNer_standard/image/video_frames/load_video.py
@@ -53,14 +53,14 @@ from .. import video_frames_group
         NumberOutput("FPS"),
         AudioStreamOutput(),
     ],
-    iterator_outputs=IteratorOutputInfo(outputs=[0, 1]),
+    iterator_outputs=IteratorOutputInfo(outputs=[0, 1, 5]),
     kind="newIterator",
 )
 def load_video_node(
     path: Path,
     use_limit: bool,
     limit: int,
-) -> tuple[Iterator[tuple[np.ndarray, int]], Path, str, float, Any]:
+) -> tuple[Iterator[tuple[np.ndarray, int, list[Any]]], Path, str, float]:
     video_dir, video_name, _ = split_file_path(path)
 
     container = av.open(
@@ -96,7 +96,16 @@ def load_video_node(
     if frame_count is None or frame_count == 0:
         frame_count = int(duration * fps)
 
-    frames_iterable = container.decode(video=0)
+    # frames_iterable = container.decode(video=0)
+    # audio_iterable = container.decode(audio=0)
+    in_stream_v = container.streams.video[0]
+    in_stream_a = container.streams.audio[0]
+
+    logger.info(f"audio format: {in_stream_a.format}")
+    logger.info(f"audio rate: {in_stream_a.rate}")
+    logger.info(f"audio frame_size: {in_stream_a.frame_size}")
+    logger.info(f"audio codec: {in_stream_a.codec}")
+    logger.info(f"audio codec.name: {in_stream_a.codec.name}")
 
     if use_limit:
         frame_count = min(frame_count, limit)
@@ -104,34 +113,57 @@ def load_video_node(
     logger.info(f"Frame count: {frame_count}")
     logger.info(f"FPS: {fps}")
 
-    if container.streams.audio:
-        audio_stream = (
-            iter(container.decode(container.streams.audio[0])),
-            container.streams.audio[0],
-        )
+    # if container.streams.audio:
+    #     (
+    #         iter(container.decode(container.streams.audio[0])),
+    #         container.streams.audio[0],
+    #     )
 
-    else:
-        audio_stream = None
+    # else:
+    #     pass
 
     logger.info(f"video_dir: {video_dir}")
     logger.info(f"video_name: {video_name}")
 
     def iterator():
         index = 0
-        for frame in frames_iterable:
+
+        audio_arr = []
+
+        for packet in container.demux(in_stream_v, in_stream_a):
+            if packet.dts is None:
+                continue
             if use_limit and index >= limit:
                 break
-            in_frame = frame.to_ndarray(format="bgr24")
-            if in_frame is None:
-                print("Can't receive frame (stream end?). Exiting ...")
-                break
-            yield in_frame, index
-            index += 1
+
+            packet_type = packet.stream.type
+
+            for frame in packet.decode():
+                if packet_type == "video":
+                    in_frame = frame.to_ndarray(format="bgr24")
+                    logger.info(f"video frame: {in_frame.shape}")
+                    yield in_frame, index, audio_arr
+                    index += 1
+                    audio_arr = []
+                elif packet_type == "audio":
+                    # audio_in_frame = frame.to_ndarray(format="fltp")
+                    # logger.info(f"audio frame: {audio_in_frame.shape}")
+                    logger.info(
+                        f"frame: {frame}, format: {frame.format}, layout: {frame.layout}, rate: {frame.rate}"
+                    )
+                    audio_arr.append(frame)
+
+            # if last_frame is not None and len(last_audio) != 0:
+            #     yield last_frame, index, last_audio
+            #     index += 1
+            #     last_frame = None
+            #     last_audio = []
+            # else:
+            #     continue
 
     return (
         Iterator.from_iter(iter_supplier=iterator, expected_length=frame_count),
         video_dir,
         video_name,
         fps,
-        audio_stream,
     )

--- a/backend/src/packages/chaiNNer_standard/image/video_frames/load_video.py
+++ b/backend/src/packages/chaiNNer_standard/image/video_frames/load_video.py
@@ -60,7 +60,7 @@ def load_video_node(
     path: Path,
     use_limit: bool,
     limit: int,
-) -> tuple[Iterator[tuple[np.ndarray, int, list[Any]]], Path, str, float]:
+) -> tuple[Iterator[tuple[np.ndarray, int, tuple[list[Any], str]]], Path, str, float]:
     video_dir, video_name, _ = split_file_path(path)
 
     container = av.open(
@@ -84,6 +84,8 @@ def load_video_node(
         raise RuntimeError("Failed to get video fps")
 
     fps = fps or (rate.as_integer_ratio()[0] / rate.as_integer_ratio()[1])
+
+    fps = round(fps, 2)
 
     frame_count = codec_context.encoded_frame_count
 
@@ -141,16 +143,16 @@ def load_video_node(
             for frame in packet.decode():
                 if packet_type == "video":
                     in_frame = frame.to_ndarray(format="bgr24")
-                    logger.info(f"video frame: {in_frame.shape}")
-                    yield in_frame, index, audio_arr
+                    # logger.info(f"video frame: {in_frame.shape}")
+                    yield in_frame, index, (audio_arr, in_stream_a.codec.name)
                     index += 1
                     audio_arr = []
                 elif packet_type == "audio":
                     # audio_in_frame = frame.to_ndarray(format="fltp")
                     # logger.info(f"audio frame: {audio_in_frame.shape}")
-                    logger.info(
-                        f"frame: {frame}, format: {frame.format}, layout: {frame.layout}, rate: {frame.rate}"
-                    )
+                    # logger.info(
+                    #     f"frame: {frame}, format: {frame.format}, layout: {frame.layout}, rate: {frame.rate}"
+                    # )
                     audio_arr.append(frame)
 
             # if last_frame is not None and len(last_audio) != 0:

--- a/backend/src/packages/chaiNNer_standard/image/video_frames/load_video.py
+++ b/backend/src/packages/chaiNNer_standard/image/video_frames/load_video.py
@@ -104,7 +104,14 @@ def load_video_node(
     logger.info(f"Frame count: {frame_count}")
     logger.info(f"FPS: {fps}")
 
-    audio_stream = container.streams.audio[0] if container.streams.audio else None
+    if container.streams.audio:
+        audio_stream = (
+            iter(container.decode(container.streams.audio[0])),
+            container.streams.audio[0],
+        )
+
+    else:
+        audio_stream = None
 
     logger.info(f"video_dir: {video_dir}")
     logger.info(f"video_name: {video_name}")


### PR DESCRIPTION
I will remove the FFMPEG downloader in a separate PR

For now, I am opening this so I can get some eyes on it. I wrote this in a bit of a hacky way to get audio to work properly and I'm open to suggestions on how to improve it.

I think one bit of future work on this could be to remove the current audio settings and replace it with a codec and sample rate selection system

# Benefits of this PR
- I can remove the FFMPEG download in a future PR, removing a potential problem point and a 100-something MB download
- Now the audio is encoded at the same time as the video, eliminating any potential complications from doing a second encode

# TODO on this PR:
I have a type error and I'm not sure why. It has something to do with the collector not liking the stupid type i had to make for audio. I'm thinking about just slapping a type: ignore comment on it