### PR TITLE
Don't re-log empty messages

### DIFF
--- a/src/main/backend/process.ts
+++ b/src/main/backend/process.ts
@@ -92,10 +92,16 @@ export class OwnedBackendProcess implements BaseBackendProcess {
             const dataString = String(data);
             // Remove unneeded timestamp
             const fixedData = dataString.split('] ').slice(1).join('] ');
-            log.info(`Backend: ${removedTrailingNewLine(fixedData)}`);
+            const message = removedTrailingNewLine(fixedData);
+            if (message) {
+                log.info(`Backend: ${message}`);
+            }
         });
         backend.stderr.on('data', (data) => {
-            log.error(`Backend: ${removedTrailingNewLine(String(data))}`);
+            const message = removedTrailingNewLine(String(data));
+            if (message) {
+                log.error(`Backend: ${message}`);
+            }
         });
 
         return backend;


### PR DESCRIPTION
No more of this in our logs:

```
[2024-04-04 14:09:04.937] [info]  Backend: 
[2024-04-04 14:09:04.940] [info]  Backend: 
[2024-04-04 14:09:05.156] [info]  Backend: 
[2024-04-04 14:09:05.158] [info]  Backend: 
[2024-04-04 14:09:05.293] [info]  Backend: 
[2024-04-04 14:09:05.295] [info]  Backend: 
```