### PR TITLE
Make view image node image inputs optional

### DIFF
--- a/backend/src/nodes/properties/outputs/numpy_outputs.py
+++ b/backend/src/nodes/properties/outputs/numpy_outputs.py
@@ -158,7 +158,10 @@ class LargeImageOutput(ImageOutput):
             assume_normalized=assume_normalized,
         )
 
-    def get_broadcast_data(self, value: np.ndarray):
+    def get_broadcast_data(self, value: np.ndarray | None):
+        if value is None:
+            return None
+
         img = value
         h, w, c = get_h_w_c(img)
         image_size = max(h, w)

--- a/backend/src/packages/chaiNNer_standard/image/io/view_image.py
+++ b/backend/src/packages/chaiNNer_standard/image/io/view_image.py
@@ -13,7 +13,7 @@ from .. import io_group
     name="View Image",
     description="See an inline preview of the image in the editor.",
     icon="BsEyeFill",
-    inputs=[ImageInput()],
+    inputs=[ImageInput().make_optional()],
     outputs=[
         LargeImageOutput(
             "Preview",
@@ -24,5 +24,5 @@ from .. import io_group
     ],
     side_effects=True,
 )
-def view_image_node(img: np.ndarray):
+def view_image_node(img: np.ndarray | None):
     return img

--- a/backend/src/packages/chaiNNer_standard/image/io/view_image_external.py
+++ b/backend/src/packages/chaiNNer_standard/image/io/view_image_external.py
@@ -24,12 +24,15 @@ from .. import io_group
         "This works by saving a temporary file that will be deleted after chaiNNer is closed. It is not recommended to be used when performing batch processing.",
     ],
     icon="BsEyeFill",
-    inputs=[ImageInput()],
+    inputs=[ImageInput().make_optional()],
     outputs=[],
     side_effects=True,
     limited_to_8bpc="The temporary file is an 8-bit PNG.",
 )
-def view_image_external_node(img: np.ndarray) -> None:
+def view_image_external_node(img: np.ndarray | None) -> None:
+    if img is None:
+        return
+
     tempdir = mkdtemp(prefix="chaiNNer-")
     logger.debug(f"Writing image to temp path: {tempdir}")
     im_name = f"{time.time()}.png"


### PR DESCRIPTION
This is a draft because I'm not sure how to fix this error that results from this change:

![image](https://github.com/chaiNNer-org/chaiNNer/assets/34788790/6f788e34-0e6e-48b4-882f-fbf85028c93e)
