### PR TITLE
Improved node progress API

### DIFF
--- a/backend/src/api/node_context.py
+++ b/backend/src/api/node_context.py
@@ -64,8 +64,15 @@ class Progress(ABC):
         """
         return _SubProgress(self, offset, length)
 
+    @staticmethod
+    def noop_progress() -> "Progress":
+        """
+        Returns a `Progress` object that does nothing. It is never paused or aborted and does not report any progress.
+        """
+        return _NoopProgress()
 
-class _NopProgress(Progress):
+
+class _NoopProgress(Progress):
     @property
     def aborted(self) -> Literal[False]:
         return False
@@ -84,7 +91,7 @@ class _NopProgress(Progress):
         pass
 
     def sub_progress(self, offset: float, length: float) -> "Progress":
-        return _NopProgress()
+        return _NoopProgress()
 
 
 class _SubProgress(Progress):

--- a/backend/src/nodes/impl/pytorch/auto_split.py
+++ b/backend/src/nodes/impl/pytorch/auto_split.py
@@ -6,7 +6,7 @@ import numpy as np
 import torch
 from spandrel import ImageModelDescriptor
 
-from api import NodeProgress
+from api import Progress
 
 from ..upscale.auto_split import Split, Tiler, auto_split
 from .utils import safe_cuda_cache_empty
@@ -55,12 +55,13 @@ def pytorch_auto_split(
     device: torch.device,
     use_fp16: bool,
     tiler: Tiler,
-    progress: NodeProgress,
+    progress: Progress,
 ) -> np.ndarray:
     dtype = torch.float16 if use_fp16 else torch.float32
     model = model.to(device, dtype)
 
     def upscale(img: np.ndarray, _: object):
+        progress.check_aborted()
         if progress.paused:
             # clear resources before pausing
             gc.collect()

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
@@ -6,7 +6,7 @@ import torch
 from sanic.log import logger
 from spandrel import ImageModelDescriptor, ModelTiling
 
-from api import KeyInfo, NodeContext, NodeProgress
+from api import KeyInfo, NodeContext, Progress
 from nodes.groups import Condition, if_group
 from nodes.impl.pytorch.auto_split import pytorch_auto_split
 from nodes.impl.upscale.auto_split_tiles import (
@@ -37,7 +37,7 @@ def upscale(
     model: ImageModelDescriptor,
     tile_size: TileSize,
     options: PyTorchSettings,
-    progress: NodeProgress,
+    progress: Progress,
 ):
     with torch.no_grad():
         # Borrowed from iNNfer


### PR DESCRIPTION
Changes:
- Rename `NodeProgress` to `Progress` because I intend to use this class as a general progress token throughout chainner in the future.
- Add sub progress API. This isn't used right now, but will be used for reporting node progress later.
- Add noop progress. This also will be used later.
- Add an abort check to PyTorch upscaling to make sure nodes can be aborted properly.