### PR TITLE
Hide label of text input in Text As Image

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image/create_images/text_as_image.py
+++ b/backend/src/packages/chaiNNer_standard/image/create_images/text_as_image.py
@@ -97,7 +97,7 @@ TEXT_AS_IMAGE_X_Y_REF_FACTORS = {
     description="Create an image using any text.",
     icon="MdTextFields",
     inputs=[
-        TextInput("Text", multiline=True),
+        TextInput("Text", multiline=True, label_style="hidden"),
         BoolInput("Bold", default=False),
         BoolInput("Italic", default=False),
         ColorInput(channels=[3], default=Color.bgr((0, 0, 0))),


### PR DESCRIPTION
Because of the name of the node and the placeholder, it's clear what the purpose of that text input is. So I think the label isn't necessary and removed it.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/42e3c7ac-caca-414f-80a9-18c0057edacd)
