### PR TITLE
Prevent chain files from being saved in install directory

### DIFF
--- a/src/main/gui/main-window.ts
+++ b/src/main/gui/main-window.ts
@@ -24,7 +24,7 @@ import { BackendProcess } from '../backend/process';
 import { setupBackend } from '../backend/setup';
 import { isArmMac, isMac } from '../env';
 import { addBrowserWindow, addFile, addFiles, removeFile, removeFiles } from '../fileWatcher';
-import { getRootDir } from '../platform';
+import { getIsPortableSync, getRootDir, installDir } from '../platform';
 import { BrowserWindowWithSafeIpc, ipcMain } from '../safeIpc';
 import { SaveFile, openSaveFile } from '../SaveFile';
 import { writeSettings } from '../setting-storage';
@@ -32,7 +32,6 @@ import { getAllFiles } from '../util';
 import { MenuData, setMainMenu } from './menu';
 
 const version = app.getVersion() as Version;
-const installDir = path.join(path.dirname(app.getPath('exe')), '..');
 
 const registerEventHandlerPreSetup = (
     mainWindow: BrowserWindowWithSafeIpc,
@@ -503,6 +502,35 @@ const setupProgressListeners = (
     });
 };
 
+const checkForChainFilesInInstallDir = async () => {
+    if (getIsPortableSync()) {
+        return;
+    }
+    // Scan install dir for chain files and warn user if they are found
+    const chainFiles = await getAllFiles(installDir);
+    const chainFilesFiltered = chainFiles.filter((f) => f.endsWith('.chn'));
+    if (chainFilesFiltered.length > 0) {
+        const result = dialog.showMessageBoxSync({
+            type: 'warning',
+            title: 'Found chain files in install directory',
+            message: `Found ${chainFilesFiltered.length} chain (.chn) file${
+                chainFilesFiltered.length === 1 ? '' : 's'
+            } in chaiNNer's install directory.`,
+            detail: `Please move them to a different location.\n\nChain files stored inside chaiNNer's install directory might be deleted *permanently* when chaiNNer is updated, re-installed, or uninstalled.\n\nStore chain files in a directory you control, for example your documents folder or your desktop.\n\nFiles:\n- ${chainFilesFiltered
+                .slice(0, 5)
+                .join('\n- ')}${
+                chainFilesFiltered.length > 5
+                    ? `\n- ...and ${chainFilesFiltered.length - 5} more.`
+                    : ''
+            }`,
+            buttons: ['Ignore', 'Open install folder'],
+        });
+        if (result === 1) {
+            await shell.openPath(installDir);
+        }
+    }
+};
+
 export const createMainWindow = async (args: OpenArguments, settings: ChainnerSettings) => {
     // Create the browser window.
     const mainWindow = new BrowserWindow({
@@ -585,18 +613,7 @@ export const createMainWindow = async (args: OpenArguments, settings: ChainnerSe
             );
         }
 
-        // Scan install dir for chain files and warn user if they are found
-        const chainFiles = await getAllFiles(installDir);
-        const chainFilesFiltered = chainFiles.filter((f) => f.endsWith('.chn'));
-        if (chainFilesFiltered.length > 0) {
-            dialog.showMessageBoxSync({
-                type: 'warning',
-                title: 'Found chain files in install directory',
-                message: `Found one or more chain (.chn) files in chaiNNer's install directory. Please move them to a different location or risk these files getting deleted.`,
-                detail: chainFilesFiltered.join('\n'),
-                buttons: ['OK'],
-            });
-        }
+        await checkForChainFilesInInstallDir();
     } catch (error) {
         if (error instanceof CriticalError) {
             await progressController.submitInterrupt(error.interrupt);

--- a/src/main/gui/main-window.ts
+++ b/src/main/gui/main-window.ts
@@ -45,7 +45,7 @@ const initiateSaveDialog = async (
     });
     if (!canceled && filePath) {
         if (filePath.startsWith(installDir)) {
-            await dialog.showMessageBox({
+            await dialog.showMessageBox(mainWindow, {
                 type: 'error',
                 title: 'Cannot save in install directory',
                 message: `Cannot save chain files in chaiNNer's install directory. Please choose a different location.`,

--- a/src/main/gui/main-window.ts
+++ b/src/main/gui/main-window.ts
@@ -33,7 +33,7 @@ import { MenuData, setMainMenu } from './menu';
 const version = app.getVersion() as Version;
 const documentsDir = app.getPath('documents');
 
-const askSaveLocation = async (
+const initiateSaveDialog = async (
     mainWindow: BrowserWindowWithSafeIpc,
     saveData: SaveData,
     defaultPath: string | undefined
@@ -45,13 +45,13 @@ const askSaveLocation = async (
     });
     if (!canceled && filePath) {
         if (filePath.startsWith(installDir)) {
-            dialog.showMessageBoxSync({
+            await dialog.showMessageBox({
                 type: 'error',
                 title: 'Cannot save in install directory',
                 message: `Cannot save chain files in chaiNNer's install directory. Please choose a different location.`,
                 buttons: ['OK'],
             });
-            return askSaveLocation(mainWindow, saveData, defaultPath);
+            return initiateSaveDialog(mainWindow, saveData, defaultPath);
         }
         await SaveFile.write(filePath, saveData, version);
         return { kind: 'Success', path: filePath };
@@ -123,7 +123,7 @@ const registerEventHandlerPreSetup = (
         'file-save-as-json',
         async (event, saveData, defaultPath): Promise<FileSaveResult> => {
             try {
-                return await askSaveLocation(mainWindow, saveData, defaultPath);
+                return await initiateSaveDialog(mainWindow, saveData, defaultPath);
             } catch (error) {
                 log.error(error);
                 throw error;

--- a/src/main/gui/main-window.ts
+++ b/src/main/gui/main-window.ts
@@ -13,7 +13,7 @@ import os from 'os';
 import path from 'path';
 import { v4 as uuid4 } from 'uuid';
 import { BackendEventMap } from '../../common/Backend';
-import { Version } from '../../common/common-types';
+import { FileSaveResult, Version } from '../../common/common-types';
 import { log } from '../../common/log';
 import { ChainnerSettings } from '../../common/settings/settings';
 import { CriticalError } from '../../common/ui/error';
@@ -26,12 +26,39 @@ import { isArmMac, isMac } from '../env';
 import { addBrowserWindow, addFile, addFiles, removeFile, removeFiles } from '../fileWatcher';
 import { getIsPortableSync, getRootDir, installDir } from '../platform';
 import { BrowserWindowWithSafeIpc, ipcMain } from '../safeIpc';
-import { SaveFile, openSaveFile } from '../SaveFile';
+import { SaveData, SaveFile, openSaveFile } from '../SaveFile';
 import { writeSettings } from '../setting-storage';
 import { getAllFiles } from '../util';
 import { MenuData, setMainMenu } from './menu';
 
 const version = app.getVersion() as Version;
+const documentsDir = app.getPath('documents');
+
+const askSaveLocation = async (
+    mainWindow: BrowserWindowWithSafeIpc,
+    saveData: SaveData,
+    defaultPath: string | undefined
+): Promise<FileSaveResult> => {
+    const { canceled, filePath } = await dialog.showSaveDialog(mainWindow, {
+        title: 'Save Chain File',
+        filters: [{ name: 'Chain File', extensions: ['chn'] }],
+        defaultPath: defaultPath ?? documentsDir,
+    });
+    if (!canceled && filePath) {
+        if (filePath.startsWith(installDir)) {
+            dialog.showMessageBoxSync({
+                type: 'error',
+                title: 'Cannot save in install directory',
+                message: `Cannot save chain files in chaiNNer's install directory. Please choose a different location.`,
+                buttons: ['OK'],
+            });
+            return askSaveLocation(mainWindow, saveData, defaultPath);
+        }
+        await SaveFile.write(filePath, saveData, version);
+        return { kind: 'Success', path: filePath };
+    }
+    return { kind: 'Canceled' };
+};
 
 const registerEventHandlerPreSetup = (
     mainWindow: BrowserWindowWithSafeIpc,
@@ -93,33 +120,17 @@ const registerEventHandlerPreSetup = (
     );
 
     // file IO
-    ipcMain.handle('file-save-as-json', async (event, saveData, defaultPath) => {
-        try {
-            const documentsDir = app.getPath('documents');
-            const { canceled, filePath } = await dialog.showSaveDialog(mainWindow, {
-                title: 'Save Chain File',
-                filters: [{ name: 'Chain File', extensions: ['chn'] }],
-                defaultPath: defaultPath ?? documentsDir,
-            });
-            if (!canceled && filePath) {
-                if (filePath.startsWith(installDir)) {
-                    dialog.showMessageBoxSync({
-                        type: 'error',
-                        title: 'Cannot save in install directory',
-                        message: `Cannot save chain files in chaiNNer's install directory. Please choose a different location.`,
-                        buttons: ['OK'],
-                    });
-                    return { kind: 'Canceled' };
-                }
-                await SaveFile.write(filePath, saveData, version);
-                return { kind: 'Success', path: filePath };
+    ipcMain.handle(
+        'file-save-as-json',
+        async (event, saveData, defaultPath): Promise<FileSaveResult> => {
+            try {
+                return await askSaveLocation(mainWindow, saveData, defaultPath);
+            } catch (error) {
+                log.error(error);
+                throw error;
             }
-            return { kind: 'Canceled' };
-        } catch (error) {
-            log.error(error);
-            throw error;
         }
-    });
+    );
 
     ipcMain.handle('file-save-json', async (event, saveData, savePath) => {
         try {

--- a/src/main/platform.ts
+++ b/src/main/platform.ts
@@ -40,3 +40,7 @@ export const getLogsFolder = lazy((): string => {
 export const getBackendStorageFolder = lazy((): string => {
     return path.join(getRootDir(), 'backend-storage');
 });
+
+export const installDir = getIsPortableSync()
+    ? path.dirname(app.getPath('exe'))
+    : path.join(path.dirname(app.getPath('exe')), '..');

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -1,8 +1,28 @@
 import { constants } from 'fs';
 import fs from 'fs/promises';
+import path from 'path';
 
 export const checkFileExists = (file: string): Promise<boolean> =>
     fs.access(file, constants.F_OK).then(
         () => true,
         () => false
     );
+
+export const getAllFiles = async (dirPath: string, fileList: string[] = []) => {
+    const files = await fs.readdir(dirPath);
+
+    await Promise.all(
+        files.map(async (file) => {
+            const filePath = path.join(dirPath, file);
+            const stat = await fs.stat(filePath);
+
+            if (stat.isDirectory()) {
+                await getAllFiles(filePath, fileList);
+            } else {
+                fileList.push(filePath);
+            }
+        })
+    );
+
+    return fileList;
+};

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -1,28 +1,8 @@
 import { constants } from 'fs';
 import fs from 'fs/promises';
-import path from 'path';
 
 export const checkFileExists = (file: string): Promise<boolean> =>
     fs.access(file, constants.F_OK).then(
         () => true,
         () => false
     );
-
-export const getAllFiles = async (dirPath: string, fileList: string[] = []) => {
-    const files = await fs.readdir(dirPath);
-
-    await Promise.all(
-        files.map(async (file) => {
-            const filePath = path.join(dirPath, file);
-            const stat = await fs.stat(filePath);
-
-            if (stat.isDirectory()) {
-                await getAllFiles(filePath, fileList);
-            } else {
-                fileList.push(filePath);
-            }
-        })
-    );
-
-    return fileList;
-};


### PR DESCRIPTION
We've had numerous reports of people thinking that it is a good idea to save their chains in chaiNNer's install dir, only to lose all their chain files after updating (for example, #1756).

This PR should prevent this in the future. Now, if someone tries to save to this directory, it will error and tell them to pick a different one. Also, it checks on startup if any chain files are stored in this directory (i.e. if someone moved them there manually) and gives a warning before starting up.

One concern is that this still applies in portable mode. It's most likely fine for people to put chain files in their portable folder, so should we not do these things for portable installs?