### PR TITLE
Optimize Clamp node

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/clamp.py
+++ b/backend/src/packages/chaiNNer_standard/image_adjustment/adjustments/clamp.py
@@ -37,8 +37,11 @@ from .. import adjustments_group
     outputs=[
         ImageOutput(
             image_type="Input0",
+            assume_normalized=True,
         )
     ],
 )
 def clamp_node(img: np.ndarray, minimum: float, maximum: float) -> np.ndarray:
+    if minimum <= 0 and maximum >= 1:
+        return img
     return np.clip(img, minimum, maximum)


### PR DESCRIPTION
Since the minimum and maximum and numbers 0-1, we know that the output image is always a normalized image. So the `ImageOutput` doesn't need to normalize again.

While this is a pretty minor optimization, since the node just does an `np.clip`, the node is now technically 2x faster.