### PR TITLE
Avoid restarting backend if no deps installed

### DIFF
--- a/backend/src/dependencies/store.py
+++ b/backend/src/dependencies/store.py
@@ -74,7 +74,7 @@ def install_dependencies_sync(
 ):
     dependencies_to_install = get_deps_to_install(dependencies)
     if len(dependencies_to_install) == 0:
-        return
+        return 0
 
     extra_index_urls = {
         dep_info.extra_index_url
@@ -104,6 +104,8 @@ def install_dependencies_sync(
     for dep_info in dependencies_to_install:
         installed_packages[dep_info.package_name] = dep_info.version
 
+    return len(dependencies_to_install)
+
 
 async def install_dependencies(
     dependencies: list[DependencyInfo],
@@ -112,12 +114,11 @@ async def install_dependencies(
 ):
     # If there's no progress callback, just install the dependencies synchronously
     if update_progress_cb is None:
-        install_dependencies_sync(dependencies)
-        return
+        return install_dependencies_sync(dependencies)
 
     dependencies_to_install = get_deps_to_install(dependencies)
     if len(dependencies_to_install) == 0:
-        return
+        return 0
 
     dependency_name_map = {
         dep_info.package_name: dep_info.display_name or dep_info.package_name
@@ -226,6 +227,8 @@ async def install_dependencies(
 
     for dep_info in dependencies_to_install:
         installed_packages[dep_info.package_name] = dep_info.version
+
+    return len(dependencies_to_install)
 
 
 __all__ = [

--- a/backend/src/server_host.py
+++ b/backend/src/server_host.py
@@ -218,23 +218,22 @@ async def import_packages(
             if dep.auto_update and is_installed:
                 to_install.append(dep)
 
-    if len(to_install) > 0:
-        try:
-            num_installed = await install_deps(to_install)
+    try:
+        num_installed = await install_deps(to_install)
 
-            if num_installed > 0:
-                flags = []
-                if config.error_on_failed_node:
-                    flags.append("--error-on-failed-node")
+        if num_installed > 0:
+            flags = []
+            if config.error_on_failed_node:
+                flags.append("--error-on-failed-node")
 
-                if config.close_after_start:
-                    flags.append("--close-after-start")
-
-                await worker.restart(flags)
-        except Exception as ex:
-            logger.error(f"Error installing dependencies: {ex}", exc_info=True)
             if config.close_after_start:
-                raise ValueError("Error installing dependencies") from ex
+                flags.append("--close-after-start")
+
+            await worker.restart(flags)
+    except Exception as ex:
+        logger.error(f"Error installing dependencies: {ex}", exc_info=True)
+        if config.close_after_start:
+            raise ValueError("Error installing dependencies") from ex
 
     logger.info("Done checking dependencies...")
 

--- a/backend/src/server_host.py
+++ b/backend/src/server_host.py
@@ -194,7 +194,8 @@ async def import_packages(
             )
             for dep in dependencies
         ]
-        await install_dependencies(dep_info, update_progress_cb, logger)
+        num_installed = await install_dependencies(dep_info, update_progress_cb, logger)
+        return num_installed
 
     packages = await worker.get_packages()
 
@@ -219,16 +220,17 @@ async def import_packages(
 
     if len(to_install) > 0:
         try:
-            await install_deps(to_install)
+            num_installed = await install_deps(to_install)
 
-            flags = []
-            if config.error_on_failed_node:
-                flags.append("--error-on-failed-node")
+            if num_installed > 0:
+                flags = []
+                if config.error_on_failed_node:
+                    flags.append("--error-on-failed-node")
 
-            if config.close_after_start:
-                flags.append("--close-after-start")
+                if config.close_after_start:
+                    flags.append("--close-after-start")
 
-            await worker.restart(flags)
+                await worker.restart(flags)
         except Exception as ex:
             logger.error(f"Error installing dependencies: {ex}", exc_info=True)
             if config.close_after_start:


### PR DESCRIPTION
This PR moves the usage of `get_deps_to_install` to outside of the installing deps functions. This makes it so that we can choose to not restart the executor server if there are no dependencies installed, which should speed up startup times.