### PR TITLE
Fix default values not being added correctly on load

### DIFF
--- a/src/renderer/contexts/GlobalNodeState.tsx
+++ b/src/renderer/contexts/GlobalNodeState.tsx
@@ -560,7 +560,11 @@ export const GlobalProvider = memo(
                                 ...node.data,
                                 inputData: {
                                     ...schemata.getDefaultInput(node.data.schemaId),
-                                    ...node.data.inputData,
+                                    ...Object.fromEntries(
+                                        Object.entries(node.data.inputData).filter(
+                                            ([, v]) => v != null
+                                        )
+                                    ),
                                 },
                             },
                         };


### PR DESCRIPTION
This fixes the bug @Kim2091 reported [here](https://discord.com/channels/930865462852591648/930865725135011851/1210660021768032257). The issue was that the node input data contained some `undefined` values from previous migrations. This is allowed by the `InputData` type, but the code for adding default values didn't handle this.
