### PR TITLE
Improve missing module error logging

### DIFF
--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -474,8 +474,24 @@ async def import_packages(
 
         if len(import_errors) > 0:
             logger.warning(f"Failed to import {len(import_errors)} modules:")
+
+            by_error: dict[str, list[api.LoadErrorInfo]] = {}
             for e in import_errors:
-                logger.warning(f"{e.error}  ->  {e.module}")
+                key = str(e.error)
+                if key not in by_error:
+                    by_error[key] = []
+                by_error[key].append(e)
+
+            for error in sorted(by_error.keys()):
+                modules = [e.module for e in by_error[error]]
+                if len(modules) == 1:
+                    logger.warning(f"{error}  ->  {modules[0]}")
+                else:
+                    count = len(modules)
+                    if count > 3:
+                        modules = modules[:2] + [f"and {count - 2} more ..."]
+                    l = "\n".join("  ->  " + m for m in modules)
+                    logger.warning(f"{error}  ->  {count} modules ...\n{l}")
 
         if config.error_on_failed_node:
             raise ValueError("Error importing nodes")


### PR DESCRIPTION
Instead of having one log line for each module that failed to import something, it will now group all errors by the package that failed to import. This significantly improves the log spam we get on fresh installs when no dependencies are installed.

```
Failed to import 23 modules:
No module named 'ncnn'  ->  3 modules ...
  ->  packages.chaiNNer_ncnn.settings
  ->  packages.chaiNNer_ncnn.ncnn.processing.upscale_image
  ->  packages.chaiNNer_ncnn.ncnn.utility.interpolate_models
No module named 'onnx'  ->  5 modules ...
  ->  packages.chaiNNer_onnx.onnx.batch_processing.load_models
  ->  packages.chaiNNer_onnx.onnx.io.load_model
  ->  and 3 more ...
No module named 'onnxruntime'  ->  3 modules ...
  ->  packages.chaiNNer_onnx.settings
  ->  packages.chaiNNer_onnx.onnx.processing.remove_background
  ->  packages.chaiNNer_onnx.onnx.processing.upscale_image
No module named 'spandrel'  ->  5 modules ...
  ->  packages.chaiNNer_pytorch.pytorch.io.load_model
  ->  packages.chaiNNer_pytorch.pytorch.iteration.load_models
  ->  and 3 more ...
No module named 'torch'  ->  7 modules ...
  ->  packages.chaiNNer_pytorch.settings
  ->  packages.chaiNNer_pytorch.pytorch.io.save_model
  ->  and 5 more ...
```