### PR TITLE
Update load_video.py - Quiet FFMPEG terminal output

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image/video_frames/load_video.py
+++ b/backend/src/packages/chaiNNer_standard/image/video_frames/load_video.py
@@ -72,6 +72,7 @@ def load_video_node(
             format="rawvideo",
             pix_fmt="bgr24",
             sws_flags="lanczos+accurate_rnd+full_chroma_int+full_chroma_inp+bitexact",
+            loglevel="error",
         )
         .run_async(pipe_stdout=True, cmd=ffmpeg_path)
     )


### PR DESCRIPTION
This removes the verbose FFMPEG output in the terminal