### PR TITLE
Fixed node background color transition

### DIFF
--- a/src/renderer/components/node/Node.tsx
+++ b/src/renderer/components/node/Node.tsx
@@ -119,6 +119,7 @@ export const NodeView = memo(
                 overflow="hidden"
                 ref={targetRef}
                 transition="0.15s ease-in-out"
+                transitionProperty="border-color, opacity"
                 onContextMenu={onContextMenu}
                 onDragOver={onDragOver}
                 onDrop={onDrop}


### PR DESCRIPTION
I made a mistake in #2633. I used the background color of the node to prevent the bleed-through, but I didn't notice that this property was transitioned. So when a user expanded a selected node, they could see the background color changing.

The fix is to exclude the background color from the transitioning properties.