### PR TITLE
Fix FLT_MAX ONNX -> NCNN error

### DIFF
--- a/backend/src/nodes/impl/ncnn/model.py
+++ b/backend/src/nodes/impl/ncnn/model.py
@@ -254,7 +254,7 @@ class NcnnParamCollection:
         for v in self.param_dict.values():
             if v.value == v.default:
                 continue
-            if isinstance(v.default, str):
+            if isinstance(v.default, str) and "FLT_MAX" not in v.default:
                 pid = None
                 for key, val in list(param_dict.items())[:-1]:
                     if v.default == val["paramPhase"]:


### PR DESCRIPTION
Finally looked into this bug. Basically, there's code that checks if a default value is a string and does some stuff if it is. Since FLT_MAX isn't a number and is instead a string, it was triggering the code to handle strings, when it really should be handled like a number. So, I just added a case to the if statement to ignore FLT_MAX and -FLT_MAX