### PR TITLE
Fix react ref warning

### DIFF
--- a/src/renderer/components/node/Node.tsx
+++ b/src/renderer/components/node/Node.tsx
@@ -71,7 +71,7 @@ export interface NodeViewProps {
     nodeProgress?: NodeProgress;
     borderColor?: string;
 
-    ref?: LegacyRef<HTMLDivElement>;
+    targetRef?: LegacyRef<HTMLDivElement>;
     onContextMenu?: MouseEventHandler<HTMLDivElement>;
     onDragOver?: DragEventHandler<HTMLDivElement>;
     onDrop?: DragEventHandler<HTMLDivElement>;
@@ -88,7 +88,7 @@ export const NodeView = memo(
         disable,
         nodeProgress,
         borderColor,
-        ref,
+        targetRef,
         onContextMenu,
         onDragOver,
         onDrop,
@@ -116,7 +116,7 @@ export const NodeView = memo(
                 minWidth="240px"
                 opacity={isEnabled ? 1 : 0.75}
                 overflow="hidden"
-                ref={ref}
+                ref={targetRef}
                 transition="0.15s ease-in-out"
                 onContextMenu={onContextMenu}
                 onDragOver={onDragOver}
@@ -293,8 +293,8 @@ const NodeInner = memo(({ data, selected }: NodeProps) => {
             isCollapsed={isCollapsed}
             nodeProgress={nodeProgress}
             nodeState={nodeState}
-            ref={targetRef}
             selected={selected}
+            targetRef={targetRef}
             toggleCollapse={toggleCollapse}
             validity={validity}
             onContextMenu={menu.onContextMenu}


### PR DESCRIPTION
![image](https://github.com/chaiNNer-org/chaiNNer/assets/34788790/d243e9bb-a861-4a82-bb77-a4fafdecca60)

React apparently doesn't like when you have a custom prop called `ref` because it thinks you're trying to set a ref on the component rather than pass one in. So, I just renamed it. 