### PR TITLE
Fix pixelate node resizing the image

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/pixelate.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/pixelate.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 import cv2
 import numpy as np
 
@@ -36,8 +38,8 @@ def pixelate_node(
     pad_y = (block_sizes[1] - height % block_sizes[1]) % block_sizes[1]
     img = cv2.copyMakeBorder(img, 0, pad_y, 0, pad_x, cv2.BORDER_REFLECT_101)
 
-    num_blocks_x = width // block_sizes[0]
-    num_blocks_y = height // block_sizes[1]
+    num_blocks_x = math.ceil(width / block_sizes[0])
+    num_blocks_y = math.ceil(height / block_sizes[1])
 
     blocks = img[: num_blocks_y * block_sizes[1], : num_blocks_x * block_sizes[0]]
     blocks = (


### PR DESCRIPTION
Fixes #2589.

The calculation for the number of blocks rounded the wrong way.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/b31bd462-fdc2-46f1-8c5b-f0817c11991b)
