### PR TITLE
Fixed search bar in node documentation being below nodes

### DIFF
--- a/src/renderer/components/NodeDocumentation/NodesList.tsx
+++ b/src/renderer/components/NodeDocumentation/NodesList.tsx
@@ -90,6 +90,7 @@ export const NodesList = memo(
                             bgColor="var(--bg-800)"
                             position="sticky"
                             top={0}
+                            zIndex={10}
                         >
                             <SearchBar
                                 value={searchQuery}


### PR DESCRIPTION
I probably broke this in #2627 when I changed how node list items are rendered.

Before:
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/4f0e0793-a92a-4224-b2d0-d88bad13310d)

After:
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/d72021f2-1947-4652-9a75-4fa358ff075e)
