### PR TITLE
Add softness for Threshold anti-aliasing

### DIFF
--- a/backend/src/packages/chaiNNer_standard/__init__.py
+++ b/backend/src/packages/chaiNNer_standard/__init__.py
@@ -77,7 +77,7 @@ package = add_package(
         Dependency(
             display_name="ChaiNNer Extensions",
             pypi_name="chainner_ext",
-            version="0.3.9",
+            version="0.3.10",
             size_estimate=2.0 * MB,
         ),
     ],

--- a/backend/src/packages/chaiNNer_standard/image_adjustment/threshold/threshold.py
+++ b/backend/src/packages/chaiNNer_standard/image_adjustment/threshold/threshold.py
@@ -62,9 +62,19 @@ _THRESHOLD_TYPE_LABELS: dict[ThresholdType, str] = {
                 controls_step=1,
             ).with_id(2),
         ),
-        BoolInput("Anti-aliasing", default=False).with_docs(
+        BoolInput("Anti-aliasing", default=False)
+        .with_docs(
             "Enables sub-pixel precision. Bilinear interpolation is used to fill in values in between pixels.",
             "Conceptually, the option is equivalent to first upscaling the image by a factor of X (with linear interpolation), thresholding it, and then downscaling it by a factor of X (where X is 20 or more).",
+        )
+        .with_id(4),
+        if_enum_group(4, 1)(
+            SliderInput("Softness", default=0, minimum=0, maximum=10)
+            .with_docs(
+                "The strength of a sub-pixel blur applied to be anti-aliased image. This can be be used to make the anti-aliasing even softer.",
+                "The blur is very small and higher-quality than a simple Gaussian blur. 0 means that no additional blur will be applied. 10 means that the anti-aliasing will be very soft.",
+            )
+            .with_id(5),
         ),
     ],
     outputs=[
@@ -82,15 +92,17 @@ def threshold_node(
     thresh_type: ThresholdType,
     max_value: float,
     anti_aliasing: bool,
+    extra_smoothness: float,
 ) -> np.ndarray:
     threshold /= 100
     max_value /= 100
+    extra_smoothness /= 10
 
     if not anti_aliasing:
         _, result = cv2.threshold(img, threshold, max_value, thresh_type.value)
         return result
 
-    binary = binary_threshold(img, threshold, True)
+    binary = binary_threshold(img, threshold, True, extra_smoothness)
     if get_h_w_c(binary)[2] == 1:
         binary = as_2d_grayscale(binary)
 


### PR DESCRIPTION
While using chainner's Threshold node to sharpen some upscaled text, I noticed that the AA is quite sharp. This is generally good, but I would have liked a bit softer in this case. So I added a high-quality sub-pixel blur to `binary_threshold` by exploiting how it calculates anti-aliased pixel. See https://github.com/chaiNNer-org/chaiNNer-rs/pull/27 for details.

This PR adds this new functionality in `chainner_ext` to the Threshold node via the new Softness slider. Users can set the softness as a value between 0 and 10.

I limited the slider to 11 values, because the blur is very subtle. A softness of 10 is roughly equivalent to a box blur of radius 0.3, and 5 roughly corresponds to 0.15. So having many in-between values wouldn't be useful. 

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/b129b0e5-d664-46a0-8987-506a6cb0495c)
