### PR TITLE
Add setting migrations for new theme system

### DIFF
--- a/src/common/settings/migration.ts
+++ b/src/common/settings/migration.ts
@@ -55,3 +55,26 @@ export const migrateOldStorageSettings = (settings: ReadonlyStorage): Partial<Ch
         },
     };
 };
+
+const newThemeSystem: SettingsMigration = (settings) => {
+    const themeMap: Record<string, string> = {
+        dark: 'default-dark',
+        light: 'default-light',
+        system: 'default-dark',
+    };
+    if (settings.theme && Object.hasOwn(themeMap, settings.theme)) {
+        // eslint-disable-next-line no-param-reassign
+        settings.theme = themeMap[settings.theme];
+    }
+    return settings;
+};
+
+type SettingsMigration = (settings: Partial<ChainnerSettings>) => Partial<ChainnerSettings>;
+const migrations: SettingsMigration[] = [newThemeSystem];
+export const migrateSettings = (settings: Partial<ChainnerSettings>): ChainnerSettings => {
+    for (const migration of migrations) {
+        // eslint-disable-next-line no-param-reassign
+        settings = migration(settings);
+    }
+    return { ...defaultSettings, ...settings };
+};

--- a/tests/common/__snapshots__/settings.test.ts.snap
+++ b/tests/common/__snapshots__/settings.test.ts.snap
@@ -43,6 +43,7 @@ exports[`Migrate settings 1`] = `
       "use_fp16": false,
     },
   },
+  "showMinimap": false,
   "snapToGrid": true,
   "snapToGridAmount": 16,
   "startupTemplate": "",
@@ -91,7 +92,7 @@ exports[`Migrate settings 1`] = `
     ],
   },
   "systemPythonLocation": "",
-  "theme": "dark",
+  "theme": "default-dark",
   "useSystemPython": false,
   "viewportExportPadding": 20,
 }

--- a/tests/common/settings.test.ts
+++ b/tests/common/settings.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { migrateOldStorageSettings } from '../../src/common/settings/migration';
+import { migrateOldStorageSettings, migrateSettings } from '../../src/common/settings/migration';
 
 const oldSettingData: Partial<Record<string, string>> = {
     'allow-multiple-instances': 'false',
@@ -78,13 +78,14 @@ const oldSettingData: Partial<Record<string, string>> = {
 
 test(`Migrate settings`, () => {
     const unusedKeys = new Set(Object.keys(oldSettingData));
-    const settings = migrateOldStorageSettings({
+    let settings = migrateOldStorageSettings({
         keys: Object.keys(oldSettingData),
         getItem: (key: string) => {
             unusedKeys.delete(key);
             return oldSettingData[key] ?? null;
         },
     });
+    settings = migrateSettings(settings);
 
     expect(settings).toMatchSnapshot();
     expect(unusedKeys).toMatchSnapshot();


### PR DESCRIPTION
Since there wasn't a way to migrate settings yet, I quickly added one. We can now have any number of settings migrations, and I added the migration to the new theme system to get us started. Migrations are also tested, so we can see the effect of every change we make to settings now.