### PR TITLE
Fixed background color bleed through for collapsed nodes

### DIFF
--- a/src/renderer/components/node/Node.tsx
+++ b/src/renderer/components/node/Node.tsx
@@ -97,6 +97,7 @@ export const NodeView = memo(
 
         const { id, schema } = nodeState;
 
+        const bgColor = 'var(--node-bg-color)';
         const accentColor = getCategoryAccentColor(categories, schema.category);
         const finalBorderColor = useMemo(() => {
             if (borderColor) return borderColor;
@@ -108,7 +109,7 @@ export const NodeView = memo(
 
         return (
             <Center
-                bg="var(--node-bg-color)"
+                bg={selected && isCollapsed ? accentColor : bgColor}
                 borderColor={finalBorderColor}
                 borderRadius="lg"
                 borderWidth="0.5px"


### PR DESCRIPTION
A small fix for something that bugged me ever since we added collapsed nodes.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/7d494c20-b6b8-49d7-a50c-01b3ef260d6b) ![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/3b44b1d7-aa09-42f6-9eb4-480de2dffa09)

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/8e4ab6be-c9a7-43e5-9dc8-2fb304722bca) ![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/59bcbe35-7ab2-440e-9791-1f7c69db4b49)
