### PR TITLE
Improved node renaming UX

### DIFF
--- a/src/renderer/components/NodeDocumentation/NodeExample.tsx
+++ b/src/renderer/components/NodeDocumentation/NodeExample.tsx
@@ -14,7 +14,7 @@ import {
 } from '../../../common/common-types';
 import { checkNodeValidity } from '../../../common/nodes/checkNodeValidity';
 import { TypeState } from '../../../common/nodes/TypeState';
-import { EMPTY_ARRAY, EMPTY_MAP, EMPTY_OBJECT, EMPTY_SET } from '../../../common/util';
+import { EMPTY_ARRAY, EMPTY_MAP, EMPTY_OBJECT, EMPTY_SET, noop } from '../../../common/util';
 import { BackendContext } from '../../contexts/BackendContext';
 import { FakeNodeProvider } from '../../contexts/FakeExampleContext';
 import { NodeState, TypeInfo, testForInputConditionTypeInfo } from '../../helpers/nodeState';
@@ -98,8 +98,6 @@ export const NodeExample = memo(({ selectedSchema }: NodeExampleProps) => {
         [setOutputHeight]
     );
 
-    const [nodeName, setNodeName] = useState<string | undefined>(undefined);
-
     const nodeIdPrefix = 'FakeId ';
     const suffixLength = 36 - nodeIdPrefix.length;
     const nodeId =
@@ -167,8 +165,8 @@ export const NodeExample = memo(({ selectedSchema }: NodeExampleProps) => {
         iteratedOutputs,
         type: typeInfo,
         testCondition: testForInputConditionTypeInfo(inputData, selectedSchema, typeInfo),
-        nodeName,
-        setNodeName,
+        nodeName: undefined,
+        setNodeName: noop,
     };
 
     return (


### PR DESCRIPTION
Changes:
- Disable node renaming in docs. Just like collapsing nodes, it's not useful for docs and just gets in the way.
- Double-clicking the node header no longer toggles collapsing/expanding the node. 
- Double-clicking the icon or name now toggles renaming. The change is that I included the icon as well, which is necessary. If our users ever find a bug to enter something that is displayed as an empty name, they won't be able to rename the node without the icon also acting as a toggle.
- Changed design of text box to be closer to the regular header. So the text is now centered and larger.
- The text box will now fill all available space (and no more).
- Added input cleaning to normalize spaces.
- ESC now cancels renaming instead of confirming it. This can be useful sometimes, but I'm not sure whether we should keep this behavior.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/a0c58fcc-d6e4-4e4d-9664-3ab0dd73a2ef)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/5df51a4a-1d00-4eff-9b6d-96b0760180d0)
