### PR TITLE
Remove sleep in upscale

### DIFF
--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -348,6 +348,10 @@ class _ExecutorNodeContext(NodeContext):
 
     @property
     def paused(self) -> bool:
+        # Python is single-threaded, so it's necessary for this thread to yield, so other threads can do some work.
+        # This is necessary because the thread for accepting the `/pause` endpoint would not be able to accept requests otherwise.
+        # This in turn would mean that `self.progress.paused` would never be set to True.
+        # For more information, see https://github.com/chaiNNer-org/chaiNNer/pull/2853
         time.sleep(0)
         return self.progress.paused
 

--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -348,6 +348,7 @@ class _ExecutorNodeContext(NodeContext):
 
     @property
     def paused(self) -> bool:
+        time.sleep(0)
         return self.progress.paused
 
     def set_progress(self, progress: float) -> None:

--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -348,7 +348,6 @@ class _ExecutorNodeContext(NodeContext):
 
     @property
     def paused(self) -> bool:
-        time.sleep(0.001)
         return self.progress.paused
 
     def set_progress(self, progress: float) -> None:


### PR DESCRIPTION
I'm assuming this has a reason to be here, otherwise I can't see why it's worth slightly slowing down every upscale.

If it doesn't, let's get rid of it. If it does, can we use a smaller number? Even though it's only a millisecond, that time can add up. A 5 minute video clip at 24fps would cost about 7 extra seconds in processing time because of this.