### PR TITLE
Set encoding to utf-8 for subprocesses

### DIFF
--- a/backend/src/dependencies/store.py
+++ b/backend/src/dependencies/store.py
@@ -165,13 +165,14 @@ async def install_dependencies(
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
+        encoding="utf-8",
     )
     installing_name = "Unknown"
     while True:
         nextline = process.stdout.readline()  # type: ignore
-        if nextline == b"" and process.poll() is not None:
+        if process.poll() is not None:
             break
-        line = nextline.decode("utf-8").strip()
+        line = nextline.strip()
         if not line:
             continue
 
@@ -298,13 +299,14 @@ async def uninstall_dependencies(
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
+        encoding="utf-8",
     )
     uninstalling_name = "Unknown"
     while True:
         nextline = process.stdout.readline()  # type: ignore
-        if nextline == b"" and process.poll() is not None:
+        if process.poll() is not None:
             break
-        line = nextline.decode("utf-8").strip()
+        line = nextline.strip()
         if not line:
             continue
 

--- a/backend/src/server_process_helper.py
+++ b/backend/src/server_process_helper.py
@@ -42,6 +42,7 @@ class _WorkerProcess:
             stdin=None,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            encoding="utf-8",
         )
         self._stop_event = threading.Event()
 
@@ -63,7 +64,7 @@ class _WorkerProcess:
         for line in self._process.stdout:
             if self._stop_event.is_set():
                 break
-            stripped_line = line.decode().rstrip()
+            stripped_line = line.rstrip()
             match_obj = re.match(SANIC_LOG_REGEX, stripped_line)
             if match_obj is not None:
                 log_level, message = match_obj.groups()


### PR DESCRIPTION
As discovered by a user in the discord, chaiNNer's subprocesses can break if you have a system language other than English on windows. This is because Popen by default lets windows decide what encoding to use.

So, to fix this, theoretically forcing the encoding to be utf-8 should prevent these kinds of issues.