### PR TITLE
Fixed Saving images with OpenCV

### DIFF
--- a/backend/src/nodes/impl/image_utils.py
+++ b/backend/src/nodes/impl/image_utils.py
@@ -2,9 +2,6 @@ from __future__ import annotations
 
 import itertools
 import math
-import os
-import random
-import string
 from enum import Enum
 from pathlib import Path
 
@@ -335,21 +332,14 @@ def cv_save_image(path: Path | str, img: np.ndarray, params: list[int]):
     A light wrapper around `cv2.imwrite` to support non-ASCII paths.
     """
 
-    # Write image with opencv if path is ascii, since imwrite doesn't support unicode
-    # This saves us from having to keep the image buffer in memory, if possible
-    if str(path).isascii():
-        cv2.imwrite(str(path), img, params)
-    else:
-        dirname, _, extension = split_file_path(path)
-        try:
-            temp_filename = f'temp-{"".join(random.choices(string.ascii_letters, k=16))}.{extension}'
-            full_temp_path = os.path.join(dirname, temp_filename)
-            cv2.imwrite(full_temp_path, img, params)
-            os.rename(full_temp_path, path)
-        except Exception:
-            _, buf_img = cv2.imencode(f".{extension}", img, params)
-            with open(path, "wb") as outf:
-                outf.write(buf_img)  # type: ignore
+    # We can't actually use `cv2.imwrite`, because it:
+    # 1. Doesn't support non-ASCII paths
+    # 2. Silently fails without doing anything if the path is invalid
+
+    _, _, extension = split_file_path(path)
+    _, buf_img = cv2.imencode(f".{extension}", img, params)
+    with open(path, "wb") as outf:
+        outf.write(buf_img)  # type: ignore
 
 
 def cartesian_product(arrays: list[np.ndarray]) -> np.ndarray:


### PR DESCRIPTION
While working on #1612, I noticed that save images with OpenCV was broken. I fixed the following:

- Saving images with invalid ASCII file names would either silently fail (e.g. `*`) or crash the backend (e.g. `%$`). I fixed this by using the same code path for both ASCII and non-ASCII file paths.
- Overwriting images with non-ASCII file paths didn't work properly. The issue was `os.rename` doesn't work when the file already exists.

The solution for both problems is to (1) `cv2.imencode` and (2) save the buffer with regular `open`. This is simple and works correctly. The only issue is that it's a tiny bit slower for very large files, but that's a reasonable price to pay for correctness.

---

I also checked saving images with PIL and the DDS stuff. Both work correctly.