### PR TITLE
Add Skip existing files option for Save Image & lazy inputs

### DIFF
--- a/backend/src/api/__init__.py
+++ b/backend/src/api/__init__.py
@@ -1,6 +1,7 @@
 from .api import *
 from .group import *
 from .input import *
+from .lazy import *
 from .node_context import *
 from .node_data import *
 from .output import *

--- a/backend/src/api/input.py
+++ b/backend/src/api/input.py
@@ -66,13 +66,19 @@ class FormattedErrorValue(TypedDict):
     formatString: str
 
 
+class PendingErrorValue(TypedDict):
+    type: Literal["pending"]
+
+
 class UnknownErrorValue(TypedDict):
     type: Literal["unknown"]
     typeName: str
     typeModule: str
 
 
-ErrorValue = Union[LiteralErrorValue, FormattedErrorValue, UnknownErrorValue]
+ErrorValue = Union[
+    LiteralErrorValue, FormattedErrorValue, UnknownErrorValue, PendingErrorValue
+]
 
 T = TypeVar("T")
 
@@ -98,6 +104,7 @@ class BaseInput(Generic[T]):
         self.associated_type: Any = associated_type
 
         self.fused: IOFusion | None = None
+        self.lazy: bool = False
 
         # Optional documentation
         self.description: str | None = None
@@ -180,6 +187,10 @@ class BaseInput(Generic[T]):
         if self.associated_type is not None:
             associated_type = self.associated_type
             self.associated_type = Optional[associated_type]
+        return self
+
+    def make_lazy(self):
+        self.lazy = True
         return self
 
     def make_fused(self, with_output: OutputId | int = 0):

--- a/backend/src/api/lazy.py
+++ b/backend/src/api/lazy.py
@@ -7,15 +7,53 @@ from typing import Any, Callable, Coroutine, Generic, TypeVar
 T = TypeVar("T")
 
 
+class _Result(Generic[T]):
+    """Either an okay value of T or an error value."""
+
+    def __init__(self, value: T | None, error: Exception | None):
+        self.value = value
+        self.error = error
+
+    def result(self) -> T:
+        """Returns the value if it is okay, otherwise raises the error."""
+        if self.error is not None:
+            raise self.error
+        return self.value  # type: ignore
+
+    @property
+    def is_ok(self) -> bool:
+        """Returns True if the result is okay, otherwise False."""
+        return self.error is None
+
+    @staticmethod
+    def ok(value: T) -> _Result[T]:
+        return _Result(value, None)
+
+    @staticmethod
+    def err(error: Exception) -> _Result[T]:
+        return _Result(None, error)
+
+
+def _to_result(fn: Callable[[], T]) -> Callable[[], _Result[T]]:
+    def wrapper() -> _Result[T]:
+        try:
+            return _Result.ok(fn())
+        except Exception as e:
+            return _Result.err(e)
+
+    return wrapper
+
+
 class Lazy(Generic[T]):
     def __init__(self, factory: Callable[[], T]):
-        self._factory = factory
-        self._value: tuple[T] | None = None
+        self._factory = _to_result(factory)
+        self._value: _Result[T] | None = None
+        self._evaluating = False
 
     @staticmethod
     def ready(value: T) -> Lazy[T]:
         lazy = Lazy(lambda: value)
-        lazy._value = (value,)  # noqa: SLF001
+        lazy._value = _Result.ok(value)  # noqa: SLF001
         return lazy
 
     @staticmethod
@@ -40,7 +78,24 @@ class Lazy(Generic[T]):
         return self._value is not None
 
     @property
+    def has_error(self) -> bool:
+        """Returns True if the value has been computed and it errored instead, otherwise False."""
+        return self._value is not None
+
+    @property
     def value(self) -> T:
         if self._value is None:
-            self._value = (self._factory(),)
-        return self._value[0]
+            if self._evaluating:
+                # wait for the value to be computed
+                while self._value is None and self._evaluating:
+                    time.sleep(0.001)
+                if self._value is None:
+                    raise ValueError("Value was not computed")
+            else:
+                self._evaluating = True
+                try:
+                    self._value = self._factory()
+                finally:
+                    self._evaluating = False
+
+        return self._value.result()

--- a/backend/src/api/lazy.py
+++ b/backend/src/api/lazy.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import time
+from asyncio import AbstractEventLoop
+from typing import Any, Callable, Coroutine, Generic, TypeVar
+
+T = TypeVar("T")
+
+
+class Lazy(Generic[T]):
+    def __init__(self, factory: Callable[[], T]):
+        self._factory = factory
+        self._value: tuple[T] | None = None
+
+    @staticmethod
+    def ready(value: T) -> Lazy[T]:
+        lazy = Lazy(lambda: value)
+        lazy._value = (value,)  # noqa: SLF001
+        return lazy
+
+    @staticmethod
+    def from_coroutine(
+        coroutine: Coroutine[Any, Any, T], loop: AbstractEventLoop
+    ) -> Lazy[T]:
+        def supplier() -> T:
+            task = loop.create_task(coroutine)
+
+            while not task.done():
+                if task.cancelled():
+                    raise ValueError("Task was cancelled")
+                time.sleep(0.001)
+
+            return task.result()
+
+        return Lazy(supplier)
+
+    @property
+    def has_value(self) -> bool:
+        """Returns True if the value has been computed, otherwise False."""
+        return self._value is not None
+
+    @property
+    def value(self) -> T:
+        if self._value is None:
+            self._value = (self._factory(),)
+        return self._value[0]

--- a/backend/src/packages/chaiNNer_standard/image/io/save_image.py
+++ b/backend/src/packages/chaiNNer_standard/image/io/save_image.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from enum import Enum
 from pathlib import Path
 from typing import Literal
@@ -10,7 +9,7 @@ import numpy as np
 from PIL import Image
 from sanic.log import logger
 
-from api import KeyInfo
+from api import KeyInfo, Lazy
 from nodes.groups import Condition, if_enum_group, if_group
 from nodes.impl.dds.format import (
     BC7_FORMATS,
@@ -159,7 +158,7 @@ def DdsMipMapsDropdown() -> DropDownInput:
     description="Save image to file at a specified directory.",
     icon="MdSave",
     inputs=[
-        ImageInput(),
+        ImageInput().make_lazy(),
         DirectoryInput(must_exist=False),
         TextInput("Subdirectory Path")
         .make_optional()
@@ -262,6 +261,11 @@ def DdsMipMapsDropdown() -> DropDownInput:
                 ),
             ),
         ),
+        BoolInput("Skip existing files", default=False)
+        .with_id(1000)
+        .with_docs(
+            "If enabled, the node will not overwrite existing files.",
+        ),
     ],
     outputs=[],
     key_info=KeyInfo.enum(4),
@@ -269,7 +273,7 @@ def DdsMipMapsDropdown() -> DropDownInput:
     limited_to_8bpc="Image will be saved with 8 bits/channel by default. Some formats support higher bit depths.",
 )
 def save_image_node(
-    img: np.ndarray,
+    lazy_image: Lazy[np.ndarray],
     base_directory: Path,
     relative_path: str | None,
     filename: str,
@@ -286,12 +290,20 @@ def save_image_node(
     dds_dithering: bool,
     dds_mipmap_levels: int,
     dds_separate_alpha: bool,
+    skip_existing_files: bool,
 ) -> None:
     full_path = get_full_path(base_directory, relative_path, filename, image_format)
-    logger.debug(f"Writing image to path: {full_path}")
 
-    # Create directory if it doesn't exist
-    os.makedirs(os.path.dirname(full_path), exist_ok=True)
+    if full_path.exists():
+        if skip_existing_files:
+            logger.debug(f"Skipping existing file: {full_path}")
+            return
+    else:
+        # Create directory if it doesn't exist
+        full_path.parent.mkdir(parents=True, exist_ok=True)
+
+    logger.debug(f"Writing image to path: {full_path}")
+    img = lazy_image.value
 
     # DDS files are handled separately
     if image_format == ImageFormat.DDS:

--- a/src/common/Backend.ts
+++ b/src/common/Backend.ts
@@ -35,10 +35,14 @@ export interface BackendUnknownErrorValue {
     typeName: string;
     typeModule: string;
 }
+export interface BackendPendingErrorValue {
+    type: 'pending';
+}
 export type BackendErrorValue =
     | BackendLiteralErrorValue
     | BackendFormattedErrorValue
-    | BackendUnknownErrorValue;
+    | BackendUnknownErrorValue
+    | BackendPendingErrorValue;
 
 export interface BackendExceptionSource {
     nodeId: string;

--- a/src/common/formatExecutionErrorMessage.ts
+++ b/src/common/formatExecutionErrorMessage.ts
@@ -27,6 +27,8 @@ export const formatExecutionErrorMessage = (
             valueStr = inputValue.formatString;
         } else if (inputValue.type === 'unknown') {
             valueStr = `Value of type '${inputValue.typeModule}.${inputValue.typeName}'`;
+        } else if (inputValue.type === 'pending') {
+            valueStr = `Pending. The value hasn't been computed.`;
         } else {
             const { value } = inputValue;
 


### PR DESCRIPTION
Fixes #2807.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/a4141107-667c-459a-92dc-36ede1898272)

This PR adds lazy inputs and uses them to add a "Skip existing files" to Save Image. Lazy inputs work with the `Lazy` type which represent a lazy infallible computation. (While `Lazy` of course handles errors correctly, its users are supposed to assume errors don't happen/pass them up the stack.) This abstraction makes everything pretty easy to implement.

One bug that I haven't addressed yet is that lazy inputs mess with node timing. Since the time it takes to evaluate a lazy input currently counts towards both the node being lazily executed and the node evaluating the lazy execution, the time durations of Save Image nodes are wrong. 
Not sure if this is a blocker for this PR or whether this can be fixed later.