### PR TITLE
Improve Python setup process

### DIFF
--- a/src/common/ui/interrupt.ts
+++ b/src/common/ui/interrupt.ts
@@ -5,8 +5,11 @@ interface ActionBase<T extends string> {
 interface OpenUrlAction extends ActionBase<'open-url'> {
     url: string;
 }
+interface RunAction extends ActionBase<'run'> {
+    action: () => void;
+}
 
-export type Action = OpenUrlAction;
+export type Action = OpenUrlAction | RunAction;
 
 export interface InteractionOption {
     title: string;

--- a/src/main/cli/run.ts
+++ b/src/main/cli/run.ts
@@ -48,8 +48,12 @@ const addProgressListeners = (monitor: ProgressMonitor) => {
                     logger(`   Go to ${action.url}`);
                     break;
 
+                case 'run':
+                    // log nothing
+                    break;
+
                 default:
-                    return assertNever(action.type);
+                    return assertNever(action);
             }
         }
 

--- a/src/main/gui/main-window.ts
+++ b/src/main/gui/main-window.ts
@@ -423,6 +423,7 @@ const setupProgressListeners = (
                 title: interrupt.title ?? 'Critical error occurred',
                 buttons: [...options.map((o) => o.title), 'Exit'],
                 defaultId: options.length,
+                cancelId: options.length,
                 message: interrupt.message,
             };
         } else {
@@ -431,6 +432,7 @@ const setupProgressListeners = (
                 title: interrupt.title ?? 'Critical error occurred',
                 buttons: [...options.map((o) => o.title), 'Ok'],
                 defaultId: options.length,
+                cancelId: options.length,
                 message: interrupt.message,
             };
         }
@@ -445,8 +447,12 @@ const setupProgressListeners = (
                         await shell.openExternal(action.url);
                         break;
                     }
+                    case 'run': {
+                        action.action();
+                        break;
+                    }
                     default:
-                        return assertNever(action.type);
+                        return assertNever(action);
                 }
             } catch (error) {
                 log.error(`Failed to execute action of type ${action.type}`, error);

--- a/src/main/python/integratedPython.ts
+++ b/src/main/python/integratedPython.ts
@@ -57,6 +57,12 @@ const extractPython = async (
     );
 };
 
+export const getIntegratedPythonExecutable = (directory: string): string => {
+    const platform = getPlatform();
+    const { path: relativePath } = downloads[platform];
+    return path.resolve(path.join(directory, relativePath));
+};
+
 /**
  * Retrieves the path of the python executable of the integrated python installation.
  *
@@ -67,9 +73,9 @@ export const getIntegratedPython = async (
     onProgress: (percentage: number, stage: 'download' | 'extract') => void
 ): Promise<PythonInfo> => {
     const platform = getPlatform();
-    const { url, version, path: relativePath } = downloads[platform];
+    const { url, version } = downloads[platform];
 
-    const pythonPath = path.resolve(path.join(directory, relativePath));
+    const pythonPath = getIntegratedPythonExecutable(directory);
     const pythonBinExists = await checkFileExists(pythonPath);
 
     if (pythonBinExists) {


### PR DESCRIPTION
Fixes #2244
Related to #926.

This improves the Python setup process in a few ways:

1. Fixed a bug where the System Python Path was `JSON.parse`d. This was a remnant of the old settings system and will always fail now. The system python path will now work correctly.
2. When we fail to find any system python, we fall back to our integrated python. This was bugged because we passed the function of checking python executable the *directory* the integrated python executable was in and not the path to the python executable.
3. I added a dialog for when installing integrated Python fails. This allows the user to easily retry the installation (e.g. after they ensure their internet connection is stable) or switch to their system python (assuming it is in PATH). This should make troubleshooting a lot more user-friendly.
    ![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/cf1c3c54-4f62-490b-99b4-9225149f8aa7)
