### PR TITLE
Fixed context selector pane moving body

### DIFF
--- a/src/renderer/global.scss
+++ b/src/renderer/global.scss
@@ -40,8 +40,12 @@
     }
 }
 
-body {
+html {
     overflow: hidden;
+}
+
+body {
+    overflow: clip;
 }
 
 .react-flow__attribution {

--- a/src/renderer/hooks/usePaneNodeSearchMenu.tsx
+++ b/src/renderer/hooks/usePaneNodeSearchMenu.tsx
@@ -287,9 +287,11 @@ const Menu = memo(({ onSelect, schemata, favorites, categories, suggestions }: M
     return (
         <MenuList
             bgColor={menuBgColor}
+            borderRadius="md"
             borderWidth={0}
             className="nodrag"
             overflow="hidden"
+            p={0}
             onContextMenu={stopPropagation}
         >
             <InputGroup
@@ -304,7 +306,7 @@ const Menu = memo(({ onSelect, schemata, favorites, categories, suggestions }: M
                 </InputLeftElement>
                 <Input
                     autoFocus
-                    borderRadius={0}
+                    borderRadius="md"
                     placeholder="Search..."
                     spellCheck={false}
                     type="text"
@@ -332,7 +334,7 @@ const Menu = memo(({ onSelect, schemata, favorites, categories, suggestions }: M
             </InputGroup>
             <Box
                 h="auto"
-                maxH={400}
+                maxH="calc(min(400px, 50vh - 50px))"
                 overflowY="scroll"
                 p={1}
             >


### PR DESCRIPTION
This fixes a visual bug for the node context selector. If the window height was too small, the node selector sometimes would not fit and cause the body to scroll.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/b0e18095-886a-4946-bd1f-b9e92b6e42f4)

I fixed this by
1. Making it so that the body can never scroll. and
2. Making sure the context selector always fits by giving it a max height of 50% viewport height.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/9c1fbb5a-8fbf-42f9-98d6-9e0592c06d9d)

As a minor design change, I also removed the weird padding at the top (and bottom) of the context selector. That one always bothered me, so I took the chance to remove it.