### PR TITLE
Use built-in nodejs UUID generator for image pasting

### DIFF
--- a/src/main/gui/main-window.ts
+++ b/src/main/gui/main-window.ts
@@ -9,9 +9,9 @@ import {
 } from 'electron/main';
 import EventSource from 'eventsource';
 import fs, { constants } from 'fs/promises';
+import crypto from 'node:crypto';
 import os from 'os';
 import path from 'path';
-import { v4 as uuid4 } from 'uuid';
 import { BackendEventMap } from '../../common/Backend';
 import { Version } from '../../common/common-types';
 import { log } from '../../common/log';
@@ -245,7 +245,7 @@ const registerEventHandlerPreSetup = (
     ipcMain.handle('clipboard-readImage-and-store', async () => {
         const clipboardData = clipboard.readImage();
         const imgData = clipboardData.toPNG();
-        const imgPath = path.join(os.tmpdir(), `chaiNNer-clipboard-${uuid4()}.png`);
+        const imgPath = path.join(os.tmpdir(), `chaiNNer-clipboard-${crypto.randomUUID()}.png`);
         await fs.writeFile(imgPath, imgData);
         return imgPath;
     });


### PR DESCRIPTION
Fixes an issue i found with image copying and pasting images directly into chaiNNer.

I'm not really sure _why_ this was broken. It definitely had something to do with Vite, but I have yet to figure out what specifically. What i did discover though, is that UUID4 just uses the native crypto.randomUUID function under the hood, when its available (so not in a browser). For some reason, calling it directly works fine, but using the uuid package does not. It does however work fine in the renderer, which is even weirder.

Something important to note is that we can't replace the renderer's use of UUID4 with this, as it sits in common/utils, where crypto is off limits.