### PR TITLE
Add smooth value noise

### DIFF
--- a/backend/src/nodes/impl/noise_functions/noise_generator.py
+++ b/backend/src/nodes/impl/noise_functions/noise_generator.py
@@ -1,0 +1,9 @@
+from abc import ABC, abstractmethod
+
+import numpy as np
+
+
+class NoiseGenerator(ABC):
+    @abstractmethod
+    def evaluate(self, points: np.ndarray) -> np.ndarray:
+        ...

--- a/backend/src/nodes/impl/noise_functions/noise_generator.py
+++ b/backend/src/nodes/impl/noise_functions/noise_generator.py
@@ -5,5 +5,4 @@ import numpy as np
 
 class NoiseGenerator(ABC):
     @abstractmethod
-    def evaluate(self, points: np.ndarray) -> np.ndarray:
-        ...
+    def evaluate(self, points: np.ndarray) -> np.ndarray: ...

--- a/backend/src/nodes/impl/noise_functions/simplex.py
+++ b/backend/src/nodes/impl/noise_functions/simplex.py
@@ -12,6 +12,9 @@ from __future__ import annotations
 import itertools
 
 import numpy as np
+from typing_extensions import override
+
+from .noise_generator import NoiseGenerator
 
 # fmt: off
 PERMUTATION_TABLE_ARRAY = np.array([
@@ -43,7 +46,7 @@ SCALE = {
 }
 
 
-class SimplexNoise:
+class SimplexNoise(NoiseGenerator):
     def __init__(self, dimensions: int, seed: int | None, r2: float = 0.5):
         if dimensions <= 0:
             raise ValueError
@@ -91,6 +94,7 @@ class SimplexNoise:
             self.permutation_table = np.arange(self.gradients.shape[0] * 16)
             np.random.default_rng(seed).shuffle(self.permutation_table)
 
+    @override
     def evaluate(self, points: np.ndarray):
         n_points = points.shape[0]
         assert points.shape == (n_points, self.dimensions)


### PR DESCRIPTION
This adds support for value noise that is linearly interpolated with a smooth step function. This improves the look of value noise at basically no computational cost.

I also made everything type safe and generally cleaned up the code a little.

| Value noise | Smooth value noise |
| --- | --- |
| ![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/2caf9bea-e657-4d78-a62b-76f6c2cf4554) | ![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/887ae183-c82c-4507-87a4-fb5bde2110c4) |
