### PR TITLE
Move startup template loading to main process

### DIFF
--- a/src/common/safeIpc.ts
+++ b/src/common/safeIpc.ts
@@ -39,7 +39,7 @@ export interface InvokeChannels {
         FileSaveResult,
         [saveData: SaveData, defaultPath: string | undefined]
     >;
-    'get-cli-open': ChannelInfo<FileOpenResult<ParsedSaveData> | undefined>;
+    'get-auto-open': ChannelInfo<FileOpenResult<ParsedSaveData> | undefined>;
     'owns-backend': ChannelInfo<boolean>;
     'restart-backend': ChannelInfo<void>;
     'relaunch-application': ChannelInfo<void>;

--- a/src/main/gui/main-window.ts
+++ b/src/main/gui/main-window.ts
@@ -151,10 +151,13 @@ const registerEventHandlerPreSetup = (
         if (globalThis.startupFile) {
             // Open file with chaiNNer on other platforms
             const result = openSaveFile(globalThis.startupFile);
-            ipcMain.handle('get-cli-open', () => result);
+            ipcMain.handle('get-auto-open', () => result);
             globalThis.startupFile = null;
+        } else if (settings.startupTemplate) {
+            const result = openSaveFile(settings.startupTemplate);
+            ipcMain.handle('get-auto-open', () => result);
         } else {
-            ipcMain.handle('get-cli-open', () => undefined);
+            ipcMain.handle('get-auto-open', () => undefined);
         }
         // We remove the event we created in main.ts earlier on
         app.removeAllListeners('open-file');
@@ -171,9 +174,12 @@ const registerEventHandlerPreSetup = (
         if (args.file) {
             // Open file with chaiNNer on other platforms
             const result = openSaveFile(args.file);
-            ipcMain.handle('get-cli-open', () => result);
+            ipcMain.handle('get-auto-open', () => result);
+        } else if (settings.startupTemplate) {
+            const result = openSaveFile(settings.startupTemplate);
+            ipcMain.handle('get-auto-open', () => result);
         } else {
-            ipcMain.handle('get-cli-open', () => undefined);
+            ipcMain.handle('get-auto-open', () => undefined);
         }
 
         app.on('second-instance', (_event, commandLine) => {

--- a/src/renderer/contexts/GlobalNodeState.tsx
+++ b/src/renderer/contexts/GlobalNodeState.tsx
@@ -29,7 +29,7 @@ import { getEffectivelyDisabledNodes } from '../../common/nodes/disabled';
 import { ChainLineage } from '../../common/nodes/lineage';
 import { TypeState } from '../../common/nodes/TypeState';
 import { ipcRenderer } from '../../common/safeIpc';
-import { ParsedSaveData, SaveData, openSaveFile } from '../../common/SaveFile';
+import { ParsedSaveData, SaveData } from '../../common/SaveFile';
 
 import {
     EMPTY_SET,
@@ -669,7 +669,7 @@ export const GlobalProvider = memo(
 
         useAsyncEffect(
             () => async () => {
-                const result = await ipcRenderer.invoke('get-cli-open');
+                const result = await ipcRenderer.invoke('get-auto-open');
                 if (result) {
                     if (result.kind === 'Success') {
                         await setStateFromJSONRef.current(result.saveData, result.path, true);
@@ -719,33 +719,6 @@ export const GlobalProvider = memo(
         );
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
         useIpcRendererListener('file-export-template', exportTemplate);
-
-        const [firstLoad, setFirstLoad] = useSessionStorage('firstLoad', true);
-        useAsyncEffect(
-            () => async () => {
-                if (firstLoad && startupTemplate) {
-                    try {
-                        const saveFile = await openSaveFile(startupTemplate);
-                        if (saveFile.kind === 'Success') {
-                            await setStateFromJSONRef.current(saveFile.saveData, '', true);
-                        } else {
-                            sendAlert({
-                                type: AlertType.ERROR,
-                                message: `Unable to open file ${startupTemplate}: ${saveFile.error}`,
-                            });
-                        }
-                    } catch (error) {
-                        log.error(error);
-                        sendAlert({
-                            type: AlertType.ERROR,
-                            message: `Unable to open file ${startupTemplate}`,
-                        });
-                    }
-                    setFirstLoad(false);
-                }
-            },
-            [firstLoad, sendAlert, setFirstLoad, startupTemplate]
-        );
 
         const removeNodesById = useCallback(
             (ids: readonly string[]) => {

--- a/src/renderer/contexts/GlobalNodeState.tsx
+++ b/src/renderer/contexts/GlobalNodeState.tsx
@@ -169,7 +169,7 @@ export const GlobalProvider = memo(
     ({ children, reactFlowWrapper }: React.PropsWithChildren<GlobalProviderProps>) => {
         const { sendAlert, sendToast, showAlert } = useContext(AlertBoxContext);
         const { schemata, functionDefinitions, scope, backend } = useContext(BackendContext);
-        const { startupTemplate, viewportExportPadding } = useSettings();
+        const { viewportExportPadding } = useSettings();
 
         const [nodeChanges, addNodeChanges, nodeChangesRef] = useChangeCounter();
         const [edgeChanges, addEdgeChanges, edgeChangesRef] = useChangeCounter();


### PR DESCRIPTION
I noticed that we open the startup template directly in the renderer process. This is bad because it makes the renderer use FS and other non-browser libraries by importing the SaveFile file. So, I reused the "get-cli-open" functionality to also check for the startup template setting and open that if applicable.