### PR TITLE
Add group to have a menu-like row of icons for Text As Image

### DIFF
--- a/backend/src/nodes/groups.py
+++ b/backend/src/nodes/groups.py
@@ -110,3 +110,13 @@ def icon_set_group(label: str):
     checkboxes. The icons are specified by the `icons` parameter.
     """
     return group("icon-set", {"label": label})
+
+
+def menu_icon_row_group():
+    """
+    This group displays multiple icon-only inputs and groups as a row of icons. Only a few inputs
+    and groups are supported.
+
+    This group is intended to be used in the "Text As Image" node.
+    """
+    return group("menu-icon-row")

--- a/backend/src/packages/chaiNNer_standard/image/create_images/text_as_image.py
+++ b/backend/src/packages/chaiNNer_standard/image/create_images/text_as_image.py
@@ -7,7 +7,7 @@ from enum import Enum
 import numpy as np
 from PIL import Image, ImageDraw, ImageFont
 
-from nodes.groups import icon_set_group
+from nodes.groups import icon_set_group, menu_icon_row_group
 from nodes.impl.caption import get_font_size
 from nodes.impl.color.color import Color
 from nodes.impl.image_utils import normalize, to_uint8
@@ -99,21 +99,23 @@ TEXT_AS_IMAGE_X_Y_REF_FACTORS = {
     icon="MdTextFields",
     inputs=[
         TextInput("Text", multiline=True, label_style="hidden"),
-        icon_set_group("Style")(
-            BoolInput("Bold", default=False, icon="FaBold").with_id(1),
-            BoolInput("Italic", default=False, icon="FaItalic").with_id(2),
+        menu_icon_row_group()(
+            icon_set_group("Style")(
+                BoolInput("Bold", default=False, icon="FaBold").with_id(1),
+                BoolInput("Italic", default=False, icon="FaItalic").with_id(2),
+            ),
+            EnumInput(
+                TextAsImageAlignment,
+                label="Alignment",
+                preferred_style="icons",
+                icons={
+                    TextAsImageAlignment.LEFT: "FaAlignLeft",
+                    TextAsImageAlignment.CENTER: "FaAlignCenter",
+                    TextAsImageAlignment.RIGHT: "FaAlignRight",
+                },
+                default=TextAsImageAlignment.CENTER,
+            ).with_id(4),
         ),
-        EnumInput(
-            TextAsImageAlignment,
-            label="Alignment",
-            preferred_style="icons",
-            icons={
-                TextAsImageAlignment.LEFT: "FaAlignLeft",
-                TextAsImageAlignment.CENTER: "FaAlignCenter",
-                TextAsImageAlignment.RIGHT: "FaAlignRight",
-            },
-            default=TextAsImageAlignment.CENTER,
-        ).with_id(4),
         ColorInput(channels=[3], default=Color.bgr((0, 0, 0))).with_id(3),
         NumberInput(
             "Width",

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -244,6 +244,10 @@ interface IconSetGroup extends GroupBase {
         readonly label: string;
     };
 }
+interface MenuIconRowGroup extends GroupBase {
+    readonly kind: 'menu-icon-row';
+    readonly options: Readonly<Record<string, never>>;
+}
 export type GroupKind = Group['kind'];
 export type Group =
     | NcnnFileInputGroup
@@ -253,7 +257,8 @@ export type Group =
     | RequiredGroup
     | SeedGroup
     | LinkedInputsGroup
-    | IconSetGroup;
+    | IconSetGroup
+    | MenuIconRowGroup;
 
 export type OfKind<T extends { readonly kind: string }, Kind extends T['kind']> = T extends {
     readonly kind: Kind;

--- a/src/common/group-inputs.ts
+++ b/src/common/group-inputs.ts
@@ -36,6 +36,7 @@ type DeclaredGroupInputs = InputGuarantees<{
     seed: readonly [NumberInput];
     'linked-inputs': readonly [Input, Input, ...Input[]];
     'icon-set': readonly DropDownInput[];
+    'menu-icon-row': readonly InputItem[];
 }>;
 
 // A bit hacky, but this ensures that GroupInputs covers exactly all group types, no more and no less
@@ -175,6 +176,9 @@ const groupInputsChecks: {
         ) {
             return `Expected all inputs to checkboxes`;
         }
+    },
+    'menu-icon-row': (inputs) => {
+        if (inputs.length < 1) return 'Expected at least at one input';
     },
 };
 

--- a/src/renderer/components/groups/Group.tsx
+++ b/src/renderer/components/groups/Group.tsx
@@ -6,6 +6,7 @@ import { ConditionalGroup } from './ConditionalGroup';
 import { FromToDropdownsGroup } from './FromToDropdownsGroup';
 import { IconSetGroup } from './IconSetGroup';
 import { LinkedInputsGroup } from './LinkedInputsGroup';
+import { MenuIconRowGroup } from './MenuIconRowGroup';
 import { NcnnFileInputsGroup } from './NcnnFileInputsGroup';
 import { OptionalInputsGroup } from './OptionalInputsGroup';
 import { GroupProps, InputItemRenderer } from './props';
@@ -23,6 +24,7 @@ const GroupComponents: {
     seed: SeedGroup,
     'linked-inputs': LinkedInputsGroup,
     'icon-set': IconSetGroup,
+    'menu-icon-row': MenuIconRowGroup,
 };
 
 interface GroupElementProps {

--- a/src/renderer/components/groups/IconSetGroup.tsx
+++ b/src/renderer/components/groups/IconSetGroup.tsx
@@ -61,7 +61,7 @@ interface IconSetProps {
     inputs: readonly DropDownInput[];
     nodeState: NodeState;
 }
-const IconSet = memo(({ inputs, nodeState }: IconSetProps) => {
+export const IconSet = memo(({ inputs, nodeState }: IconSetProps) => {
     const { inputData, setInputValue, isLocked } = nodeState;
 
     return (

--- a/src/renderer/components/groups/MenuIconRowGroup.tsx
+++ b/src/renderer/components/groups/MenuIconRowGroup.tsx
@@ -1,0 +1,49 @@
+import { Box } from '@chakra-ui/react';
+import { memo } from 'react';
+import { getUniqueKey } from '../../../common/group-inputs';
+import { IconList } from '../inputs/elements/IconList';
+import { InputContainer, WithoutLabel } from '../inputs/InputContainer';
+import { IconSet } from './IconSetGroup';
+import { GroupProps } from './props';
+
+export const MenuIconRowGroup = memo(({ inputs, nodeState }: GroupProps<'menu-icon-row'>) => {
+    return (
+        <InputContainer>
+            <WithoutLabel>
+                <Box
+                    display="flex"
+                    gap={2}
+                    pl={2}
+                >
+                    {inputs.map((item) => {
+                        const key = getUniqueKey(item);
+                        if (item.kind === 'group' && item.group.kind === 'icon-set') {
+                            return (
+                                <IconSet
+                                    inputs={item.inputs as never}
+                                    key={key}
+                                    nodeState={nodeState}
+                                />
+                            );
+                        }
+
+                        if (item.kind === 'dropdown' && item.preferredStyle === 'icons') {
+                            return (
+                                <IconList
+                                    isDisabled={nodeState.isLocked}
+                                    key={key}
+                                    options={item.options}
+                                    reset={() => nodeState.setInputValue(item.id, item.def)}
+                                    value={nodeState.inputData[item.id]}
+                                    onChange={(value) => nodeState.setInputValue(item.id, value)}
+                                />
+                            );
+                        }
+
+                        return '<unsupported>';
+                    })}
+                </Box>
+            </WithoutLabel>
+        </InputContainer>
+    );
+});


### PR DESCRIPTION
The implementation of `MenuIconRowGroup` is a bit hacky, because it needs to handle groups and inputs itself. So I only supported the 2 that I needed.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/3db7a22e-0bf1-41f2-8d18-925166472392)
