### PR TITLE
Specify return type hint of ModelOutput tag broadcast

### DIFF
--- a/backend/src/nodes/properties/outputs/pytorch_outputs.py
+++ b/backend/src/nodes/properties/outputs/pytorch_outputs.py
@@ -17,7 +17,7 @@ class ModelOutput(BaseOutput):
     ):
         super().__init__(model_type, label, kind=kind, associated_type=ModelDescriptor)
 
-    def get_broadcast_data(self, value: ModelDescriptor):
+    def get_broadcast_data(self, value: ModelDescriptor) -> dict[str, list[str]]:
         return {
             "tags": [
                 value.architecture,


### PR DESCRIPTION
This should fail until #2661 is merged