### PR TITLE
Fix unused side-effect node optimization for Copy To Clipboard

### DIFF
--- a/src/common/SchemaMap.ts
+++ b/src/common/SchemaMap.ts
@@ -8,6 +8,7 @@ import {
     SchemaId,
 } from './common-types';
 import { log } from './log';
+import { getDefaultValue } from './util';
 
 const BLANK_SCHEMA: NodeSchema = {
     inputs: [],
@@ -77,9 +78,7 @@ export class SchemaMap {
         const defaultData: Record<InputId, InputValue> = {};
         const { inputs } = this.get(schemaId);
         inputs.forEach((input) => {
-            if ('def' in input) {
-                defaultData[input.id] = input.def ?? undefined;
-            }
+            defaultData[input.id] = getDefaultValue(input);
         });
         return defaultData;
     }

--- a/src/common/nodes/optimize.ts
+++ b/src/common/nodes/optimize.ts
@@ -1,6 +1,7 @@
 import { Edge, Node } from 'reactflow';
 import { EdgeData, NodeData } from '../common-types';
 import { SchemaMap } from '../SchemaMap';
+import { getDefaultValue } from '../util';
 import { getEffectivelyDisabledNodes } from './disabled';
 import { getNodesWithSideEffects } from './sideEffect';
 
@@ -39,7 +40,9 @@ const removeUnusedSideEffectNodes = (
         }
 
         // if all inputs don't require connections, that's fine too
-        const requireConnection = schema.inputs.some((i) => i.kind === 'generic' && !i.optional);
+        const requireConnection = schema.inputs.some(
+            (i) => !i.optional && getDefaultValue(i) === undefined
+        );
         if (!requireConnection) {
             return true;
         }

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -268,6 +268,14 @@ export const getInputValue = <T extends NonNullable<InputValue>>(
 
 export const isAutoInput = (input: Input): boolean =>
     input.kind === 'generic' && input.optional && !input.hasHandle;
+export const getDefaultValue = <I extends Input>(
+    input: I
+): undefined | (I extends { readonly def: unknown } ? NonNullable<I['def']> : never) => {
+    if ('def' in input) {
+        return (input.def ?? undefined) as never;
+    }
+    return undefined;
+};
 
 export const escapeRegExp = (string: string) => string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 


### PR DESCRIPTION
The optimization for removing unused side effect nodes didn't work on Copy To Clipboard, because it uses a text input without a default value instead of a generic input like the other side effect nodes. So I changed the detection to "required inputs without defaults" to fix this issue.