### PR TITLE
Refactor `useSourceTypeColor` and some parts of handles

### DIFF
--- a/src/renderer/components/inputs/InputContainer.tsx
+++ b/src/renderer/components/inputs/InputContainer.tsx
@@ -2,10 +2,10 @@ import { Type } from '@chainner/navi';
 import { QuestionIcon } from '@chakra-ui/icons';
 import { Box, Center, HStack, Text, Tooltip } from '@chakra-ui/react';
 import React, { memo, useCallback, useMemo } from 'react';
-import { Connection, useReactFlow } from 'reactflow';
+import { Connection } from 'reactflow';
 import { useContext } from 'use-context-selector';
 import { InputId, LabelStyle } from '../../../common/common-types';
-import { assertNever, parseTargetHandle, stringifyTargetHandle } from '../../../common/util';
+import { assertNever, stringifyTargetHandle } from '../../../common/util';
 import { VALID, invalid } from '../../../common/Validity';
 import { GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { InputContext } from '../../contexts/InputContext';
@@ -20,6 +20,7 @@ export interface InputHandleProps {
     inputId: InputId;
     connectableType: Type;
     isIterated: boolean;
+    isConnected: boolean;
 }
 
 export const InputHandle = memo(
@@ -29,18 +30,9 @@ export const InputHandle = memo(
         inputId,
         connectableType,
         isIterated,
+        isConnected,
     }: React.PropsWithChildren<InputHandleProps>) => {
-        const { isValidConnection, edgeChanges, useConnectingFrom } =
-            useContext(GlobalVolatileContext);
-        const { getEdges } = useReactFlow();
-
-        const connectedEdge = useMemo(() => {
-            return getEdges().find(
-                (e) => e.target === id && parseTargetHandle(e.targetHandle!).inputId === inputId
-            );
-            // eslint-disable-next-line react-hooks/exhaustive-deps
-        }, [edgeChanges, getEdges, id, inputId]);
-        const isConnected = !!connectedEdge;
+        const { isValidConnection, useConnectingFrom } = useContext(GlobalVolatileContext);
         const [connectingFrom] = useConnectingFrom;
 
         const targetHandle = stringifyTargetHandle({ nodeId: id, inputId });
@@ -74,7 +66,7 @@ export const InputHandle = memo(
 
         const handleColors = getTypeAccentColors(connectableType);
 
-        const sourceTypeColor = useSourceTypeColor(id, inputId);
+        const sourceTypeColor = useSourceTypeColor(targetHandle);
 
         return (
             <HStack

--- a/src/renderer/components/inputs/SchemaInput.tsx
+++ b/src/renderer/components/inputs/SchemaInput.tsx
@@ -131,6 +131,7 @@ export const SchemaInput = memo(({ input, nodeState, afterInput }: SingleInputPr
                 connectableType={connectableType}
                 id={nodeId}
                 inputId={inputId}
+                isConnected={connectedInputs.has(inputId)}
                 isIterated={iteratedInputs.has(inputId)}
             >
                 {inputElement}

--- a/src/renderer/components/node/CollapsedHandles.tsx
+++ b/src/renderer/components/node/CollapsedHandles.tsx
@@ -3,7 +3,6 @@ import { Box } from '@chakra-ui/react';
 import { memo } from 'react';
 import { Handle, Position } from 'reactflow';
 import { useContextSelector } from 'use-context-selector';
-import { InputId } from '../../../common/common-types';
 import { stringifySourceHandle, stringifyTargetHandle } from '../../../common/util';
 import { BackendContext } from '../../contexts/BackendContext';
 import { defaultColor, getTypeAccentColors } from '../../helpers/accentColors';
@@ -12,14 +11,12 @@ import { useSourceTypeColor } from '../../hooks/useSourceTypeColor';
 import { getBackground } from '../Handle';
 
 interface InputHandleProps {
-    nodeId: string;
-    inputId: InputId;
     isIterated: boolean;
-    handleId: string;
+    targetHandle: string;
 }
 
-const InputHandle = memo(({ nodeId, isIterated, inputId, handleId }: InputHandleProps) => {
-    const sourceTypeColor = useSourceTypeColor(nodeId, inputId);
+const InputHandle = memo(({ isIterated, targetHandle }: InputHandleProps) => {
+    const sourceTypeColor = useSourceTypeColor(targetHandle);
 
     return (
         <Box
@@ -30,7 +27,7 @@ const InputHandle = memo(({ nodeId, isIterated, inputId, handleId }: InputHandle
         >
             <Handle
                 className="input-handle"
-                id={handleId}
+                id={targetHandle}
                 isConnectable={false}
                 position={Position.Left}
                 style={{
@@ -69,22 +66,19 @@ export const CollapsedHandles = memo(({ nodeState }: CollapsedHandlesProps) => {
                 <Box>
                     {inputs.map((input) => {
                         const isConnected = nodeState.connectedInputs.has(input.id);
-
                         if (!isConnected) {
                             return null;
                         }
 
                         const isIterated = iteratedInputs.has(input.id);
 
-                        const handleId = stringifyTargetHandle({ nodeId, inputId: input.id });
+                        const targetHandle = stringifyTargetHandle({ nodeId, inputId: input.id });
 
                         return (
                             <InputHandle
-                                handleId={handleId}
-                                inputId={input.id}
                                 isIterated={isIterated}
-                                key={handleId}
-                                nodeId={nodeId}
+                                key={targetHandle}
+                                targetHandle={targetHandle}
                             />
                         );
                     })}
@@ -100,33 +94,31 @@ export const CollapsedHandles = memo(({ nodeState }: CollapsedHandlesProps) => {
             >
                 <Box>
                     {outputs.map((output) => {
-                        const functions = functionDefinition?.outputDefaults;
-                        const definitionType = functions?.get(output.id) ?? NeverType.instance;
-                        const type = nodeState.type.instance?.outputs.get(output.id);
-
                         const isConnected = nodeState.connectedOutputs.has(output.id);
-
                         if (!isConnected) {
                             return null;
                         }
 
+                        const functions = functionDefinition?.outputDefaults;
+                        const definitionType = functions?.get(output.id) ?? NeverType.instance;
+                        const type = nodeState.type.instance?.outputs.get(output.id);
                         const handleColors = getTypeAccentColors(type || definitionType);
 
                         const isIterated = iteratedOutputs.has(output.id);
 
-                        const handleId = stringifySourceHandle({ nodeId, outputId: output.id });
+                        const sourceHandle = stringifySourceHandle({ nodeId, outputId: output.id });
 
                         return (
                             <Box
                                 h="6px"
-                                key={handleId}
+                                key={sourceHandle}
                                 ml="auto"
                                 position="relative"
                                 w="6px"
                             >
                                 <Handle
                                     className="output-handle"
-                                    id={handleId}
+                                    id={sourceHandle}
                                     isConnectable={false}
                                     position={Position.Right}
                                     style={{

--- a/src/renderer/hooks/useSourceTypeColor.ts
+++ b/src/renderer/hooks/useSourceTypeColor.ts
@@ -1,36 +1,34 @@
 import { useMemo } from 'react';
 import { Node, useReactFlow } from 'reactflow';
 import { useContext } from 'use-context-selector';
-import { InputId, NodeData } from '../../common/common-types';
-import { parseSourceHandle, parseTargetHandle } from '../../common/util';
+import { NodeData } from '../../common/common-types';
+import { parseSourceHandle } from '../../common/util';
 import { BackendContext } from '../contexts/BackendContext';
 import { GlobalVolatileContext } from '../contexts/GlobalNodeState';
 import { defaultColor, getTypeAccentColors } from '../helpers/accentColors';
 
-export const useSourceTypeColor = (nodeId: string, inputId: InputId) => {
+export const useSourceTypeColor = (targetHandle: string) => {
     const { functionDefinitions } = useContext(BackendContext);
     const { edgeChanges, typeState } = useContext(GlobalVolatileContext);
     const { getEdges, getNode } = useReactFlow();
 
-    const connectedEdge = useMemo(() => {
-        return getEdges().find(
-            (e) => e.target === nodeId && parseTargetHandle(e.targetHandle!).inputId === inputId
-        );
+    const sourceHandle = useMemo(() => {
+        return getEdges().find((e) => e.targetHandle === targetHandle)?.sourceHandle;
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [edgeChanges, getEdges, nodeId, inputId]);
+    }, [edgeChanges, getEdges, targetHandle]);
 
     const sourceTypeColor = useMemo(() => {
-        if (connectedEdge) {
-            const sourceNode: Node<NodeData> | undefined = getNode(connectedEdge.source);
-            const sourceOutputId = parseSourceHandle(connectedEdge.sourceHandle!).outputId;
+        if (sourceHandle) {
+            const source = parseSourceHandle(sourceHandle);
+            const sourceNode: Node<NodeData> | undefined = getNode(source.nodeId);
             if (sourceNode) {
                 const sourceDef = functionDefinitions.get(sourceNode.data.schemaId);
                 if (!sourceDef) {
                     return defaultColor;
                 }
                 const sourceType =
-                    typeState.functions.get(sourceNode.id)?.outputs.get(sourceOutputId) ??
-                    sourceDef.outputDefaults.get(sourceOutputId);
+                    typeState.functions.get(source.nodeId)?.outputs.get(source.outputId) ??
+                    sourceDef.outputDefaults.get(source.outputId);
                 if (!sourceType) {
                     return defaultColor;
                 }
@@ -39,7 +37,7 @@ export const useSourceTypeColor = (nodeId: string, inputId: InputId) => {
             return defaultColor;
         }
         return null;
-    }, [connectedEdge, functionDefinitions, typeState, getNode]);
+    }, [sourceHandle, functionDefinitions, typeState, getNode]);
 
     return sourceTypeColor;
 };


### PR DESCRIPTION
Changes:
- Make `useSourceTypeColor` take a target handle.
- `InputHandle` now takes a `isConnected` prop instead of computing this value itself (it's already computed for node state).
- Some minor changes to `CollapsedHandles`.