### PR TITLE
Feature - Add MiniMap to chaiNNer

### DIFF
--- a/src/renderer/components/ReactFlowBox.tsx
+++ b/src/renderer/components/ReactFlowBox.tsx
@@ -520,7 +520,8 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
                     maskColor="rgb(11, 13, 18, 0.175)"
                     maskStrokeColor="rgb(255, 255, 255, 1.0"
                     maskStrokeWidth={10}
-                    nodeColor="rgb(255, 255, 255, 0.66)"
+                    nodeColor="rgb(255, 255, 255, 0.5)"
+                    zoomStep={3}
                 />
                 <Controls>
                     <ControlButton

--- a/src/renderer/components/ReactFlowBox.tsx
+++ b/src/renderer/components/ReactFlowBox.tsx
@@ -9,6 +9,7 @@ import ReactFlow, {
     Controls,
     Edge,
     EdgeTypes,
+    MiniMap,
     Node,
     NodeTypes,
     OnEdgesChange,
@@ -511,6 +512,15 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
                     gap={16}
                     size={1}
                     variant={BackgroundVariant.Dots}
+                />
+                <MiniMap
+                    nodeColor="rgb(255, 255, 255, 0.66)"
+                    maskColor="rgb(11, 13, 18, 0.175)"
+                    maskStrokeColor="rgb(255, 255, 255, 1.0"
+                    maskStrokeWidth={10}
+                    pannable
+                    zoomable
+                    ariaLabel=""
                 />
                 <Controls>
                     <ControlButton

--- a/src/renderer/components/ReactFlowBox.tsx
+++ b/src/renderer/components/ReactFlowBox.tsx
@@ -518,7 +518,7 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
                     zoomable
                     ariaLabel=""
                     maskColor="rgb(11, 13, 18, 0.175)"
-                    maskStrokeColor="rgb(255, 255, 255, 1.0"
+                    maskStrokeColor="rgb(255, 255, 255, 1.0)"
                     maskStrokeWidth={10}
                     nodeColor="rgb(255, 255, 255, 0.5)"
                     zoomStep={3}

--- a/src/renderer/components/ReactFlowBox.tsx
+++ b/src/renderer/components/ReactFlowBox.tsx
@@ -517,10 +517,6 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
                     pannable
                     zoomable
                     ariaLabel=""
-                    maskColor="rgb(11, 13, 18, 0.175)"
-                    maskStrokeColor="rgb(255, 255, 255, 1.0)"
-                    maskStrokeWidth={10}
-                    nodeColor="rgb(255, 255, 255, 0.5)"
                     zoomStep={3}
                 />
                 <Controls>

--- a/src/renderer/components/ReactFlowBox.tsx
+++ b/src/renderer/components/ReactFlowBox.tsx
@@ -514,13 +514,13 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
                     variant={BackgroundVariant.Dots}
                 />
                 <MiniMap
-                    nodeColor="rgb(255, 255, 255, 0.66)"
-                    maskColor="rgb(11, 13, 18, 0.175)"
-                    maskStrokeColor="rgb(255, 255, 255, 1.0"
-                    maskStrokeWidth={10}
                     pannable
                     zoomable
                     ariaLabel=""
+                    maskColor="rgb(11, 13, 18, 0.175)"
+                    maskStrokeColor="rgb(255, 255, 255, 1.0"
+                    maskStrokeWidth={10}
+                    nodeColor="rgb(255, 255, 255, 0.66)"
                 />
                 <Controls>
                     <ControlButton

--- a/src/renderer/global.scss
+++ b/src/renderer/global.scss
@@ -102,15 +102,15 @@ body {
     border-radius: 0 0 8px 8px;
 }
 
-.react-flow__minimap {
-    background-color: rgb(
-        45 55 72 / 66%
-    ) !important; /* - defines base minimap opacity, everything sits on top of this */
-}
-
 [data-theme='light'] {
     .react-flow__controls:hover {
         background: var(--gray-300) !important;
+    }
+
+    .react-flow__minimap {
+        background-color: rgb(
+            176 182 187 / 70%
+        ) !important; /* - defines base minimap opacity, everything sits on top of this */
     }
 
     .react-flow__controls-button {
@@ -131,6 +131,12 @@ body {
 [data-theme='dark'] {
     .react-flow__controls:hover {
         background: var(--gray-700) !important;
+    }
+
+    .react-flow__minimap {
+        background-color: rgb(
+            45 55 72 / 70%
+        ) !important; /* - defines base minimap opacity, everything sits on top of this */
     }
 
     .react-flow__controls-button {

--- a/src/renderer/global.scss
+++ b/src/renderer/global.scss
@@ -103,7 +103,9 @@ body {
 }
 
 .react-flow__minimap {
-    background-color: rgb(45 55 72 / 66%) !important; /* - defines base minimap opacity, everything sits on top of this */
+    background-color: rgb(
+        45 55 72 / 66%
+    ) !important; /* - defines base minimap opacity, everything sits on top of this */
 }
 
 [data-theme='light'] {

--- a/src/renderer/global.scss
+++ b/src/renderer/global.scss
@@ -102,6 +102,10 @@ body {
     border-radius: 0 0 8px 8px;
 }
 
+.react-flow__minimap {
+    background-color: rgb(45 55 72 / 66%) !important; /* - defines base minimap opacity, everything sits on top of this */
+}
+
 [data-theme='light'] {
     .react-flow__controls:hover {
         background: var(--gray-300) !important;

--- a/src/renderer/global.scss
+++ b/src/renderer/global.scss
@@ -109,8 +109,19 @@ body {
 
     .react-flow__minimap {
         background-color: rgb(
-            176 182 187 / 70%
-        ) !important; /* - defines base minimap opacity, everything sits on top of this */
+            220 227 234 / 80%
+        ); /* - defines base minimap opacity, everything sits on top of this */
+    }
+
+    .react-flow__minimap-node {
+        fill: rgb(255 255 255 / 75%);
+        stroke: none;
+    }
+
+    .react-flow__minimap-mask {
+        fill: rgb(220 227 234 / 50%);
+        stroke: rgb(255 255 255 / 100%);
+        stroke-width: 15;
     }
 
     .react-flow__controls-button {
@@ -135,8 +146,19 @@ body {
 
     .react-flow__minimap {
         background-color: rgb(
-            45 55 72 / 70%
-        ) !important; /* - defines base minimap opacity, everything sits on top of this */
+            49 58 72 / 80%
+        ); /* - defines base minimap opacity, everything sits on top of this */
+    }
+
+    .react-flow__minimap-node {
+        fill: rgb(255 255 255 / 50%);
+        stroke: none;
+    }
+
+    .react-flow__minimap-mask {
+        fill: rgb(49 58 72 / 80%);
+        stroke: rgb(255 255 255 / 50%);
+        stroke-width: 15;
     }
 
     .react-flow__controls-button {


### PR DESCRIPTION
The minimap feature enables the user to quickly navigate around a large chaiNNer schematic and also allows for zooming/panning directly within the minimap to help ease schematic navigation.

It shows the entirety of the chaiNNer schematic with all of the nodes and also a highlighted "active window" area within the minimap to show the currently visible focus area.

The minimap is semi transparent to not obscure any of the content behind it.

![Screenshot 2024-02-19 at 09 53 11](https://github.com/chaiNNer-org/chaiNNer/assets/30782821/fd6f856b-a4d5-4f09-9292-3c4ef12b6268)