### PR TITLE
Automatically create directory for Save X nodes

### DIFF
--- a/backend/src/nodes/properties/inputs/file_inputs.py
+++ b/backend/src/nodes/properties/inputs/file_inputs.py
@@ -118,6 +118,7 @@ class DirectoryInput(BaseInput):
         label: str = "Directory",
         has_handle: bool = True,
         must_exist: bool = True,
+        create: bool = False,
         label_style: LabelStyle = "default",
     ):
         super().__init__("Directory", label, kind="directory", has_handle=has_handle)
@@ -130,6 +131,7 @@ class DirectoryInput(BaseInput):
         """
 
         self.must_exist: bool = must_exist
+        self.create: bool = create
         self.label_style: LabelStyle = label_style
 
         self.associated_type = Path
@@ -144,8 +146,12 @@ class DirectoryInput(BaseInput):
         if isinstance(value, str):
             value = Path(value)
         assert isinstance(value, Path)
-        if self.must_exist:
+
+        if self.create:
+            value.mkdir(parents=True, exist_ok=True)
+        elif self.must_exist:
             assert value.exists(), f"Directory {value} does not exist"
+
         return value
 
 

--- a/backend/src/packages/chaiNNer_ncnn/ncnn/io/save_model.py
+++ b/backend/src/packages/chaiNNer_ncnn/ncnn/io/save_model.py
@@ -15,7 +15,7 @@ from .. import io_group
     icon="MdSave",
     inputs=[
         NcnnModelInput(),
-        DirectoryInput(has_handle=True),
+        DirectoryInput(create=True),
         TextInput("Param/Bin Name"),
     ],
     outputs=[],

--- a/backend/src/packages/chaiNNer_onnx/onnx/io/save_model.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/io/save_model.py
@@ -17,7 +17,7 @@ from .. import io_group
     icon="MdSave",
     inputs=[
         OnnxModelInput(),
-        DirectoryInput(has_handle=True),
+        DirectoryInput(create=True),
         TextInput("Model Name"),
     ],
     outputs=[],

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/io/save_model.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/io/save_model.py
@@ -28,7 +28,7 @@ class WeightFormat(Enum):
     icon="MdSave",
     inputs=[
         ModelInput(),
-        DirectoryInput(has_handle=True),
+        DirectoryInput(create=True),
         TextInput("Model Name"),
         EnumInput(
             WeightFormat,

--- a/backend/src/packages/chaiNNer_standard/image/io/save_image.py
+++ b/backend/src/packages/chaiNNer_standard/image/io/save_image.py
@@ -108,7 +108,7 @@ class TiffColorDepth(Enum):
     icon="MdSave",
     inputs=[
         ImageInput(),
-        DirectoryInput(must_exist=False, has_handle=True),
+        DirectoryInput(must_exist=False),
         TextInput("Subdirectory Path")
         .make_optional()
         .with_docs(

--- a/backend/src/packages/chaiNNer_standard/image/video_frames/save_video.py
+++ b/backend/src/packages/chaiNNer_standard/image/video_frames/save_video.py
@@ -216,7 +216,7 @@ class Writer:
     icon="MdVideoCameraBack",
     inputs=[
         ImageInput("Image Sequence", channels=3),
-        DirectoryInput("Directory", has_handle=True),
+        DirectoryInput(create=True),
         TextInput("Video Name"),
         EnumInput(
             VideoFormat,

--- a/backend/src/packages/chaiNNer_standard/utility/value/directory.py
+++ b/backend/src/packages/chaiNNer_standard/utility/value/directory.py
@@ -14,12 +14,10 @@ from .. import value_group
     description="Outputs the given directory.",
     icon="BsFolder",
     inputs=[
-        DirectoryInput(
-            "Directory", must_exist=False, label_style="hidden", has_handle=True
-        ).make_fused(),
+        DirectoryInput(must_exist=False, label_style="hidden").make_fused(),
     ],
     outputs=[
-        DirectoryOutput("Directory", output_type="Input0").suggest(),
+        DirectoryOutput(output_type="Input0").suggest(),
     ],
 )
 def directory_node(directory: Path) -> Path:


### PR DESCRIPTION
Since all Save X nodes write files, they might as well create the directory they save the file in as well. Save Image already did this, but the others didn't. I added this feature via an optional `create: bool` parameter on `DirectoryInput`, so we don't need to duplicate `must_exist=False` and `dir.mkdir(parents=True, exist_ok=True)` everywhere.

This is preparation for directory nodes.