### PR TITLE
#1525 add avif support

### DIFF
--- a/backend/src/nodes/impl/image_formats.py
+++ b/backend/src/nodes/impl/image_formats.py
@@ -68,6 +68,8 @@ def get_pil_formats():
         ".pnm",
         # TGA
         ".tga",
+        # AVIF,
+        ".avif",
     ]
 
 

--- a/backend/src/packages/chaiNNer_standard/__init__.py
+++ b/backend/src/packages/chaiNNer_standard/__init__.py
@@ -29,6 +29,13 @@ package = add_package(
             import_name="PIL",
         ),
         Dependency(
+            display_name="pillow-avif-plugin",
+            pypi_name="pillow-avif-plugin",
+            version="1.4.3",
+            size_estimate=11 * MB,
+            import_name="pillow_avif",
+        ),
+        Dependency(
             display_name="FFMPEG",
             pypi_name="ffmpeg-python",
             version="0.2.0",

--- a/backend/src/packages/chaiNNer_standard/image/io/load_image.py
+++ b/backend/src/packages/chaiNNer_standard/image/io/load_image.py
@@ -7,8 +7,8 @@ from typing import Callable, Iterable, Union
 
 import cv2
 import numpy as np
+import pillow_avif  # noqa: F401
 from PIL import Image
-import pillow_avif
 from sanic.log import logger
 
 from nodes.impl.dds.texconv import dds_to_png_texconv

--- a/backend/src/packages/chaiNNer_standard/image/io/load_image.py
+++ b/backend/src/packages/chaiNNer_standard/image/io/load_image.py
@@ -8,6 +8,7 @@ from typing import Callable, Iterable, Union
 import cv2
 import numpy as np
 from PIL import Image
+import pillow_avif
 from sanic.log import logger
 
 from nodes.impl.dds.texconv import dds_to_png_texconv

--- a/backend/src/packages/chaiNNer_standard/image/io/save_image.py
+++ b/backend/src/packages/chaiNNer_standard/image/io/save_image.py
@@ -6,8 +6,8 @@ from typing import Literal
 
 import cv2
 import numpy as np
+import pillow_avif  # noqa: F401
 from PIL import Image
-import pillow_avif
 from sanic.log import logger
 
 from api import KeyInfo, Lazy


### PR DESCRIPTION
Adds support for loading and saving images in the AVIF format, using `pillow-avif-plugin` as suggested in #1525. 

There are tons of potential options that could be added to the save node for AVIF (see options from [libavif](https://github.com/AOMediaCodec/libavif/blob/main/doc/avifenc.1.md) and options exposed by [pillow-avif-plugin](https://github.com/fdintino/pillow-avif-plugin/blob/aa7ac7f74c84ac409ad8668cd25f466334fd3753/src/pillow_avif/AvifImagePlugin.py#L119)). I kept things to a minimum and only exposed quality and subsampling. Notably, the lossless option is missing since `pillow-avif-plugin` doesn't expose it. I've read that AVIF lossless isn't that great at reducing file sizes anyway, but I'm not sure how true that is. 

Also, I made some guesses when working with `with_id` and `if_enum_group`, please let me know if those magic numbers need any corrections. 