### PR TITLE
Clarify Node reset wording

### DIFF
--- a/src/renderer/hooks/useNodeMenu.tsx
+++ b/src/renderer/hooks/useNodeMenu.tsx
@@ -68,7 +68,7 @@ export const useNodeMenu = (
                     clearNodes([id]);
                 }}
             >
-                Clear
+                Reset Node
             </MenuItem>
             {canDisable && (
                 <MenuItem

--- a/src/renderer/hooks/useNodesMenu.tsx
+++ b/src/renderer/hooks/useNodesMenu.tsx
@@ -39,7 +39,7 @@ export const useNodesMenu = (nodes: Node<NodeData>[]): UseContextMenu => {
                     clearNodes(nodeIds);
                 }}
             >
-                Clear
+                Reset Selected Nodes
             </MenuItem>
             <MenuItem
                 icon={<DeleteIcon />}


### PR DESCRIPTION
Previously the word "Clear" was used to describe how the user would "reset" a node or group of nodes to the relevant node defaults. This PR rewords "Clear" to "Reset" making it very apparent what the action does.