### PR TITLE
Default chain file saving to documents folder

### DIFF
--- a/src/main/gui/main-window.ts
+++ b/src/main/gui/main-window.ts
@@ -94,10 +94,11 @@ const registerEventHandlerPreSetup = (
     // file IO
     ipcMain.handle('file-save-as-json', async (event, saveData, defaultPath) => {
         try {
+            const documentsDir = app.getPath('documents');
             const { canceled, filePath } = await dialog.showSaveDialog(mainWindow, {
                 title: 'Save Chain File',
                 filters: [{ name: 'Chain File', extensions: ['chn'] }],
-                defaultPath,
+                defaultPath: defaultPath ?? documentsDir,
             });
             if (!canceled && filePath) {
                 await SaveFile.write(filePath, saveData, version);


### PR DESCRIPTION
Similar to #2835. This should prevent the dialog box from going to the install dir by default, and instead point users to somewhere safe to save their files.