### PR TITLE
Fixed connection error tooltip getting stuck

### DIFF
--- a/src/renderer/components/Handle.tsx
+++ b/src/renderer/components/Handle.tsx
@@ -39,7 +39,9 @@ const HandleElement = memo(
                 borderRadius={8}
                 display={validity.isValid ? 'none' : 'block'}
                 label={
-                    validity.isValid ? undefined : (
+                    validity.isValid ? (
+                        'Connection is valid'
+                    ) : (
                         <Markdown
                             nonInteractive
                         >{`Unable to connect: ${validity.reason}`}</Markdown>


### PR DESCRIPTION
Fixes #2550 

Apparently, setting the label to any value that renders to nothing (`undefined`, `null`, `''`, `false`) causes problems.