### PR TITLE
Fixed server getting stuck on deleted files

### DIFF
--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -46,25 +46,25 @@ def collect_input_information(
             if not enforced:
                 try:
                     value = node_input.enforce_(value)  # noqa
-                except Exception as e:
+                except Exception:
                     logger.error(
                         f"Error enforcing input {node_input.label} (id {node_input.id})",
-                        e,
+                        exc_info=True,
                     )
                     # We'll just try using the un-enforced value. Maybe it'll work.
 
             try:
                 input_dict[node_input.id] = node_input.get_error_value(value)
-            except Exception as e:
+            except Exception:
                 logger.error(
                     f"Error getting error value for input {node_input.label} (id {node_input.id})",
-                    e,
+                    exc_info=True,
                 )
 
         return input_dict
-    except Exception as outer_e:
+    except Exception:
         # this method must not throw
-        logger.error("Error collecting input information.", outer_e)
+        logger.error("Error collecting input information.", exc_info=True)
         return {}
 
 


### PR DESCRIPTION
Fixes #2679

The cause of this bug is absolutely stupid. The issue is that passing an exception as the second positional argument to `logger.debug/info/warn/error` will cause the messages to be formatted with it. Sanic essentially does `message.format(args)` behind the scenes, so the intended usage is `logger.error("My name is %s!", name)`. (We never use this because f-strings exist.) The problem is that formatting will fail if any positional argument goes unused. (Yes, it's great API design when something as important as logging can trivially fail...) For whatever reason, if you fail to format 3 times, the thread you log in will get stuck and never respond to anything again. 

The fix for now is to fix the formatting by not using it. The long term fix is to switch to a competent logger. 

---

Btw, I also check for other instances of positional arguments being used: there were none. 