### PR TITLE
Fixed that empty string was not allowed as the default value

### DIFF
--- a/backend/src/nodes/properties/inputs/generic_inputs.py
+++ b/backend/src/nodes/properties/inputs/generic_inputs.py
@@ -310,8 +310,8 @@ class TextInput(BaseInput[str]):
         self.invalid_pattern = invalid_pattern
 
         if default is not None:
-            assert default != ""
-            assert min_length < len(default)
+            assert default != "" or allow_empty_string
+            assert min_length <= len(default)
             assert max_length is None or len(default) < max_length
 
         self.associated_type = str


### PR DESCRIPTION
This fixes a small bug in `TextInput` that disallowed the empty string as the default value even if `allow_empty_string` was set to True. I also fixed the length check right below.