### PR TITLE
Hide Copy to Clipboard input label

### DIFF
--- a/backend/src/nodes/properties/inputs/generic_inputs.py
+++ b/backend/src/nodes/properties/inputs/generic_inputs.py
@@ -17,7 +17,7 @@ from ...condition import Condition, ConditionJson
 from ...impl.blend import BlendMode
 from ...impl.color.color import Color
 from ...impl.dds.format import DDSFormat
-from ...impl.image_utils import FillColor, normalize
+from ...impl.image_utils import FillColor
 from ...impl.upscale.auto_split_tiles import TileSize
 from ...utils.format import format_color_with_channels
 from ...utils.seed import Seed
@@ -346,15 +346,23 @@ class ClipboardInput(BaseInput):
         super().__init__(["Image", "string", "number"], label, kind="text")
         self.input_conversions = [InputConversion("Image", '"<Image>"')]
 
+        self.label_style: LabelStyle = "hidden"
+
     def enforce(self, value: object):
         if isinstance(value, np.ndarray):
-            return normalize(value)
+            return value
 
         if isinstance(value, float) and int(value) == value:
             # stringify integers values
             return str(int(value))
 
         return str(value)
+
+    def to_dict(self):
+        return {
+            **super().to_dict(),
+            "labelStyle": self.label_style,
+        }
 
 
 class AnyInput(BaseInput):


### PR DESCRIPTION
It's pretty obvious that the only input of a node called "Copy to clipboard" is the clipboard input. The placeholder also says so. Since the label on the input wasn't necessary, I removed it.

I also changed the `enforce` of `ClipboardInput`. Images are always normalized, so `normalize` was unnecessary. This makes the node about 25% faster.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/237a2d6b-a97c-4e34-8536-b73e862b2180)
