### PR TITLE
Actually fix symbols in path type tags

### DIFF
--- a/src/renderer/components/TypeTag.tsx
+++ b/src/renderer/components/TypeTag.tsx
@@ -311,7 +311,7 @@ const TagRenderer = memo(({ tag, longText }: TagRendererProps) => {
             tt = value;
             if (longText) {
                 text = value;
-                if (!/^\p{P}|\p{P}$/u.test(value)) {
+                if (/^[\p{L}\p{D}_]/u.test(value) && /[\p{L}\p{D}_]$/u.test(value)) {
                     // punctuation will be messed up in rtl
                     direction = 'rtl';
                 }


### PR DESCRIPTION
#2701 wasn't enough. While testing for #2702, I discovered that `rtl` even effects pretty much every non-letter or non-digit character. So this PR adjusts the condition to require letter or digit characters at the start and end to avoid weird `rtl` behavior.