### PR TITLE
Fix glob negation

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/load_images.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/load_images.py
@@ -37,7 +37,6 @@ def list_glob(directory: Path, globexpr: str, ext_filter: list[str]) -> list[Pat
         | glob.GLOBSTAR
         | glob.NEGATE
         | glob.DOTGLOB
-        | glob.MINUSNEGATE
         | glob.NEGATEALL
     )
 

--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/load_images.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/load_images.py
@@ -31,7 +31,15 @@ def extension_filter(lst: list[str]) -> str:
 def list_glob(directory: Path, globexpr: str, ext_filter: list[str]) -> list[Path]:
     extension_expr = extension_filter(ext_filter)
 
-    flags = glob.EXTGLOB | glob.BRACE | glob.GLOBSTAR | glob.NEGATE | glob.DOTGLOB
+    flags = (
+        glob.EXTGLOB
+        | glob.BRACE
+        | glob.GLOBSTAR
+        | glob.NEGATE
+        | glob.DOTGLOB
+        | glob.MINUSNEGATE
+        | glob.NEGATEALL
+    )
 
     foo = list(glob.iglob(globexpr, root_dir=directory, flags=flags))
 


### PR DESCRIPTION
Discord link for context: https://discord.com/channels/930865462852591648/930875396277280788/1217655737178656798

Basically, the negate flag wasn't enough. I guess negating doesn't assume you want to match everything that doesnt match the negation by default, so to enable that i had to enable negateall.

Docs for negateall: https://facelessuser.github.io/wcmatch/glob/#negateall. No it wont break regular globs.

Specifically, this enables global pattern negation (which appears to be enabled on glob tester websites). For example, with this you can write `!**/*_ab.*` instead of `**/!(*_ab).*`