### PR TITLE
Fixed F5 (and others) from inside number and text inputs

### DIFF
--- a/src/renderer/components/inputs/TextInput.tsx
+++ b/src/renderer/components/inputs/TextInput.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from 'react-i18next';
 import { MdContentCopy, MdContentPaste } from 'react-icons/md';
 import { useContextSelector } from 'use-context-selector';
 import { useDebouncedCallback } from 'use-debounce';
-import { stopPropagation } from '../../../common/util';
 import { GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { typeToString } from '../../helpers/naviHelpers';
 import { useContextMenu } from '../../hooks/useContextMenu';
@@ -189,7 +188,6 @@ export const TextInput = memo(
                             handleChange(event);
                         }}
                         onContextMenu={menu.onContextMenu}
-                        onKeyDown={stopPropagation}
                     />
                 </Resizable>
             );
@@ -210,7 +208,6 @@ export const TextInput = memo(
                         handleChange(event);
                     }}
                     onContextMenu={menu.onContextMenu}
-                    onKeyDown={stopPropagation}
                 />
             );
         }

--- a/src/renderer/components/inputs/elements/AdvanceNumberInput.tsx
+++ b/src/renderer/components/inputs/elements/AdvanceNumberInput.tsx
@@ -8,7 +8,7 @@ import {
     NumberInputStepper,
 } from '@chakra-ui/react';
 import { MouseEventHandler, memo } from 'react';
-import { areApproximatelyEqual, noop, stopPropagation } from '../../../../common/util';
+import { areApproximatelyEqual, noop } from '../../../../common/util';
 import './AdvancedNumberInput.scss';
 
 const clamp = (value: number, min?: number | null, max?: number | null): number => {
@@ -136,7 +136,6 @@ export const AdvancedNumberInput = memo(
                         value={inputString}
                         onBlur={onBlur}
                         onChange={setInputString}
-                        onKeyDown={stopPropagation}
                     >
                         <NumberInputField
                             borderLeftRadius={unit ? 0 : 'md'}
@@ -189,7 +188,6 @@ export const AdvancedNumberInput = memo(
                     w="full"
                     onBlur={onBlur}
                     onChange={setInputString}
-                    onKeyDown={stopPropagation}
                 >
                     <NumberInputField
                         borderLeftRadius={unit ? 0 : 'lg'}

--- a/src/renderer/components/inputs/elements/RgbHexInput.tsx
+++ b/src/renderer/components/inputs/elements/RgbHexInput.tsx
@@ -1,7 +1,6 @@
 import { HStack, Input, Spacer, Text } from '@chakra-ui/react';
 import { memo, useEffect, useState } from 'react';
 import { RgbColor } from 'react-colorful';
-import { stopPropagation } from '../../../../common/util';
 import { parseRgbHex, rgbToHex } from '../../../helpers/colorUtil';
 
 interface RgbHexInputProps {
@@ -46,7 +45,6 @@ export const RgbHexInput = memo(({ rgb, onChange }: RgbHexInputProps) => {
                 value={inputString}
                 w="4.5rem"
                 onChange={(event) => changeInputString(event.target.value)}
-                onKeyDown={stopPropagation}
             />
         </HStack>
     );

--- a/src/renderer/components/node/special/NoteNode.tsx
+++ b/src/renderer/components/node/special/NoteNode.tsx
@@ -369,9 +369,6 @@ const NoteNodeInner = memo(({ data, selected }: NodeProps) => {
                                     handleChange(event);
                                 }}
                                 onContextMenu={textAreaContextMenu.onContextMenu}
-                                onKeyDown={(e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-                                    e.stopPropagation();
-                                }}
                             />
                         ) : (
                             <Box


### PR DESCRIPTION
This fixes F5 not working when the focus is on a number or text input. We previously stopped event propagation for keydown events, because using arrow keys caused RF to move the node. Seems like they fixed that, so stopping event propagation isn't necessary anymore. 