### PR TITLE
Add key information to collapsed nodes

### DIFF
--- a/backend/src/api/api.py
+++ b/backend/src/api/api.py
@@ -24,7 +24,7 @@ from .node_check import (
     check_naming_conventions,
     check_schema_types,
 )
-from .node_data import IteratorInputInfo, IteratorOutputInfo, NodeData
+from .node_data import IteratorInputInfo, IteratorOutputInfo, KeyInfo, NodeData
 from .output import BaseOutput
 from .settings import Setting
 from .types import FeatureId, InputId, NodeId, NodeKind, OutputId, RunFn
@@ -113,6 +113,7 @@ class NodeGroup:
         iterator_inputs: list[IteratorInputInfo] | IteratorInputInfo | None = None,
         iterator_outputs: list[IteratorOutputInfo] | IteratorOutputInfo | None = None,
         node_context: bool = False,
+        key_info: KeyInfo | None = None,
     ):
         if not isinstance(description, str):
             description = "\n\n".join(description)
@@ -181,6 +182,7 @@ class NodeGroup:
                 outputs=p_outputs,
                 iterator_inputs=iterator_inputs,
                 iterator_outputs=iterator_outputs,
+                key_info=key_info,
                 side_effects=side_effects,
                 deprecated=deprecated,
                 node_context=node_context,

--- a/backend/src/api/node_data.py
+++ b/backend/src/api/node_data.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 import navi
 
@@ -50,6 +51,22 @@ class IteratorOutputInfo:
         }
 
 
+class KeyInfo:
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._data = data
+
+    @staticmethod
+    def enum(enum_input: InputId | int) -> KeyInfo:
+        return KeyInfo({"kind": "enum", "enum": enum_input})
+
+    @staticmethod
+    def type(expression: navi.ExpressionJson) -> KeyInfo:
+        return KeyInfo({"kind": "type", "expression": expression})
+
+    def to_dict(self):
+        return self._data
+
+
 @dataclass(frozen=True)
 class NodeData:
     schema_id: str
@@ -65,6 +82,8 @@ class NodeData:
 
     iterator_inputs: list[IteratorInputInfo]
     iterator_outputs: list[IteratorOutputInfo]
+
+    key_info: KeyInfo | None
 
     side_effects: bool
     deprecated: bool

--- a/backend/src/packages/chaiNNer_standard/image/io/save_image.py
+++ b/backend/src/packages/chaiNNer_standard/image/io/save_image.py
@@ -10,6 +10,7 @@ import numpy as np
 from PIL import Image
 from sanic.log import logger
 
+from api import KeyInfo
 from nodes.groups import Condition, if_enum_group, if_group
 from nodes.impl.dds.format import (
     BC7_FORMATS,
@@ -211,6 +212,7 @@ class TiffColorDepth(Enum):
         ),
     ],
     outputs=[],
+    key_info=KeyInfo.enum(4),
     side_effects=True,
     limited_to_8bpc="Image will be saved with 8 bits/channel by default. Some formats support higher bit depths.",
 )

--- a/backend/src/packages/chaiNNer_standard/image_dimension/border/pad.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/border/pad.py
@@ -4,6 +4,7 @@ from enum import Enum
 
 import numpy as np
 
+from api import KeyInfo
 from nodes.groups import if_enum_group
 from nodes.impl.color.color import Color
 from nodes.impl.image_utils import BorderType, create_border
@@ -95,6 +96,7 @@ class BorderMode(Enum):
             assume_normalized=True,
         )
     ],
+    key_info=KeyInfo.enum(3),
 )
 def pad_node(
     img: np.ndarray,

--- a/backend/src/packages/chaiNNer_standard/image_dimension/crop/crop.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/crop/crop.py
@@ -4,6 +4,7 @@ from enum import Enum
 
 import numpy as np
 
+from api import KeyInfo
 from nodes.groups import if_enum_group
 from nodes.properties.inputs import EnumInput, ImageInput, NumberInput
 from nodes.properties.outputs import ImageOutput
@@ -77,6 +78,7 @@ class CropMode(Enum):
             "The cropped area would result in an image with no width or no height."
         )
     ],
+    key_info=KeyInfo.enum(1),
 )
 def crop_node(
     img: np.ndarray,

--- a/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize.py
@@ -4,6 +4,7 @@ from enum import Enum
 
 import numpy as np
 
+from api import KeyInfo
 from nodes.groups import Condition, if_enum_group, if_group
 from nodes.impl.resize import ResizeFilter, resize
 from nodes.properties.inputs import (
@@ -89,6 +90,20 @@ class ImageResizeMode(Enum):
             assume_normalized=True,
         )
     ],
+    key_info=KeyInfo.type(
+        """
+        let mode = Input1;
+
+        let scale = Input2;
+        let width = Input3;
+        let height = Input4;
+
+        match mode {
+            ImageResizeMode::Percentage => string::concat(toString(scale), "%"),
+            ImageResizeMode::Absolute => string::concat(toString(width), "x", toString(height)),
+        }
+        """
+    ),
 )
 def resize_node(
     img: np.ndarray,

--- a/backend/src/packages/chaiNNer_standard/utility/color/color_from.py
+++ b/backend/src/packages/chaiNNer_standard/utility/color/color_from.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from enum import Enum
 
+from api import KeyInfo
 from nodes.groups import if_enum_group
 from nodes.impl.color.color import Color
 from nodes.properties.inputs import EnumInput, SliderInput
@@ -22,7 +23,9 @@ class ColorType(Enum):
     description="Create a new color value from individual channels.",
     icon="MdColorLens",
     inputs=[
-        EnumInput(ColorType, "Color Type", ColorType.RGBA, preferred_style="tabs"),
+        EnumInput(
+            ColorType, "Color Type", ColorType.RGBA, preferred_style="tabs"
+        ).with_id(0),
         if_enum_group(0, ColorType.GRAY)(
             SliderInput(
                 "Luma",
@@ -96,6 +99,7 @@ class ColorType(Enum):
             """
         )
     ],
+    key_info=KeyInfo.enum(0),
 )
 def color_from_node(
     color_type: ColorType,

--- a/backend/src/packages/chaiNNer_standard/utility/value/number.py
+++ b/backend/src/packages/chaiNNer_standard/utility/value/number.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from api import KeyInfo
 from nodes.properties.inputs import NumberInput
 from nodes.properties.outputs import NumberOutput
 
@@ -24,6 +25,7 @@ from .. import value_group
     outputs=[
         NumberOutput("Number", output_type="Input0").suggest(),
     ],
+    key_info=KeyInfo.type("""toString(Input0)"""),
 )
 def number_node(number: float) -> float:
     return number

--- a/backend/src/packages/chaiNNer_standard/utility/value/percent.py
+++ b/backend/src/packages/chaiNNer_standard/utility/value/percent.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from api import KeyInfo
 from nodes.properties.inputs import SliderInput
 from nodes.properties.outputs import NumberOutput
 
@@ -25,6 +26,7 @@ from .. import value_group
     outputs=[
         NumberOutput("Percent", output_type="Input0"),
     ],
+    key_info=KeyInfo.type("""string::concat(toString(Input0), "%")"""),
 )
 def percent_node(number: int) -> int:
     return number

--- a/backend/src/packages/chaiNNer_standard/utility/value/switch.py
+++ b/backend/src/packages/chaiNNer_standard/utility/value/switch.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from enum import Enum
 
+from api import KeyInfo
 from nodes.groups import optional_list_group
 from nodes.properties.inputs import AnyInput, EnumInput
 from nodes.properties.outputs import BaseOutput
@@ -29,7 +30,7 @@ class ValueIndex(Enum):
     description="Allows you to pass in multiple inputs and then change which one passes through to the output.",
     icon="BsShuffle",
     inputs=[
-        EnumInput(ValueIndex),
+        EnumInput(ValueIndex).with_id(0),
         AnyInput(label="Value A"),
         AnyInput(label="Value B"),
         optional_list_group(
@@ -64,6 +65,7 @@ class ValueIndex(Enum):
             label="Value",
         ).with_never_reason("The selected value should have a connection.")
     ],
+    key_info=KeyInfo.enum(0),
     see_also=["chainner:utility:pass_through"],
 )
 def switch_node(selection: ValueIndex, *args: object | None) -> object:

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -120,6 +120,7 @@ async def nodes(_request: Request):
             ],
             "iteratorInputs": [x.to_dict() for x in node.iterator_inputs],
             "iteratorOutputs": [x.to_dict() for x in node.iterator_outputs],
+            "keyInfo": node.key_info.to_dict() if node.key_info else None,
             "description": node.description,
             "seeAlso": node.see_also,
             "icon": node.icon,

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -286,6 +286,16 @@ export interface IteratorOutputInfo {
     readonly lengthType: ExpressionJson;
 }
 
+export type KeyInfo = EnumKeyInfo | TypeKeyInfo;
+export interface EnumKeyInfo {
+    readonly kind: 'enum';
+    readonly enum: InputId;
+}
+export interface TypeKeyInfo {
+    readonly kind: 'type';
+    readonly expression: ExpressionJson;
+}
+
 export interface NodeSchema {
     readonly name: string;
     readonly category: CategoryId;
@@ -299,6 +309,7 @@ export interface NodeSchema {
     readonly groupLayout: readonly (InputId | Group)[];
     readonly iteratorInputs: readonly IteratorInputInfo[];
     readonly iteratorOutputs: readonly IteratorOutputInfo[];
+    readonly keyInfo?: KeyInfo | null;
     readonly schemaId: SchemaId;
     readonly hasSideEffects: boolean;
     readonly deprecated: boolean;

--- a/src/common/nodes/keyInfo.ts
+++ b/src/common/nodes/keyInfo.ts
@@ -1,0 +1,92 @@
+import {
+    ParameterDefinition,
+    Scope,
+    ScopeBuilder,
+    StringType,
+    evaluate,
+    isStringLiteral,
+    isSubsetOf,
+} from '@chainner/navi';
+import { InputData, KeyInfo, NodeSchema, OfKind } from '../common-types';
+import {
+    FunctionDefinition,
+    FunctionInstance,
+    getInputParamName,
+    getOutputParamName,
+} from '../types/function';
+import { fromJson } from '../types/json';
+import { lazyKeyed } from '../util';
+
+const getKeyInfoScopeTemplate = lazyKeyed((definition: FunctionDefinition): Scope => {
+    const builder = new ScopeBuilder('key info', definition.scope);
+
+    // assign inputs and outputs
+    definition.inputDefaults.forEach((input, inputId) => {
+        builder.add(new ParameterDefinition(getInputParamName(inputId), input));
+    });
+    definition.outputDefaults.forEach((output, outputId) => {
+        builder.add(new ParameterDefinition(getOutputParamName(outputId), output));
+    });
+
+    return builder.createScope();
+});
+const getKeyInfoScope = (instance: FunctionInstance): Scope => {
+    const scope = getKeyInfoScopeTemplate(instance.definition);
+
+    // assign inputs and outputs
+    instance.inputs.forEach((input, inputId) => {
+        scope.assignParameter(getInputParamName(inputId), input);
+    });
+    instance.outputs.forEach((output, outputId) => {
+        scope.assignParameter(getOutputParamName(outputId), output);
+    });
+
+    return scope;
+};
+
+const accessors: {
+    [kind in KeyInfo['kind']]: (
+        info: OfKind<KeyInfo, kind>,
+        node: NodeSchema,
+        inputData: InputData,
+        types: FunctionInstance | undefined
+    ) => string | undefined;
+} = {
+    enum: (info, node, inputData) => {
+        const input = node.inputs.find((i) => i.id === info.enum);
+        if (!input) throw new Error(`Input ${info.enum} not found`);
+        if (input.kind !== 'dropdown') throw new Error(`Input ${info.enum} is not a dropdown`);
+
+        const value = inputData[input.id];
+        const option = input.options.find((o) => o.value === value);
+        return option?.option;
+    },
+    type: (info, node, inputData, types) => {
+        if (!types) return undefined;
+
+        const expression = fromJson(info.expression);
+        const scope = getKeyInfoScope(types);
+        const result = evaluate(expression, scope);
+
+        if (isStringLiteral(result)) return result.value;
+
+        // check that the expression actually evaluates to a string
+        if (!isSubsetOf(result, StringType.instance)) {
+            throw new Error(
+                `Key info expression must evaluate to a string, but got ${result.toString()}`
+            );
+        }
+
+        return undefined;
+    },
+};
+
+export const getKeyInfo = (
+    node: NodeSchema,
+    inputData: InputData,
+    types: FunctionInstance | undefined
+): string | undefined => {
+    const { keyInfo } = node;
+    if (!keyInfo) return undefined;
+    return accessors[keyInfo.kind](keyInfo as never, node, inputData, types);
+};

--- a/src/common/types/function.ts
+++ b/src/common/types/function.ts
@@ -49,8 +49,8 @@ const getParamRefs = <P extends 'Input' | 'Output'>(
     return refs;
 };
 
-const getInputParamName = (inputId: InputId) => `Input${inputId}` as const;
-const getOutputParamName = (outputId: OutputId) => `Output${outputId}` as const;
+export const getInputParamName = (inputId: InputId) => `Input${inputId}` as const;
+export const getOutputParamName = (outputId: OutputId) => `Output${outputId}` as const;
 
 interface InputInfo {
     expression: Expression;

--- a/src/renderer/components/node/NodeHeader.tsx
+++ b/src/renderer/components/node/NodeHeader.tsx
@@ -1,8 +1,11 @@
 import { ChevronDownIcon, ChevronRightIcon } from '@chakra-ui/icons';
 import { Box, Center, HStack, Heading, IconButton, Spacer, Text, VStack } from '@chakra-ui/react';
-import { memo } from 'react';
+import { memo, useEffect, useMemo } from 'react';
 import ReactTimeAgo from 'react-time-ago';
+import { useContext } from 'use-context-selector';
+import { getKeyInfo } from '../../../common/nodes/keyInfo';
 import { Validity } from '../../../common/Validity';
+import { AlertBoxContext, AlertType } from '../../contexts/AlertBoxContext';
 import { NodeProgress } from '../../contexts/ExecutionContext';
 import { interpolateColor } from '../../helpers/colorTools';
 import { NodeState } from '../../helpers/nodeState';
@@ -69,6 +72,50 @@ const IteratorProcess = memo(({ nodeProgress, progressColor }: IteratorProcessPr
                 />
             </Box>
         </Box>
+    );
+});
+
+interface KeyInfoLabelProps {
+    nodeState: NodeState;
+}
+
+const KeyInfoLabel = memo(({ nodeState }: KeyInfoLabelProps) => {
+    const { sendAlert } = useContext(AlertBoxContext);
+
+    const { schema, inputData, type } = nodeState;
+    const [info, error] = useMemo((): [string | undefined, unknown] => {
+        try {
+            return [getKeyInfo(schema, inputData, type.instance), undefined];
+        } catch (e) {
+            return [undefined, e];
+        }
+    }, [schema, inputData, type.instance]);
+
+    useEffect(() => {
+        if (error) {
+            sendAlert({
+                type: AlertType.ERROR,
+                title: 'Implementation Error',
+                message: `Unable to determine key info for node ${schema.name} (${
+                    schema.schemaId
+                }) due to an error in the implementation of the key info:\n\n${String(error)}`,
+            });
+        }
+    }, [schema, error, sendAlert]);
+
+    // eslint-disable-next-line react/jsx-no-useless-fragment
+    if (!info) return <></>;
+
+    return (
+        <Text
+            as="span"
+            fontSize="sm"
+            fontWeight="medium"
+            ml={2}
+            textTransform="none"
+        >
+            {info}
+        </Text>
     );
 });
 
@@ -165,6 +212,9 @@ export const NodeHeader = memo(
                                 whiteSpace="nowrap"
                             >
                                 {nodeState.schema.name}
+                                {isCollapsed && nodeState.schema.keyInfo && (
+                                    <KeyInfoLabel nodeState={nodeState} />
+                                )}
                             </Heading>
                         </Center>
                     </HStack>

--- a/src/renderer/components/node/NodeHeader.tsx
+++ b/src/renderer/components/node/NodeHeader.tsx
@@ -111,7 +111,9 @@ const KeyInfoLabel = memo(({ nodeState }: KeyInfoLabelProps) => {
             as="span"
             fontSize="sm"
             fontWeight="medium"
-            ml={2}
+            h="full"
+            lineHeight={0}
+            my="auto"
             textTransform="none"
         >
             {info}
@@ -197,25 +199,27 @@ export const NodeHeader = memo(
                             />
                         </Center>
                         <Center verticalAlign="middle">
-                            <Heading
-                                alignContent="center"
-                                as="h5"
-                                fontWeight={700}
-                                lineHeight="auto"
-                                m={0}
-                                opacity={isEnabled ? 1 : 0.5}
-                                p={0}
-                                size="sm"
-                                textAlign="center"
-                                textTransform="uppercase"
-                                verticalAlign="middle"
-                                whiteSpace="nowrap"
-                            >
-                                {nodeState.schema.name}
+                            <HStack>
+                                <Heading
+                                    alignContent="center"
+                                    as="h5"
+                                    fontWeight={700}
+                                    lineHeight="auto"
+                                    m={0}
+                                    opacity={isEnabled ? 1 : 0.5}
+                                    p={0}
+                                    size="sm"
+                                    textAlign="center"
+                                    textTransform="uppercase"
+                                    verticalAlign="middle"
+                                    whiteSpace="nowrap"
+                                >
+                                    {nodeState.schema.name}
+                                </Heading>
                                 {isCollapsed && nodeState.schema.keyInfo && (
                                     <KeyInfoLabel nodeState={nodeState} />
                                 )}
-                            </Heading>
+                            </HStack>
                         </Center>
                     </HStack>
                     <Spacer />


### PR DESCRIPTION
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/8106e54d-cdf8-4880-9cb2-fa04c7eae6d6)

This adds the key information of nodes next to the title of collapsed nodes. This should make collapsed nodes more useful as the functionality of the node can be seen more easily without needing to expand it.

As for the implementation: I used the term "key info" everywhere for now, but I don't really like it. It doesn't convey that this information is only used when the node is collapsed (although maybe we'll use it somewhere also too in future? idk).