### PR TITLE
Icon style for dropdowns

### DIFF
--- a/backend/src/nodes/properties/inputs/generic_inputs.py
+++ b/backend/src/nodes/properties/inputs/generic_inputs.py
@@ -33,12 +33,13 @@ from .numeric_inputs import NumberInput
 
 class DropDownOption(TypedDict):
     option: str
+    icon: NotRequired[str | None]
     value: str | int
     type: NotRequired[navi.ExpressionJson]
     condition: NotRequired[ConditionJson | None]
 
 
-DropDownStyle = Literal["dropdown", "checkbox", "tabs"]
+DropDownStyle = Literal["dropdown", "checkbox", "tabs", "icons"]
 """
 This specified the preferred style in which the frontend may display the dropdown.
 
@@ -46,6 +47,7 @@ This specified the preferred style in which the frontend may display the dropdow
 - `checkbox`: If the dropdown has 2 options, then it will be displayed as a checkbox.
   The first option will be interpreted as the yes/true option while the second option will be interpreted as the no/false option.
 - `tabs`: The options are displayed as tab list. The label of the input itself will *not* be displayed.
+- `icons`: The options are displayed as a list of icons. This is only available if all options have icons. Labels are still required for all options.
 """
 
 
@@ -200,6 +202,7 @@ class EnumInput(Generic[T], DropDownInput):
         label_style: LabelStyle = "default",
         categories: list[DropDownGroup] | None = None,
         conditions: dict[T, Condition] | None = None,
+        icons: dict[T, str] | None = None,
     ):
         if type_name is None:
             type_name = enum.__name__
@@ -209,6 +212,8 @@ class EnumInput(Generic[T], DropDownInput):
             option_labels = {}
         if conditions is None:
             conditions = {}
+        if icons is None:
+            icons = {}
 
         options: list[DropDownOption] = []
         variant_types: list[str] = []
@@ -234,6 +239,7 @@ class EnumInput(Generic[T], DropDownInput):
                     "value": value,
                     "type": variant_type,
                     "condition": condition,
+                    "icon": icons.get(variant),
                 }
             )
 

--- a/backend/src/packages/chaiNNer_standard/image/create_images/text_as_image.py
+++ b/backend/src/packages/chaiNNer_standard/image/create_images/text_as_image.py
@@ -36,13 +36,6 @@ class TextAsImageAlignment(Enum):
     RIGHT = "right"
 
 
-TEXT_AS_IMAGE_ALIGNMENT_LABELS = {
-    TextAsImageAlignment.LEFT: "Left",
-    TextAsImageAlignment.CENTERED: "Centered",
-    TextAsImageAlignment.RIGHT: "Right",
-}
-
-
 class TextAsImagePosition(Enum):
     TOP_LEFT = "top_left"
     TOP_CENTERED = "top_centered"
@@ -110,8 +103,18 @@ TEXT_AS_IMAGE_X_Y_REF_FACTORS = {
         ColorInput(channels=[3], default=Color.bgr((0, 0, 0))),
         EnumInput(
             TextAsImageAlignment,
-            label="Text alignment",
-            option_labels=TEXT_AS_IMAGE_ALIGNMENT_LABELS,
+            label="Alignment",
+            preferred_style="icons",
+            option_labels={
+                TextAsImageAlignment.LEFT: "Left",
+                TextAsImageAlignment.CENTERED: "Center",
+                TextAsImageAlignment.RIGHT: "Right",
+            },
+            icons={
+                TextAsImageAlignment.LEFT: "FaAlignLeft",
+                TextAsImageAlignment.CENTERED: "FaAlignCenter",
+                TextAsImageAlignment.RIGHT: "FaAlignRight",
+            },
             default=TextAsImageAlignment.CENTERED,
         ),
         NumberInput(

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -61,13 +61,14 @@ interface InputBase {
     readonly fused?: IOFusion | null;
 }
 export interface InputOption {
-    option: string;
-    value: InputSchemaValue;
-    type?: ExpressionJson;
-    condition?: Condition | null;
+    readonly option: string;
+    readonly value: InputSchemaValue;
+    readonly icon?: string | null;
+    readonly type?: ExpressionJson;
+    readonly condition?: Condition | null;
 }
 export type FileInputKind = 'image' | 'pth' | 'pt' | 'video' | 'bin' | 'param' | 'onnx';
-export type DropDownStyle = 'dropdown' | 'checkbox' | 'tabs';
+export type DropDownStyle = 'dropdown' | 'checkbox' | 'tabs' | 'icons';
 export interface DropdownGroup {
     readonly label?: string | null;
     readonly startAt: InputSchemaValue;

--- a/src/renderer/components/CustomIcons.tsx
+++ b/src/renderer/components/CustomIcons.tsx
@@ -12,7 +12,14 @@ import * as md from 'react-icons/md';
 const fa = { FaPaintBrush, FaAlignCenter, FaAlignLeft, FaAlignRight };
 const gi = { GiRolledCloth };
 
-const libraries = { bs, cg, md, im, fa, gi };
+const libraries: Partial<Record<string, Partial<Record<string, IconType>>>> = {
+    bs,
+    cg,
+    md,
+    im,
+    fa,
+    gi,
+};
 
 export const PyTorchIcon = createIcon({
     displayName: 'PyTorchIcon',
@@ -161,9 +168,7 @@ export const IconFactory = memo(({ icon, accentColor, boxSize = 4 }: IconFactory
     }
 
     const prefix = icon.slice(0, 2).toLowerCase();
-    const library = (libraries as Partial<Record<string, Partial<Record<string, IconType>>>>)[
-        prefix
-    ];
+    const library = libraries[prefix];
     if (!library) {
         return unknownIcon;
     }

--- a/src/renderer/components/CustomIcons.tsx
+++ b/src/renderer/components/CustomIcons.tsx
@@ -4,12 +4,12 @@ import { memo } from 'react';
 import { IconType } from 'react-icons';
 import * as bs from 'react-icons/bs';
 import * as cg from 'react-icons/cg';
-import { FaPaintBrush } from 'react-icons/fa';
+import { FaAlignCenter, FaAlignLeft, FaAlignRight, FaPaintBrush } from 'react-icons/fa';
 import { GiRolledCloth } from 'react-icons/gi';
 import * as im from 'react-icons/im';
 import * as md from 'react-icons/md';
 
-const fa = { FaPaintBrush };
+const fa = { FaPaintBrush, FaAlignCenter, FaAlignLeft, FaAlignRight };
 const gi = { GiRolledCloth };
 
 const libraries = { bs, cg, md, im, fa, gi };
@@ -92,98 +92,93 @@ export const NcnnIcon = createIcon({
     ),
 });
 
-export const IconFactory = memo(
-    ({
-        icon,
-        accentColor,
-        boxSize = 4,
-    }: {
-        icon?: string;
-        accentColor?: string;
-        boxSize?: number;
-    }) => {
-        const unknownIcon = (
-            <Icon
-                alignContent="center"
-                alignItems="center"
-                as={bs.BsQuestionDiamond}
-                boxSize={boxSize}
-                color="gray.500"
-                transition="0.15s ease-in-out"
-            />
-        );
-        if (!icon) {
-            return unknownIcon;
-        }
-        switch (icon) {
-            // TODO: Get rid of these hardcoded icons
-            case 'PyTorch':
-                return (
-                    <PyTorchIcon
-                        color={accentColor}
-                        transition="0.15s ease-in-out"
-                    />
-                );
-            case 'ONNX':
-                return (
-                    <OnnxIcon
-                        color={accentColor}
-                        transition="0.15s ease-in-out"
-                    />
-                );
-            case 'NCNN':
-                return (
-                    <NcnnIcon
-                        color={accentColor}
-                        transition="0.15s ease-in-out"
-                    />
-                );
-            default:
-                break;
-        }
-
-        // using segmenter to account for non-latin and emoji characters
-        const isSingleCharacter = [...new Intl.Segmenter().segment(icon)].length === 1;
-        if (isSingleCharacter) {
+interface IconFactoryProps {
+    icon?: string | null;
+    accentColor?: string;
+    boxSize?: number;
+}
+export const IconFactory = memo(({ icon, accentColor, boxSize = 4 }: IconFactoryProps) => {
+    const unknownIcon = (
+        <Icon
+            alignContent="center"
+            alignItems="center"
+            as={bs.BsQuestionDiamond}
+            boxSize={boxSize}
+            color="gray.500"
+            transition="0.15s ease-in-out"
+        />
+    );
+    if (!icon) {
+        return unknownIcon;
+    }
+    switch (icon) {
+        // TODO: Get rid of these hardcoded icons
+        case 'PyTorch':
             return (
-                <h5
-                    aria-hidden="true"
-                    className="chakra-heading"
-                    role="presentation"
-                    style={{
-                        color: accentColor,
-                        fontWeight: 'bold',
-                        textAlign: 'center',
-                        verticalAlign: 'middle',
-                        textRendering: 'geometricPrecision',
-                        fontFamily: 'Noto Emoji, Open Sans, sans-serif',
-                    }}
-                >
-                    {icon}
-                </h5>
+                <PyTorchIcon
+                    color={accentColor}
+                    transition="0.15s ease-in-out"
+                />
             );
-        }
+        case 'ONNX':
+            return (
+                <OnnxIcon
+                    color={accentColor}
+                    transition="0.15s ease-in-out"
+                />
+            );
+        case 'NCNN':
+            return (
+                <NcnnIcon
+                    color={accentColor}
+                    transition="0.15s ease-in-out"
+                />
+            );
+        default:
+            break;
+    }
 
-        const prefix = icon.slice(0, 2).toLowerCase();
-        const library = (libraries as Partial<Record<string, Partial<Record<string, IconType>>>>)[
-            prefix
-        ];
-        if (!library) {
-            return unknownIcon;
-        }
-        const libraryIcon = library[icon];
+    // using segmenter to account for non-latin and emoji characters
+    const isSingleCharacter = [...new Intl.Segmenter().segment(icon)].length === 1;
+    if (isSingleCharacter) {
         return (
-            <Icon
-                alignContent="center"
-                alignItems="center"
-                as={libraryIcon}
-                boxSize={boxSize}
-                color={accentColor}
-                transition="0.15s ease-in-out"
-            />
+            <h5
+                aria-hidden="true"
+                className="chakra-heading"
+                role="presentation"
+                style={{
+                    color: accentColor,
+                    fontWeight: 'bold',
+                    textAlign: 'center',
+                    verticalAlign: 'middle',
+                    textRendering: 'geometricPrecision',
+                    fontFamily: 'Noto Emoji, Open Sans, sans-serif',
+                }}
+            >
+                {icon}
+            </h5>
         );
     }
-);
+
+    const prefix = icon.slice(0, 2).toLowerCase();
+    const library = (libraries as Partial<Record<string, Partial<Record<string, IconType>>>>)[
+        prefix
+    ];
+    if (!library) {
+        return unknownIcon;
+    }
+    const libraryIcon = library[icon];
+    return (
+        <Icon
+            alignContent="center"
+            alignItems="center"
+            as={libraryIcon}
+            boxSize={boxSize}
+            color={accentColor}
+            transition="0.15s ease-in-out"
+        />
+    );
+});
 
 export const DragHandleSVG = createIcon({
     displayName: 'DragHandle',

--- a/src/renderer/components/inputs/DropDownInput.tsx
+++ b/src/renderer/components/inputs/DropDownInput.tsx
@@ -4,8 +4,9 @@ import { memo, useCallback } from 'react';
 import { Markdown } from '../Markdown';
 import { Checkbox } from './elements/Checkbox';
 import { DropDown } from './elements/Dropdown';
+import { IconList } from './elements/IconList';
 import { TabList } from './elements/TabList';
-import { AutoLabel, WithoutLabel } from './InputContainer';
+import { AutoLabel, InlineLabel, WithoutLabel } from './InputContainer';
 import { InputProps } from './props';
 
 type DropDownInputProps = InputProps<'dropdown', string | number>;
@@ -65,6 +66,20 @@ export const DropDownInput = memo(
                         onChange={setValue}
                     />
                 </WithoutLabel>
+            );
+        }
+
+        if (preferredStyle === 'icons') {
+            return (
+                <InlineLabel input={input}>
+                    <IconList
+                        isDisabled={isLocked}
+                        options={input.options}
+                        reset={reset}
+                        value={value}
+                        onChange={setValue}
+                    />
+                </InlineLabel>
             );
         }
 

--- a/src/renderer/components/inputs/elements/IconList.tsx
+++ b/src/renderer/components/inputs/elements/IconList.tsx
@@ -41,7 +41,7 @@ export const IconList = memo(({ value, onChange, reset, isDisabled, options }: I
                         isDisabled={isDisabled}
                         key={o.value}
                         label={o.option}
-                        openDelay={200}
+                        openDelay={500}
                         placement="top"
                     >
                         <Button

--- a/src/renderer/components/inputs/elements/IconList.tsx
+++ b/src/renderer/components/inputs/elements/IconList.tsx
@@ -1,0 +1,65 @@
+import { Button, ButtonGroup, Tooltip } from '@chakra-ui/react';
+import { memo, useEffect } from 'react';
+import { DropDownInput, InputSchemaValue } from '../../../../common/common-types';
+import { IconFactory } from '../../CustomIcons';
+
+export interface IconListProps {
+    value: InputSchemaValue | undefined;
+    onChange: (value: InputSchemaValue) => void;
+    reset: () => void;
+    isDisabled?: boolean;
+    options: DropDownInput['options'];
+}
+
+export const IconList = memo(({ value, onChange, reset, isDisabled, options }: IconListProps) => {
+    // reset invalid values to default
+    useEffect(() => {
+        if (value === undefined || options.every((o) => o.value !== value)) {
+            reset();
+        }
+    }, [value, reset, options]);
+
+    let selection = options.findIndex((o) => o.value === value);
+    if (selection === -1) selection = 0;
+
+    return (
+        <ButtonGroup
+            isAttached
+            className="nodrag"
+            variant="outline"
+        >
+            {options.map((o, i) => {
+                const selected = i === selection;
+
+                // n: var(--chakra-colors-whiteAlpha-200)
+                return (
+                    <Tooltip
+                        closeOnClick
+                        closeOnPointerDown
+                        hasArrow
+                        borderRadius={8}
+                        isDisabled={isDisabled}
+                        key={o.value}
+                        label={o.option}
+                        openDelay={200}
+                        placement="top"
+                    >
+                        <Button
+                            border={selected ? '1px solid' : undefined}
+                            borderLeft={i === selection + 1 ? 'none' : undefined}
+                            boxSizing="content-box"
+                            height="calc(2rem - 2px)"
+                            isDisabled={isDisabled}
+                            minWidth={0}
+                            px={2}
+                            variant={selected ? 'solid' : 'outline'}
+                            onClick={() => onChange(o.value)}
+                        >
+                            <IconFactory icon={o.icon} />
+                        </Button>
+                    </Tooltip>
+                );
+            })}
+        </ButtonGroup>
+    );
+});


### PR DESCRIPTION
This PR adds a new style for dropdowns that displays the options as a list of icon buttons. I used this to make the Text Alignment input of the Text As Image node easier to use.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/60a7acd3-04d0-4dea-975c-90075eab3586)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/da0bd7e1-b729-4336-8d62-dbae7d5fdb31)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/0f36072b-2f06-4ff5-8260-29552878c1f0)

Other changes:
- I slightly refactored `IconFactory` to allow `null` icons. Since I extracted the props type into its own interface, there was a lot of reformatting...
- Removed a type case in `IconFactory`.