### PR TITLE
Move important nodes up in Image category

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image/__init__.py
+++ b/backend/src/packages/chaiNNer_standard/image/__init__.py
@@ -1,6 +1,13 @@
 from .. import image_category
 
 io_group = image_category.add_node_group("Input & Output")
-create_images_group = image_category.add_node_group("Create Images")
 batch_processing_group = image_category.add_node_group("Batch Processing")
 video_frames_group = image_category.add_node_group("Video Frames")
+create_images_group = image_category.add_node_group("Create Images")
+
+batch_processing_group.order = [
+    "chainner:image:load_images",
+    "chainner:image:load_image_pairs",
+    "chainner:image:split_spritesheet",
+    "chainner:image:merge_spritesheet",
+]


### PR DESCRIPTION
Since we recently had new users not find Load Images, I moved the Batch Processing group up and the Create Images group down. So chainner's most important nodes are the now the first ones users will see.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/5e6d6df4-cee9-4028-aa2e-460dd1c92e97)
