### PR TITLE
Support hints for inline labels

### DIFF
--- a/src/renderer/components/inputs/InputContainer.tsx
+++ b/src/renderer/components/inputs/InputContainer.tsx
@@ -211,7 +211,7 @@ export const WithoutLabel = memo(
 export const InlineLabel = memo(({ input, children }: React.PropsWithChildren<WithLabelProps>) => {
     const { conditionallyInactive } = useContext(InputContext);
 
-    const { hasHandle = false } = input;
+    const { hasHandle = false, hint = false, description } = input;
 
     return (
         <WithoutLabel>
@@ -231,12 +231,27 @@ export const InlineLabel = memo(({ input, children }: React.PropsWithChildren<Wi
                     >
                         {input.label}
                     </Text>
-                    {/* <Center>
-                <TypeTags
-                    isOptional={input.optional}
-                    type={definitionType}
-                />
-            </Center> */}
+                    {hint && description && (
+                        <Tooltip
+                            hasArrow
+                            borderRadius={8}
+                            label={<Markdown nonInteractive>{description}</Markdown>}
+                            openDelay={500}
+                            px={2}
+                            py={1}
+                        >
+                            <Center
+                                h="auto"
+                                m={0}
+                                p={0}
+                            >
+                                <QuestionIcon
+                                    boxSize={3}
+                                    ml={1}
+                                />
+                            </Center>
+                        </Tooltip>
+                    )}
                 </Box>
 
                 <Box flexGrow={1}>{children}</Box>


### PR DESCRIPTION
Hints weren't supported before for inline labels, so I added it.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/a1adefaa-b0b3-4515-8cb4-477f9b37aa9f)
