### PR TITLE
Cache estimated tile sizes (pytorch)

### DIFF
--- a/backend/src/api/node_context.py
+++ b/backend/src/api/node_context.py
@@ -131,6 +131,8 @@ class NodeContext(Progress, ABC):
     The execution context of the current node.
     """
 
+    cache: dict
+
     @property
     @abstractmethod
     def settings(self) -> SettingsParser:

--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -342,6 +342,8 @@ class _ExecutorNodeContext(NodeContext):
         self.__settings = settings
         self._storage_dir = storage_dir
 
+        self.cache = {}
+
     @property
     def aborted(self) -> bool:
         return self.progress.aborted


### PR DESCRIPTION
Note: this may not be necessary after https://github.com/chaiNNer-org/spandrel/pull/260

But, we can save on the cost of re-estimating when we already have encountered the same model and image dimensions. Obviously this doesn't take into account when the user suddenly has more or less vram, but i think that shouldn't matter too much.

Will need to be benchmarked and traced to see if this actually saves any time comparatively. We might save enough from not having to sum up the byte size that it's negligible. 