### PR TITLE
Don't create empty `settings_old` folder for fresh installs

### DIFF
--- a/src/main/setting-storage.ts
+++ b/src/main/setting-storage.ts
@@ -19,6 +19,11 @@ export const readSettings = (): ChainnerSettings => {
 
     // legacy settings
     const storagePath = path.join(getRootDirSync(), 'settings');
+    if (!existsSync(storagePath)) {
+        // neither settings.json nor old settings exist, so this is a fresh install
+        return { ...defaultSettings };
+    }
+
     const storage = new LocalStorage(storagePath);
     const partialSettings = migrateOldStorageSettings({
         keys: Array.from({ length: storage.length }, (_, i) => storage.key(i)),


### PR DESCRIPTION
This fixes a small oversight in #2640. 

Fresh installs have neither a `settings.json` nor a `settings` folder, but node local storage will create the `settings` folder. This cause fresh installs to always create an empty `settings` folder that was then migrated to a `settings_old` folder.

Of course, none of this was necessary. So I now check whether the `settings` folder exists before doing the migration.