### PR TITLE
Use package display name in dependency manager

### DIFF
--- a/src/renderer/contexts/DependencyContext.tsx
+++ b/src/renderer/contexts/DependencyContext.tsx
@@ -120,7 +120,7 @@ const PackageDependencyView = memo(
                     textAlign="left"
                     width="fit-content"
                 >
-                    {pkg.pypiName}
+                    {pkg.displayName}
                 </Text>
                 {!!tagText && <Tag color={color}>{tagText}</Tag>}
                 <Tag>{versionString}</Tag>


### PR DESCRIPTION
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/dd12a0af-a93c-42bb-a248-4d9a92c46474)
