### PR TITLE
Only do .to if necessary

### DIFF
--- a/backend/src/nodes/impl/pytorch/auto_split.py
+++ b/backend/src/nodes/impl/pytorch/auto_split.py
@@ -58,7 +58,8 @@ def pytorch_auto_split(
     progress: Progress,
 ) -> np.ndarray:
     dtype = torch.float16 if use_fp16 else torch.float32
-    model = model.to(device, dtype)
+    if model.dtype != dtype or model.device != device:
+        model = model.to(device, dtype)
 
     def upscale(img: np.ndarray, _: object):
         progress.check_aborted()


### PR DESCRIPTION
This is also not a noop (like constantly calling .eval) so i made it only do it if the device or dtype does not match.