### PR TITLE
Create "Clamp" Node

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/clamp.py
+++ b/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/clamp.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import numpy as np
+
+from nodes.properties.inputs import ImageInput, SliderInput
+from nodes.properties.outputs import ImageOutput
+
+from .. import adjustments_group
+
+
+@adjustments_group.register(
+    schema_id="chainner:image:clamp",
+    name="Clamp",
+    description="Clamps the values of an image.",
+    icon="ImContrast",
+    inputs=[
+        ImageInput(),
+        SliderInput(
+            "Minimum",
+            minimum=0.0,
+            maximum=1.0,
+            default=0.0,
+            precision=4,
+            controls_step=0.001,
+            scale="log",
+        ),
+        SliderInput(
+            "Maximum",
+            minimum=0.0,
+            maximum=1.0,
+            default=1.0,
+            precision=4,
+            controls_step=0.001,
+            scale="log",
+        ),
+    ],
+    outputs=[
+        ImageOutput(
+            image_type="Input0",
+        )
+    ],
+)
+def clamp_node(img: np.ndarray, minimum: float, maximum: float) -> np.ndarray:
+    return np.clip(img, minimum, maximum)


### PR DESCRIPTION
Add a new node to the chaiNNer toolset that will allow the user to Clamp the pixel ranges in an image to a user defined Minimum and Maximum value.