### PR TITLE
Update to Navi v0.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPLv3",
       "dependencies": {
         "@babel/plugin-transform-react-jsx": "^7.17.12",
-        "@chainner/navi": "^0.7.1",
+        "@chainner/navi": "^0.7.2",
         "@chakra-ui/icons": "^2.1.1",
         "@chakra-ui/react": "^2.8.2",
         "@emotion/react": "^11.9.0",
@@ -969,9 +969,9 @@
       "dev": true
     },
     "node_modules/@chainner/navi": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@chainner/navi/-/navi-0.7.1.tgz",
-      "integrity": "sha512-YQZngMQ28U6I5NONuKufUQPtWO6pPgztQ5Y6oDP+75oaH2aPDCI5A6AKVSH8fAgfCl/IOeff81RlhvfYvryvUQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@chainner/navi/-/navi-0.7.2.tgz",
+      "integrity": "sha512-977yWl5vj4770h6NZ63j1n6Ke8YKnJL0+PcAqm96ufLZ2UMN2hgTWILqgWkfc9ZN4UpiO+//TlQxaSGjDVXptQ==",
       "engines": {
         "node": ">=16.0.0"
       }
@@ -26008,9 +26008,9 @@
       "dev": true
     },
     "@chainner/navi": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@chainner/navi/-/navi-0.7.1.tgz",
-      "integrity": "sha512-YQZngMQ28U6I5NONuKufUQPtWO6pPgztQ5Y6oDP+75oaH2aPDCI5A6AKVSH8fAgfCl/IOeff81RlhvfYvryvUQ=="
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@chainner/navi/-/navi-0.7.2.tgz",
+      "integrity": "sha512-977yWl5vj4770h6NZ63j1n6Ke8YKnJL0+PcAqm96ufLZ2UMN2hgTWILqgWkfc9ZN4UpiO+//TlQxaSGjDVXptQ=="
     },
     "@chakra-ui/accordion": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@babel/plugin-transform-react-jsx": "^7.17.12",
-    "@chainner/navi": "^0.7.1",
+    "@chainner/navi": "^0.7.2",
     "@chakra-ui/icons": "^2.1.1",
     "@chakra-ui/react": "^2.8.2",
     "@emotion/react": "^11.9.0",


### PR DESCRIPTION
Since the `fs` import became an issue, I updated ANTLR4 to the latest version which includes a web distribution. This made it possible to remove the `fs` import, so Navi doesn't import anything at all anymore.