### PR TITLE
Removed unnecessary `__init__` files in Image Channels

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image_channel/all/__init__.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/all/__init__.py
@@ -1,3 +1,0 @@
-from .. import all_group
-
-node_group = all_group

--- a/backend/src/packages/chaiNNer_standard/image_channel/all/combine_rgba.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/all/combine_rgba.py
@@ -6,10 +6,10 @@ from nodes.impl.color.color import Color
 from nodes.properties.inputs import ImageInput
 from nodes.properties.outputs import ImageOutput
 
-from . import node_group
+from .. import all_group
 
 
-@node_group.register(
+@all_group.register(
     schema_id="chainner:image:combine_rgba",
     name="Combine RGBA",
     description=(

--- a/backend/src/packages/chaiNNer_standard/image_channel/all/merge_channels.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/all/merge_channels.py
@@ -8,10 +8,10 @@ from nodes.properties.inputs import ImageInput
 from nodes.properties.outputs import ImageOutput
 from nodes.utils.utils import get_h_w_c
 
-from . import node_group
+from .. import all_group
 
 
-@node_group.register(
+@all_group.register(
     schema_id="chainner:image:merge_channels",
     name="Merge Channels",
     description=(

--- a/backend/src/packages/chaiNNer_standard/image_channel/all/separate_rgba.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/all/separate_rgba.py
@@ -7,10 +7,10 @@ from nodes.properties.inputs import ImageInput
 from nodes.properties.outputs import ImageOutput
 from nodes.utils.utils import get_h_w_c
 
-from . import node_group
+from .. import all_group
 
 
-@node_group.register(
+@all_group.register(
     schema_id="chainner:image:split_channels",
     name="Separate RGBA",
     description=(

--- a/backend/src/packages/chaiNNer_standard/image_channel/misc/__init__.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/misc/__init__.py
@@ -1,3 +1,0 @@
-from .. import miscellaneous_group
-
-node_group = miscellaneous_group

--- a/backend/src/packages/chaiNNer_standard/image_channel/misc/alpha_matting.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/misc/alpha_matting.py
@@ -8,10 +8,10 @@ from nodes.properties.inputs import ImageInput, SliderInput
 from nodes.properties.outputs import ImageOutput
 from nodes.utils.utils import get_h_w_c
 
-from . import node_group
+from .. import miscellaneous_group
 
 
-@node_group.register(
+@miscellaneous_group.register(
     schema_id="chainner:image:alpha_matting",
     name="Alpha Matting",
     description=[

--- a/backend/src/packages/chaiNNer_standard/image_channel/misc/chroma_key.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/misc/chroma_key.py
@@ -19,7 +19,7 @@ from nodes.properties.inputs import (
 from nodes.properties.outputs import ImageOutput
 from nodes.utils.utils import get_h_w_c
 
-from . import node_group
+from .. import miscellaneous_group
 
 
 class KeyMethod(Enum):
@@ -27,7 +27,7 @@ class KeyMethod(Enum):
     TRIMAP_MATTING = 2
 
 
-@node_group.register(
+@miscellaneous_group.register(
     schema_id="chainner:image:chroma_key",
     name="Chroma Key",
     description=[

--- a/backend/src/packages/chaiNNer_standard/image_channel/misc/fill_alpha.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/misc/fill_alpha.py
@@ -13,7 +13,7 @@ import navi
 from nodes.properties.inputs import EnumInput, ImageInput
 from nodes.properties.outputs import ImageOutput
 
-from . import node_group
+from .. import miscellaneous_group
 
 
 class AlphaFillMethod(Enum):
@@ -22,7 +22,7 @@ class AlphaFillMethod(Enum):
     NEAREST_COLOR = 3
 
 
-@node_group.register(
+@miscellaneous_group.register(
     schema_id="chainner:image:fill_alpha",
     name="Fill Alpha",
     description="Splits the image into color and transparency, and fills the transparent pixels of an image with nearby colors.",

--- a/backend/src/packages/chaiNNer_standard/image_channel/transparency/__init__.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/transparency/__init__.py
@@ -1,3 +1,0 @@
-from .. import transparency_group
-
-node_group = transparency_group

--- a/backend/src/packages/chaiNNer_standard/image_channel/transparency/merge_transparency.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/transparency/merge_transparency.py
@@ -7,10 +7,10 @@ from nodes.impl.image_utils import as_target_channels
 from nodes.properties.inputs import ImageInput
 from nodes.properties.outputs import ImageOutput
 
-from . import node_group
+from .. import transparency_group
 
 
-@node_group.register(
+@transparency_group.register(
     schema_id="chainner:image:merge_transparency",
     name="Merge Transparency",
     description="Merge RGB and Alpha (transparency) image channels into 4-channel RGBA channels.",

--- a/backend/src/packages/chaiNNer_standard/image_channel/transparency/split_transparency.py
+++ b/backend/src/packages/chaiNNer_standard/image_channel/transparency/split_transparency.py
@@ -8,10 +8,10 @@ from nodes.properties.inputs import ImageInput
 from nodes.properties.outputs import ImageOutput
 from nodes.utils.utils import get_h_w_c
 
-from . import node_group
+from .. import transparency_group
 
 
-@node_group.register(
+@transparency_group.register(
     schema_id="chainner:image:split_transparency",
     name="Split Transparency",
     description="Split image channels into RGB and Alpha (transparency) channels.",


### PR DESCRIPTION
Very small change. I noticed that we had 2 styles for importing the node group of a node:
1. Import it directly from the module where the node group is defined. E.g. `from .. import all_group`
2. Import it from a local `__init__.py` file. E.g. `from . import node_group`

We used style 1 everywhere except for the Image Channels category, so I changed this category to use style 1 as well.