### PR TITLE
Add "Clear" options for file and directory inputs

### DIFF
--- a/src/common/locales/en/translation.json
+++ b/src/common/locales/en/translation.json
@@ -30,12 +30,14 @@
   "inputs": {
     "copyInputOverrideId": "Copy Input Override Id",
     "directory": {
+      "clear": "Clear",
       "copyFullDirectoryPath": "Copy Full Directory Path",
       "openInFileExplorer": "Open in File Explorer",
       "selectDirectory": "Select a directory..."
     },
     "extractValueIntoNode": "Extract value into node",
     "file": {
+      "clear": "Clear",
       "copyFileName": "Copy File Name",
       "copyFullFilePath": "Copy Full File Path",
       "openInFileExplorer": "Open in File Explorer",

--- a/src/renderer/components/inputs/DirectoryInput.tsx
+++ b/src/renderer/components/inputs/DirectoryInput.tsx
@@ -1,4 +1,5 @@
 import { Type, isStringLiteral } from '@chainner/navi';
+import { CloseIcon } from '@chakra-ui/icons';
 import {
     Icon,
     Input,
@@ -37,6 +38,7 @@ export const DirectoryInput = memo(
     ({
         value,
         setValue,
+        resetValue,
         isLocked,
         input,
         inputKey,
@@ -98,6 +100,14 @@ export const DirectoryInput = memo(
                     }}
                 >
                     {t('inputs.directory.copyFullDirectoryPath', 'Copy Full Directory Path')}
+                </MenuItem>
+                <MenuDivider />
+                <MenuItem
+                    icon={<CloseIcon />}
+                    isDisabled={!value}
+                    onClick={resetValue}
+                >
+                    {t('inputs.directory.clear', 'Clear')}
                 </MenuItem>
                 {refactor}
             </MenuList>

--- a/src/renderer/components/inputs/FileInput.tsx
+++ b/src/renderer/components/inputs/FileInput.tsx
@@ -1,3 +1,4 @@
+import { CloseIcon } from '@chakra-ui/icons';
 import {
     Icon,
     Input,
@@ -30,6 +31,7 @@ export const FileInput = memo(
     ({
         value: filePath,
         setValue: setFilePath,
+        resetValue: resetFilePath,
         input,
         inputKey,
         isConnected,
@@ -148,6 +150,14 @@ export const FileInput = memo(
                     }}
                 >
                     {t('inputs.file.copyFullFilePath', 'Copy Full File Path')}
+                </MenuItem>
+                <MenuDivider />
+                <MenuItem
+                    icon={<CloseIcon />}
+                    isDisabled={!filePath}
+                    onClick={resetFilePath}
+                >
+                    {t('inputs.file.clear', 'Clear')}
                 </MenuItem>
                 {refactor}
             </MenuList>


### PR DESCRIPTION
Resolves #2521

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/d91c4cac-a8b6-4f82-8c03-6a3057031588)

I named the entry "Clear" because I think it describes the function better than "Reset". IMO, "reset" implies a certain value the input is reset to, but that's not the case for file and directory inputs, because the default value is nothing.