### PR TITLE
Ignore worker exit code when the worker was closed intentionally

### DIFF
--- a/backend/src/server_process_helper.py
+++ b/backend/src/server_process_helper.py
@@ -105,6 +105,7 @@ class _WorkerProcess:
         cause = "stop event" if stopped else "stdout ending"
         logger.info(f"Stopped reading worker stdout due to {cause}")
 
+        stopped = self._stop_event.is_set()
         if not stopped:
             # the worker ended on its own, so it likely crashed
             returncode = p.wait()


### PR DESCRIPTION
We don't need to log the exit code 1 of the worker when we were the ones that killed it.