### PR TITLE
Fixed punctuation in path type tags

### DIFF
--- a/src/renderer/components/TypeTag.tsx
+++ b/src/renderer/components/TypeTag.tsx
@@ -311,7 +311,10 @@ const TagRenderer = memo(({ tag, longText }: TagRendererProps) => {
             tt = value;
             if (longText) {
                 text = value;
-                direction = 'rtl';
+                if (!/^\p{P}|\p{P}$/u.test(value)) {
+                    // punctuation will be messed up in rtl
+                    direction = 'rtl';
+                }
             } else {
                 const maxLength = 14;
                 text = (


### PR DESCRIPTION
Path type tags use `direction: rtl` to make the ellipsis appear on the left side of the text. However, this is not the only effect of `rtl`. It also puts punctuation at the end of a string in front.

Example: That path should be `C:\`, but we'll see something else:
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/3738f714-9090-4b29-8938-8075af2d3933)

Similarly, it will also put punctuation at the start of the string at the end. This messes with Unix-style paths. The follow is supposed to be `/home/name`:
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/020e48d6-d0fc-492e-b760-b0c5c079d005)

My fix for this issue is quite simple: if the path starts or ends with a punctuation character, don't do `direction: rtl`. This means that left ellipsis are a windows-only feature now, but that's a small price to pay for correct visuals.

With the fix:
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/6c87d7c2-03f1-43ce-9068-5b4b4af296fa)
