### PR TITLE
Ignore error types in docs

### DIFF
--- a/src/common/types/util.ts
+++ b/src/common/types/util.ts
@@ -58,3 +58,6 @@ export const getFields = <N extends keyof KnownStructDefinitions>(
 export const nullType = getStructDescriptor(getChainnerScope(), 'null').default;
 
 export const withoutNull = (type: Type): Type => without(type, nullType);
+
+export const withoutError = (type: Type): Type =>
+    without(type, getStructDescriptor(getChainnerScope(), 'Error').default);

--- a/src/renderer/components/NodeDocumentation/NodeDocs.tsx
+++ b/src/renderer/components/NodeDocumentation/NodeDocs.tsx
@@ -22,7 +22,7 @@ import { getInputCondition } from '../../../common/nodes/inputCondition';
 import { explain } from '../../../common/types/explain';
 import { FunctionDefinition } from '../../../common/types/function';
 import { prettyPrintType } from '../../../common/types/pretty';
-import { withoutNull } from '../../../common/types/util';
+import { withoutError, withoutNull } from '../../../common/types/util';
 import { capitalize, isAutoInput } from '../../../common/util';
 import { BackendContext } from '../../contexts/BackendContext';
 import { getCategoryAccentColor, getTypeAccentColors } from '../../helpers/accentColors';
@@ -239,7 +239,7 @@ const InputOutputItem = memo(
                                 >
                                     Type:
                                 </Text>
-                                <TypeView type={type} />
+                                <TypeView type={withoutError(type)} />
                             </Box>
                         )}
                     </VStack>


### PR DESCRIPTION
I noticed that the documentation of nodes with custom errors in their output types would display those errors in their docs. This was not intentional, so I removed it in this PR.

Before:
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/9091c9d0-f972-4aa2-8a8a-36e209273952)


After:
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/1055760e-89e8-49f2-8179-ec4249b0f45c)
