### PR TITLE
Add Directory Go Into node

### DIFF
--- a/backend/src/packages/chaiNNer_standard/utility/directory/directory_go_into.py
+++ b/backend/src/packages/chaiNNer_standard/utility/directory/directory_go_into.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from nodes.groups import optional_list_group
+from nodes.properties.inputs import DirectoryInput, TextInput
+from nodes.properties.outputs import DirectoryOutput
+
+from .. import directory_group
+
+INVALID_CHARS = re.compile(r"[<>:\"|?*\x00-\x1F]")
+
+
+def is_abs(path: str) -> bool:
+    return path.startswith(("/", "\\")) or Path(path).is_absolute()
+
+
+def go_into(dir: Path, folder: str) -> Path:
+    if is_abs(folder):
+        raise ValueError("Absolute paths are not allowed as folders.")
+
+    invalid = INVALID_CHARS.search(folder)
+    if invalid is not None:
+        raise ValueError(f"Invalid character '{invalid.group()}' in folder name.")
+
+    return (dir / folder).resolve()
+
+
+@directory_group.register(
+    schema_id="chainner:utility:into_directory",
+    name="Directory Go Into",
+    description="Goes forward into a directory.",
+    icon="BsFolder",
+    inputs=[
+        DirectoryInput(must_exist=False, label_style="hidden"),
+        TextInput("Folder"),
+        optional_list_group(
+            *[TextInput(f"Folder {i}").make_optional() for i in range(2, 11)],
+        ),
+    ],
+    outputs=[
+        DirectoryOutput(
+            output_type="""
+                def into(dir: Directory | Error, folder: string | null): Directory | Error {
+                    match dir {
+                        Error as e => e,
+                        Directory => {
+                            match folder {
+                                null => dir,
+                                string => {
+                                    let result = goIntoDirectory(dir.path, folder);
+                                    match result {
+                                        string => Directory { path: result },
+                                        Error => result,
+                                    }
+                                },
+                            }
+                        },
+                    }
+                }
+
+                let d1 = into(Input0, Input1);
+                let d2 = into(d1, Input2);
+                let d3 = into(d2, Input3);
+                let d4 = into(d3, Input4);
+                let d5 = into(d4, Input5);
+                let d6 = into(d5, Input6);
+                let d7 = into(d6, Input7);
+                let d8 = into(d7, Input8);
+                let d9 = into(d8, Input9);
+                let d10 = into(d9, Input10);
+                d10
+            """,
+        ),
+    ],
+)
+def directory_go_into_node(directory: Path, *folders: str | None) -> Path:
+    for folder in folders:
+        if folder is not None:
+            directory = go_into(directory, folder)
+    return directory

--- a/src/common/types/chainner-scope.ts
+++ b/src/common/types/chainner-scope.ts
@@ -13,6 +13,7 @@ import { lazy } from '../util';
 import {
     formatTextPattern,
     getParentDirectory,
+    goIntoDirectory,
     padCenter,
     padEnd,
     padStart,
@@ -128,6 +129,7 @@ intrinsic def padCenter(text: string, width: uint, padding: string): string;
 intrinsic def splitFilePath(path: string): SplitFilePath;
 intrinsic def parseColorJson(json: string): Color;
 intrinsic def getParentDirectory(path: string, times: uint): string;
+intrinsic def goIntoDirectory(basePath: string, path: string): string | Error;
 `;
 
 export const getChainnerScope = lazy((): Scope => {
@@ -142,6 +144,7 @@ export const getChainnerScope = lazy((): Scope => {
         splitFilePath,
         parseColorJson,
         getParentDirectory: makeScoped(getParentDirectory),
+        goIntoDirectory,
     };
 
     const definitions = parseDefinitions(new SourceDocument(code, 'chainner-internal'));


### PR DESCRIPTION
Closes #2519
Closes #606

This adds the last node from #2519. As before I made a few changes:

- I named it "Directory Go Into" to be consistent with the "Directory Go Up" node.
- I added a few optional folder inputs, so users can join multiple folders without needing to know that `/` and `\` are usually used to denote this.
- More path validation: no invalid characters and absolute paths.

The output type of this node is kind of insane because Navi doesn't have early returns.


![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/a67eed07-3773-4960-af5e-9b13268aa539)
