### PR TITLE
Move Save-Image-specific input to Save Image node

### DIFF
--- a/backend/src/nodes/properties/inputs/generic_inputs.py
+++ b/backend/src/nodes/properties/inputs/generic_inputs.py
@@ -16,7 +16,6 @@ from api import BaseInput, InputConversion, group
 from ...condition import Condition, ConditionJson
 from ...impl.blend import BlendMode
 from ...impl.color.color import Color
-from ...impl.dds.format import DDSFormat
 from ...impl.image_utils import FillColor
 from ...impl.upscale.auto_split_tiles import TileSize
 from ...utils.format import format_color_with_channels
@@ -536,59 +535,6 @@ def TileSizeDropdown(
         options=options,
         associated_type=TileSize,
         default_value=default,
-    )
-
-
-SUPPORTED_DDS_FORMATS: list[tuple[DDSFormat, str]] = [
-    ("BC1_UNORM_SRGB", "BC1 (4bpp, sRGB, 1-bit Alpha)"),
-    ("BC1_UNORM", "BC1 (4bpp, Linear, 1-bit Alpha)"),
-    ("BC3_UNORM_SRGB", "BC3 (8bpp, sRGB, 8-bit Alpha)"),
-    ("BC3_UNORM", "BC3 (8bpp, Linear, 8-bit Alpha)"),
-    ("BC4_UNORM", "BC4 (4bpp, Grayscale)"),
-    ("BC5_UNORM", "BC5 (8bpp, Unsigned, 2-channel normal)"),
-    ("BC5_SNORM", "BC5 (8bpp, Signed, 2-channel normal)"),
-    ("BC7_UNORM_SRGB", "BC7 (8bpp, sRGB, 8-bit Alpha)"),
-    ("BC7_UNORM", "BC7 (8bpp, Linear, 8-bit Alpha)"),
-    ("DXT1", "DXT1 (4bpp, Linear, 1-bit Alpha)"),
-    ("DXT3", "DXT3 (8bpp, Linear, 4-bit Alpha)"),
-    ("DXT5", "DXT5 (8bpp, Linear, 8-bit Alpha)"),
-    ("R8G8B8A8_UNORM_SRGB", "RGBA (32bpp, sRGB, 8-bit Alpha)"),
-    ("R8G8B8A8_UNORM", "RGBA (32bpp, Linear, 8-bit Alpha)"),
-    ("B8G8R8A8_UNORM_SRGB", "BGRA (32bpp, sRGB, 8-bit Alpha)"),
-    ("B8G8R8A8_UNORM", "BGRA (32bpp, Linear, 8-bit Alpha)"),
-    ("B5G5R5A1_UNORM", "BGRA (16bpp, Linear, 1-bit Alpha)"),
-    ("B5G6R5_UNORM", "BGR (16bpp, Linear)"),
-    ("B8G8R8X8_UNORM_SRGB", "BGRX (32bpp, sRGB)"),
-    ("B8G8R8X8_UNORM", "BGRX (32bpp, Linear)"),
-    ("R8G8_UNORM", "RG (16bpp, Linear)"),
-    ("R8_UNORM", "R (8bpp, Linear)"),
-]
-
-
-def DdsFormatDropdown() -> DropDownInput:
-    return DropDownInput(
-        input_type="DdsFormat",
-        label="DDS Format",
-        options=[{"option": title, "value": f} for f, title in SUPPORTED_DDS_FORMATS],
-        associated_type=DDSFormat,
-        groups=[
-            DropDownGroup("Compressed", start_at="BC1_UNORM_SRGB"),
-            DropDownGroup("Uncompressed", start_at="R8G8B8A8_UNORM_SRGB"),
-            DropDownGroup("Legacy Compressed", start_at="DXT1"),
-        ],
-    )
-
-
-def DdsMipMapsDropdown() -> DropDownInput:
-    return DropDownInput(
-        input_type="DdsMipMaps",
-        label="Generate Mip Maps",
-        preferred_style="checkbox",
-        options=[
-            # these are not boolean values, see dds.py for more info
-            {"option": "Yes", "value": 0},
-            {"option": "No", "value": 1},
-        ],
     )
 
 


### PR DESCRIPTION
There was no reason for those inputs to be in `generic_inputs.py`.