### PR TITLE
Optimize Hue & Saturation node

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/hue_and_saturation.py
+++ b/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/hue_and_saturation.py
@@ -12,8 +12,12 @@ from .. import adjustments_group
 
 def with_lightness(img: np.ndarray, lightness: float) -> np.ndarray:
     if lightness > 0:
-        return img + (1 - img) * lightness
+        assert lightness <= 1
+        res = img * (1 - lightness)
+        res += lightness
+        return res
     elif lightness < 0:
+        assert lightness >= -1
         return img * (1 + lightness)
     else:
         return img
@@ -63,7 +67,9 @@ def with_lightness(img: np.ndarray, lightness: float) -> np.ndarray:
             gradient=["#000000", "#ffffff"],
         ),
     ],
-    outputs=[ImageOutput(image_type="Input0")],
+    outputs=[
+        ImageOutput(image_type="Input0", assume_normalized=True),
+    ],
 )
 def hue_and_saturation_node(
     img: np.ndarray,
@@ -88,24 +94,32 @@ def hue_and_saturation_node(
     alpha = None
     if c > 3:
         alpha = img[:, :, 3]
+        img = img[:, :, :3]
 
-    h, l, s = cv2.split(cv2.cvtColor(img[:, :, :3], cv2.COLOR_BGR2HLS))
+    if hue != 0 or saturation != 0:
+        # Convert to HLS color space
+        h, l, s = cv2.split(cv2.cvtColor(img, cv2.COLOR_BGR2HLS))
 
-    # Adjust hue
-    if hue != 0:
-        h += hue  # type: ignore
-        h[h >= 360] -= 360  # Wrap positive overflow
-        h[h < 0] += 360  # Wrap negative overflow
+        # Adjust hue
+        if hue != 0:
+            h += hue
+            h[h >= 360] -= 360  # Wrap positive overflow
+            h[h < 0] += 360  # Wrap negative overflow
 
-    # Adjust saturation
-    if saturation != 0:
-        saturation = 1 + saturation
-        s = np.clip(s * saturation, 0, 1)  # type: ignore
+        # Adjust saturation
+        if saturation != 0:
+            factor = 1 + saturation
+            s *= factor
+            if factor > 1:
+                s = np.clip(s, 0, 1, out=s)
 
-    img = cv2.cvtColor(cv2.merge([h, l, s]), cv2.COLOR_HLS2BGR)
+        # we assume that this returns normalized values in Change Color Model,
+        # so it should be fine here as well
+        img = cv2.cvtColor(cv2.merge([h, l, s]), cv2.COLOR_HLS2BGR)
 
     # Adjust lightness
-    img = with_lightness(img, lightness)
+    if lightness != 0:
+        img = with_lightness(img, lightness)
 
     # Re-add alpha, if it exists
     if alpha is not None:


### PR DESCRIPTION
Optimizations:
- Remove normalization on output. This was entirely unnecessary.
- Optimize `with_lightness` to reuse arrays.
- Only do HSL conversion if necessary.

| Configuration    | Before | After | Note                        |
| ---------------- | ------ | ----- | --------------------------- |
| H=0 S=0 L=0      | 150ms  | 0     | Pass through is free now    |
| H=0 S=0 L=-35    | 710ms  | 90ms  |                             |
| H=0 S=0 L=-33    | 1000ms | 140ms |                             |
| H=0 S=29 L=0     | 820ms  | 510ms |                             |
| H=0 S=-39 L=0    | 740ms  | 480ms | Saved a `np.clip` over S=29 |
| H=-62 S=24 L=-18 | 1000ms | 830ms |                             |

Tested on a 8468x4320 RGB image.

<details>

Before:
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/1a095180-69b7-4c7c-ab19-5d9b5bff42a5)


After:
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/e60befc0-602b-45b1-9bd2-4db201870821)

</details>