### PR TITLE
Remove `__repr__` and `__iter__` from `BaseInput` and `BaseOutput`

### DIFF
--- a/backend/src/api/input.py
+++ b/backend/src/api/input.py
@@ -183,9 +183,3 @@ class BaseInput:
     def make_fused(self, with_output: OutputId | int = 0):
         self.fused = IOFusion(output_id=OutputId(with_output))
         return self
-
-    def __repr__(self):
-        return str(self.to_dict())
-
-    def __iter__(self):
-        yield from self.to_dict().items()

--- a/backend/src/api/output.py
+++ b/backend/src/api/output.py
@@ -59,12 +59,6 @@ class BaseOutput:
         self.should_suggest = True
         return self
 
-    def __repr__(self):
-        return str(self.to_dict())
-
-    def __iter__(self):
-        yield from self.to_dict().items()
-
     def get_broadcast_data(self, _value: object):
         return None
 


### PR DESCRIPTION
`__repr__` just made debugging harder, because the debugger would show the repr which contains less information than the default view the debugger would have generated absent `__repr__`.

`__iter__` was just useless.