### PR TITLE
Don't call Buffer from renderer

### DIFF
--- a/src/common/safeIpc.ts
+++ b/src/common/safeIpc.ts
@@ -94,7 +94,12 @@ export interface InvokeChannels {
         void,
         [format: string, buffer: Buffer, type?: 'selection' | 'clipboard' | undefined]
     >;
+    'clipboard-writeBuffer-fromString': ChannelInfo<
+        void,
+        [format: string, json: string, type?: 'selection' | 'clipboard' | undefined]
+    >;
     'clipboard-readBuffer': ChannelInfo<Buffer, [format: string]>;
+    'clipboard-readBuffer-toString': ChannelInfo<string, [format: string]>;
     'clipboard-availableFormats': ChannelInfo<string[]>;
     'clipboard-readHTML': ChannelInfo<string>;
     'clipboard-readRTF': ChannelInfo<string>;

--- a/src/main/gui/main-window.ts
+++ b/src/main/gui/main-window.ts
@@ -238,7 +238,13 @@ const registerEventHandlerPreSetup = (
     ipcMain.handle('clipboard-writeBuffer', (event, format, buffer, type) =>
         clipboard.writeBuffer(format, buffer, type)
     );
+    ipcMain.handle('clipboard-writeBuffer-fromString', (event, format, json, type) =>
+        clipboard.writeBuffer(format, Buffer.from(json), type)
+    );
     ipcMain.handle('clipboard-readBuffer', (event, format) => clipboard.readBuffer(format));
+    ipcMain.handle('clipboard-readBuffer-toString', (event, format) =>
+        Buffer.from(clipboard.readBuffer(format)).toString()
+    );
     ipcMain.handle('clipboard-availableFormats', () => clipboard.availableFormats());
     ipcMain.handle('clipboard-readHTML', () => clipboard.readHTML());
     ipcMain.handle('clipboard-readRTF', () => clipboard.readRTF());

--- a/src/renderer/helpers/copyAndPaste.ts
+++ b/src/renderer/helpers/copyAndPaste.ts
@@ -25,9 +25,13 @@ export const copyToClipboard = (
         nodes: nodes.filter((n) => copyIds.has(n.id)),
         edges: edges.filter((e) => copyIds.has(e.source) && copyIds.has(e.target)),
     };
-    const copyData = Buffer.from(JSON.stringify(data));
     ipcRenderer
-        .invoke('clipboard-writeBuffer', 'application/chainner.chain', copyData, 'clipboard')
+        .invoke(
+            'clipboard-writeBuffer-fromString',
+            'application/chainner.chain',
+            JSON.stringify(data),
+            'clipboard'
+        )
         .catch(log.error);
 };
 
@@ -61,10 +65,10 @@ export const pasteFromClipboard = async (
     if (availableFormats.length === 0) {
         try {
             const clipboardData = await ipcRenderer.invoke(
-                'clipboard-readBuffer',
+                'clipboard-readBuffer-toString',
                 'application/chainner.chain'
             );
-            const chain = JSON.parse(Buffer.from(clipboardData).toString()) as ClipboardChain;
+            const chain = JSON.parse(clipboardData) as ClipboardChain;
 
             const duplicationId = createUniqueId();
             const deriveId = (oldId: string) => deriveUniqueId(duplicationId + oldId);


### PR DESCRIPTION
This is now broken as Buffer is a global that only exists in node contexts