### PR TITLE
Manually set python encoding env var in subprocesses (to fix language issue)

### DIFF
--- a/backend/src/dependencies/store.py
+++ b/backend/src/dependencies/store.py
@@ -21,6 +21,8 @@ UNINSTALLING_REGEX = re.compile(r"Uninstalling ([a-zA-Z0-9-_]+)-+")
 
 DEP_MAX_PROGRESS = 0.8
 
+ENV = {**os.environ, "PYTHONIOENCODING": "utf-8"}
+
 
 @dataclass(frozen=True)
 class DependencyInfo:
@@ -101,6 +103,7 @@ def install_dependencies_sync(
             "--no-warn-script-location",
             *extra_index_args,
         ],
+        env=ENV,
     )
     if exit_code != 0:
         raise ValueError("An error occurred while installing dependencies.")
@@ -167,6 +170,7 @@ async def install_dependencies(
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         encoding="utf-8",
+        env=ENV,
     )
     installing_name = "Unknown"
     while True:
@@ -252,6 +256,7 @@ def uninstall_dependencies_sync(
             *[d.package_name for d in dependencies],
             "-y",
         ],
+        env=ENV,
     )
     if exit_code != 0:
         raise ValueError("An error occurred while uninstalling dependencies.")
@@ -301,6 +306,7 @@ async def uninstall_dependencies(
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         encoding="utf-8",
+        env=ENV,
     )
     uninstalling_name = "Unknown"
     while True:

--- a/backend/src/server_process_helper.py
+++ b/backend/src/server_process_helper.py
@@ -30,6 +30,8 @@ def _port_in_use(port: int):
 
 SANIC_LOG_REGEX = re.compile(r"^\s*\[[^\[\]]*\] \[\d*\] \[(\w*)\] (.*)")
 
+ENV = {**os.environ, "PYTHONIOENCODING": "utf-8"}
+
 
 class _WorkerProcess:
     def __init__(self, flags: list[str]):
@@ -43,6 +45,7 @@ class _WorkerProcess:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             encoding="utf-8",
+            env=ENV,
         )
         self._stop_event = threading.Event()
 


### PR DESCRIPTION
Allegedly (according to [this](https://github.com/python/cpython/issues/105312#issuecomment-1919348455)), this is how you force a python subprocess to output utf-8 only. 

This should theoretically fix the remaining issues around people using non-utf8 windows languages. I have not tested this myself as my system language is english.