### PR TITLE
Fixed Execution number node not working when collapsed

### DIFF
--- a/src/renderer/components/Handle.tsx
+++ b/src/renderer/components/Handle.tsx
@@ -3,6 +3,7 @@ import React, { memo } from 'react';
 import { Connection, Position, Handle as RFHandle } from 'reactflow';
 import { useContext } from 'use-context-selector';
 import { Validity } from '../../common/Validity';
+import { useIsCollapsedNode } from '../contexts/CollapsedNodeContext';
 import { FakeNodeContext } from '../contexts/FakeExampleContext';
 import { noContextMenu } from '../hooks/useContextMenu';
 import { Markdown } from './Markdown';
@@ -123,8 +124,10 @@ export const Handle = memo(
         connectedColor,
         isIterated,
     }: HandleProps) => {
-        const isConnected = !!connectedColor;
+        const isCollapsed = useIsCollapsedNode();
+        if (isCollapsed) return null;
 
+        const isConnected = !!connectedColor;
         const connectedBg = 'var(--connection-color)';
 
         return (

--- a/src/renderer/components/node/Node.tsx
+++ b/src/renderer/components/node/Node.tsx
@@ -144,14 +144,12 @@ export const NodeView = memo(
                             toggleCollapse={toggleCollapse}
                             validity={validity}
                         />
-                        {!isCollapsed ? (
-                            <NodeBody
-                                animated={animated}
-                                nodeState={nodeState}
-                            />
-                        ) : (
-                            <CollapsedHandles nodeState={nodeState} />
-                        )}
+                        <NodeBody
+                            animated={animated}
+                            isCollapsed={isCollapsed}
+                            nodeState={nodeState}
+                        />
+                        {isCollapsed && <CollapsedHandles nodeState={nodeState} />}
                     </VStack>
                     {!isCollapsed && (
                         <NodeFooter

--- a/src/renderer/components/node/NodeBody.tsx
+++ b/src/renderer/components/node/NodeBody.tsx
@@ -2,22 +2,36 @@ import { Box } from '@chakra-ui/react';
 import { memo } from 'react';
 
 import { isAutoInput } from '../../../common/util';
+import { CollapsedNode } from '../../contexts/CollapsedNodeContext';
 import { NodeState } from '../../helpers/nodeState';
 import { NodeInputs } from './NodeInputs';
 import { NodeOutputs } from './NodeOutputs';
 
 interface NodeBodyProps {
     nodeState: NodeState;
-    animated?: boolean;
+    isCollapsed: boolean;
+    animated: boolean;
 }
 
-export const NodeBody = memo(({ nodeState, animated = false }: NodeBodyProps) => {
+export const NodeBody = memo(({ nodeState, isCollapsed, animated }: NodeBodyProps) => {
     const { inputs, outputs } = nodeState.schema;
 
     const autoInput = inputs.length === 1 && isAutoInput(inputs[0]);
     const anyVisibleOutputs = outputs.some((output) => {
         return !inputs.some((input) => input.fused?.outputId === output.id);
     });
+
+    if (isCollapsed) {
+        return (
+            <CollapsedNode>
+                <NodeInputs nodeState={nodeState} />
+                <NodeOutputs
+                    animated={animated}
+                    nodeState={nodeState}
+                />
+            </CollapsedNode>
+        );
+    }
 
     return (
         <>

--- a/src/renderer/components/node/NodeOutputs.tsx
+++ b/src/renderer/components/node/NodeOutputs.tsx
@@ -7,6 +7,7 @@ import { getChainnerScope } from '../../../common/types/chainner-scope';
 import { ExpressionJson, fromJson } from '../../../common/types/json';
 import { isStartingNode } from '../../../common/util';
 import { BackendContext } from '../../contexts/BackendContext';
+import { useIsCollapsedNode } from '../../contexts/CollapsedNodeContext';
 import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { NodeState } from '../../helpers/nodeState';
 import { DefaultImageOutput } from '../outputs/DefaultImageOutput';
@@ -91,6 +92,12 @@ export const NodeOutputs = memo(({ nodeState, animated }: NodeOutputProps) => {
             }
         }
     }, [id, currentTypes, schema, setManualOutputType]);
+
+    const isCollapsed = useIsCollapsedNode();
+    if (isCollapsed) {
+        // just need the effect for collapsed nodes, not the elements
+        return null;
+    }
 
     const functions = functionDefinitions.get(schemaId)?.outputDefaults;
     return (

--- a/src/renderer/contexts/CollapsedNodeContext.tsx
+++ b/src/renderer/contexts/CollapsedNodeContext.tsx
@@ -1,0 +1,17 @@
+import { Box } from '@chakra-ui/react';
+import React, { memo } from 'react';
+import { createContext, useContext } from 'use-context-selector';
+
+const IsCollapsedContext = createContext<boolean>(false);
+
+export const CollapsedNode = memo(({ children }: React.PropsWithChildren<unknown>) => {
+    return (
+        <Box display="none">
+            <IsCollapsedContext.Provider value>{children}</IsCollapsedContext.Provider>
+        </Box>
+    );
+});
+
+export const useIsCollapsedNode = (): boolean => {
+    return useContext(IsCollapsedContext);
+};

--- a/src/renderer/contexts/CollapsedNodeContext.tsx
+++ b/src/renderer/contexts/CollapsedNodeContext.tsx
@@ -6,7 +6,10 @@ const IsCollapsedContext = createContext<boolean>(false);
 
 export const CollapsedNode = memo(({ children }: React.PropsWithChildren<unknown>) => {
     return (
-        <Box display="none">
+        <Box
+            display="none"
+            style={{ contain: 'strict' }}
+        >
             <IsCollapsedContext.Provider value>{children}</IsCollapsedContext.Provider>
         </Box>
     );


### PR DESCRIPTION
The Execution Number node didn't work when collapsed because its value was set using [a `useEffect` in its input element](https://github.com/chaiNNer-org/chaiNNer/blob/135f1f668c8a323146375fff3eb8974b1e83f193/src/renderer/components/inputs/StaticValueInput.tsx#L16). Since that input element wasn't rendered when collapsed, the side effect didn't happen, and so the execution number didn't update.

The same bug of input/output side effects not working could so be observed for other nodes. E.g. Load Image would stop updating the output type of the image when collapsed.

This PR fixes this by always rendering input and output element, which ensures that their side effects happen. Since we don't actually want to show them, elements are rendered into a box with `display: none` and `contain: strict`. This ensures that the browser can basically ignore the rendered input/output elements, so there won't be a perf impact.

Lastly, I had to disable handles for the collapsed input/output elements. ReactFlow also uses side effects for its handles, but we don't want those side effects.