### PR TITLE
Fix Threshold + AA resulting in wrong broadcasting

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image_adjustment/threshold/threshold.py
+++ b/backend/src/packages/chaiNNer_standard/image_adjustment/threshold/threshold.py
@@ -10,6 +10,7 @@ from nodes.groups import if_enum_group
 from nodes.impl.image_utils import as_2d_grayscale
 from nodes.properties.inputs import BoolInput, EnumInput, ImageInput, SliderInput
 from nodes.properties.outputs import ImageOutput
+from nodes.utils.utils import get_h_w_c
 
 from .. import threshold_group
 
@@ -85,7 +86,10 @@ def threshold_node(
         _, result = cv2.threshold(img, threshold, max_value, thresh_type.value)
         return result
 
-    binary = as_2d_grayscale(binary_threshold(img, threshold, True))
+    binary = binary_threshold(img, threshold, True)
+    if get_h_w_c(binary)[2] == 1:
+        binary = as_2d_grayscale(binary)
+
     if thresh_type == ThresholdType.BINARY_INV:
         binary = 1 - binary
 

--- a/backend/src/packages/chaiNNer_standard/image_adjustment/threshold/threshold.py
+++ b/backend/src/packages/chaiNNer_standard/image_adjustment/threshold/threshold.py
@@ -7,6 +7,7 @@ import numpy as np
 from chainner_ext import binary_threshold
 
 from nodes.groups import if_enum_group
+from nodes.impl.image_utils import as_2d_grayscale
 from nodes.properties.inputs import BoolInput, EnumInput, ImageInput, SliderInput
 from nodes.properties.outputs import ImageOutput
 
@@ -84,7 +85,7 @@ def threshold_node(
         _, result = cv2.threshold(img, threshold, max_value, thresh_type.value)
         return result
 
-    binary = binary_threshold(img, threshold, True)
+    binary = as_2d_grayscale(binary_threshold(img, threshold, True))
     if thresh_type == ThresholdType.BINARY_INV:
         binary = 1 - binary
 


### PR DESCRIPTION
`binary_threshold` from chainner_rs returned an image of the shape `binary = (h, w, 1)` when given a grayscale image of the shape `img = (h, w)`. Multiplying those to image then resulted in an image of the shape `(h, w, h)` (for some reason) which obviously takes up an insane amount of memory. E.g. an image `(4096, 4096, 4096)` takes up 256GB of RAM.

The fix is to cast `binary` to the shape `(h, w)` if it's 2D anyway.