### PR TITLE
Enable strict method overrides

### DIFF
--- a/backend/src/api/input.py
+++ b/backend/src/api/input.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Any, Literal, Optional, TypedDict, Union
+from typing import Any, Generic, Literal, Mapping, Optional, TypedDict, TypeVar, Union
 
 import navi
 
@@ -74,8 +74,10 @@ class UnknownErrorValue(TypedDict):
 
 ErrorValue = Union[LiteralErrorValue, FormattedErrorValue, UnknownErrorValue]
 
+T = TypeVar("T")
 
-class BaseInput:
+
+class BaseInput(Generic[T]):
     def __init__(
         self,
         input_type: navi.ExpressionJson,
@@ -103,12 +105,12 @@ class BaseInput:
         self.should_suggest: bool = False
 
     # This is the method that should be created by each input
-    def enforce(self, value: object):
+    def enforce(self, value: object) -> T:
         """Enforce the input type"""
-        return value
+        return value  # type: ignore
 
     # This is the method that should be called by the processing code
-    def enforce_(self, value: object | None):
+    def enforce_(self, value: object | None) -> T | None:
         if self.optional and value is None:
             return None
         assert value is not None, (
@@ -138,7 +140,7 @@ class BaseInput:
             "typeModule": type(value).__module__,
         }
 
-    def to_dict(self):
+    def to_dict(self) -> Mapping[str, Any]:
         actual_type = [self.input_type, "null"] if self.optional else self.input_type
         return {
             "id": self.id,

--- a/backend/src/api/output.py
+++ b/backend/src/api/output.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any, Generic, Literal, Mapping, TypeVar
 
 import navi
 
-from .types import OutputId
+from .types import InputId, OutputId
 
 OutputKind = Literal["image", "large-image", "tagged", "generic"]
+BroadcastData = Mapping[str, object]
+
+T = TypeVar("T")
 
 
-class BaseOutput:
+class BaseOutput(Generic[T]):
     def __init__(
         self,
         output_type: navi.ExpressionJson,
@@ -24,6 +27,7 @@ class BaseOutput:
         self.never_reason: str | None = None
         self.kind: OutputKind = kind
         self.has_handle: bool = has_handle
+        self.pass_through_of: InputId | None = None
 
         self.associated_type: Any = associated_type
 
@@ -39,6 +43,7 @@ class BaseOutput:
             "neverReason": self.never_reason,
             "kind": self.kind,
             "hasHandle": self.has_handle,
+            "passThroughOf": self.pass_through_of,
             "description": self.description,
             "suggest": self.should_suggest,
         }
@@ -59,12 +64,16 @@ class BaseOutput:
         self.should_suggest = True
         return self
 
-    def get_broadcast_data(self, _value: object):
+    def as_pass_through_of(self, input_id: InputId | int):
+        self.pass_through_of = InputId(input_id)
+        return self
+
+    def get_broadcast_data(self, _value: T) -> BroadcastData | None:
         return None
 
-    def get_broadcast_type(self, _value: object) -> navi.ExpressionJson | None:
+    def get_broadcast_type(self, _value: T) -> navi.ExpressionJson | None:
         return None
 
-    def enforce(self, value: object) -> object:
+    def enforce(self, value: object) -> T:
         assert value is not None
-        return value
+        return value  # type: ignore

--- a/backend/src/nodes/impl/pytorch/pix_transform/auto_split.py
+++ b/backend/src/nodes/impl/pytorch/pix_transform/auto_split.py
@@ -22,7 +22,7 @@ class _PixTiler(Tiler):
     def allow_smaller_tile_size(self) -> bool:
         return False
 
-    def starting_tile_size(self, width: int, height: int, _channels: int) -> Size:
+    def starting_tile_size(self, width: int, height: int, channels: int) -> Size:
         square = min(width, height, self.max_tile_size)
         return square, square
 

--- a/backend/src/nodes/impl/rembg/session_base.py
+++ b/backend/src/nodes/impl/rembg/session_base.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
+
 import numpy as np
 import onnxruntime as ort
 
 from nodes.impl.resize import ResizeFilter, resize
 
 
-class BaseSession:
+class BaseSession(ABC):
     def __init__(
         self,
         inner_session: ort.InferenceSession,
@@ -33,5 +35,6 @@ class BaseSession:
 
         return {model_input_name: np.expand_dims(tmp_img, 0).astype(np.float32)}
 
-    def predict(self, _: np.ndarray) -> list[np.ndarray]:
-        raise NotImplementedError
+    @abstractmethod
+    def predict(self, img: np.ndarray) -> list[np.ndarray]:
+        pass

--- a/backend/src/nodes/impl/upscale/tiler.py
+++ b/backend/src/nodes/impl/upscale/tiler.py
@@ -31,12 +31,12 @@ class NoTiling(Tiler):
     def allow_smaller_tile_size(self) -> bool:
         return True
 
-    def starting_tile_size(self, width: int, height: int, _channels: int) -> Size:
+    def starting_tile_size(self, width: int, height: int, channels: int) -> Size:
         size = max(width, height)
         # we prefer square tiles
         return size, size
 
-    def split(self, _: Size) -> Size:
+    def split(self, tile_size: Size) -> Size:
         raise ValueError("Image cannot be upscale with No Tiling mode.")
 
 
@@ -47,7 +47,7 @@ class MaxTileSize(Tiler):
     def allow_smaller_tile_size(self) -> bool:
         return True
 
-    def starting_tile_size(self, width: int, height: int, _channels: int) -> Size:
+    def starting_tile_size(self, width: int, height: int, channels: int) -> Size:
         # Tile size a lot larger than the image don't make sense.
         # So we use the minimum of the image dimensions and the given tile size.
         max_tile_size = max(width + 10, height + 10)
@@ -62,10 +62,10 @@ class ExactTileSize(Tiler):
     def allow_smaller_tile_size(self) -> bool:
         return False
 
-    def starting_tile_size(self, _width: int, _height: int, _channels: int) -> Size:
+    def starting_tile_size(self, width: int, height: int, channels: int) -> Size:
         return self.exact_size
 
-    def split(self, _tile_size: Size) -> Size:
+    def split(self, tile_size: Size) -> Size:
         raise ValueError(
             f"Splits are not supported for exact size ({self.exact_size[0]}x{self.exact_size[1]}px) splitting."
             f" This typically means that your machine does not have enough VRAM to run the current model."

--- a/backend/src/nodes/properties/outputs/file_outputs.py
+++ b/backend/src/nodes/properties/outputs/file_outputs.py
@@ -6,7 +6,7 @@ import navi
 from api import BaseOutput
 
 
-class DirectoryOutput(BaseOutput):
+class DirectoryOutput(BaseOutput[Path]):
     """Output for saving to a directory"""
 
     def __init__(

--- a/backend/src/nodes/properties/outputs/generic_outputs.py
+++ b/backend/src/nodes/properties/outputs/generic_outputs.py
@@ -10,7 +10,7 @@ from ...utils.format import format_color_with_channels
 from ...utils.seed import Seed
 
 
-class NumberOutput(BaseOutput):
+class NumberOutput(BaseOutput[Union[int, float]]):
     def __init__(
         self,
         label: str,

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -17,6 +17,7 @@
 	"reportDuplicateImport": "warning",
 	"reportImportCycles": "error",
 	"reportIncompatibleVariableOverride": "error",
+	"reportIncompatibleMethodOverride": "error",
 	"reportOverlappingOverload": "error",
 	"reportPrivateImportUsage": "error",
 	"reportUninitializedInstanceVariable": "error",


### PR DESCRIPTION
I plan to make some changes to the `enforce` method of outputs soon, and I need the type checker to have my back for this change. So this PR enables the "reportIncompatibleMethodOverride" option to make pyright check method overrrides.