### PR TITLE
Optimize node selector panel and use group hover

### DIFF
--- a/src/renderer/components/CustomEdge/CustomEdge.scss
+++ b/src/renderer/components/CustomEdge/CustomEdge.scss
@@ -21,7 +21,7 @@
     transition-timing-function: ease-in-out;
     stroke: var(--bg-700);
 
-    &.hovered {
+    .edge-chain-group:hover & {
         stroke-width: 4px;
     }
 }
@@ -36,9 +36,9 @@
     stroke-dashoffset: 0;
     stroke-linecap: round;
     animation: 'none';
-    opacity: 100%;
+    opacity: 1;
 
-    &.hovered {
+    .edge-chain-group:hover & {
         stroke-width: 4px;
     }
 
@@ -64,7 +64,7 @@
             opacity: 1;
         }
 
-        &.hovered {
+        .edge-chain-group:hover & {
             stroke-width: 4px;
         }
 

--- a/src/renderer/components/NodeSelectorPanel/RepresentativeNode.tsx
+++ b/src/renderer/components/NodeSelectorPanel/RepresentativeNode.tsx
@@ -1,170 +1,170 @@
+/* eslint-disable react/prop-types */
 import { StarIcon } from '@chakra-ui/icons';
 import { Box, Center, Flex, HStack, Heading, Spacer } from '@chakra-ui/react';
-import { memo, useState } from 'react';
+import { memo, useMemo } from 'react';
 import { useContext } from 'use-context-selector';
-import { CategoryId, SchemaId } from '../../../common/common-types';
+import { NodeSchema } from '../../../common/common-types';
 import { BackendContext } from '../../contexts/BackendContext';
 import { getCategoryAccentColor } from '../../helpers/accentColors';
 import { useNodeFavorites } from '../../hooks/useNodeFavorites';
 import { IconFactory } from '../CustomIcons';
 
 interface RepresentativeNodeProps {
-    category: CategoryId;
-    icon: string;
-    name: string;
-    collapsed?: boolean;
-    schemaId: SchemaId;
-    createNodeFromSelector: () => void;
+    schema: NodeSchema;
+    collapsed: boolean;
+    onCreateNode: () => void;
 }
 
 export const RepresentativeNode = memo(
-    ({
-        category,
-        name,
-        icon,
-        schemaId,
-        collapsed = false,
-        createNodeFromSelector,
-    }: RepresentativeNodeProps) => {
-        const { categories, schemata } = useContext(BackendContext);
-        const schema = schemata.get(schemaId);
+    ({ schema, collapsed, onCreateNode }: RepresentativeNodeProps) => {
+        const { categories } = useContext(BackendContext);
 
         const bgColor = 'var(--selector-node-bg)';
-        const accentColor = getCategoryAccentColor(categories, category);
-
-        const [hover, setHover] = useState<boolean>(false);
+        const accentColor = getCategoryAccentColor(categories, schema.category);
 
         const { favorites, addFavorites, removeFavorite } = useNodeFavorites();
-        const isFavorite = favorites.has(schemaId);
+        const isFavorite = favorites.has(schema.schemaId);
 
         const isIterator = schema.kind === 'newIterator' || schema.kind === 'collector';
         let bgGradient = `linear-gradient(90deg, ${accentColor} 0%, ${accentColor} 100%)`;
         if (isIterator) {
             bgGradient = `repeating-linear(to right,${accentColor},${accentColor} 2px,${bgColor} 2px,${bgColor} 4px)`;
-        } else if (!hover) {
-            bgGradient = `linear-gradient(90deg, ${accentColor} 0%, ${bgColor} 100%)`;
         }
 
-        return (
-            <Center
-                _active={{ outlineColor: accentColor }}
-                _focus={{ outlineColor: accentColor }}
-                _hover={{ outlineColor: accentColor }}
-                bgGradient={bgGradient}
-                borderColor={bgColor}
-                borderRadius="lg"
-                borderWidth="0px"
-                boxShadow="lg"
-                outline="1px solid"
-                outlineColor={bgColor}
-                overflow="hidden"
-                tabIndex={0}
-                transition="outline 0.15s ease-in-out"
-                w="full"
-                onKeyDown={(e) => {
-                    if (e.key === 'Enter') {
-                        createNodeFromSelector();
-                    }
-                }}
-                onMouseEnter={() => setHover(true)}
-                onMouseLeave={() => setHover(false)}
-            >
-                <Box
-                    bg={bgColor}
-                    borderRadius="8px 0 0 8px"
-                    h="auto"
-                    ml="5px"
+        return useMemo(
+            () => (
+                <Center
+                    data-group
+                    _active={{ outlineColor: accentColor }}
+                    _focus={{ outlineColor: accentColor }}
+                    _hover={{ outlineColor: accentColor }}
+                    bgGradient={bgGradient}
+                    borderColor={bgColor}
+                    borderRadius="lg"
+                    borderWidth="0px"
+                    boxShadow="lg"
+                    outline="1px solid"
+                    outlineColor={bgColor}
                     overflow="hidden"
-                    py={0.5}
-                    verticalAlign="middle"
+                    tabIndex={0}
+                    transition="outline 0.15s ease-in-out"
                     w="full"
+                    onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                            onCreateNode();
+                        }
+                    }}
                 >
-                    <HStack
+                    <Box
+                        bg={bgColor}
+                        borderRadius="8px 0 0 8px"
+                        h="auto"
+                        ml="5px"
                         overflow="hidden"
-                        pl={2}
-                        textOverflow="ellipsis"
+                        py={0.5}
                         verticalAlign="middle"
+                        w="full"
                     >
-                        <Center
-                            alignContent="center"
-                            alignItems="center"
-                            h={4}
-                            py={3}
+                        <HStack
+                            overflow="hidden"
+                            pl={2}
+                            textOverflow="ellipsis"
                             verticalAlign="middle"
-                            w={4}
                         >
-                            <IconFactory
-                                accentColor="var(--selector-icon)"
-                                icon={icon}
-                            />
-                        </Center>
-                        {!collapsed && (
-                            <Flex
-                                overflow="hidden"
-                                w="300px"
+                            <Center
+                                alignContent="center"
+                                alignItems="center"
+                                h={4}
+                                py={3}
+                                verticalAlign="middle"
+                                w={4}
                             >
-                                <Box
+                                <IconFactory
+                                    accentColor="var(--selector-icon)"
+                                    icon={schema.icon}
+                                />
+                            </Center>
+                            {!collapsed && (
+                                <Flex
                                     overflow="hidden"
-                                    textOverflow="ellipsis"
-                                    verticalAlign="middle"
+                                    w="300px"
                                 >
-                                    <Heading
-                                        alignContent="center"
-                                        as="h5"
-                                        fontWeight={700}
-                                        h="20px"
-                                        lineHeight="20px"
-                                        m={0}
-                                        opacity={0.92}
+                                    <Box
                                         overflow="hidden"
-                                        p={0}
-                                        size="xs"
-                                        textAlign="left"
-                                        textOverflow="truncate"
-                                        textTransform="uppercase"
+                                        textOverflow="ellipsis"
                                         verticalAlign="middle"
-                                        whiteSpace="nowrap"
                                     >
-                                        {name}
-                                    </Heading>
-                                </Box>
-                                <Spacer />
-                                <HStack
-                                    overflow="hidden"
-                                    px={2}
-                                    verticalAlign="middle"
-                                    w="fit-content"
-                                >
-                                    <StarIcon
-                                        _hover={{
-                                            stroke: 'yellow.500',
-                                            color: isFavorite ? 'yellow.500' : bgColor,
-                                            transition: '0.15s ease-in-out',
-                                        }}
-                                        aria-label="Favorites"
-                                        color={isFavorite ? 'gray.500' : bgColor}
-                                        opacity={isFavorite || hover ? '100%' : '0%'}
+                                        <Heading
+                                            alignContent="center"
+                                            as="h5"
+                                            fontWeight={700}
+                                            h="20px"
+                                            lineHeight="20px"
+                                            m={0}
+                                            opacity={0.92}
+                                            overflow="hidden"
+                                            p={0}
+                                            size="xs"
+                                            textAlign="left"
+                                            textOverflow="truncate"
+                                            textTransform="uppercase"
+                                            verticalAlign="middle"
+                                            whiteSpace="nowrap"
+                                        >
+                                            {schema.name}
+                                        </Heading>
+                                    </Box>
+                                    <Spacer />
+                                    <HStack
                                         overflow="hidden"
-                                        stroke="gray.500"
-                                        strokeWidth={isFavorite ? 0 : 2}
-                                        transition="0.15s ease-in-out"
+                                        px={2}
                                         verticalAlign="middle"
-                                        onClick={(e) => {
-                                            e.stopPropagation();
-                                            if (isFavorite) {
-                                                removeFavorite(schemaId);
-                                            } else {
-                                                addFavorites(schemaId);
-                                            }
-                                        }}
-                                        onDoubleClick={(e) => e.stopPropagation()}
-                                    />
-                                </HStack>
-                            </Flex>
-                        )}
-                    </HStack>
-                </Box>
-            </Center>
+                                        w="fit-content"
+                                    >
+                                        <StarIcon
+                                            _groupHover={{
+                                                opacity: '100%',
+                                            }}
+                                            _hover={{
+                                                stroke: 'yellow.500',
+                                                color: isFavorite ? 'yellow.500' : bgColor,
+                                                transition: '0.15s ease-in-out',
+                                            }}
+                                            aria-label="Favorites"
+                                            color={isFavorite ? 'gray.500' : bgColor}
+                                            opacity={isFavorite ? '100%' : '0%'}
+                                            overflow="hidden"
+                                            stroke="gray.500"
+                                            strokeWidth={isFavorite ? 0 : 2}
+                                            transition="0.15s ease-in-out"
+                                            verticalAlign="middle"
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                if (isFavorite) {
+                                                    removeFavorite(schema.schemaId);
+                                                } else {
+                                                    addFavorites(schema.schemaId);
+                                                }
+                                            }}
+                                            onDoubleClick={(e) => e.stopPropagation()}
+                                        />
+                                    </HStack>
+                                </Flex>
+                            )}
+                        </HStack>
+                    </Box>
+                </Center>
+            ),
+            [
+                accentColor,
+                addFavorites,
+                bgGradient,
+                collapsed,
+                isFavorite,
+                onCreateNode,
+                removeFavorite,
+                schema,
+            ]
         );
     }
 );

--- a/src/renderer/components/NodeSelectorPanel/RepresentativeNodeWrapper.tsx
+++ b/src/renderer/components/NodeSelectorPanel/RepresentativeNodeWrapper.tsx
@@ -1,6 +1,7 @@
+/* eslint-disable react/prop-types */
 import { StarIcon } from '@chakra-ui/icons';
 import { Box, Center, MenuItem, MenuList, Text, Tooltip, useDisclosure } from '@chakra-ui/react';
-import { DragEvent, memo, useCallback, useEffect, useState } from 'react';
+import { DragEvent, memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { BsFillJournalBookmarkFill } from 'react-icons/bs';
 import { useReactFlow } from 'reactflow';
 import { useContext } from 'use-context-selector';
@@ -50,11 +51,11 @@ const onDragStart = (event: DragEvent<HTMLDivElement>, node: NodeSchema) => {
 
 interface RepresentativeNodeWrapperProps {
     node: NodeSchema;
-    collapsed?: boolean;
+    collapsed: boolean;
 }
 
 export const RepresentativeNodeWrapper = memo(
-    ({ node, collapsed = false }: RepresentativeNodeWrapperProps) => {
+    ({ node, collapsed }: RepresentativeNodeWrapperProps) => {
         const { reactFlowWrapper, createNode } = useContext(GlobalContext);
         const { featureStates } = useContext(BackendContext);
         const reactFlowInstance = useReactFlow();
@@ -100,7 +101,7 @@ export const RepresentativeNodeWrapper = memo(
             </MenuList>
         ));
 
-        const createNodeFromSelector = useCallback(() => {
+        const onCreateNode = useCallback(() => {
             if (!reactFlowWrapper.current) return;
 
             const {
@@ -137,69 +138,78 @@ export const RepresentativeNodeWrapper = memo(
                   .join('\n')
             : undefined;
 
-        return (
-            <Box
-                my={1.5}
-                onContextMenu={onContextMenu}
-            >
-                <Tooltip
-                    closeOnMouseDown
-                    hasArrow
-                    borderRadius={8}
-                    isOpen={isOpen}
-                    label="Either double-click or drag and drop to add nodes to the canvas."
-                    placement="top"
-                    px={2}
-                    py={1}
-                    onClose={onClose}
+        return useMemo(
+            () => (
+                <Box
+                    my={1.5}
+                    onContextMenu={onContextMenu}
                 >
-                    <Box>
-                        <Tooltip
-                            closeOnMouseDown
-                            hasArrow
-                            borderRadius={8}
-                            label={
-                                <TooltipLabel
-                                    description={node.description}
-                                    name={collapsed ? node.name : undefined}
-                                    unavailableReason={unavailableReason}
-                                />
-                            }
-                            openDelay={500}
-                            placement="bottom"
-                            px={2}
-                            py={1}
-                        >
-                            <Center
-                                draggable
-                                boxSizing="content-box"
-                                display="block"
-                                opacity={isDisabled ? 0.5 : 1}
-                                onClick={() => {
-                                    setDidSingleClick(true);
-                                }}
-                                onDoubleClick={() => {
-                                    setDidSingleClick(false);
-                                    createNodeFromSelector();
-                                }}
-                                onDragStart={(event) => {
-                                    setDidSingleClick(false);
-                                    onDragStart(event, node);
-                                }}
+                    <Tooltip
+                        closeOnMouseDown
+                        hasArrow
+                        borderRadius={8}
+                        isOpen={isOpen}
+                        label="Either double-click or drag and drop to add nodes to the canvas."
+                        placement="top"
+                        px={2}
+                        py={1}
+                        onClose={onClose}
+                    >
+                        <Box>
+                            <Tooltip
+                                closeOnMouseDown
+                                hasArrow
+                                borderRadius={8}
+                                label={
+                                    <TooltipLabel
+                                        description={node.description}
+                                        name={collapsed ? node.name : undefined}
+                                        unavailableReason={unavailableReason}
+                                    />
+                                }
+                                openDelay={500}
+                                placement="bottom"
+                                px={2}
+                                py={1}
                             >
-                                <RepresentativeNode
-                                    category={node.category}
-                                    collapsed={collapsed}
-                                    createNodeFromSelector={createNodeFromSelector}
-                                    icon={node.icon}
-                                    name={node.name}
-                                    schemaId={node.schemaId}
-                                />
-                            </Center>
-                        </Tooltip>
-                    </Box>
-                </Tooltip>
-            </Box>
+                                <Center
+                                    draggable
+                                    boxSizing="content-box"
+                                    display="block"
+                                    opacity={isDisabled ? 0.5 : 1}
+                                    onClick={() => {
+                                        setDidSingleClick(true);
+                                    }}
+                                    onDoubleClick={() => {
+                                        setDidSingleClick(false);
+                                        onCreateNode();
+                                    }}
+                                    onDragStart={(event) => {
+                                        setDidSingleClick(false);
+                                        onDragStart(event, node);
+                                    }}
+                                >
+                                    <RepresentativeNode
+                                        collapsed={collapsed}
+                                        schema={node}
+                                        onCreateNode={onCreateNode}
+                                    />
+                                </Center>
+                            </Tooltip>
+                        </Box>
+                    </Tooltip>
+                </Box>
+            ),
+            [
+                collapsed,
+                isDisabled,
+                isOpen,
+                node,
+                onClose,
+                onContextMenu,
+                onCreateNode,
+                unavailableReason,
+            ]
         );
     }
 );

--- a/src/renderer/components/node/BreakPoint.tsx
+++ b/src/renderer/components/node/BreakPoint.tsx
@@ -1,10 +1,9 @@
 import { NeverType } from '@chainner/navi';
 import { DeleteIcon } from '@chakra-ui/icons';
 import { Box, Center, MenuItem, MenuList } from '@chakra-ui/react';
-import { memo, useEffect, useMemo, useState } from 'react';
+import { memo, useEffect, useMemo } from 'react';
 import { Handle, Position, useReactFlow } from 'reactflow';
 import { useContext, useContextSelector } from 'use-context-selector';
-import { useDebouncedCallback } from 'use-debounce';
 import { EdgeData, NodeData, OutputId } from '../../../common/common-types';
 import { BackendContext } from '../../contexts/BackendContext';
 import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
@@ -102,35 +101,27 @@ const BreakPointInner = memo(({ id }: NodeProps) => {
         [type, definitionType]
     );
 
-    const [isHovered, setIsHovered] = useState(false);
-    // Prevent hovered state from getting stuck
-    const hoverTimeout = useDebouncedCallback(() => {
-        setIsHovered(false);
-    }, 7500);
-
     return (
         <Box
+            data-group
             height="1px"
             position="relative"
             width="1px"
+            onContextMenu={menu.onContextMenu}
+            onDoubleClick={() => removeEdgeBreakpoint(id)}
         >
             <Center
-                _hover={{
+                _groupHover={{
                     height: '16px',
                     width: '16px',
                 }}
                 backgroundColor={accentColor}
                 borderRadius="100%"
-                height={isHovered ? '16px' : '12px'}
+                height="12px"
                 position="absolute"
                 transform="translate(-50%, -50%)"
                 transition="all 0.2s ease-in-out"
-                width={isHovered ? '16px' : '12px'}
-                onContextMenu={menu.onContextMenu}
-                onDoubleClick={() => removeEdgeBreakpoint(id)}
-                onMouseEnter={() => setIsHovered(true)}
-                onMouseLeave={() => setIsHovered(false)}
-                onMouseOver={() => hoverTimeout()}
+                width="12px"
             >
                 <Box
                     height="1px"
@@ -177,11 +168,6 @@ const BreakPointInner = memo(({ id }: NodeProps) => {
                 transform="translate(-50%, -50%)"
                 transition="all 0.2s ease-in-out"
                 width="26px"
-                onContextMenu={menu.onContextMenu}
-                onDoubleClick={() => removeEdgeBreakpoint(id)}
-                onMouseEnter={() => setIsHovered(true)}
-                onMouseLeave={() => setIsHovered(false)}
-                onMouseOver={() => hoverTimeout()}
             />
         </Box>
     );


### PR DESCRIPTION
Changes:
- Use `useMemo` for the JSX tree inside `RepresentativeNodeWrapper` and `RepresentativeNode`. While these components are already `memo`ed, `memo` is ineffective when one of the used contexts updates. Even if the updated context values do not lead to any changes in the DOM, React still has to re-create and diff the JSX tree of the component. `useMemo` not only caches the tree, it also allows React to immediately see that the cache tree didn't change (since they are the same object).
- I removed 3 instances of using `useState` to track whether a component is hovered, and replaced them with `_groupHover`. This makes the hover effects instant (because we don't need to re-render anything) and means that hover effects can't get stuck.