### PR TITLE
Stop progress bar from moving logo

### DIFF
--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -122,15 +122,13 @@ export const Main = memo(() => {
                                     {status}
                                 </Text>
                             </Center>
-                            {statusProgress !== null && (
-                                <Center>
-                                    <Progress
-                                        hasStripe
-                                        value={statusProgress * 100}
-                                        w="350px"
-                                    />
-                                </Center>
-                            )}
+                            <Center opacity={statusProgress === null ? 0 : 1}>
+                                <Progress
+                                    hasStripe
+                                    value={(statusProgress ?? 0) * 100}
+                                    w="350px"
+                                />
+                            </Center>
                         </VStack>
                     </Flex>
                 </Center>


### PR DESCRIPTION
When the progress bar appears, the logo is moved up to center everything. This causes the logo to bounce up and down when installing many dependencies.

This PR just makes the progress bar invisible when no sub progress is available. Since the progress bar is always present, displaying it when sub progress is available won't move the logo.