### PR TITLE
Validate all relative paths

### DIFF
--- a/backend/src/nodes/properties/inputs/file_inputs.py
+++ b/backend/src/nodes/properties/inputs/file_inputs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Literal, Union
 
@@ -8,6 +9,7 @@ from api import BaseInput
 
 # pylint: disable=relative-beyond-top-level
 from ...impl.image_formats import get_available_image_formats
+from .generic_inputs import TextInput
 from .label import LabelStyle
 
 FileInputKind = Union[
@@ -112,51 +114,6 @@ def PthFileInput(primary_input: bool = False) -> FileInput:
     )
 
 
-class DirectoryInput(BaseInput):
-    """Input for submitting a local directory"""
-
-    def __init__(
-        self,
-        label: str = "Directory",
-        has_handle: bool = True,
-        must_exist: bool = True,
-        create: bool = False,
-        label_style: LabelStyle = "default",
-    ):
-        super().__init__("Directory", label, kind="directory", has_handle=has_handle)
-
-        self.input_adapt = """
-            match Input {
-                string as path => Directory { path: path },
-                _ => never
-            }
-        """
-
-        self.must_exist: bool = must_exist
-        self.create: bool = create
-        self.label_style: LabelStyle = label_style
-
-        self.associated_type = Path
-
-    def to_dict(self):
-        return {
-            **super().to_dict(),
-            "labelStyle": self.label_style,
-        }
-
-    def enforce(self, value: object):
-        if isinstance(value, str):
-            value = Path(value)
-        assert isinstance(value, Path)
-
-        if self.create:
-            value.mkdir(parents=True, exist_ok=True)
-        elif self.must_exist:
-            assert value.exists(), f"Directory {value} does not exist"
-
-        return value
-
-
 def BinFileInput(primary_input: bool = False) -> FileInput:
     """Input for submitting a local .bin file"""
     return FileInput(
@@ -185,3 +142,88 @@ def OnnxFileInput(primary_input: bool = False) -> FileInput:
         filetypes=[".onnx"],
         primary_input=primary_input,
     )
+
+
+class DirectoryInput(BaseInput[Path]):
+    """Input for submitting a local directory"""
+
+    def __init__(
+        self,
+        label: str = "Directory",
+        has_handle: bool = True,
+        must_exist: bool = True,
+        label_style: LabelStyle = "default",
+    ):
+        super().__init__("Directory", label, kind="directory", has_handle=has_handle)
+
+        self.input_adapt = """
+            match Input {
+                string as path => Directory { path: path },
+                _ => never
+            }
+        """
+
+        self.must_exist: bool = must_exist
+        self.label_style: LabelStyle = label_style
+
+        self.associated_type = Path
+
+    def to_dict(self):
+        return {
+            **super().to_dict(),
+            "labelStyle": self.label_style,
+        }
+
+    def enforce(self, value: object) -> Path:
+        if isinstance(value, str):
+            value = Path(value)
+        assert isinstance(value, Path)
+
+        if self.must_exist:
+            assert value.exists(), f"Directory {value} does not exist"
+
+        return value
+
+
+_INVALID_PATH_CHARS = re.compile(r'[<>:"|?*\x00-\x1F]')
+
+
+def _is_abs_path(path: str) -> bool:
+    return path.startswith(("/", "\\")) or Path(path).is_absolute()
+
+
+class RelativePathInput(TextInput):
+    def __init__(
+        self,
+        label: str,
+        has_handle: bool = True,
+        placeholder: str | None = None,
+        allow_numbers: bool = True,
+        default: str | None = None,
+        label_style: LabelStyle = "default",
+    ):
+        super().__init__(
+            label,
+            has_handle=has_handle,
+            min_length=1,
+            max_length=None,
+            placeholder=placeholder,
+            multiline=False,
+            allow_numbers=allow_numbers,
+            default=default,
+            label_style=label_style,
+            allow_empty_string=False,
+            invalid_pattern=_INVALID_PATH_CHARS.pattern,
+        )
+
+    def enforce(self, value: object) -> str:
+        value = super().enforce(value)
+
+        if _is_abs_path(value):
+            raise ValueError(f"Absolute paths are not allowed for input {self.label}.")
+
+        invalid = _INVALID_PATH_CHARS.search(value)
+        if invalid is not None:
+            raise ValueError(f"Invalid character '{invalid.group()}' in {self.label}.")
+
+        return value

--- a/backend/src/nodes/properties/inputs/file_inputs.py
+++ b/backend/src/nodes/properties/inputs/file_inputs.py
@@ -114,36 +114,6 @@ def PthFileInput(primary_input: bool = False) -> FileInput:
     )
 
 
-def BinFileInput(primary_input: bool = False) -> FileInput:
-    """Input for submitting a local .bin file"""
-    return FileInput(
-        label="NCNN Bin File",
-        file_kind="bin",
-        filetypes=[".bin"],
-        primary_input=primary_input,
-    )
-
-
-def ParamFileInput(primary_input: bool = False) -> FileInput:
-    """Input for submitting a local .param file"""
-    return FileInput(
-        label="NCNN Param File",
-        file_kind="param",
-        filetypes=[".param"],
-        primary_input=primary_input,
-    )
-
-
-def OnnxFileInput(primary_input: bool = False) -> FileInput:
-    """Input for submitting a local .onnx file"""
-    return FileInput(
-        label="ONNX Model File",
-        file_kind="onnx",
-        filetypes=[".onnx"],
-        primary_input=primary_input,
-    )
-
-
 class DirectoryInput(BaseInput[Path]):
     """Input for submitting a local directory"""
 
@@ -183,6 +153,36 @@ class DirectoryInput(BaseInput[Path]):
             assert value.exists(), f"Directory {value} does not exist"
 
         return value
+
+
+def BinFileInput(primary_input: bool = False) -> FileInput:
+    """Input for submitting a local .bin file"""
+    return FileInput(
+        label="NCNN Bin File",
+        file_kind="bin",
+        filetypes=[".bin"],
+        primary_input=primary_input,
+    )
+
+
+def ParamFileInput(primary_input: bool = False) -> FileInput:
+    """Input for submitting a local .param file"""
+    return FileInput(
+        label="NCNN Param File",
+        file_kind="param",
+        filetypes=[".param"],
+        primary_input=primary_input,
+    )
+
+
+def OnnxFileInput(primary_input: bool = False) -> FileInput:
+    """Input for submitting a local .onnx file"""
+    return FileInput(
+        label="ONNX Model File",
+        file_kind="onnx",
+        filetypes=[".onnx"],
+        primary_input=primary_input,
+    )
 
 
 _INVALID_PATH_CHARS = re.compile(r'[<>:"|?*\x00-\x1F]')

--- a/backend/src/nodes/properties/inputs/generic_inputs.py
+++ b/backend/src/nodes/properties/inputs/generic_inputs.py
@@ -286,6 +286,7 @@ class TextInput(BaseInput[str]):
         default: str | None = None,
         label_style: LabelStyle = "default",
         allow_empty_string: bool = False,
+        invalid_pattern: str | None = None,
     ):
         super().__init__(
             input_type="string" if min_length == 0 else 'invStrSet("")',
@@ -300,6 +301,7 @@ class TextInput(BaseInput[str]):
         self.multiline = multiline
         self.label_style: LabelStyle = label_style
         self.allow_empty_string = allow_empty_string
+        self.invalid_pattern = invalid_pattern
 
         if default is not None:
             assert default != ""
@@ -339,6 +341,7 @@ class TextInput(BaseInput[str]):
             "def": self.default,
             "labelStyle": self.label_style,
             "allowEmptyString": self.allow_empty_string,
+            "invalidPattern": self.invalid_pattern,
         }
 
 

--- a/backend/src/packages/chaiNNer_ncnn/ncnn/io/save_model.py
+++ b/backend/src/packages/chaiNNer_ncnn/ncnn/io/save_model.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from sanic.log import logger
 
 from nodes.impl.ncnn.model import NcnnModelWrapper
-from nodes.properties.inputs import DirectoryInput, NcnnModelInput, TextInput
+from nodes.properties.inputs import DirectoryInput, NcnnModelInput, RelativePathInput
 
 from .. import io_group
 
@@ -15,18 +15,18 @@ from .. import io_group
     icon="MdSave",
     inputs=[
         NcnnModelInput(),
-        DirectoryInput(create=True),
-        TextInput("Param/Bin Name"),
+        DirectoryInput(must_exist=False),
+        RelativePathInput("Param/Bin Name"),
     ],
     outputs=[],
     side_effects=True,
 )
 def save_model_node(model: NcnnModelWrapper, directory: Path, name: str) -> None:
-    full_bin = f"{name}.bin"
-    full_param = f"{name}.param"
-    full_bin_path = directory / full_bin
-    full_param_path = directory / full_param
+    full_bin_path = (directory / f"{name}.bin").resolve()
+    full_param_path = (directory / f"{name}.param").resolve()
 
     logger.debug(f"Writing NCNN model to paths: {full_bin_path} {full_param_path}")
+
+    full_bin_path.parent.mkdir(parents=True, exist_ok=True)
     model.model.write_bin(full_bin_path)
     model.model.write_param(full_param_path)

--- a/backend/src/packages/chaiNNer_onnx/onnx/io/save_model.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/io/save_model.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from sanic.log import logger
 
 from nodes.impl.onnx.model import OnnxModel
-from nodes.properties.inputs import DirectoryInput, OnnxModelInput, TextInput
+from nodes.properties.inputs import DirectoryInput, OnnxModelInput, RelativePathInput
 
 from .. import io_group
 
@@ -17,14 +17,15 @@ from .. import io_group
     icon="MdSave",
     inputs=[
         OnnxModelInput(),
-        DirectoryInput(create=True),
-        TextInput("Model Name"),
+        DirectoryInput(must_exist=False),
+        RelativePathInput("Model Name"),
     ],
     outputs=[],
     side_effects=True,
 )
 def save_model_node(model: OnnxModel, directory: Path, model_name: str) -> None:
-    full_path = f"{directory / model_name}.onnx"
+    full_path = (directory / f"{model_name}.onnx").resolve()
     logger.debug(f"Writing file to path: {full_path}")
+    full_path.parent.mkdir(parents=True, exist_ok=True)
     with open(full_path, "wb") as f:
         f.write(model.bytes)

--- a/backend/src/packages/chaiNNer_standard/image/io/save_image.py
+++ b/backend/src/packages/chaiNNer_standard/image/io/save_image.py
@@ -30,8 +30,8 @@ from nodes.properties.inputs import (
     DropDownInput,
     EnumInput,
     ImageInput,
+    RelativePathInput,
     SliderInput,
-    TextInput,
 )
 from nodes.utils.utils import get_h_w_c
 
@@ -161,13 +161,13 @@ def DdsMipMapsDropdown() -> DropDownInput:
     inputs=[
         ImageInput(),
         DirectoryInput(must_exist=False),
-        TextInput("Subdirectory Path")
+        RelativePathInput("Subdirectory Path")
         .make_optional()
         .with_docs(
             "An optional subdirectory path. Use this to save the image to a subdirectory of the specified directory. If the subdirectory does not exist, it will be created. Multiple subdirectories can be specified by separating them with a forward slash (`/`).",
             "Example: `foo/bar`",
         ),
-        TextInput("Image Name").with_docs(
+        RelativePathInput("Image Name").with_docs(
             "The name of the image file **without** the file extension. If the file already exists, it will be overwritten.",
             "Example: `my-image`",
         ),
@@ -385,4 +385,4 @@ def get_full_path(
     if relative_path and relative_path != ".":
         base_directory = base_directory / relative_path
     full_path = base_directory / file
-    return full_path
+    return full_path.resolve()

--- a/backend/src/packages/chaiNNer_standard/utility/directory/directory_go_into.py
+++ b/backend/src/packages/chaiNNer_standard/utility/directory/directory_go_into.py
@@ -1,30 +1,12 @@
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 from nodes.groups import optional_list_group
-from nodes.properties.inputs import DirectoryInput, TextInput
+from nodes.properties.inputs import DirectoryInput, RelativePathInput
 from nodes.properties.outputs import DirectoryOutput
 
 from .. import directory_group
-
-INVALID_CHARS = re.compile(r"[<>:\"|?*\x00-\x1F]")
-
-
-def is_abs(path: str) -> bool:
-    return path.startswith(("/", "\\")) or Path(path).is_absolute()
-
-
-def go_into(dir: Path, folder: str) -> Path:
-    if is_abs(folder):
-        raise ValueError("Absolute paths are not allowed as folders.")
-
-    invalid = INVALID_CHARS.search(folder)
-    if invalid is not None:
-        raise ValueError(f"Invalid character '{invalid.group()}' in folder name.")
-
-    return (dir / folder).resolve()
 
 
 @directory_group.register(
@@ -34,9 +16,9 @@ def go_into(dir: Path, folder: str) -> Path:
     icon="BsFolder",
     inputs=[
         DirectoryInput(must_exist=False, label_style="hidden"),
-        TextInput("Folder"),
+        RelativePathInput("Folder"),
         optional_list_group(
-            *[TextInput(f"Folder {i}").make_optional() for i in range(2, 11)],
+            *[RelativePathInput(f"Folder {i}").make_optional() for i in range(2, 11)],
         ),
     ],
     outputs=[
@@ -78,5 +60,5 @@ def go_into(dir: Path, folder: str) -> Path:
 def directory_go_into_node(directory: Path, *folders: str | None) -> Path:
     for folder in folders:
         if folder is not None:
-            directory = go_into(directory, folder)
+            directory = (directory / folder).resolve()
     return directory

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -105,6 +105,7 @@ export interface TextInput extends InputBase {
     readonly placeholder?: string | null;
     readonly def?: string | null;
     readonly allowEmptyString?: boolean;
+    readonly invalidPattern?: string | null;
     readonly labelStyle: LabelStyle | undefined;
 }
 export interface NumberInput extends InputBase {


### PR DESCRIPTION
Fixes #1612

This PR adds the `RelativePathInput` for relative paths. All file name inputs now use this input and get the same file path validation as folder name in Directory Go Into. This also means that all file name inputs now "officially" support relative paths. E.g.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/e162ee2f-4e44-489d-9581-b5be004daff7)

This was allowed before already, so this doesn't change existing behavior, it just makes it more explicit.

One thing that did change are absolute file paths as names. E.g. the following was allowed before and created the model `C:\foo\bar.pth`:
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/f3acaceb-a0de-4195-9b1b-ee6834acfcf5)

This has now been fixed. Absolute paths are now an error.

If the user inputs invalid characters, they'll get this "error" and the character input won't go through. This makes it impossible to input invalid relative paths. 

Kinda. Input validation currently only work on an input level. Users can trivially input invalid characters using a Text node. These invalid characters will cause an error at runtime, but there is no type error.

Example: I tried to type "foo*"
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/b4c74fe8-7d44-4e19-bdb9-bb998d523e6f)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/eee09957-5b5c-446e-92dc-9809276510ea)


---

Other changes:
- Removed `create: bool` from `DirectoryInput`. Since names are now officially relative paths, we can only know which directory to create after combining the directory and name (e.g. `C:\a\b\c` and `..\name`). I also changed all relevant nodes to create the directory themselves.