### PR TITLE
Show key info on more nodes

### DIFF
--- a/backend/src/api/node_data.py
+++ b/backend/src/api/node_data.py
@@ -57,7 +57,11 @@ class KeyInfo:
 
     @staticmethod
     def enum(enum_input: InputId | int) -> KeyInfo:
-        return KeyInfo({"kind": "enum", "enum": enum_input})
+        return KeyInfo({"kind": "enum", "inputId": enum_input})
+
+    @staticmethod
+    def number(number_input: InputId | int) -> KeyInfo:
+        return KeyInfo({"kind": "number", "inputId": number_input})
 
     @staticmethod
     def type(expression: navi.ExpressionJson) -> KeyInfo:

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/restoration/upscale_face.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/restoration/upscale_face.py
@@ -11,7 +11,7 @@ from sanic.log import logger
 from spandrel import ImageModelDescriptor
 from torchvision.transforms.functional import normalize as tv_normalize
 
-from api import NodeContext
+from api import KeyInfo, NodeContext
 from nodes.groups import Condition, if_group
 from nodes.impl.image_utils import to_uint8
 from nodes.impl.pytorch.utils import np2tensor, safe_cuda_cache_empty, tensor2np
@@ -146,6 +146,7 @@ def upscale(
             channels=3,
         )
     ],
+    key_info=KeyInfo.number(3),
     limited_to_8bpc=True,
     node_context=True,
 )

--- a/backend/src/packages/chaiNNer_standard/image/video_frames/save_video.py
+++ b/backend/src/packages/chaiNNer_standard/image/video_frames/save_video.py
@@ -10,7 +10,7 @@ import ffmpeg
 import numpy as np
 from sanic.log import logger
 
-from api import Collector, IteratorInputInfo
+from api import Collector, IteratorInputInfo, KeyInfo
 from nodes.groups import Condition, if_enum_group, if_group
 from nodes.impl.image_utils import to_uint8
 from nodes.impl.video import FFMPEG_PATH
@@ -313,6 +313,7 @@ class Writer:
     ],
     iterator_inputs=IteratorInputInfo(inputs=0),
     outputs=[],
+    key_info=KeyInfo.enum(4),
     kind="collector",
     side_effects=True,
 )

--- a/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/opacity.py
+++ b/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/opacity.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import numpy as np
 
 import navi
+from api import KeyInfo
 from nodes.impl.pil_utils import convert_to_bgra
 from nodes.properties.inputs import ImageInput, SliderInput
 from nodes.properties.outputs import ImageOutput
@@ -34,6 +35,7 @@ from .. import adjustments_group
             assume_normalized=True,
         )
     ],
+    key_info=KeyInfo.number(1),
 )
 def opacity_node(img: np.ndarray, opacity: float) -> np.ndarray:
     # Convert inputs

--- a/backend/src/packages/chaiNNer_standard/image_adjustment/threshold/threshold.py
+++ b/backend/src/packages/chaiNNer_standard/image_adjustment/threshold/threshold.py
@@ -6,6 +6,7 @@ import cv2
 import numpy as np
 from chainner_ext import binary_threshold
 
+from api import KeyInfo
 from nodes.groups import if_enum_group
 from nodes.impl.image_utils import as_2d_grayscale
 from nodes.properties.inputs import BoolInput, EnumInput, ImageInput, SliderInput
@@ -66,7 +67,10 @@ _THRESHOLD_TYPE_LABELS: dict[ThresholdType, str] = {
             "Conceptually, the option is equivalent to first upscaling the image by a factor of X (with linear interpolation), thresholding it, and then downscaling it by a factor of X (where X is 20 or more).",
         ),
     ],
-    outputs=[ImageOutput(image_type="Input0")],
+    outputs=[
+        ImageOutput(image_type="Input0"),
+    ],
+    key_info=KeyInfo.number(1),
     see_also=[
         "chainner:image:generate_threshold",
         "chainner:image:threshold_adaptive",

--- a/backend/src/packages/chaiNNer_standard/image_utility/modification/flip.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/modification/flip.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 
+from api import KeyInfo
 from nodes.impl.image_utils import FlipAxis
 from nodes.properties.inputs import EnumInput, ImageInput
 from nodes.properties.outputs import ImageOutput
@@ -19,6 +20,7 @@ from .. import modification_group
         EnumInput(FlipAxis),
     ],
     outputs=[ImageOutput(image_type="Input0", assume_normalized=True)],
+    key_info=KeyInfo.enum(1),
 )
 def flip_node(img: np.ndarray, axis: FlipAxis) -> np.ndarray:
     return axis.flip(img)

--- a/backend/src/packages/chaiNNer_standard/image_utility/modification/rotate.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/modification/rotate.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 
+from api import KeyInfo
 from nodes.impl.pil_utils import (
     FillColor,
     RotateSizeChange,
@@ -120,6 +121,7 @@ from .. import modification_group
             assume_normalized=True,
         )
     ],
+    key_info=KeyInfo.number(1),
     limited_to_8bpc=True,
 )
 def rotate_node(

--- a/backend/src/packages/chaiNNer_standard/utility/color/color.py
+++ b/backend/src/packages/chaiNNer_standard/utility/color/color.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from api import KeyInfo
 from nodes.impl.color.color import Color
 from nodes.properties.inputs import ColorInput
 from nodes.properties.outputs import ColorOutput
@@ -18,6 +19,17 @@ from .. import color_group
     outputs=[
         ColorOutput(color_type="Input0").suggest(),
     ],
+    key_info=KeyInfo.type(
+        """
+        let channels = Input0.channels;
+        match channels {
+            1 => "Gray",
+            3 => "RGB",
+            4 => "RGBA",
+            _ => never
+        }
+        """
+    ),
 )
 def color_node(color: Color) -> Color:
     return color

--- a/backend/src/packages/chaiNNer_standard/utility/value/number.py
+++ b/backend/src/packages/chaiNNer_standard/utility/value/number.py
@@ -25,7 +25,7 @@ from .. import value_group
     outputs=[
         NumberOutput("Number", output_type="Input0").suggest(),
     ],
-    key_info=KeyInfo.type("""toString(Input0)"""),
+    key_info=KeyInfo.number(0),
 )
 def number_node(number: float) -> float:
     return number

--- a/backend/src/packages/chaiNNer_standard/utility/value/percent.py
+++ b/backend/src/packages/chaiNNer_standard/utility/value/percent.py
@@ -26,7 +26,7 @@ from .. import value_group
     outputs=[
         NumberOutput("Percent", output_type="Input0"),
     ],
-    key_info=KeyInfo.type("""string::concat(toString(Input0), "%")"""),
+    key_info=KeyInfo.number(0),
 )
 def percent_node(number: int) -> int:
     return number

--- a/backend/src/packages/chaiNNer_standard/utility/value/range.py
+++ b/backend/src/packages/chaiNNer_standard/utility/value/range.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from api import Iterator, IteratorOutputInfo
+from api import Iterator, IteratorOutputInfo, KeyInfo
 from nodes.properties.inputs import BoolInput, NumberInput
 from nodes.properties.outputs import NumberOutput
 
@@ -29,6 +29,14 @@ from .. import value_group
             """,
         ).with_never_reason("The range is empty."),
     ],
+    key_info=KeyInfo.type(
+        """
+        let start = if Input1 { Input0 } else { Input0 + 1 };
+        let stop = if Input3 { Input2 } else { Input2 - 1 };
+
+        string::concat(toString(start), "..", toString(stop))
+        """
+    ),
     iterator_outputs=IteratorOutputInfo(outputs=0),
     kind="newIterator",
 )

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -286,10 +286,14 @@ export interface IteratorOutputInfo {
     readonly lengthType: ExpressionJson;
 }
 
-export type KeyInfo = EnumKeyInfo | TypeKeyInfo;
+export type KeyInfo = EnumKeyInfo | NumberKeyInfo | TypeKeyInfo;
 export interface EnumKeyInfo {
     readonly kind: 'enum';
-    readonly enum: InputId;
+    readonly inputId: InputId;
+}
+export interface NumberKeyInfo {
+    readonly kind: 'number';
+    readonly inputId: InputId;
 }
 export interface TypeKeyInfo {
     readonly kind: 'type';

--- a/src/common/nodes/keyInfo.ts
+++ b/src/common/nodes/keyInfo.ts
@@ -4,6 +4,7 @@ import {
     ScopeBuilder,
     StringType,
     evaluate,
+    isNumericLiteral,
     isStringLiteral,
     isSubsetOf,
 } from '@chainner/navi';
@@ -53,13 +54,30 @@ const accessors: {
     ) => string | undefined;
 } = {
     enum: (info, node, inputData) => {
-        const input = node.inputs.find((i) => i.id === info.enum);
-        if (!input) throw new Error(`Input ${info.enum} not found`);
-        if (input.kind !== 'dropdown') throw new Error(`Input ${info.enum} is not a dropdown`);
+        const input = node.inputs.find((i) => i.id === info.inputId);
+        if (!input) throw new Error(`Input ${info.inputId} not found`);
+        if (input.kind !== 'dropdown') throw new Error(`Input ${info.inputId} is not a dropdown`);
 
         const value = inputData[input.id];
         const option = input.options.find((o) => o.value === value);
         return option?.option;
+    },
+    number: (info, node, inputData, types) => {
+        const input = node.inputs.find((i) => i.id === info.inputId);
+        if (!input) throw new Error(`Input ${info.inputId} not found`);
+        if (input.kind !== 'number' && input.kind !== 'slider')
+            throw new Error(`Input ${info.inputId} is not a number/slider`);
+
+        let value = inputData[input.id];
+        if (types) {
+            const t = types.inputs.get(input.id);
+            if (t && isNumericLiteral(t)) {
+                value = t.value;
+            }
+        }
+
+        const unit = input.unit ?? '';
+        return String(value) + unit;
     },
     type: (info, node, inputData, types) => {
         if (!types) return undefined;


### PR DESCRIPTION
Changes:
- Added `KeyInfo.number(input_id)` to use a number/slider input as the key info. This will automatically add units if any.
- Add key info to more nodes.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/70e0d470-c372-461d-ba80-a4dcd913ec57)
