### PR TITLE
Add `NodeView` component

### DIFF
--- a/src/renderer/components/NodeDocumentation/NodeDocs.tsx
+++ b/src/renderer/components/NodeDocumentation/NodeDocs.tsx
@@ -436,12 +436,10 @@ export const NodeDocs = memo(({ schema }: NodeDocsProps) => {
                         <Flex
                             direction={isLargerThan1200 ? 'row' : 'column'}
                             gap={4}
-                            key={schema.schemaId}
                         >
                             <SingleNodeInfo
                                 accentColor={selectedAccentColor}
                                 functionDefinition={nodeFunctionDefinition}
-                                key={schema.schemaId}
                                 schema={schema}
                             />
                             <Center
@@ -455,11 +453,7 @@ export const NodeDocs = memo(({ schema }: NodeDocsProps) => {
                                     position="relative"
                                     w="auto"
                                 >
-                                    <NodeExample
-                                        accentColor={selectedAccentColor}
-                                        key={schema.schemaId}
-                                        selectedSchema={schema}
-                                    />
+                                    <NodeExample selectedSchema={schema} />
                                 </Box>
                             </Center>
                         </Flex>

--- a/src/renderer/components/NodeDocumentation/NodeExample.tsx
+++ b/src/renderer/components/NodeDocumentation/NodeExample.tsx
@@ -1,4 +1,4 @@
-import { Center, VStack } from '@chakra-ui/react';
+import { Center } from '@chakra-ui/react';
 import { memo, useCallback, useMemo, useState } from 'react';
 import { Node } from 'reactflow';
 import { useContext } from 'use-context-selector';
@@ -13,15 +13,12 @@ import {
     OutputId,
 } from '../../../common/common-types';
 import { checkNodeValidity } from '../../../common/nodes/checkNodeValidity';
-import { DisabledStatus } from '../../../common/nodes/disabled';
 import { TypeState } from '../../../common/nodes/TypeState';
 import { EMPTY_ARRAY, EMPTY_MAP, EMPTY_OBJECT, EMPTY_SET } from '../../../common/util';
 import { BackendContext } from '../../contexts/BackendContext';
 import { FakeNodeProvider } from '../../contexts/FakeExampleContext';
 import { NodeState, TypeInfo, testForInputConditionTypeInfo } from '../../helpers/nodeState';
-import { NodeBody } from '../node/NodeBody';
-import { NodeFooter } from '../node/NodeFooter/NodeFooter';
-import { NodeHeader } from '../node/NodeHeader';
+import { NodeView } from '../node/Node';
 
 // eslint-disable-next-line prefer-arrow-functions/prefer-arrow-functions, func-names
 const useStateForSchema = function <T>(
@@ -51,10 +48,9 @@ const useStateForSchema = function <T>(
 };
 
 interface NodeExampleProps {
-    accentColor: string;
     selectedSchema: NodeSchema;
 }
-export const NodeExample = memo(({ accentColor, selectedSchema }: NodeExampleProps) => {
+export const NodeExample = memo(({ selectedSchema }: NodeExampleProps) => {
     const { schemata, functionDefinitions } = useContext(BackendContext);
 
     const defaultInput = useMemo<InputData>(() => {
@@ -174,46 +170,10 @@ export const NodeExample = memo(({ accentColor, selectedSchema }: NodeExamplePro
     return (
         <Center key={selectedSchema.schemaId}>
             <FakeNodeProvider isFake>
-                <Center
-                    bg="var(--node-bg-color)"
-                    borderColor="var(--node-border-color)"
-                    borderRadius="lg"
-                    borderWidth="0.5px"
-                    boxShadow="lg"
-                    minWidth="240px"
-                    overflow="hidden"
-                    transition="0.15s ease-in-out"
-                >
-                    <VStack
-                        spacing={0}
-                        w="full"
-                    >
-                        <VStack
-                            spacing={0}
-                            w="full"
-                        >
-                            <NodeHeader
-                                accentColor={accentColor}
-                                animated={false}
-                                disabledStatus={DisabledStatus.Enabled}
-                                icon={selectedSchema.icon}
-                                name={selectedSchema.name}
-                                nodeState={nodeState}
-                                selected={false}
-                                validity={validity}
-                            />
-                            <NodeBody
-                                animated={false}
-                                nodeState={nodeState}
-                            />
-                        </VStack>
-                        <NodeFooter
-                            animated={false}
-                            id={nodeId}
-                            validity={validity}
-                        />
-                    </VStack>
-                </Center>
+                <NodeView
+                    nodeState={nodeState}
+                    validity={validity}
+                />
             </FakeNodeProvider>
         </Center>
     );

--- a/src/renderer/components/node/NodeFooter/DisableToggle.tsx
+++ b/src/renderer/components/node/NodeFooter/DisableToggle.tsx
@@ -4,11 +4,11 @@ import { MdPlayArrow, MdPlayDisabled } from 'react-icons/md';
 import { UseDisabled } from '../../../hooks/useDisabled';
 
 interface DisableToggleProps {
-    useDisable: UseDisabled;
+    disable: UseDisabled;
 }
 
-export const DisableToggle = memo(({ useDisable }: DisableToggleProps) => {
-    const { isDirectlyDisabled, toggleDirectlyDisabled } = useDisable;
+export const DisableToggle = memo(({ disable }: DisableToggleProps) => {
+    const { isDirectlyDisabled, toggleDirectlyDisabled } = disable;
 
     return (
         <Tooltip

--- a/src/renderer/components/node/NodeFooter/NodeFooter.tsx
+++ b/src/renderer/components/node/NodeFooter/NodeFooter.tsx
@@ -10,13 +10,13 @@ import { ValidityIndicator } from './ValidityIndicator';
 
 interface NodeFooterProps {
     validity: Validity;
-    useDisable?: UseDisabled;
+    disable?: UseDisabled;
     animated: boolean;
     id: string;
 }
 
-export const NodeFooter = memo(({ id, validity, useDisable, animated }: NodeFooterProps) => {
-    const { canDisable } = useDisable ?? { canDisable: false };
+export const NodeFooter = memo(({ id, validity, disable, animated }: NodeFooterProps) => {
+    const { canDisable } = disable ?? { canDisable: false };
     const lastExecutionTime = useContextSelector(
         GlobalVolatileContext,
         (c) => c.outputDataMap.get(id)?.lastExecutionTime
@@ -35,7 +35,7 @@ export const NodeFooter = memo(({ id, validity, useDisable, animated }: NodeFoot
                 w="full"
             >
                 <Center marginRight="auto">
-                    {canDisable && useDisable && <DisableToggle useDisable={useDisable} />}
+                    {canDisable && disable && <DisableToggle disable={disable} />}
                 </Center>
 
                 <Center w="full">

--- a/src/renderer/components/node/NodeHeader.tsx
+++ b/src/renderer/components/node/NodeHeader.tsx
@@ -2,7 +2,6 @@ import { ChevronDownIcon, ChevronRightIcon } from '@chakra-ui/icons';
 import { Box, Center, HStack, Heading, IconButton, Spacer, Text, VStack } from '@chakra-ui/react';
 import { memo } from 'react';
 import ReactTimeAgo from 'react-time-ago';
-import { DisabledStatus } from '../../../common/nodes/disabled';
 import { Validity } from '../../../common/Validity';
 import { NodeProgress } from '../../contexts/ExecutionContext';
 import { interpolateColor } from '../../helpers/colorTools';
@@ -74,32 +73,28 @@ const IteratorProcess = memo(({ nodeProgress, progressColor }: IteratorProcessPr
 });
 
 interface NodeHeaderProps {
-    name: string;
-    icon: string;
+    nodeState: NodeState;
     accentColor: string;
     selected: boolean;
-    disabledStatus: DisabledStatus;
+    isEnabled: boolean;
     animated: boolean;
     validity: Validity;
     nodeProgress?: NodeProgress;
     isCollapsed?: boolean;
     toggleCollapse?: () => void;
-    nodeState: NodeState;
 }
 
 export const NodeHeader = memo(
     ({
-        name,
-        icon,
+        nodeState,
         accentColor,
         selected,
-        disabledStatus,
+        isEnabled,
         animated,
         validity,
         nodeProgress,
         isCollapsed = false,
         toggleCollapse,
-        nodeState,
     }: NodeHeaderProps) => {
         const bgColor = useThemeColor('--bg-700');
         const gradL = interpolateColor(accentColor, bgColor, 0.9);
@@ -151,7 +146,7 @@ export const NodeHeader = memo(
                         >
                             <IconFactory
                                 accentColor={selected ? accentColor : 'var(--node-icon-color)'}
-                                icon={icon}
+                                icon={nodeState.schema.icon}
                             />
                         </Center>
                         <Center verticalAlign="middle">
@@ -161,7 +156,7 @@ export const NodeHeader = memo(
                                 fontWeight={700}
                                 lineHeight="auto"
                                 m={0}
-                                opacity={disabledStatus === DisabledStatus.Enabled ? 1 : 0.5}
+                                opacity={isEnabled ? 1 : 0.5}
                                 p={0}
                                 size="sm"
                                 textAlign="center"
@@ -169,7 +164,7 @@ export const NodeHeader = memo(
                                 verticalAlign="middle"
                                 whiteSpace="nowrap"
                             >
-                                {name}
+                                {nodeState.schema.name}
                             </Heading>
                         </Center>
                     </HStack>


### PR DESCRIPTION
This adds a `NodeView` component so `NodeExample` doesn't have to piece together head, body, and footer anymore. This component decouples the effects of `NodeInner` from its view.