### PR TITLE
Don't allow unversioned dependencies

### DIFF
--- a/backend/src/dependencies/store.py
+++ b/backend/src/dependencies/store.py
@@ -13,7 +13,7 @@ from custom_types import UpdateProgressFn
 python_path = sys.executable
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
-installed_packages: dict[str, str | None] = {}
+installed_packages: dict[str, str] = {}
 
 COLLECTING_REGEX = re.compile(r"Collecting ([a-zA-Z0-9-_]+)")
 UNINSTALLING_REGEX = re.compile(r"Uninstalling ([a-zA-Z0-9-_]+)-+")
@@ -24,8 +24,8 @@ DEP_MAX_PROGRESS = 0.8
 @dataclass(frozen=True)
 class DependencyInfo:
     package_name: str
+    version: str
     display_name: str | None = None
-    version: str | None = None
     from_file: str | None = None
     extra_index_url: str | None = None
 
@@ -37,9 +37,6 @@ def pin(dependency: DependencyInfo) -> str:
         whl_file = f"{dir_path}/whls/{package_name}/{dependency.from_file}"
         if os.path.isfile(whl_file):
             return whl_file
-
-    if dependency.version is None:
-        return package_name
 
     return f"{package_name}=={dependency.version}"
 
@@ -62,7 +59,7 @@ def get_deps_to_install(dependencies: list[DependencyInfo]):
     dependencies_to_install: list[DependencyInfo] = []
     for dependency in dependencies:
         version = installed_packages.get(dependency.package_name, None)
-        if dependency.version and version:
+        if version:
             installed_version = coerce_semver(version)
             dep_version = coerce_semver(dependency.version)
             if installed_version < dep_version:


### PR DESCRIPTION
Just a little something I noticed. I think we used dependencies without specific versions before, but we since specified versions for all of them, and I think we should continue doing that going forward. This PR just removes support for dependencies without versions.