### PR TITLE
Remove extra npm ci command from macos release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,6 @@ jobs:
                   APPLE_SIGNING_ID: ${{ secrets.APPLE_SIGNING_ID }}
               shell: bash
               run: |
-                  npm ci
                   if [[ "${{ matrix.os }}" != "macos-13" ]]; then
                       npm run publish
                   else


### PR DESCRIPTION
We already npm ci in a separate step, so doing it here is a waste.