### PR TITLE
Fixed Edge Detect node

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/edge_detection.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/edge_detection.py
@@ -173,7 +173,7 @@ def edge_detection_node(
             return cv2.filter2D(img, -1, filter_x)
 
         def g_y() -> np.ndarray:
-            filter = filter_y or np.rot90(filter_x, 1)
+            filter = filter_y if filter_y is not None else np.rot90(filter_x, 1)
             return cv2.filter2D(img, -1, filter)
 
         if algorithm == Algorithm.ROBERTS:


### PR DESCRIPTION
Fixes #2588.

This issue was that numpy apparently has an implicit bool conversion that is only defined for single-value arrays. I think the `filter_y or` was a last minute refactor I did while writing the description for #2509.