### PR TITLE
Move all fs calls to main process, invoke via IPC

### DIFF
--- a/src/common/input-override-common.ts
+++ b/src/common/input-override-common.ts
@@ -1,0 +1,9 @@
+import { InputId } from './common-types';
+
+export type InputOverrideId = string & { readonly __input_override_id?: never };
+
+export const createInputOverrideId = (nodeId: string, inputId: InputId): InputOverrideId => {
+    if (nodeId.length !== 36)
+        throw new Error('Expected node id to be a 36 character hexadecimal UUID.');
+    return `#${nodeId}:${inputId}`;
+};

--- a/src/common/input-override.ts
+++ b/src/common/input-override.ts
@@ -1,18 +1,11 @@
 import { readFile } from 'fs/promises';
 import { extname } from 'path';
 import { EdgeData, InputData, InputId, InputValue, Mutable, NodeData } from './common-types';
+import { InputOverrideId } from './input-override-common';
 import { log } from './log';
 import { SchemaMap } from './SchemaMap';
 import { joinEnglish } from './util';
 import type { Edge, Node } from 'reactflow';
-
-export type InputOverrideId = string & { readonly __input_override_id?: never };
-
-export const createInputOverrideId = (nodeId: string, inputId: InputId): InputOverrideId => {
-    if (nodeId.length !== 36)
-        throw new Error('Expected node id to be a 36 character hexadecimal UUID.');
-    return `#${nodeId}:${inputId}`;
-};
 
 const isValidInputOverrideId = (id: InputOverrideId) => /^#[a-f0-9-]{36}:\d+$/.test(id);
 export const parseInputOverrideId = (id: InputOverrideId): { nodeId: string; inputId: InputId } => {

--- a/src/common/safeIpc.ts
+++ b/src/common/safeIpc.ts
@@ -8,6 +8,7 @@ import {
     ipcMain as unsafeIpcMain,
     ipcRenderer as unsafeIpcRenderer,
 } from 'electron';
+import { MakeDirectoryOptions } from 'fs';
 import { FileOpenResult, FileSaveResult, PythonInfo, Version } from './common-types';
 import { ParsedSaveData, SaveData } from './SaveFile';
 import { ChainnerSettings } from './settings/settings';
@@ -50,6 +51,15 @@ export interface InvokeChannels {
     // settings
     'get-settings': ChannelInfo<ChainnerSettings>;
     'set-settings': ChannelInfo<void, [settings: ChainnerSettings]>;
+
+    // fs
+    'fs-read-file': ChannelInfo<string, [path: string]>;
+    'fs-write-file': ChannelInfo<void, [path: string, content: string | Buffer]>;
+    'fs-exists': ChannelInfo<boolean, [path: string]>;
+    'fs-mkdir': ChannelInfo<string | undefined, [path: string, options: MakeDirectoryOptions]>;
+    'fs-readdir': ChannelInfo<string[], [path: string]>;
+    'fs-unlink': ChannelInfo<void, [path: string]>;
+    'fs-access': ChannelInfo<void, [path: string]>;
 }
 
 export interface SendChannels {

--- a/src/common/safeIpc.ts
+++ b/src/common/safeIpc.ts
@@ -9,6 +9,7 @@ import {
     ipcRenderer as unsafeIpcRenderer,
 } from 'electron';
 import { MakeDirectoryOptions } from 'fs';
+import { Mode, ObjectEncodingOptions, OpenMode, PathLike } from 'original-fs';
 import { FileOpenResult, FileSaveResult, PythonInfo, Version } from './common-types';
 import { ParsedSaveData, SaveData } from './SaveFile';
 import { ChainnerSettings } from './settings/settings';
@@ -53,8 +54,38 @@ export interface InvokeChannels {
     'set-settings': ChannelInfo<void, [settings: ChainnerSettings]>;
 
     // fs
-    'fs-read-file': ChannelInfo<string, [path: string]>;
-    'fs-write-file': ChannelInfo<void, [path: string, content: string | Buffer]>;
+    'fs-read-file': ChannelInfo<
+        string,
+        // Mostly copied this from the original fs.readFile, but had to remove some bits due to being unable to import the types
+        [
+            path: PathLike,
+            options:
+                | {
+                      encoding: BufferEncoding;
+                      flag?: OpenMode | undefined;
+                  }
+                | BufferEncoding
+        ]
+    >;
+    'fs-write-file': ChannelInfo<
+        void,
+        // Mostly copied this from the original fs.writeFile, but had to remove some bits due to being unable to import the types
+        [
+            file: PathLike,
+            data:
+                | string
+                | NodeJS.ArrayBufferView
+                | Iterable<string | NodeJS.ArrayBufferView>
+                | AsyncIterable<string | NodeJS.ArrayBufferView>,
+            options?:
+                | (ObjectEncodingOptions & {
+                      mode?: Mode | undefined;
+                      flag?: OpenMode | undefined;
+                  })
+                | BufferEncoding
+                | null
+        ]
+    >;
     'fs-exists': ChannelInfo<boolean, [path: string]>;
     'fs-mkdir': ChannelInfo<string | undefined, [path: string, options: MakeDirectoryOptions]>;
     'fs-readdir': ChannelInfo<string[], [path: string]>;

--- a/src/common/safeIpc.ts
+++ b/src/common/safeIpc.ts
@@ -39,7 +39,7 @@ export interface InvokeChannels {
         FileSaveResult,
         [saveData: SaveData, defaultPath: string | undefined]
     >;
-    'get-cli-open': ChannelInfo<FileOpenResult<ParsedSaveData> | undefined>;
+    'get-auto-open': ChannelInfo<FileOpenResult<ParsedSaveData> | undefined>;
     'owns-backend': ChannelInfo<boolean>;
     'restart-backend': ChannelInfo<void>;
     'relaunch-application': ChannelInfo<void>;

--- a/src/main/gui/main-window.ts
+++ b/src/main/gui/main-window.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow, app, dialog, nativeTheme, powerSaveBlocker, shell } from 'electron';
 import EventSource from 'eventsource';
+import fs, { constants } from 'fs/promises';
 import { t } from 'i18next';
 import { BackendEventMap } from '../../common/Backend';
 import { Version } from '../../common/common-types';
@@ -195,6 +196,24 @@ const registerEventHandlerPreSetup = (
             })().catch(log.error);
         });
     }
+
+    // Handle filesystem
+    ipcMain.handle('fs-read-file', async (event, path) => fs.readFile(path, { encoding: 'utf8' }));
+    ipcMain.handle('fs-write-file', async (event, path, content) =>
+        fs.writeFile(path, content, { encoding: 'utf8' })
+    );
+    ipcMain.handle('fs-exists', async (event, path) => {
+        try {
+            await fs.access(path, constants.F_OK);
+            return true;
+        } catch {
+            return false;
+        }
+    });
+    ipcMain.handle('fs-mkdir', async (event, path, options) => fs.mkdir(path, options));
+    ipcMain.handle('fs-readdir', async (event, path) => fs.readdir(path));
+    ipcMain.handle('fs-unlink', async (event, path) => fs.unlink(path));
+    ipcMain.handle('fs-access', async (event, path) => fs.access(path));
 };
 
 const registerEventHandlerPostSetup = (

--- a/src/main/gui/main-window.ts
+++ b/src/main/gui/main-window.ts
@@ -198,9 +198,9 @@ const registerEventHandlerPreSetup = (
     }
 
     // Handle filesystem
-    ipcMain.handle('fs-read-file', async (event, path) => fs.readFile(path, { encoding: 'utf8' }));
-    ipcMain.handle('fs-write-file', async (event, path, content) =>
-        fs.writeFile(path, content, { encoding: 'utf8' })
+    ipcMain.handle('fs-read-file', async (event, path, options) => fs.readFile(path, options));
+    ipcMain.handle('fs-write-file', async (event, path, content, options) =>
+        fs.writeFile(path, content, options)
     );
     ipcMain.handle('fs-exists', async (event, path) => {
         try {

--- a/src/main/gui/main-window.ts
+++ b/src/main/gui/main-window.ts
@@ -151,10 +151,13 @@ const registerEventHandlerPreSetup = (
         if (globalThis.startupFile) {
             // Open file with chaiNNer on other platforms
             const result = openSaveFile(globalThis.startupFile);
-            ipcMain.handle('get-cli-open', () => result);
+            ipcMain.handle('get-auto-open', () => result);
             globalThis.startupFile = null;
+        } else if (settings.startupTemplate) {
+            const result = openSaveFile(settings.startupTemplate);
+            ipcMain.handle('get-auto-open', () => result);
         } else {
-            ipcMain.handle('get-cli-open', () => undefined);
+            ipcMain.handle('get-auto-open', () => undefined);
         }
         // We remove the event we created in main.ts earlier on
         app.removeAllListeners('open-file');
@@ -171,9 +174,12 @@ const registerEventHandlerPreSetup = (
         if (args.file) {
             // Open file with chaiNNer on other platforms
             const result = openSaveFile(args.file);
-            ipcMain.handle('get-cli-open', () => result);
+            ipcMain.handle('get-auto-open', () => result);
+        } else if (settings.startupTemplate) {
+            const result = openSaveFile(settings.startupTemplate);
+            ipcMain.handle('get-auto-open', () => result);
         } else {
-            ipcMain.handle('get-cli-open', () => undefined);
+            ipcMain.handle('get-auto-open', () => undefined);
         }
 
         app.on('second-instance', (_event, commandLine) => {

--- a/src/renderer/components/groups/NcnnFileInputsGroup.tsx
+++ b/src/renderer/components/groups/NcnnFileInputsGroup.tsx
@@ -1,11 +1,13 @@
 import { memo, useEffect } from 'react';
 import { log } from '../../../common/log';
-import { checkFileExists, getInputValue } from '../../../common/util';
+import { ipcRenderer } from '../../../common/safeIpc';
+import { getInputValue } from '../../../common/util';
 import { SchemaInput } from '../inputs/SchemaInput';
 import { GroupProps } from './props';
 
 const ifExists = (file: string, then: () => void) => {
-    checkFileExists(file)
+    ipcRenderer
+        .invoke('fs-exists', file)
         .then((exists) => {
             if (exists) {
                 then();

--- a/src/renderer/components/settings/components.tsx
+++ b/src/renderer/components/settings/components.tsx
@@ -9,7 +9,6 @@ import {
     Select,
     Switch,
 } from '@chakra-ui/react';
-import { access, mkdir, readdir, unlink } from 'fs/promises';
 import path from 'path';
 import { memo, useEffect, useMemo } from 'react';
 import { Setting } from '../../../common/common-types';
@@ -130,9 +129,14 @@ const CacheSetting = memo(({ setting, value, setValue }: SettingsProps<'cache'>)
                     onClick={() => {
                         locationPromise
                             .then(async (cacheLocation) => {
-                                const files = await readdir(cacheLocation);
+                                const files = await ipcRenderer.invoke('fs-readdir', cacheLocation);
                                 await Promise.all(
-                                    files.map((file) => unlink(path.join(cacheLocation, file)))
+                                    files.map((file) =>
+                                        ipcRenderer.invoke(
+                                            'fs-unlink',
+                                            path.join(cacheLocation, file)
+                                        )
+                                    )
                                 );
                             })
                             .catch(log.error);
@@ -151,9 +155,11 @@ const CacheSetting = memo(({ setting, value, setValue }: SettingsProps<'cache'>)
                             locationPromise
                                 .then(async (cacheLocation) => {
                                     try {
-                                        await access(cacheLocation);
+                                        await ipcRenderer.invoke('fs-access', cacheLocation);
                                     } catch (error) {
-                                        await mkdir(cacheLocation, { recursive: true });
+                                        await ipcRenderer.invoke('fs-mkdir', cacheLocation, {
+                                            recursive: true,
+                                        });
                                     }
                                     setValue(cacheLocation);
                                 })

--- a/src/renderer/contexts/GlobalNodeState.tsx
+++ b/src/renderer/contexts/GlobalNodeState.tsx
@@ -29,7 +29,7 @@ import { getEffectivelyDisabledNodes } from '../../common/nodes/disabled';
 import { ChainLineage } from '../../common/nodes/lineage';
 import { TypeState } from '../../common/nodes/TypeState';
 import { ipcRenderer } from '../../common/safeIpc';
-import { ParsedSaveData, SaveData, openSaveFile } from '../../common/SaveFile';
+import { ParsedSaveData, SaveData } from '../../common/SaveFile';
 
 import {
     EMPTY_SET,
@@ -669,7 +669,7 @@ export const GlobalProvider = memo(
 
         useAsyncEffect(
             () => async () => {
-                const result = await ipcRenderer.invoke('get-cli-open');
+                const result = await ipcRenderer.invoke('get-auto-open');
                 if (result) {
                     if (result.kind === 'Success') {
                         await setStateFromJSONRef.current(result.saveData, result.path, true);
@@ -719,33 +719,6 @@ export const GlobalProvider = memo(
         );
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
         useIpcRendererListener('file-export-template', exportTemplate);
-
-        const [firstLoad, setFirstLoad] = useSessionStorage('firstLoad', true);
-        useAsyncEffect(
-            () => async () => {
-                if (firstLoad && startupTemplate) {
-                    try {
-                        const saveFile = await openSaveFile(startupTemplate);
-                        if (saveFile.kind === 'Success') {
-                            await setStateFromJSONRef.current(saveFile.saveData, '', true);
-                        } else {
-                            sendAlert({
-                                type: AlertType.ERROR,
-                                message: `Unable to open file ${startupTemplate}: ${saveFile.error}`,
-                            });
-                        }
-                    } catch (error) {
-                        log.error(error);
-                        sendAlert({
-                            type: AlertType.ERROR,
-                            message: `Unable to open file ${startupTemplate}`,
-                        });
-                    }
-                    setFirstLoad(false);
-                }
-            },
-            [firstLoad, sendAlert, setFirstLoad, startupTemplate]
-        );
 
         const removeNodesById = useCallback(
             (ids: readonly string[]) => {

--- a/src/renderer/contexts/GlobalNodeState.tsx
+++ b/src/renderer/contexts/GlobalNodeState.tsx
@@ -169,7 +169,7 @@ export const GlobalProvider = memo(
     ({ children, reactFlowWrapper }: React.PropsWithChildren<GlobalProviderProps>) => {
         const { sendAlert, sendToast, showAlert } = useContext(AlertBoxContext);
         const { schemata, functionDefinitions, scope, backend } = useContext(BackendContext);
-        const { startupTemplate, viewportExportPadding } = useSettings();
+        const { viewportExportPadding } = useSettings();
 
         const [nodeChanges, addNodeChanges, nodeChangesRef] = useChangeCounter();
         const [edgeChanges, addEdgeChanges, edgeChangesRef] = useChangeCounter();

--- a/src/renderer/helpers/copyAndPaste.ts
+++ b/src/renderer/helpers/copyAndPaste.ts
@@ -1,11 +1,11 @@
 import { clipboard } from 'electron';
-import { writeFile } from 'fs/promises';
 import os from 'os';
 import path from 'path';
 import { Edge, Node, Project } from 'reactflow';
 import { v4 as uuid4 } from 'uuid';
 import { EdgeData, InputId, NodeData, SchemaId } from '../../common/common-types';
 import { log } from '../../common/log';
+import { ipcRenderer } from '../../common/safeIpc';
 import { createUniqueId, deriveUniqueId } from '../../common/util';
 import { NodeProto, copyEdges, copyNodes, setSelected } from './reactFlowUtil';
 import { SetState } from './types';
@@ -108,7 +108,8 @@ export const pasteFromClipboard = (
                 case 'image/png': {
                     const imgData = clipboard.readImage().toPNG();
                     const imgPath = path.join(os.tmpdir(), `chaiNNer-clipboard-${uuid4()}.png`);
-                    writeFile(imgPath, imgData)
+                    ipcRenderer
+                        .invoke('fs-write-file', imgPath, imgData)
                         .then(() => {
                             log.debug('Clipboard image', imgPath);
                             let positionX = 0;

--- a/src/renderer/hooks/useInputRefactor.tsx
+++ b/src/renderer/hooks/useInputRefactor.tsx
@@ -16,7 +16,7 @@ import {
     PartialBy,
     SchemaId,
 } from '../../common/common-types';
-import { createInputOverrideId } from '../../common/input-override';
+import { createInputOverrideId } from '../../common/input-override-common';
 import { createUniqueId } from '../../common/util';
 import { BackendContext } from '../contexts/BackendContext';
 import { FakeNodeContext } from '../contexts/FakeExampleContext';


### PR DESCRIPTION
This moves all the usage of FS out of the renderer.

One unfortunate thing I had to do was move a bit of code out of input-overrides, as that file imports from FS, so I moved the tiny bit that was used in the renderer out into its own file.