### PR TITLE
Fixed slow SSE events

### DIFF
--- a/backend/src/server_process_helper.py
+++ b/backend/src/server_process_helper.py
@@ -185,7 +185,7 @@ class WorkerServer:
             "/sse",
             headers=request.headers,
             data=request.body,
-            timeout=5,
+            timeout=aiohttp.ClientTimeout(total=60 * 60, connect=5),
         ) as resp:
             async for data, _ in resp.content.iter_chunks():
                 yield data


### PR DESCRIPTION
This fixes the issue that SSE events were flow to reach the frontend. Results like View Image and type data are now instant again.

The issue was the SSE proxy had a timeout of 5sec. The *total* timeout was 5sec. This means that the SSE connection would reset of 5s and each reset took 3~4s to set up a new connection. This was the cause of the inconsistent delays.

The fix is to use a [`ClientTimeout`](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientTimeout) to specify that the SSE connection should time out if it takes longer than 5s to *connect* to the worker. I set the total timeout to 1h, because it didn't let me set it to `float("inf")`.