### PR TITLE
Disallow NodeJS imports and globals from src/common and src/renderer using ESLint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -142,6 +142,27 @@ module.exports = {
                 'regexp/prefer-d': ['warn', { insideCharacterClass: 'ignore' }],
             },
         },
+        {
+            files: ['src/common/**/*.ts', 'src/renderer/**/*.ts', 'src/renderer/**/*.tsx'],
+            env: {
+                browser: true,
+                node: false,
+            },
+            rules: {
+                'no-restricted-globals': [
+                    'error',
+                    'process',
+                    'global',
+                    '__dirname',
+                    '__filename',
+                    'require',
+                    'module',
+                    'exports',
+                    'setImmediate',
+                ],
+                'import/no-nodejs-modules': ['error', { allow: ['path'] }],
+            },
+        },
     ],
 
     ignorePatterns: ['**/antlr4/*.js'],

--- a/src/common/env.ts
+++ b/src/common/env.ts
@@ -1,1 +1,0 @@
-export const isRenderer = typeof process === 'undefined' || process.type === 'renderer';

--- a/src/common/safeIpc.ts
+++ b/src/common/safeIpc.ts
@@ -1,10 +1,12 @@
-import { MakeDirectoryOptions } from 'fs';
-import { Mode, ObjectEncodingOptions, OpenMode, PathLike } from 'original-fs';
 import { FileOpenResult, FileSaveResult, PythonInfo, Version } from './common-types';
 import { ChainnerSettings } from './settings/settings';
 import { Progress } from './ui/progress';
 import type { ParsedSaveData, SaveData } from '../main/SaveFile';
+// eslint-disable-next-line import/no-nodejs-modules
 import type { FileFilter, OpenDialogReturnValue } from 'electron/common';
+// eslint-disable-next-line import/no-nodejs-modules
+import type { MakeDirectoryOptions } from 'fs';
+import type { Mode, ObjectEncodingOptions, OpenMode, PathLike } from 'original-fs';
 
 interface ChannelInfo<ReturnType, Args extends unknown[] = []> {
     returnType: ReturnType;
@@ -96,7 +98,7 @@ export interface InvokeChannels {
     'clipboard-availableFormats': ChannelInfo<string[]>;
     'clipboard-readHTML': ChannelInfo<string>;
     'clipboard-readRTF': ChannelInfo<string>;
-    'clipboard-readImage': ChannelInfo<Electron.NativeImage>;
+    'clipboard-readImage-and-store': ChannelInfo<string>;
     'clipboard-writeImage': ChannelInfo<void, [image: Electron.NativeImage]>;
     'clipboard-writeImageFromURL': ChannelInfo<void, [url: string]>;
 }

--- a/src/main/gui/main-window.ts
+++ b/src/main/gui/main-window.ts
@@ -9,7 +9,9 @@ import {
 } from 'electron/main';
 import EventSource from 'eventsource';
 import fs, { constants } from 'fs/promises';
+import os from 'os';
 import path from 'path';
+import { v4 as uuid4 } from 'uuid';
 import { BackendEventMap } from '../../common/Backend';
 import { Version } from '../../common/common-types';
 import { log } from '../../common/log';
@@ -239,7 +241,13 @@ const registerEventHandlerPreSetup = (
     ipcMain.handle('clipboard-availableFormats', () => clipboard.availableFormats());
     ipcMain.handle('clipboard-readHTML', () => clipboard.readHTML());
     ipcMain.handle('clipboard-readRTF', () => clipboard.readRTF());
-    ipcMain.handle('clipboard-readImage', () => clipboard.readImage());
+    ipcMain.handle('clipboard-readImage-and-store', async () => {
+        const clipboardData = clipboard.readImage();
+        const imgData = clipboardData.toPNG();
+        const imgPath = path.join(os.tmpdir(), `chaiNNer-clipboard-${uuid4()}.png`);
+        await fs.writeFile(imgPath, imgData);
+        return imgPath;
+    });
     ipcMain.handle('clipboard-writeImage', (event, image) => clipboard.writeImage(image));
     ipcMain.handle('clipboard-writeImageFromURL', (event, url) => {
         const image = nativeImage.createFromDataURL(url);

--- a/src/renderer/helpers/copyAndPaste.ts
+++ b/src/renderer/helpers/copyAndPaste.ts
@@ -1,7 +1,4 @@
-import os from 'os';
-import path from 'path';
 import { Edge, Node, Project } from 'reactflow';
-import { v4 as uuid4 } from 'uuid';
 import { EdgeData, InputId, NodeData, SchemaId } from '../../common/common-types';
 import { log } from '../../common/log';
 import { createUniqueId, deriveUniqueId } from '../../common/util';
@@ -110,44 +107,32 @@ export const pasteFromClipboard = async (
                 case 'image/tiff':
                 case 'image/png': {
                     ipcRenderer
-                        .invoke('clipboard-readImage')
-                        .then((clipboardData) => {
-                            const imgData = clipboardData.toPNG();
-                            const imgPath = path.join(
-                                os.tmpdir(),
-                                `chaiNNer-clipboard-${uuid4()}.png`
-                            );
-                            ipcRenderer
-                                .invoke('fs-write-file', imgPath, imgData)
-                                .then(() => {
-                                    log.debug('Clipboard image', imgPath);
-                                    let positionX = 0;
-                                    let positionY = 0;
-                                    if (reactFlowWrapper.current) {
-                                        const { height, width, x, y } =
-                                            reactFlowWrapper.current.getBoundingClientRect();
-                                        positionX = (width + x) / 2;
-                                        positionY = (height + y) / 2;
-                                    }
-                                    createNode({
-                                        position: screenToFlowPosition({
-                                            x: positionX,
-                                            y: positionY,
-                                        }),
-                                        data: {
-                                            schemaId: 'chainner:image:load' as SchemaId,
-                                            inputData: {
-                                                [0 as InputId]: imgPath,
-                                            },
-                                        },
-                                    });
-                                })
-                                .catch((e) => {
-                                    log.error('Failed to write clipboard image', e);
-                                });
+                        .invoke('clipboard-readImage-and-store')
+                        .then((imgPath) => {
+                            log.debug('Clipboard image', imgPath);
+                            let positionX = 0;
+                            let positionY = 0;
+                            if (reactFlowWrapper.current) {
+                                const { height, width, x, y } =
+                                    reactFlowWrapper.current.getBoundingClientRect();
+                                positionX = (width + x) / 2;
+                                positionY = (height + y) / 2;
+                            }
+                            createNode({
+                                position: screenToFlowPosition({
+                                    x: positionX,
+                                    y: positionY,
+                                }),
+                                data: {
+                                    schemaId: 'chainner:image:load' as SchemaId,
+                                    inputData: {
+                                        [0 as InputId]: imgPath,
+                                    },
+                                },
+                            });
                         })
                         .catch((e) => {
-                            log.error('Failed to read clipboard image', e);
+                            log.error('Failed to read clipboard image and save to disk', e);
                         });
                     break;
                 }

--- a/src/renderer/hooks/useIpcRendererListener.ts
+++ b/src/renderer/hooks/useIpcRendererListener.ts
@@ -1,7 +1,8 @@
-import { IpcRendererEvent } from 'electron/renderer';
 import { useEffect } from 'react';
 import { ChannelArgs, SendChannels } from '../../common/safeIpc';
 import { ipcRenderer } from '../safeIpc';
+// eslint-disable-next-line import/no-nodejs-modules
+import type { IpcRendererEvent } from 'electron/renderer';
 
 export const useIpcRendererListener = <C extends keyof SendChannels>(
     channel: C,

--- a/src/renderer/safeIpc.ts
+++ b/src/renderer/safeIpc.ts
@@ -1,5 +1,6 @@
-import { IpcRendererEvent } from 'electron/renderer';
 import { ChannelArgs, ChannelReturn, InvokeChannels, SendChannels } from '../common/safeIpc';
+// eslint-disable-next-line import/no-nodejs-modules
+import type { IpcRendererEvent } from 'electron/renderer';
 
 interface SafeIpcRenderer extends Electron.IpcRenderer {
     invoke<C extends keyof InvokeChannels>(


### PR DESCRIPTION
I used `import/no-nodejs-modules` to disallow NodeJS modules (except for `path`) and `no-restricted-globals` to disallow NodeJS globals.

Changes:
- A few imports to disallowed modules were type-only, so I just allowed them with `eslint-disable`.
- Pasting images from clipboard happens in 2 step: (1) get the image from clipboard and (2) save the image to disk in temp folder. I combined both steps into one ICP call, so the renderer doesn't need to know the system's temp directory anymore.
- `isRenderer` was unused, so I removed it.