### PR TITLE
Protect against huge image sizes

### DIFF
--- a/backend/src/nodes/properties/outputs/numpy_outputs.py
+++ b/backend/src/nodes/properties/outputs/numpy_outputs.py
@@ -11,7 +11,7 @@ from api import BaseOutput, BroadcastData, InputId, OutputKind
 from ...impl.image_utils import normalize, to_uint8
 from ...impl.resize import ResizeFilter, resize
 from ...utils.format import format_image_with_channels
-from ...utils.utils import get_h_w_c, round_half_up
+from ...utils.utils import IMAGE_SIZE_LIMIT, get_h_w_c, round_half_up
 
 
 class NumPyOutput(BaseOutput[np.ndarray]):
@@ -60,6 +60,9 @@ class ImageOutput(NumPyOutput):
             )
         if shape_as is not None:
             image_type = navi.intersect_with_error(image_type, f"Input{shape_as}")
+        image_type = navi.fn(
+            "assert_image_size", image_type, navi.literal(IMAGE_SIZE_LIMIT)
+        )
 
         super().__init__(image_type, label, kind=kind, has_handle=has_handle)
 

--- a/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize.py
@@ -15,7 +15,7 @@ from nodes.properties.inputs import (
     ResizeFilterInput,
 )
 from nodes.properties.outputs import ImageOutput
-from nodes.utils.utils import get_h_w_c, round_half_up
+from nodes.utils.utils import assert_image_dimensions, get_h_w_c, round_half_up
 
 from .. import resize_group
 
@@ -114,7 +114,7 @@ def resize_node(
     filter: ResizeFilter,
     separate_alpha: bool,
 ) -> np.ndarray:
-    h, w, _ = get_h_w_c(img)
+    h, w, c = get_h_w_c(img)
 
     out_dims: tuple[int, int]
     if mode == ImageResizeMode.PERCENTAGE:
@@ -124,6 +124,8 @@ def resize_node(
         )
     else:
         out_dims = (width, height)
+
+    assert_image_dimensions((out_dims[1], out_dims[0], c))
 
     return resize(
         img,

--- a/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize_pixel_art.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize_pixel_art.py
@@ -10,6 +10,7 @@ from nodes.properties.inputs import (
     ImageInput,
 )
 from nodes.properties.outputs import ImageOutput
+from nodes.utils.utils import assert_image_dimensions, get_h_w_c
 
 from .. import resize_group
 
@@ -106,4 +107,8 @@ def resize_pixel_art_node(
     img: np.ndarray,
     algorithm: ResizeAlgorithm,
 ) -> np.ndarray:
+    h, w, c = get_h_w_c(img)
+
+    assert_image_dimensions((h * algorithm.scale, w * algorithm.scale, c))
+
     return pixel_art_upscale(img, algorithm.algorithm, algorithm.scale)

--- a/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize_to_side.py
+++ b/backend/src/packages/chaiNNer_standard/image_dimension/resize/resize_to_side.py
@@ -12,7 +12,7 @@ from nodes.properties.inputs import (
     ResizeFilterInput,
 )
 from nodes.properties.outputs import ImageOutput
-from nodes.utils.utils import get_h_w_c, round_half_up
+from nodes.utils.utils import assert_image_dimensions, get_h_w_c, round_half_up
 
 from .. import resize_group
 
@@ -173,7 +173,9 @@ def resize_to_side_node(
     condition: ResizeCondition,
     filter: ResizeFilter,
 ) -> np.ndarray:
-    h, w, _ = get_h_w_c(img)
+    h, w, c = get_h_w_c(img)
     out_dims = resize_to_side_conditional(w, h, target, side, condition)
+
+    assert_image_dimensions((out_dims[1], out_dims[0], c))
 
     return resize(img, out_dims, filter)

--- a/src/common/types/chainner-scope.ts
+++ b/src/common/types/chainner-scope.ts
@@ -47,6 +47,18 @@ struct Image {
     channels: int(1..),
 }
 struct Color { channels: int(1..) }
+def assert_image_size(value: any, max_size: uint): any {
+    match value {
+        Image as image => {
+            if image.width * image.height * image.channels * 4 > max_size {
+                error("The output image of this operation is too large for your machine. Please reduce the size of the image.")
+            } else {
+                image
+            }
+        },
+        _ => value,
+    }
+}
 
 struct Video;
 


### PR DESCRIPTION
Fixes #2832.

This adds the `assert_image_dimensions` util function I proposed to protect against huge image sizes at runtime.

I also implemented a type-based check, but I'm not satisfied with it yet. I'll try to improve the UX a bit more before requesting review.