### PR TITLE
Clean up files on uninstall

### DIFF
--- a/src/main/cli/run.ts
+++ b/src/main/cli/run.ts
@@ -21,7 +21,7 @@ import { assertNever, delay } from '../../common/util';
 import { RunArguments } from '../arguments';
 import { BackendProcess } from '../backend/process';
 import { setupBackend } from '../backend/setup';
-import { getRootDirSync } from '../platform';
+import { getRootDir } from '../platform';
 import { readSettings } from '../setting-storage';
 import { Exit } from './exit';
 import type { Edge, Node } from 'reactflow';
@@ -70,7 +70,7 @@ const createBackend = async (
         token,
         settings.useSystemPython,
         settings.systemPythonLocation,
-        getRootDirSync(),
+        getRootDir(),
         args.remoteBackend
     );
 };

--- a/src/main/gui/main-window.ts
+++ b/src/main/gui/main-window.ts
@@ -14,7 +14,7 @@ import { ProgressController, ProgressToken, SubProgress } from '../../common/ui/
 import { OpenArguments, parseArgs } from '../arguments';
 import { BackendProcess } from '../backend/process';
 import { setupBackend } from '../backend/setup';
-import { getRootDirSync } from '../platform';
+import { getRootDir } from '../platform';
 import { BrowserWindowWithSafeIpc, ipcMain } from '../safeIpc';
 import { writeSettings } from '../setting-storage';
 import { MenuData, setMainMenu } from './menu';
@@ -28,7 +28,7 @@ const registerEventHandlerPreSetup = (
     settings: ChainnerSettings
 ) => {
     ipcMain.handle('get-app-version', () => version);
-    ipcMain.handle('get-appdata', () => getRootDirSync());
+    ipcMain.handle('get-appdata', () => getRootDir());
     ipcMain.handle('refresh-nodes', () => args.refresh);
 
     // settings
@@ -361,7 +361,7 @@ const createBackend = async (
         token,
         settings.useSystemPython,
         settings.systemPythonLocation,
-        getRootDirSync(),
+        getRootDir(),
         args.remoteBackend
     );
 };

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -9,7 +9,8 @@ import { parseArgs } from './arguments';
 import { createCli } from './cli/create';
 import { runChainInCli } from './cli/run';
 import { createGuiApp } from './gui/create';
-import { getLogsFolder, getRootDirSync } from './platform';
+import { getLogsFolder, getRootDir } from './platform';
+import { handleSquirrel } from './squirrel';
 
 const startApp = () => {
     const args = parseArgs(process.argv.slice(app.isPackaged ? 1 : 2));
@@ -27,7 +28,7 @@ const startApp = () => {
 
     process.env.ELECTRON_DISABLE_SECURITY_WARNINGS = 'true';
 
-    app.setPath('userData', getRootDirSync());
+    app.setPath('userData', getRootDir());
 
     // On macOS, we need to store the file-path when chaiNNer got started via a double
     // click on a .chn file. This listener gets remove later on.
@@ -60,9 +61,7 @@ const startApp = () => {
     }
 };
 
-// Handle creating/removing shortcuts on Windows when installing/uninstalling.
-// eslint-disable-next-line global-require
-if (require('electron-squirrel-startup')) {
+if (handleSquirrel()) {
     app.quit();
 } else {
     startApp();

--- a/src/main/platform.ts
+++ b/src/main/platform.ts
@@ -27,12 +27,12 @@ export const getIsPortableSync = lazy((): boolean => {
     return isPortable;
 });
 
-export const getRootDirSync = lazy((): string => {
+export const getRootDir = lazy((): string => {
     const isPortable = getIsPortableSync();
     const rootDir = isPortable ? currentExecutableDir : app.getPath('userData');
     return rootDir;
 });
 
 export const getLogsFolder = lazy((): string => {
-    return path.join(getRootDirSync(), 'logs');
+    return path.join(getRootDir(), 'logs');
 });

--- a/src/main/setting-storage.ts
+++ b/src/main/setting-storage.ts
@@ -3,9 +3,9 @@ import { LocalStorage } from 'node-localstorage';
 import path from 'path';
 import { migrateOldStorageSettings } from '../common/settings/migration';
 import { ChainnerSettings, defaultSettings } from '../common/settings/settings';
-import { getRootDirSync } from './platform';
+import { getRootDir } from './platform';
 
-const settingsJson = path.join(getRootDirSync(), 'settings.json');
+const settingsJson = path.join(getRootDir(), 'settings.json');
 
 export const writeSettings = (settings: ChainnerSettings) => {
     writeFileSync(settingsJson, JSON.stringify(settings, null, 4), 'utf-8');
@@ -18,7 +18,7 @@ export const readSettings = (): ChainnerSettings => {
     }
 
     // legacy settings
-    const storagePath = path.join(getRootDirSync(), 'settings');
+    const storagePath = path.join(getRootDir(), 'settings');
     if (!existsSync(storagePath)) {
         // neither settings.json nor old settings exist, so this is a fresh install
         return { ...defaultSettings };
@@ -37,7 +37,7 @@ export const readSettings = (): ChainnerSettings => {
     // write a new settings.json we'll use form now on
     writeSettings(settings);
     // don't delete the old settings in case we need to revert
-    renameSync(storagePath, path.join(getRootDirSync(), 'settings_old'));
+    renameSync(storagePath, path.join(getRootDir(), 'settings_old'));
 
     return settings;
 };

--- a/src/main/squirrel.ts
+++ b/src/main/squirrel.ts
@@ -44,7 +44,7 @@ const onUninstall = () => {
     // delete all folders + their content
     for (const folder of foldersToCleanUp) {
         const p = path.join(getRootDir(), folder);
-        log.info('Deleting folder: ', p);
+        log.info(`Deleting folder: ${p}`);
         try {
             if (existsSync(p)) {
                 rmdirSync(p, { recursive: true });

--- a/src/main/squirrel.ts
+++ b/src/main/squirrel.ts
@@ -1,0 +1,101 @@
+// Windows-only (un)install hooks
+
+import { appendFileSync, existsSync, rmdirSync } from 'fs';
+import path from 'path';
+import { LEVEL_NAME, log } from '../common/log';
+import { getLogsFolder, getRootDir } from './platform';
+
+const setupLogging = () => {
+    // setup logging
+    // I don't trust electron-log to work properly in this context, so I'm
+    // rolling my simple log file. It's going to be append-only.
+    const logFile = path.join(getLogsFolder(), 'install.log');
+    log.addTransport({
+        log: ({ level, message, additional }) => {
+            const timestamp = new Date().toISOString();
+            const logLevel = LEVEL_NAME[level].toUpperCase();
+            const fullMessage = [message, ...additional].map((a) => String(a)).join(' ');
+            const line = `[${timestamp}] [${logLevel}] ${fullMessage}`;
+            try {
+                appendFileSync(logFile, `${line}\n`, 'utf8');
+            } catch (error) {
+                // eslint-disable-next-line no-console
+                console.log(line);
+            }
+        },
+    });
+};
+
+const onInstall = () => {
+    // nothing right now
+};
+
+const onUninstall = () => {
+    const foldersToCleanUp = [
+        // chaiNNer folders
+        'ffmpeg',
+        'python',
+        'settings',
+        'settings_old',
+        // don't delete the logs folder, it's important to us and doesn't take up much space
+        // don't delete settings.json in case the user re-installs the app
+    ];
+
+    // delete all folders + their content
+    for (const folder of foldersToCleanUp) {
+        const p = path.join(getRootDir(), folder);
+        log.info('Deleting folder: ', p);
+        try {
+            if (existsSync(p)) {
+                rmdirSync(p, { recursive: true });
+            }
+        } catch (error) {
+            log.error(`Error deleting folder: ${String(error)}`);
+        }
+    }
+};
+
+/**
+ * Handle creating/removing shortcuts on Windows when installing/uninstalling.
+ *
+ * If `true` is returned, the app should quit immediately.
+ */
+export const handleSquirrel = (): boolean => {
+    if (process.platform !== 'win32') {
+        return false;
+    }
+
+    // We use electron-squirrel-startup to process Squirrel events. It will do
+    // the most important work for us, so we can focus on our custom logic.
+    // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+    const isSquirrelCommand = Boolean(require('electron-squirrel-startup'));
+    if (!isSquirrelCommand) {
+        return false;
+    }
+
+    setupLogging();
+
+    // https://github.com/electron-archive/grunt-electron-installer#handling-squirrel-events
+    const squirrelCommand = process.argv[1];
+    log.info(`Squirrel command: ${squirrelCommand}`);
+    log.info(`Process execPath: ${process.execPath}`);
+
+    try {
+        switch (squirrelCommand) {
+            case '--squirrel-install':
+            case '--squirrel-updated':
+                onInstall();
+                break;
+            case '--squirrel-uninstall':
+                onUninstall();
+                break;
+            default:
+                break;
+        }
+    } catch {
+        // since this is all optional work, we can ignore any errors
+        // errors are especially irrelevant when the app is being uninstalled
+    }
+
+    return true;
+};

--- a/src/main/squirrel.ts
+++ b/src/main/squirrel.ts
@@ -92,9 +92,8 @@ export const handleSquirrel = (): boolean => {
             default:
                 break;
         }
-    } catch {
-        // since this is all optional work, we can ignore any errors
-        // errors are especially irrelevant when the app is being uninstalled
+    } catch (e) {
+        log.error(e);
     }
 
     return true;


### PR DESCRIPTION
Fixes #2347.

Chainner will now delete the `python` and `ffmpeg` folders when being uninstalled. Some folders and files (e.g. logs and settings) are intentionally left, because they are important and don't take up much space. 

There are also some electron folders left that cannot be deleted by chainner directly because they are actively used. They only add up to less than 10MB, so they shouldn't be a huge issue.

Since we are now running custom code during (un)install, I also added logging for the (un)installation process. Since I don't trust electron-log while the app is being (un)installed, I rolled my own simple logging solution. It produces an `install.log` file that looks like this: 
```
[2024-04-05T10:08:22.847Z] [INFO] Squirrel command: --squirrel-install
[2024-04-05T10:08:22.849Z] [INFO] Process execPath: C:\Users\micha\AppData\Local\chaiNNer\app-0.22.2\chaiNNer.exe
[2024-04-05T10:10:27.577Z] [INFO] Squirrel command: --squirrel-uninstall
[2024-04-05T10:10:27.579Z] [INFO] Process execPath: C:\Users\micha\AppData\Local\chaiNNer\app-0.22.2\chaiNNer.exe
[2024-04-05T10:10:27.579Z] [INFO] Deleting folder: C:\Users\micha\AppData\Roaming\chaiNNer\ffmpeg
[2024-04-05T10:10:27.592Z] [INFO] Deleting folder: C:\Users\micha\AppData\Roaming\chaiNNer\python
```

Other changes:
- I renamed `getRootDirSync` to `getRootDir` because the name fits better. Sorry for the noisy diff.