### PR TITLE
Make PyTorch upscaling pauseable

### DIFF
--- a/backend/src/api/node_context.py
+++ b/backend/src/api/node_context.py
@@ -1,3 +1,4 @@
+import time
 from abc import ABC, abstractmethod
 
 from .settings import SettingsParser
@@ -15,6 +16,13 @@ class NodeProgress(ABC):
         Returns whether the current operation was aborted.
         """
 
+    @property
+    @abstractmethod
+    def paused(self) -> bool:
+        """
+        Returns whether the current operation was paused.
+        """
+
     def check_aborted(self) -> None:
         """
         Raises an `Aborted` exception if the current operation was aborted. Does nothing otherwise.
@@ -22,6 +30,18 @@ class NodeProgress(ABC):
 
         if self.aborted:
             raise Aborted()
+
+    def suspend(self) -> None:
+        """
+        If the operation was aborted, this method will throw an `Aborted` exception.
+        If the operation is paused, this method will wait until the operation is resumed or aborted.
+        """
+
+        while True:
+            self.check_aborted()
+            if not self.paused:
+                break
+            time.sleep(0.1)
 
     @abstractmethod
     def set_progress(self, progress: float) -> None:

--- a/backend/src/nodes/impl/pytorch/auto_split.py
+++ b/backend/src/nodes/impl/pytorch/auto_split.py
@@ -6,6 +6,8 @@ import numpy as np
 import torch
 from spandrel import ImageModelDescriptor
 
+from api import NodeProgress
+
 from ..upscale.auto_split import Split, Tiler, auto_split
 from .utils import safe_cuda_cache_empty
 
@@ -53,11 +55,18 @@ def pytorch_auto_split(
     device: torch.device,
     use_fp16: bool,
     tiler: Tiler,
+    progress: NodeProgress,
 ) -> np.ndarray:
     dtype = torch.float16 if use_fp16 else torch.float32
     model = model.to(device, dtype)
 
     def upscale(img: np.ndarray, _: object):
+        if progress.paused:
+            # clear resources before pausing
+            gc.collect()
+            safe_cuda_cache_empty()
+            progress.suspend()
+
         input_tensor = None
         try:
             # convert to tensor

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
@@ -6,7 +6,7 @@ import torch
 from sanic.log import logger
 from spandrel import ImageModelDescriptor, ModelTiling
 
-from api import KeyInfo, NodeContext
+from api import KeyInfo, NodeContext, NodeProgress
 from nodes.groups import Condition, if_group
 from nodes.impl.pytorch.auto_split import pytorch_auto_split
 from nodes.impl.upscale.auto_split_tiles import (
@@ -37,6 +37,7 @@ def upscale(
     model: ImageModelDescriptor,
     tile_size: TileSize,
     options: PyTorchSettings,
+    progress: NodeProgress,
 ):
     with torch.no_grad():
         # Borrowed from iNNfer
@@ -93,6 +94,7 @@ def upscale(
             device=device,
             use_fp16=use_fp16,
             tiler=parse_tile_size_input(tile_size, estimate),
+            progress=progress,
         )
         logger.debug("Done upscaling")
 
@@ -260,7 +262,7 @@ def upscale_image_node(
             img,
             in_nc,
             out_nc,
-            lambda i: upscale(i, model, tile_size, exec_options),
+            lambda i: upscale(i, model, tile_size, exec_options, context),
             separate_alpha,
             clip=False,  # pytorch_auto_split already does clipping internally
         )

--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -291,6 +291,11 @@ class _ExecutorNodeContext(NodeContext):
     def aborted(self) -> bool:
         return self.progress.aborted
 
+    @property
+    def paused(self) -> bool:
+        time.sleep(0.001)
+        return self.progress.paused
+
     def set_progress(self, progress: float) -> None:
         self.check_aborted()
 


### PR DESCRIPTION
This adds support for pausing within a PyTorch Upscale Image node.

The implementation of pausing is quite simple. The executor runs all nodes in their own thread (well, it's a thread pool, but close enough), so I can just spin with `time.sleep` to allow other threads to run until the execution is resumed. This gives us pausing for minimal effort.

Edit: I forgot to mention, alongside pausing, aborting the current execution is also supported within PyTorch upscaling with this PR. So we'll hopefully need to kill the worker less frequently now.