### PR TITLE
Improved error reporting

### DIFF
--- a/backend/src/events.py
+++ b/backend/src/events.py
@@ -44,6 +44,7 @@ class ExecutionErrorSource(TypedDict):
 class ExecutionErrorData(TypedDict):
     message: str
     exception: str
+    exceptionTrace: str
     source: ExecutionErrorSource | None
 
 

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -188,13 +188,27 @@ async def run(request: Request):
 
         return json(success_response(), status=200)
     except Exception as exception:
-        logger.error(exception, exc_info=True)
-        logger.error(traceback.format_exc())
+        logger.error(exception)
+        if (
+            isinstance(exception, NodeExecutionError)
+            and exception.__cause__ is not None
+        ):
+            trace = "".join(
+                traceback.format_exception(
+                    type(exception.__cause__),
+                    exception.__cause__,
+                    exception.__cause__.__traceback__,
+                )
+            )
+        else:
+            trace = traceback.format_exc()
+        logger.error(trace)
 
         error: ExecutionErrorData = {
             "message": "Error running nodes!",
             "source": None,
             "exception": str(exception),
+            "exceptionTrace": trace,
         }
         if isinstance(exception, NodeExecutionError):
             error["source"] = {

--- a/src/common/Backend.ts
+++ b/src/common/Backend.ts
@@ -263,6 +263,7 @@ export interface BackendEventMap {
         message: string;
         source?: BackendExceptionSource | null;
         exception: string;
+        exceptionTrace: string;
     };
     'chain-start': {
         nodes: string[];

--- a/src/common/formatExecutionErrorMessage.ts
+++ b/src/common/formatExecutionErrorMessage.ts
@@ -4,7 +4,7 @@ import { SchemaMap } from './SchemaMap';
 const defaultListItem = (label: string, value: string) => `- ${label}: ${value}`;
 
 export const formatExecutionErrorMessage = (
-    { exception, source }: BackendEventMap['execution-error'],
+    { exception, source }: Pick<BackendEventMap['execution-error'], 'exception' | 'source'>,
     schemata: SchemaMap,
     formatListItem: (label: string, value: string) => string = defaultListItem
 ): string => {

--- a/src/renderer/contexts/AlertBoxContext.tsx
+++ b/src/renderer/contexts/AlertBoxContext.tsx
@@ -314,6 +314,7 @@ const AlertBoxDialog = memo(
                                 aria-label="Copy to Clipboard"
                                 background="transparent"
                                 icon={<CopyIcon />}
+                                title="Copy to Clipboard"
                                 onClick={() => clipboard.writeText(copyText)}
                             />
                             <HStack

--- a/src/renderer/contexts/AlertBoxContext.tsx
+++ b/src/renderer/contexts/AlertBoxContext.tsx
@@ -7,7 +7,9 @@ import {
     AlertDialogFooter,
     AlertDialogHeader,
     AlertDialogOverlay,
+    Box,
     Button,
+    Code,
     HStack,
     IconButton,
     UseToastOptions,
@@ -29,7 +31,7 @@ export type AlertId = number & { __alertId: never };
 
 interface AlertBox {
     sendToast: (options: UseToastOptions) => void;
-    sendAlert: (message: Pick<AlertOptions, 'type' | 'title' | 'message'>) => AlertId;
+    sendAlert: (message: Pick<AlertOptions, 'type' | 'title' | 'message' | 'trace'>) => AlertId;
     forgetAlert: (id: AlertId) => void;
     showAlert: (message: AlertOptions) => Promise<number>;
 }
@@ -45,6 +47,7 @@ export interface AlertOptions {
     type: AlertType;
     title?: string;
     message: string;
+    trace?: string;
     buttons?: string[];
     /**
      * The button to that will be selected by default. Defaults to `0`.
@@ -215,6 +218,118 @@ const getButtons = (
     return <>{buttonElements}</>;
 };
 
+const getCopyText = (message: InternalMessage): string => {
+    let text = `${message.title}\n\n${message.message}`;
+    if (message.trace) {
+        text += `\n\nStack Trace:\n${message.trace}`;
+    }
+    return text;
+};
+
+interface AlertBoxDialogProps {
+    isOpen: boolean;
+    current: InternalMessage | undefined;
+    onClose: (button: number) => void;
+    cancelRef: React.RefObject<HTMLButtonElement>;
+    progressTotal: number;
+    progressCurrent: number;
+}
+const AlertBoxDialog = memo(
+    ({
+        isOpen,
+        current,
+        onClose,
+        cancelRef,
+        progressTotal,
+        progressCurrent,
+    }: AlertBoxDialogProps) => {
+        const buttons = useMemo(() => {
+            return getButtons(current ?? EMPTY_MESSAGE, onClose, cancelRef, ALERT_FOCUS_ID);
+        }, [current, onClose, cancelRef]);
+
+        useEffect(() => {
+            const timerId = setTimeout(() => {
+                if (isOpen) {
+                    document.querySelector<HTMLElement>(`#${ALERT_FOCUS_ID}`)?.focus();
+                }
+            }, 50);
+            return () => clearTimeout(timerId);
+        }, [isOpen, buttons]);
+
+        const copyText = current ? getCopyText(current) : '';
+        const displayTrace = current?.trace?.replace(
+            /File "(?:[^\\/]*[\\/])*?backend[\\/]src[\\/]/g,
+            'File "'
+        );
+
+        return (
+            <AlertDialog
+                isCentered
+                isOpen={isOpen && current !== undefined}
+                leastDestructiveRef={cancelRef}
+                scrollBehavior="inside"
+                onClose={() => cancelRef.current?.click()}
+            >
+                <AlertDialogOverlay />
+
+                <AlertDialogContent
+                    bgColor="var(--chain-editor-bg)"
+                    maxWidth="xl"
+                >
+                    <AlertDialogHeader>
+                        {pickAlertIcon(current?.type ?? AlertType.INFO)}
+                        {current?.title}
+                        {progressTotal > 1 ? ` (${progressCurrent}/${progressTotal})` : ''}
+                    </AlertDialogHeader>
+
+                    <AlertDialogCloseButton />
+                    <AlertDialogBody
+                        userSelect="text"
+                        whiteSpace="pre-wrap"
+                    >
+                        {current?.message}
+
+                        {displayTrace && (
+                            <Box mt={4}>
+                                <details>
+                                    <summary style={{ cursor: 'pointer' }}>Stack Trace</summary>
+                                    <Code
+                                        display="block"
+                                        overflow="auto"
+                                        px={4}
+                                        py={2}
+                                        userSelect="text"
+                                        whiteSpace="pre"
+                                    >
+                                        {displayTrace}
+                                    </Code>
+                                </details>
+                            </Box>
+                        )}
+                    </AlertDialogBody>
+                    <AlertDialogFooter>
+                        <HStack width="full">
+                            <IconButton
+                                _hover={{ background: 'var(--chakra-colors-whiteAlpha-300)' }}
+                                aria-label="Copy to Clipboard"
+                                background="transparent"
+                                icon={<CopyIcon />}
+                                onClick={() => clipboard.writeText(copyText)}
+                            />
+                            <HStack
+                                justifyContent="flex-end"
+                                width="full"
+                            >
+                                {buttons}
+                            </HStack>
+                        </HStack>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+        );
+    }
+);
+
 export const AlertBoxContext = createContext<Readonly<AlertBox>>({} as AlertBox);
 
 export const AlertBoxProvider = memo(({ children }: React.PropsWithChildren<unknown>) => {
@@ -283,10 +398,6 @@ export const AlertBoxProvider = memo(({ children }: React.PropsWithChildren<unkn
         [current]
     );
 
-    const buttons = useMemo(() => {
-        return getButtons(current ?? EMPTY_MESSAGE, onClose, cancelRef, ALERT_FOCUS_ID);
-    }, [current, onClose]);
-
     const toast = useToast();
     const sendToast = useCallback(
         (options: UseToastOptions) => {
@@ -305,64 +416,16 @@ export const AlertBoxProvider = memo(({ children }: React.PropsWithChildren<unkn
 
     const value = useMemoObject<AlertBox>({ sendAlert, forgetAlert, showAlert, sendToast });
 
-    useEffect(() => {
-        const timerId = setTimeout(() => {
-            if (isOpen) {
-                document.querySelector<HTMLElement>(`#${ALERT_FOCUS_ID}`)?.focus();
-            }
-        }, 50);
-        return () => clearTimeout(timerId);
-    }, [isOpen, buttons]);
-
-    const progressCurrent = done + 1;
-    const progressTotal = done + queue.length;
-
-    const copyText = current ? `${current.title}\n\n${current.message}` : '';
-
     return (
         <AlertBoxContext.Provider value={value}>
-            <AlertDialog
-                isCentered
-                isOpen={isOpen && current !== undefined}
-                leastDestructiveRef={cancelRef}
-                scrollBehavior="inside"
-                onClose={() => cancelRef.current?.click()}
-            >
-                <AlertDialogOverlay />
-
-                <AlertDialogContent bgColor="var(--chain-editor-bg)">
-                    <AlertDialogHeader>
-                        {pickAlertIcon(current?.type ?? AlertType.INFO)}
-                        {current?.title}
-                        {progressTotal > 1 ? ` (${progressCurrent}/${progressTotal})` : ''}
-                    </AlertDialogHeader>
-
-                    <AlertDialogCloseButton />
-                    <AlertDialogBody
-                        userSelect="text"
-                        whiteSpace="pre-wrap"
-                    >
-                        {current?.message}
-                    </AlertDialogBody>
-                    <AlertDialogFooter>
-                        <HStack width="full">
-                            <IconButton
-                                _hover={{ background: 'var(--chakra-colors-whiteAlpha-300)' }}
-                                aria-label="Copy to Clipboard"
-                                background="transparent"
-                                icon={<CopyIcon />}
-                                onClick={() => clipboard.writeText(copyText)}
-                            />
-                            <HStack
-                                justifyContent="flex-end"
-                                width="full"
-                            >
-                                {buttons}
-                            </HStack>
-                        </HStack>
-                    </AlertDialogFooter>
-                </AlertDialogContent>
-            </AlertDialog>
+            <AlertBoxDialog
+                cancelRef={cancelRef}
+                current={current}
+                isOpen={isOpen}
+                progressCurrent={done + 1}
+                progressTotal={done + queue.length}
+                onClose={onClose}
+            />
             {children}
         </AlertBoxContext.Provider>
     );

--- a/src/renderer/contexts/ExecutionContext.tsx
+++ b/src/renderer/contexts/ExecutionContext.tsx
@@ -284,6 +284,7 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
                     schemata,
                     (label, value) => `• ${label}: ${value}`
                 ),
+                trace: data.exceptionTrace,
             });
             clearNodeStatusMap();
             setStatus(ExecutionStatus.READY);


### PR DESCRIPTION
This improves the error reporting in 2 ways:

1. Logged errors will no longer contain the stack trace of the `NodeExecutionError`. `NodeExecutionError` is a wrapper to add additional info to errors, its trace doesn't matter.
2. Send the full stack trace of an error to the frontend. Since the trace isn't usually interesting for users, it's tugged away inside a `<details>`.

Both changes together should make errors easier to diagnose and fix in the future. Stack traces are now shorter and don't spam logs anymore, and users can send us a full stack trace by simply clicking Copy To Clipboard on an error message.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/bdd968d8-82f0-4f50-bf79-31e2c0b87505)

---

Aside from those changes, I also refactored `AlertBoxProvider` to extract out the `AlertDialog` into its own component.