### PR TITLE
Fixed VSCode formatting for TypeScript

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
 		"ms-python.vscode-pylance",
 		"streetsidesoftware.code-spell-checker",
 		"dbaeumer.vscode-eslint",
-		"charliermarsh.ruff"
+		"charliermarsh.ruff",
+		"esbenp.prettier-vscode"
 	]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -121,6 +121,7 @@
     "editor.formatOnSave": true,
   },
   "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,
   },
   "[javascript]": {


### PR DESCRIPTION
So I just ran into a problem in #2855. When formatting TypeScript files, my VSCode formatted the code with ESLint/Prettier and then re-formatted with the VSCode built-in JS/TS formatter. I can only assume that a recent update caused this. My guess is that they changed the order in which formatters are run or something similar.

To work around this issue, I set the VSCode prettier plugin as the default formatter for TS files in our local settings. This solves the issue for chainner. 

I'll have to look and see whether this problem also occurs in other projects.