### PR TITLE
Make the "Random Seed" button non-draggable

### DIFF
--- a/src/renderer/components/groups/SeedGroup.tsx
+++ b/src/renderer/components/groups/SeedGroup.tsx
@@ -33,6 +33,7 @@ export const SeedGroup = memo(({ inputs, nodeState }: GroupProps<'seed'>) => {
                     >
                         <IconButton
                             aria-label="Random Seed"
+                            className="nodrag"
                             h="2rem"
                             icon={<HiOutlineRefresh />}
                             isDisabled={isLocked || isInputLocked}


### PR DESCRIPTION
The button was sometimes hard to click, because it would drag the node instead. Now it's non-draggable, just like any other button.