### PR TITLE
Improve Add Caption node

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image_utility/compositing/add_caption.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/compositing/add_caption.py
@@ -17,8 +17,13 @@ from .. import compositing_group
     inputs=[
         ImageInput(),
         TextInput("Caption"),
-        NumberInput("Caption Size", minimum=20, default=42, unit="px"),
-        EnumInput(CaptionPosition, default=CaptionPosition.BOTTOM),
+        NumberInput("Size", minimum=20, default=42, unit="px"),
+        EnumInput(
+            CaptionPosition,
+            "Position",
+            default=CaptionPosition.BOTTOM,
+            label_style="inline",
+        ),
     ],
     outputs=[
         ImageOutput(
@@ -34,7 +39,6 @@ from .. import compositing_group
             assume_normalized=True,
         )
     ],
-    limited_to_8bpc=True,
 )
 def add_caption_node(
     img: np.ndarray, caption: str, size: int, position: CaptionPosition


### PR DESCRIPTION
I used inline labels to make the node more compact and changed the way captions are added. The `add_caption` function will no longer convert the whole image to 8 bit. This not only means that the image will retain all of its depth, it also makes the node a lot faster. In my tests, adding captions to very large images is up to 10x faster now.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/b31c47dc-f145-4ac4-8eeb-1a0661b67d8d)
