### PR TITLE
Fix executor passthrough logging

### DIFF
--- a/backend/src/server_process_helper.py
+++ b/backend/src/server_process_helper.py
@@ -59,7 +59,20 @@ class _WorkerProcess:
         for line in self._process.stdout:
             if self._stop_event.is_set():
                 break
-            print(line.decode().strip())
+            stripped_line = line.decode().strip()
+            words = stripped_line.split()
+            log_level = words[4].lower()[1:-1]  # remove brackets
+            rest = " ".join(words[5:])
+            if log_level == "debug":
+                logger.debug(rest)
+            elif log_level == "info":
+                logger.info(rest)
+            elif log_level == "warning":
+                logger.warning(rest)
+            elif log_level == "error":
+                logger.error(rest)
+            elif log_level == "critical":
+                logger.critical(rest)
 
 
 class WorkerServer:

--- a/backend/src/server_process_helper.py
+++ b/backend/src/server_process_helper.py
@@ -28,7 +28,7 @@ def _port_in_use(port: int):
         return s.connect_ex(("127.0.0.1", port)) == 0
 
 
-SANIC_LOG_REGEX = re.compile(r"\[.*\] \[\d*\] \[(\w*)\] (.*)")
+SANIC_LOG_REGEX = re.compile(r"^\[[^\[\]]*\] \[\d*\] \[(\w*)\] (.*)")
 
 
 class _WorkerProcess:

--- a/backend/src/server_process_helper.py
+++ b/backend/src/server_process_helper.py
@@ -28,7 +28,7 @@ def _port_in_use(port: int):
         return s.connect_ex(("127.0.0.1", port)) == 0
 
 
-SANIC_LOG_REGEX = r"\[.*\] \[\d*\] \[(\w*)\] (.*)"
+SANIC_LOG_REGEX = re.compile(r"\[.*\] \[\d*\] \[(\w*)\] (.*)")
 
 
 class _WorkerProcess:

--- a/backend/src/server_process_helper.py
+++ b/backend/src/server_process_helper.py
@@ -67,17 +67,16 @@ class _WorkerProcess:
             match_obj = re.match(SANIC_LOG_REGEX, stripped_line)
             if match_obj is not None:
                 log_level, message = match_obj.groups()
-                log_level = log_level.lower()
                 message = f"[Executor] {message.strip()}"
-                if log_level == "debug":
+                if log_level == "DEBUG":
                     logger.debug(message)
-                elif log_level == "info":
+                elif log_level == "INFO":
                     logger.info(message)
-                elif log_level == "warning":
+                elif log_level == "WARNING":
                     logger.warning(message)
-                elif log_level == "error":
+                elif log_level == "ERROR":
                     logger.error(message)
-                elif log_level == "critical":
+                elif log_level == "CRITICAL":
                     logger.critical(message)
                 else:
                     logger.info(stripped_line)


### PR DESCRIPTION
The biggest thing I dislike about this is the amount of code that now has to run per-log. This could wind up being a minor performance impact if we have a lot of logging