### PR TITLE
Use float32 images in Remove Background node

### DIFF
--- a/backend/src/nodes/impl/rembg/bg.py
+++ b/backend/src/nodes/impl/rembg/bg.py
@@ -1,46 +1,35 @@
 from __future__ import annotations
 
+import cv2
 import numpy as np
 import onnxruntime as ort
-from cv2 import (
-    BORDER_DEFAULT,
-    COLOR_BGR2RGB,
-    COLOR_BGRA2RGB,
-    COLOR_RGBA2BGRA,
-    MORPH_ELLIPSE,
-    MORPH_OPEN,
-    GaussianBlur,
-    cvtColor,
-    getStructuringElement,
-    morphologyEx,
-)
-from PIL import Image
-from PIL.Image import Image as PILImage
 from pymatting import estimate_alpha_cf, estimate_foreground_ml
 from scipy.ndimage import binary_erosion
 
-from ...impl.image_utils import normalize
 from ...utils.utils import get_h_w_c
 from .session_factory import new_session
 
-kernel = getStructuringElement(MORPH_ELLIPSE, (3, 3))
+
+def assert_rgb(img: np.ndarray):
+    assert get_h_w_c(img)[2] == 3
+
+
+def assert_gray(img: np.ndarray):
+    assert img.ndim == 2
 
 
 def alpha_matting_cutout(
-    img: PILImage,
-    mask: PILImage,
+    img: np.ndarray,
+    mask: np.ndarray,
     foreground_threshold: int,
     background_threshold: int,
     erode_structure_size: int,
-) -> PILImage:
-    if img.mode in ("RGBA", "CMYK"):
-        img = img.convert("RGB")
+) -> np.ndarray:
+    assert_rgb(img)
+    assert_gray(mask)
 
-    npimg = np.asarray(img)
-    npmask = np.asarray(mask)
-
-    is_foreground = npmask > foreground_threshold
-    is_background = npmask < background_threshold
+    is_foreground = mask > (foreground_threshold / 255)
+    is_background = mask < (background_threshold / 255)
 
     structure = None
     if erode_structure_size > 0:
@@ -51,41 +40,22 @@ def alpha_matting_cutout(
     is_foreground = binary_erosion(is_foreground, structure=structure)
     is_background = binary_erosion(is_background, structure=structure, border_value=1)
 
-    trimap = np.full(npmask.shape, dtype=np.uint8, fill_value=128)
-    trimap[is_foreground] = 255
+    trimap = np.full(mask.shape, dtype=np.float64, fill_value=0.5)
+    trimap[is_foreground] = 1
     trimap[is_background] = 0
 
-    img_normalized = npimg / 255.0
-    trimap_normalized = trimap / 255.0
+    img64 = img.astype(np.float64)
+    alpha = estimate_alpha_cf(img64, trimap)
+    foreground = estimate_foreground_ml(img64, alpha)
+    assert isinstance(foreground, np.ndarray)
 
-    alpha = estimate_alpha_cf(img_normalized, trimap_normalized)
-    foreground = estimate_foreground_ml(img_normalized, alpha)
-    cutout = np.dstack((foreground, alpha))
-
-    cutout = np.clip(cutout * 255, 0, 255).astype(np.uint8)  # type: ignore
-    cutout = Image.fromarray(cutout)
-
-    return cutout
+    return np.dstack((foreground.astype(np.float32), alpha.astype(np.float32)))
 
 
-def naive_cutout(img: PILImage, mask: PILImage) -> PILImage:
-    empty = Image.new("RGBA", (img.size), 0)
-    cutout = Image.composite(img, empty, mask)
-    return cutout
-
-
-def get_concat_v_multi(imgs: list[PILImage]) -> PILImage:
-    pivot = imgs.pop(0)
-    for im in imgs:
-        pivot = get_concat_v(pivot, im)
-    return pivot
-
-
-def get_concat_v(img1: PILImage, img2: PILImage) -> PILImage:
-    dst = Image.new("RGBA", (img1.width, img1.height + img2.height))
-    dst.paste(img1, (0, 0))
-    dst.paste(img2, (0, img1.height))
-    return dst
+def naive_cutout(img: np.ndarray, mask: np.ndarray) -> np.ndarray:
+    assert_rgb(img)
+    assert_gray(mask)
+    return np.dstack((img, mask))
 
 
 def post_process(mask: np.ndarray) -> np.ndarray:
@@ -95,11 +65,12 @@ def post_process(mask: np.ndarray) -> np.ndarray:
     args:
         mask: Binary Numpy Mask
     """
-    mask = morphologyEx(mask, MORPH_OPEN, kernel)
-    mask = GaussianBlur(mask, (5, 5), sigmaX=2, sigmaY=2, borderType=BORDER_DEFAULT)
-    mask = np.where(mask < 127, 0, 255).astype(  # type: ignore
-        np.uint8
-    )  # convert again to binary
+    kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (3, 3))
+    mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, kernel)
+    mask = cv2.GaussianBlur(
+        mask, (5, 5), sigmaX=2, sigmaY=2, borderType=cv2.BORDER_DEFAULT
+    )
+    mask = np.where(mask < 0.5, 0, 1).astype(np.float32)
     return mask
 
 
@@ -112,46 +83,40 @@ def remove_bg(
     alpha_matting_erode_size: int = 10,
     post_process_mask: bool = False,
 ) -> tuple[np.ndarray, np.ndarray]:
-    # Flip channels to RGB mode and convert to PIL Image
-    img = (img * 255).astype(np.uint8)
-    _, _, c = get_h_w_c(img)
-    if c == 3:
-        img = cvtColor(img, COLOR_BGR2RGB)
-    elif c == 4:
-        img = cvtColor(img, COLOR_BGRA2RGB)
-    pimg = Image.fromarray(img)
-
+    # Flip channels to RGB mode
+    assert_rgb(img)
+    img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
     session = new_session(ort_session)
 
-    masks = session.predict(pimg)
-    cutouts = []
+    masks: list[np.ndarray] = session.predict(img)
+    cutouts: list[np.ndarray] = []
 
     assert len(masks) > 0, "Model failed to generate masks"
 
+    mask = None
     for mask in masks:
         if post_process_mask:
-            mask = Image.fromarray(post_process(np.array(mask)))  # noqa
+            mask = post_process(mask)  # noqa
 
         if alpha_matting:
             try:
                 cutout = alpha_matting_cutout(
-                    pimg,
+                    img,
                     mask,
                     alpha_matting_foreground_threshold,
                     alpha_matting_background_threshold,
                     alpha_matting_erode_size,
                 )
             except ValueError:
-                cutout = naive_cutout(pimg, mask)
+                cutout = naive_cutout(img, mask)
         else:
-            cutout = naive_cutout(pimg, mask)
+            cutout = naive_cutout(img, mask)
 
         cutouts.append(cutout)
 
-    cutout = pimg
-    if len(cutouts) > 0:
-        cutout = get_concat_v_multi(cutouts)
+    if mask is None or len(cutouts) == 0:
+        raise ValueError("Model failed to generate masks")
 
-    return cvtColor(normalize(np.asarray(cutout)), COLOR_RGBA2BGRA), normalize(
-        np.asarray(mask)  # type: ignore
-    )
+    cutout = cv2.vconcat(cutouts)
+
+    return cv2.cvtColor(cutout, cv2.COLOR_RGBA2BGRA), mask

--- a/backend/src/nodes/impl/rembg/session_base.py
+++ b/backend/src/nodes/impl/rembg/session_base.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import numpy as np
 import onnxruntime as ort
-from PIL import Image
-from PIL.Image import Image as PILImage
+
+from nodes.impl.resize import ResizeFilter, resize
 
 
 class BaseSession:
@@ -19,15 +19,13 @@ class BaseSession:
         self.std = std
         self.size = size
 
-    def normalize(self, img: PILImage) -> dict[str, np.ndarray]:
-        im = img.convert("RGB").resize(self.size, Image.LANCZOS)
-        im_ary = np.array(im)
-        im_ary = im_ary / np.max(im_ary)
+    def normalize(self, img: np.ndarray) -> dict[str, np.ndarray]:
+        img = resize(img, self.size, ResizeFilter.LANCZOS)
 
-        tmp_img = np.zeros((im_ary.shape[0], im_ary.shape[1], 3))
-        tmp_img[:, :, 0] = (im_ary[:, :, 0] - self.mean[0]) / self.std[0]
-        tmp_img[:, :, 1] = (im_ary[:, :, 1] - self.mean[1]) / self.std[1]
-        tmp_img[:, :, 2] = (im_ary[:, :, 2] - self.mean[2]) / self.std[2]
+        tmp_img = np.zeros((img.shape[0], img.shape[1], 3))
+        tmp_img[:, :, 0] = (img[:, :, 0] - self.mean[0]) / self.std[0]
+        tmp_img[:, :, 1] = (img[:, :, 1] - self.mean[1]) / self.std[1]
+        tmp_img[:, :, 2] = (img[:, :, 2] - self.mean[2]) / self.std[2]
 
         tmp_img = tmp_img.transpose((2, 0, 1))
 
@@ -35,5 +33,5 @@ class BaseSession:
 
         return {model_input_name: np.expand_dims(tmp_img, 0).astype(np.float32)}
 
-    def predict(self, _: PILImage) -> list[PILImage]:
+    def predict(self, _: np.ndarray) -> list[np.ndarray]:
         raise NotImplementedError

--- a/backend/src/packages/chaiNNer_onnx/onnx/processing/remove_background.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/processing/remove_background.py
@@ -53,7 +53,6 @@ from .. import processing_group
         ),
         ImageOutput("Mask", image_type=navi.Image(size_as="Input0"), channels=1),
     ],
-    limited_to_8bpc=True,
     node_context=True,
 )
 def remove_background_node(
@@ -74,6 +73,10 @@ def remove_background_node(
         settings.tensorrt_fp16_mode,
         settings.tensorrt_cache_path,
     )
+
+    # Remove alpha channel
+    if img.shape[2] == 4:
+        img = img[:, :, :3]
 
     return remove_bg(
         img,


### PR DESCRIPTION
Remove Background was the last nodes that limited to 8 bit for no good reason. I changed its implementation to use regular f32 numpy arrays instead of u8 PIL images.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/d2f8a150-9f9f-48e1-b498-d34abf29e5e5)
