### PR TITLE
Always stop backend before start if updating/installing deps

### DIFF
--- a/backend/src/server_host.py
+++ b/backend/src/server_host.py
@@ -352,9 +352,10 @@ async def import_packages(
                 to_install.append(dep)
 
     try:
-        num_installed = await install_deps(to_install)
+        if len(to_install) > 0:
+            await worker.stop()
 
-        if num_installed > 0:
+            await install_deps(to_install)
             flags = []
             if config.error_on_failed_node:
                 flags.append("--error-on-failed-node")
@@ -362,7 +363,7 @@ async def import_packages(
             if config.close_after_start:
                 flags.append("--close-after-start")
 
-            await worker.restart(flags)
+            await worker.start(flags)
     except Exception as ex:
         logger.error(f"Error installing dependencies: {ex}", exc_info=True)
         if config.close_after_start:


### PR DESCRIPTION
I was right. This was a general issue caused by us not stopping the worker server (which is using the deps) before updating. So, onnx wasn't able to be deleted since it was locked by the OS.

So, I replaced the restart that only happens if anything installed, to just always stop > install > start. I initially had it this way but changed it since i thought it would optimize startup a bit, but it seems to only cause more issues.

this could potentially be resolved by some refactoring where this bit of code could only stop the server if there is a dep that is already installed that's just being updated, but for now this works.