### PR TITLE
Hide minimap by default

### DIFF
--- a/src/common/settings/settings.ts
+++ b/src/common/settings/settings.ts
@@ -39,7 +39,7 @@ export const defaultSettings: Readonly<ChainnerSettings> = {
     snapToGrid: false,
     snapToGridAmount: 16,
     viewportExportPadding: 20,
-    showMinimap: true,
+    showMinimap: false,
 
     experimentalFeatures: false,
     hardwareAcceleration: false,


### PR DESCRIPTION
This PR hides the minimap by default for all new installations. New users that want the minimap can enable it in the settings. Old installations are unaffected by this change, they will continue to use whatever the user configured before.

I think that the minimap is not very useful for most users and might overload new users. Chainner is already quite complex software, so I don't want to overload new users with a bunch of UI elements. 

The minimap also has another issue for new users: it's not self-explanatory. It only shows *something* when there are nodes in the editor, which requires users to add them. Of course, this is just a small bump, but I want to keep the learning curve as gentle as possible and I think the minimap works against that.