### PR TITLE
Refactor video loading

### DIFF
--- a/backend/src/nodes/impl/video.py
+++ b/backend/src/nodes/impl/video.py
@@ -1,0 +1,110 @@
+import os
+import subprocess
+from dataclasses import dataclass
+from io import BufferedIOBase
+from pathlib import Path
+
+import ffmpeg
+import numpy as np
+from sanic.log import logger
+
+FFMPEG_PATH = os.environ.get("STATIC_FFMPEG_PATH", "ffmpeg")
+FFPROBE_PATH = os.environ.get("STATIC_FFPROBE_PATH", "ffprobe")
+
+
+@dataclass(frozen=True)
+class VideoMetadata:
+    width: int
+    height: int
+    fps: float
+    frame_count: int
+
+    @staticmethod
+    def from_file(path: Path):
+        probe = ffmpeg.probe(path, cmd=FFPROBE_PATH)
+        video_format = probe.get("format", None)
+        if video_format is None:
+            raise RuntimeError("Failed to get video format. Please report.")
+        video_stream = next(
+            (stream for stream in probe["streams"] if stream["codec_type"] == "video"),
+            None,
+        )
+
+        if video_stream is None:
+            raise RuntimeError("No video stream found in file")
+
+        width = video_stream.get("width", None)
+        if width is None:
+            raise RuntimeError("No width found in video stream")
+        width = int(width)
+
+        height = video_stream.get("height", None)
+        if height is None:
+            raise RuntimeError("No height found in video stream")
+        height = int(height)
+
+        fps = video_stream.get("r_frame_rate", None)
+        if fps is None:
+            raise RuntimeError("No fps found in video stream")
+        fps = int(fps.split("/")[0]) / int(fps.split("/")[1])
+
+        frame_count = video_stream.get("nb_frames", None)
+        if frame_count is None:
+            duration = video_stream.get("duration", None)
+            if duration is None:
+                duration = video_format.get("duration", None)
+            if duration is not None:
+                frame_count = float(duration) * fps
+            else:
+                raise RuntimeError(
+                    "No frame count or duration found in video stream. Unable to determine video length. Please report."
+                )
+        frame_count = int(frame_count)
+
+        return VideoMetadata(
+            width=width,
+            height=height,
+            fps=fps,
+            frame_count=frame_count,
+        )
+
+
+class VideoLoader:
+    def __init__(self, path: Path):
+        self.path = path
+        self.metadata = VideoMetadata.from_file(path)
+
+    def get_audio_stream(self):
+        return ffmpeg.input(self.path).audio
+
+    def stream_frames(self):
+        """
+        Returns an iterator that yields frames as BGR uint8 numpy arrays.
+        """
+
+        ffmpeg_reader = (
+            ffmpeg.input(self.path)
+            .output(
+                "pipe:",
+                format="rawvideo",
+                pix_fmt="bgr24",
+                sws_flags="lanczos+accurate_rnd+full_chroma_int+full_chroma_inp+bitexact",
+                loglevel="error",
+            )
+            .run_async(pipe_stdout=True, cmd=FFMPEG_PATH)
+        )
+        assert isinstance(ffmpeg_reader, subprocess.Popen)
+
+        with ffmpeg_reader:
+            assert isinstance(ffmpeg_reader.stdout, BufferedIOBase)
+
+            width = self.metadata.width
+            height = self.metadata.height
+
+            while True:
+                in_bytes = ffmpeg_reader.stdout.read(width * height * 3)
+                if not in_bytes:
+                    logger.debug("Can't receive frame (stream end?). Exiting ...")
+                    break
+
+                yield np.frombuffer(in_bytes, np.uint8).reshape([height, width, 3])

--- a/backend/src/packages/chaiNNer_standard/image/video_frames/load_video.py
+++ b/backend/src/packages/chaiNNer_standard/image/video_frames/load_video.py
@@ -72,7 +72,7 @@ def load_video_node(
         for index, frame in enumerate(loader.stream_frames()):
             yield frame, index
 
-            if use_limit and index >= limit:
+            if use_limit and index + 1 >= limit:
                 break
 
     return (

--- a/backend/src/packages/chaiNNer_standard/image/video_frames/load_video.py
+++ b/backend/src/packages/chaiNNer_standard/image/video_frames/load_video.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from typing import Any
 
-import ffmpeg
 import numpy as np
 
 from api import Iterator, IteratorOutputInfo
 from nodes.groups import Condition, if_group
+from nodes.impl.video import VideoLoader
 from nodes.properties.inputs import BoolInput, NumberInput, VideoFileInput
 from nodes.properties.outputs import (
     AudioStreamOutput,
@@ -20,9 +19,6 @@ from nodes.properties.outputs import (
 from nodes.utils.utils import split_file_path
 
 from .. import video_frames_group
-
-ffmpeg_path = os.environ.get("STATIC_FFMPEG_PATH", "ffmpeg")
-ffprobe_path = os.environ.get("STATIC_FFPROBE_PATH", "ffprobe")
 
 
 @video_frames_group.register(
@@ -52,7 +48,7 @@ ffprobe_path = os.environ.get("STATIC_FFPROBE_PATH", "ffprobe")
         ).with_docs("A counter that starts at 0 and increments by 1 for each frame."),
         DirectoryOutput("Video Directory", of_input=0),
         FileNameOutput("Name", of_input=0),
-        NumberOutput("FPS"),
+        NumberOutput("FPS", output_type="0.."),
         AudioStreamOutput(),
     ],
     iterator_outputs=IteratorOutputInfo(outputs=[0, 1]),
@@ -65,76 +61,24 @@ def load_video_node(
 ) -> tuple[Iterator[tuple[np.ndarray, int]], Path, str, float, Any]:
     video_dir, video_name, _ = split_file_path(path)
 
-    ffmpeg_reader = (
-        ffmpeg.input(path)
-        .output(
-            "pipe:",
-            format="rawvideo",
-            pix_fmt="bgr24",
-            sws_flags="lanczos+accurate_rnd+full_chroma_int+full_chroma_inp+bitexact",
-            loglevel="error",
-        )
-        .run_async(pipe_stdout=True, cmd=ffmpeg_path)
-    )
-
-    probe = ffmpeg.probe(path, cmd=ffprobe_path)
-    video_format = probe.get("format", None)
-    if video_format is None:
-        raise RuntimeError("Failed to get video format. Please report.")
-    video_stream = next(
-        (stream for stream in probe["streams"] if stream["codec_type"] == "video"),
-        None,
-    )
-
-    if video_stream is None:
-        raise RuntimeError("No video stream found in file")
-
-    width = video_stream.get("width", None)
-    if width is None:
-        raise RuntimeError("No width found in video stream")
-    width = int(width)
-    height = video_stream.get("height", None)
-    if height is None:
-        raise RuntimeError("No height found in video stream")
-    height = int(height)
-    fps = video_stream.get("r_frame_rate", None)
-    if fps is None:
-        raise RuntimeError("No fps found in video stream")
-    fps = int(fps.split("/")[0]) / int(fps.split("/")[1])
-    frame_count = video_stream.get("nb_frames", None)
-    if frame_count is None:
-        duration = video_stream.get("duration", None)
-        if duration is None:
-            duration = video_format.get("duration", None)
-        if duration is not None:
-            frame_count = float(duration) * fps
-        else:
-            raise RuntimeError(
-                "No frame count or duration found in video stream. Unable to determine video length. Please report."
-            )
-    frame_count = int(frame_count)
+    loader = VideoLoader(path)
+    frame_count = loader.metadata.frame_count
     if use_limit:
         frame_count = min(frame_count, limit)
 
-    audio_stream = ffmpeg.input(path).audio
+    audio_stream = loader.get_audio_stream()
 
     def iterator():
-        index = 0
-        while True:
+        for index, frame in enumerate(loader.stream_frames()):
+            yield frame, index
+
             if use_limit and index >= limit:
                 break
-            in_bytes = ffmpeg_reader.stdout.read(width * height * 3)
-            if not in_bytes:
-                print("Can't receive frame (stream end?). Exiting ...")
-                break
-            in_frame = np.frombuffer(in_bytes, np.uint8).reshape([height, width, 3])
-            yield in_frame, index
-            index += 1
 
     return (
         Iterator.from_iter(iter_supplier=iterator, expected_length=frame_count),
         video_dir,
         video_name,
-        fps,
+        loader.metadata.fps,
         audio_stream,
     )

--- a/backend/src/packages/chaiNNer_standard/image/video_frames/save_video.py
+++ b/backend/src/packages/chaiNNer_standard/image/video_frames/save_video.py
@@ -14,6 +14,7 @@ from sanic.log import logger
 from api import Collector, IteratorInputInfo
 from nodes.groups import Condition, if_enum_group, if_group
 from nodes.impl.image_utils import to_uint8
+from nodes.impl.video import FFMPEG_PATH
 from nodes.properties.inputs import (
     BoolInput,
     DirectoryInput,
@@ -96,9 +97,6 @@ class AudioSettings(Enum):
     TRANSCODE = "transcode"
 
 
-ffmpeg_path = os.environ.get("STATIC_FFMPEG_PATH", "ffmpeg")
-ffprobe_path = os.environ.get("STATIC_FFPROBE_PATH", "ffprobe")
-
 PARAMETERS: dict[VideoEncoder, list[Literal["preset", "crf"]]] = {
     VideoEncoder.H264: ["preset", "crf"],
     VideoEncoder.H265: ["preset", "crf"],
@@ -140,7 +138,7 @@ class Writer:
                     .output(**self.output_params)
                     .overwrite_output()
                     .global_args(*self.global_params)
-                    .run_async(pipe_stdin=True, cmd=ffmpeg_path)
+                    .run_async(pipe_stdin=True, cmd=FFMPEG_PATH)
                 )
 
             except Exception as e:


### PR DESCRIPTION
This moves the video loading logic into 2 classes: `VideoMetadata` and `VideoLoader`. `VideoMetadata` is powered by `ffprobe` and gets metadata like frame width and frame height. `VideoLoader` basically just returns an iterators for all frames in the video.

I also added a bit of type checking for `ffmpeg_reader` and used a `with` block for resource safety.