### PR TITLE
Create "Checkerboard" node

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image/create_images/create_checkerboard.py
+++ b/backend/src/packages/chaiNNer_standard/image/create_images/create_checkerboard.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import numpy as np
+
+import navi
+from nodes.impl.color.color import Color
+from nodes.properties.inputs import ColorInput, NumberInput
+from nodes.properties.outputs import ImageOutput
+
+from .. import create_images_group
+
+
+@create_images_group.register(
+    schema_id="chainner:image:create_checkerboard",
+    name="Create Checkerboard",
+    description="Create a Checkerboard of specified dimensions filled with the given colors for the squares.",
+    icon="MdBorderAll",
+    inputs=[
+        NumberInput("Width", minimum=1, unit="px", default=1024),
+        NumberInput("Height", minimum=1, unit="px", default=1024),
+        ColorInput(
+            "Color 1", channels=[3], default=Color.bgr((0.75, 0.75, 0.75))
+        ).with_id(2),
+        ColorInput(
+            "Color 2", channels=[3], default=Color.bgr((0.35, 0.35, 0.35))
+        ).with_id(3),
+        NumberInput("Square Size", minimum=1, default=32),
+    ],
+    outputs=[
+        ImageOutput(
+            image_type=navi.Image(
+                width="Input0",
+                height="Input1",
+                channels=3,
+            ),
+        )
+    ],
+)
+def create_checkerboard_node(
+    width: float,
+    height: float,
+    color_1: Color,
+    color_2: Color,
+    square_size: float,
+) -> np.ndarray:
+    img = np.zeros(
+        (height, width, 3), dtype=np.float32
+    )  # Create a new buffer with all zeros
+
+    # Determine the number of squares in each direction
+    num_cols = (width + square_size - 1) // square_size
+    num_rows = (height + square_size - 1) // square_size
+
+    # Fill the checkerboard with alternating squares
+    for i in range(num_rows):
+        for j in range(num_cols):
+            if (i + j) % 2 == 0:
+                img[
+                    max(0, height - (i + 1) * square_size) : max(
+                        0, height - i * square_size
+                    ),
+                    j * square_size : min(width, (j + 1) * square_size),
+                ] = color_1.value
+            else:
+                img[
+                    max(0, height - (i + 1) * square_size) : max(
+                        0, height - i * square_size
+                    ),
+                    j * square_size : min(width, (j + 1) * square_size),
+                ] = color_2.value
+
+    return img

--- a/backend/src/packages/chaiNNer_standard/image/create_images/create_checkerboard.py
+++ b/backend/src/packages/chaiNNer_standard/image/create_images/create_checkerboard.py
@@ -37,11 +37,11 @@ from .. import create_images_group
     ],
 )
 def create_checkerboard_node(
-    width: float,
-    height: float,
+    width: int,
+    height: int,
     color_1: Color,
     color_2: Color,
-    square_size: float,
+    square_size: int,
 ) -> np.ndarray:
     img = np.zeros(
         (height, width, 3), dtype=np.float32

--- a/backend/src/packages/chaiNNer_standard/image/create_images/create_checkerboard.py
+++ b/backend/src/packages/chaiNNer_standard/image/create_images/create_checkerboard.py
@@ -22,7 +22,7 @@ from .. import create_images_group
             "Color 1", channels=[4], default=Color.bgra((0.75, 0.75, 0.75, 1.0))
         ).with_id(2),
         ColorInput(
-            "Color 2", channels=[4], default=Color.bgr((0.35, 0.35, 0.35, 1.0))
+            "Color 2", channels=[4], default=Color.bgra((0.35, 0.35, 0.35, 1.0))
         ).with_id(3),
         NumberInput("Square Size", minimum=1, default=32),
     ],

--- a/backend/src/packages/chaiNNer_standard/image/create_images/create_checkerboard.py
+++ b/backend/src/packages/chaiNNer_standard/image/create_images/create_checkerboard.py
@@ -19,10 +19,10 @@ from .. import create_images_group
         NumberInput("Width", minimum=1, unit="px", default=1024),
         NumberInput("Height", minimum=1, unit="px", default=1024),
         ColorInput(
-            "Color 1", channels=[3], default=Color.bgr((0.75, 0.75, 0.75))
+            "Color 1", channels=[4], default=Color.bgra((0.75, 0.75, 0.75, 1.0))
         ).with_id(2),
         ColorInput(
-            "Color 2", channels=[3], default=Color.bgr((0.35, 0.35, 0.35))
+            "Color 2", channels=[4], default=Color.bgr((0.35, 0.35, 0.35, 1.0))
         ).with_id(3),
         NumberInput("Square Size", minimum=1, default=32),
     ],
@@ -31,7 +31,7 @@ from .. import create_images_group
             image_type=navi.Image(
                 width="Input0",
                 height="Input1",
-                channels=3,
+                channels=4,
             ),
         )
     ],
@@ -44,7 +44,7 @@ def create_checkerboard_node(
     square_size: int,
 ) -> np.ndarray:
     img = np.zeros(
-        (height, width, 3), dtype=np.float32
+        (height, width, 4), dtype=np.float32
     )  # Create a new buffer with all zeros
 
     # Determine the number of squares in each direction


### PR DESCRIPTION
This node creates a checkerboard with user definable colors and size for the squares. 

Sometimes it can be useful to be able to quickly composite images over a checkerboard to evaluate the transparency/alpha channel association. 