### PR TITLE
Improved validation for `goIntoDirectory`

### DIFF
--- a/src/common/types/chainner-builtin.ts
+++ b/src/common/types/chainner-builtin.ts
@@ -416,17 +416,20 @@ export const getParentDirectory = wrapBinary<StringPrimitive, Int, StringPrimiti
 
 // eslint-disable-next-line no-control-regex
 const INVALID_PATH_CHARS = /[<>:"|?*\x00-\x1F]/;
-const goIntoDirectoryImpl = (basePath: string, relPath: string): string | Error => {
+const validateRelPath = (relPath: string): string | undefined => {
     const isAbsolute = /^[/\\]/.test(relPath) || path.isAbsolute(relPath);
     if (isAbsolute) {
-        return new Error('Absolute paths are not allowed as folders.');
+        return 'Absolute paths are not allowed as folders.';
     }
 
     const invalid = INVALID_PATH_CHARS.exec(relPath);
     if (invalid) {
-        return new Error(`Invalid character '${invalid[0]}' in folder name.`);
+        return `Invalid character '${invalid[0]}' in folder name.`;
     }
 
+    return undefined;
+};
+const goIntoDirectoryImpl = (basePath: string, relPath: string): string => {
     const joined = path.join(basePath, relPath);
     return path.resolve(joined);
 };
@@ -438,20 +441,24 @@ export const goIntoDirectory = wrapScopedBinary(
     ): Arg<StringPrimitive | StructInstanceType> => {
         const errorDesc = getStructDescriptor(scope, 'Error');
 
-        if (basePath.type === 'literal' && relPath.type === 'literal') {
-            try {
-                const result = goIntoDirectoryImpl(basePath.value, relPath.value);
-                if (typeof result === 'string') {
+        try {
+            if (relPath.type === 'literal') {
+                const error = validateRelPath(relPath.value);
+                if (error) {
+                    return createInstance(errorDesc, {
+                        message: literal(error),
+                    });
+                }
+
+                if (basePath.type === 'literal') {
+                    const result = goIntoDirectoryImpl(basePath.value, relPath.value);
                     return literal(result);
                 }
-                return createInstance(errorDesc, {
-                    message: literal(result.message),
-                });
-            } catch (e) {
-                return createInstance(errorDesc, {
-                    message: literal(String(e)),
-                });
             }
+        } catch (e) {
+            return createInstance(errorDesc, {
+                message: literal(String(e)),
+            });
         }
 
         return union(StringType.instance, errorDesc.default);


### PR DESCRIPTION
The folder name validation now happens even if we don't know the directory.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/12a3f81c-6c6e-4d63-9cd6-ce93681cc106)
