### PR TITLE
Improved snapping for breakpoints

### DIFF
--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -324,7 +324,6 @@ export interface EdgeData {
     sourceY?: number;
     targetX?: number;
     targetY?: number;
-    breakpoints?: readonly [number, number][];
 }
 
 export interface PyPiPackage {

--- a/src/renderer/components/ReactFlowBox.tsx
+++ b/src/renderer/components/ReactFlowBox.tsx
@@ -119,14 +119,7 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
 
         if (isSnapToGrid) {
             for (const n of displayNodes) {
-                if (n.type === 'breakPoint') {
-                    const snapped = snapToGrid(n.position, snapToGridAmount);
-                    const pos = {
-                        x: snapped.x - (n.width ?? 0) / 2,
-                        y: snapped.y - (n.height ?? 0) / 2,
-                    };
-                    n.position = pos;
-                } else if (!isSnappedToGrid(n.position, snapToGridAmount)) {
+                if (!isSnappedToGrid(n.position, snapToGridAmount)) {
                     n.position = snapToGrid(n.position, snapToGridAmount);
                 }
             }

--- a/src/renderer/components/node/BreakPoint.tsx
+++ b/src/renderer/components/node/BreakPoint.tsx
@@ -1,6 +1,6 @@
 import { NeverType } from '@chainner/navi';
 import { DeleteIcon } from '@chakra-ui/icons';
-import { Box, Flex, MenuItem, MenuList } from '@chakra-ui/react';
+import { Box, Center, MenuItem, MenuList } from '@chakra-ui/react';
 import { memo, useEffect, useMemo, useState } from 'react';
 import { Handle, Position, useReactFlow } from 'reactflow';
 import { useContext, useContextSelector } from 'use-context-selector';
@@ -109,18 +109,21 @@ const BreakPointInner = memo(({ id }: NodeProps) => {
     }, 7500);
 
     return (
-        <>
-            <Box
+        <Box
+            height="1px"
+            position="relative"
+            width="1px"
+        >
+            <Center
                 _hover={{
                     height: '16px',
                     width: '16px',
-                    margin: '-2px',
                 }}
                 backgroundColor={accentColor}
                 borderRadius="100%"
                 height={isHovered ? '16px' : '12px'}
-                margin={isHovered ? '-2px' : '0'}
-                position="relative"
+                position="absolute"
+                transform="translate(-50%, -50%)"
                 transition="all 0.2s ease-in-out"
                 width={isHovered ? '16px' : '12px'}
                 onContextMenu={menu.onContextMenu}
@@ -129,61 +132,48 @@ const BreakPointInner = memo(({ id }: NodeProps) => {
                 onMouseLeave={() => setIsHovered(false)}
                 onMouseOver={() => hoverTimeout()}
             >
-                <Flex
-                    align="center"
-                    height="full"
+                <Box
+                    height="1px"
                     position="relative"
-                    verticalAlign="middle"
-                    width="full"
+                    width="1px"
                 >
-                    <Flex
-                        align="center"
-                        height="1px"
-                        margin="auto"
-                        position="relative"
-                        verticalAlign="middle"
-                        width="1px"
-                    >
-                        <Handle
-                            className="absolute-fifty"
-                            id={`${id}-0`}
-                            isConnectable={false}
-                            position={Position.Left}
-                            style={{
-                                margin: 'auto',
-                                width: '12px',
-                                height: '12px',
-                                border: 'none',
-                                opacity: 0,
-                            }}
-                            type="target"
-                        />
-                        <Handle
-                            className="absolute-fifty"
-                            id={`${id}-0`}
-                            isConnectable={false}
-                            position={Position.Right}
-                            style={{
-                                margin: 'auto',
-                                width: '12px',
-                                height: '12px',
-                                border: 'none',
-                                opacity: 0,
-                            }}
-                            type="source"
-                        />
-                    </Flex>
-                </Flex>
-            </Box>
+                    <Handle
+                        className="absolute-fifty"
+                        id={`${id}-0`}
+                        isConnectable={false}
+                        position={Position.Left}
+                        style={{
+                            margin: 'auto',
+                            width: '12px',
+                            height: '12px',
+                            border: 'none',
+                            opacity: 0,
+                        }}
+                        type="target"
+                    />
+                    <Handle
+                        className="absolute-fifty"
+                        id={`${id}-0`}
+                        isConnectable={false}
+                        position={Position.Right}
+                        style={{
+                            margin: 'auto',
+                            width: '12px',
+                            height: '12px',
+                            border: 'none',
+                            opacity: 0,
+                        }}
+                        type="source"
+                    />
+                </Box>
+            </Center>
             {/* This is a ghost circle meant to help increase the hoverable diameter without visually making it look too large */}
             <Box
                 backgroundColor="red"
                 borderRadius="100%"
                 height="26px"
-                left="50%"
                 opacity={0}
                 position="absolute"
-                top="50%"
                 transform="translate(-50%, -50%)"
                 transition="all 0.2s ease-in-out"
                 width="26px"
@@ -193,6 +183,6 @@ const BreakPointInner = memo(({ id }: NodeProps) => {
                 onMouseLeave={() => setIsHovered(false)}
                 onMouseOver={() => hoverTimeout()}
             />
-        </>
+        </Box>
     );
 });


### PR DESCRIPTION
This implements the CSS positions I talked about [here](https://github.com/chaiNNer-org/chaiNNer/pull/2548#discussion_r1485105525). The trick is simple: we have a 1x1 box that is the node, and then we use CSS to absolute position the actual handles.

Other changes:
- I used a `Center` to center the handles instead of 2 `Flex` components.
- I removed the unused `breakpoints` property.