### PR TITLE
Improve iterator ETA

### DIFF
--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -830,8 +830,6 @@ class Executor:
             remaining = max(0, length - index)
             return avg_time * remaining
 
-        logger.info(f"times {times}")
-
         await self.queue.put(
             {
                 "event": "node-progress",

--- a/src/renderer/components/node/NodeHeader.tsx
+++ b/src/renderer/components/node/NodeHeader.tsx
@@ -16,7 +16,7 @@ import { useContext } from 'use-context-selector';
 import { getKeyInfo } from '../../../common/nodes/keyInfo';
 import { Validity } from '../../../common/Validity';
 import { AlertBoxContext, AlertType } from '../../contexts/AlertBoxContext';
-import { NodeProgress } from '../../contexts/ExecutionContext';
+import { ExecutionStatusContext, NodeProgress } from '../../contexts/ExecutionContext';
 import { FakeNodeContext } from '../../contexts/FakeExampleContext';
 import { interpolateColor } from '../../helpers/colorTools';
 import { NodeState } from '../../helpers/nodeState';
@@ -30,9 +30,31 @@ interface IteratorProcessProps {
 }
 
 const IteratorProcess = memo(({ nodeProgress, progressColor }: IteratorProcessProps) => {
+    const { paused } = useContext(ExecutionStatusContext);
+
     const { progress, eta, index, total } = nodeProgress;
     const etaDate = new Date();
     etaDate.setSeconds(etaDate.getSeconds() + eta);
+
+    let etaText;
+    if (paused) {
+        etaText = 'Paused';
+    } else if (progress >= 1) {
+        etaText = 'Finished';
+    } else {
+        etaText = (
+            <>
+                ETA:{' '}
+                <ReactTimeAgo
+                    future
+                    date={etaDate}
+                    locale="en-US"
+                    timeStyle="round"
+                    tooltip={false}
+                />
+            </>
+        );
+    }
 
     return (
         <Box
@@ -55,18 +77,7 @@ const IteratorProcess = memo(({ nodeProgress, progressColor }: IteratorProcessPr
                         fontSize="sm"
                         fontWeight="medium"
                     >
-                        ETA:{' '}
-                        {progress === 1 ? (
-                            'Finished'
-                        ) : (
-                            <ReactTimeAgo
-                                future
-                                date={etaDate}
-                                locale="en-US"
-                                timeStyle="round"
-                                tooltip={false}
-                            />
-                        )}
+                        {etaText}
                     </Text>
                 </HStack>
             </Center>


### PR DESCRIPTION


Changes:
- Use a mix between an exponential and harmonic falloff to calculate a weighted average that favors recent samples. I also capped it at 100 samples to (1) ignore very old samples and (2) keep the computational overhead to a minimum. 
   Fixes #2324
- Use `time.monotonic()` to measure time.
- Move logic for keeping track of time into `_IterationTimer` class.
- Account for pauses when measuring time.
- Don't let ETA continue to count down and show "Paused" instead when the execution is paused.
    ![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/a3dfcd67-3f06-4ad0-a47b-7a915e33159a)
