### PR TITLE
Fixed text overflow for long node names

### DIFF
--- a/src/renderer/components/NodeDocumentation/NodesList.tsx
+++ b/src/renderer/components/NodeDocumentation/NodesList.tsx
@@ -174,6 +174,9 @@ export const NodesList = memo(
                                                         <Text
                                                             cursor="pointer"
                                                             key={node.schemaId}
+                                                            overflow="hidden"
+                                                            textOverflow="ellipsis"
+                                                            whiteSpace="nowrap"
                                                         >
                                                             {node.name}
                                                         </Text>

--- a/src/renderer/hooks/usePaneNodeSearchMenu.tsx
+++ b/src/renderer/hooks/usePaneNodeSearchMenu.tsx
@@ -8,7 +8,6 @@ import {
     InputLeftElement,
     InputRightElement,
     MenuList,
-    Spacer,
     Text,
 } from '@chakra-ui/react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -104,23 +103,24 @@ const SchemaItem = memo(
                     icon={schema.icon}
                 />
                 <Text
+                    flex={1}
                     h="full"
+                    overflow="hidden"
+                    textOverflow="ellipsis"
                     verticalAlign="middle"
+                    whiteSpace="nowrap"
                 >
                     {schema.name}
                 </Text>
                 {isFavorite && (
-                    <>
-                        <Spacer />
-                        <StarIcon
-                            aria-label="Favorites"
-                            boxSize={2.5}
-                            color="gray.500"
-                            overflow="hidden"
-                            stroke="gray.500"
-                            verticalAlign="middle"
-                        />
-                    </>
+                    <StarIcon
+                        aria-label="Favorites"
+                        boxSize={2.5}
+                        color="gray.500"
+                        overflow="hidden"
+                        stroke="gray.500"
+                        verticalAlign="middle"
+                    />
                 )}
             </HStack>
         );


### PR DESCRIPTION
Since the new visibility optimization requires that we know the exact height beforehand, nodes with very long names are a problem. So I used `textOverflow="ellipsis"` there as well.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/7ed0223b-cd3f-4cd8-96f7-0ff448d80f2a) ![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/7467f459-3f8a-4af3-8636-f52bd4bcfafb)

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/63d04e68-5206-438c-aa3f-d43ecf45facf)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/7019bdcb-561b-4954-815d-55d555adc411)
