### PR TITLE
Optimized Box Blur for different x-y radii

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image_filter/blur/box_blur.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/blur/box_blur.py
@@ -83,17 +83,15 @@ def box_blur_node(
     radius_x: float,
     radius_y: float,
 ) -> np.ndarray:
-    if radius_x == 0 or radius_y == 0:
+    if radius_x == 0 and radius_y == 0:
         return img
 
-    use_optimized_int = (
-        # both radii are integers
-        int(radius_x) == radius_x
-        and int(radius_y) == radius_y
-        # you can't tell the difference between a float and an integer when the radius is large enough
-        or radius_x > 200
-        and radius_y > 200
-    )
+    # you can't tell the difference between a float and an integer when the radius is large enough
+    radius_x = round(radius_x) if radius_x > 200 else radius_x
+    radius_y = round(radius_y) if radius_y > 200 else radius_y
+
+    # both radii are integers
+    use_optimized_int = int(radius_x) == radius_x and int(radius_y) == radius_y
 
     if use_optimized_int:
         # we can use an optimized box blur implementation
@@ -102,6 +100,20 @@ def box_blur_node(
         return cv2.blur(
             img, (radius_x * 2 + 1, radius_y * 2 + 1), borderType=cv2.BORDER_REFLECT_101
         )
+
+    # cv2.blur is so much faster than the other methods, that it's worth manually separating the kernel.
+    # the idea here is that we blur with cv2.blur in x or y if we can
+    threshold = 15
+    if radius_x >= threshold and int(radius_x) == radius_x:
+        img = cv2.blur(
+            img, (int(radius_x) * 2 + 1, 1), borderType=cv2.BORDER_REFLECT_101
+        )
+        radius_x = 1
+    if radius_y >= threshold and int(radius_y) == radius_y:
+        img = cv2.blur(
+            img, (1, int(radius_y) * 2 + 1), borderType=cv2.BORDER_REFLECT_101
+        )
+        radius_y = 1
 
     # Separable filter is faster for relatively small kernels, but after a certain size it becomes
     # slower than filter2D's DFT implementation. The exact cutoff depends on the hardware.


### PR DESCRIPTION
Changes:
- A box blur only has no effect is the both radii are 0, not when just one 1. I fixed this, which allows users to blur solely in the X or Y direction now.
- Round large radii to integer independently of each other.
- Use very fast `cv2.blur` if possible when separating kernel.

These optimizations make certain edges cases more than 10x faster.

Before:
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/456b7a52-9404-413a-bfcf-2e58601371ea)

After:
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/8be055a5-9b5b-4e36-9dc9-4696a22dda4d)
