### PR TITLE
Only copy non-writeable image when CPU upscaling

### DIFF
--- a/backend/src/nodes/impl/pytorch/auto_split.py
+++ b/backend/src/nodes/impl/pytorch/auto_split.py
@@ -52,8 +52,9 @@ def _into_tensor(
     img: np.ndarray, device: torch.device, dtype: torch.dtype
 ) -> torch.Tensor:
     img = np.ascontiguousarray(img)
+    writeable = img.flags.writeable
     try:
-        if not img.flags.writeable and device == torch.device("cpu"):
+        if not writeable and device == torch.device("cpu"):
             img = np.copy(img)
         else:
             # since we are going to copy the image to the GPU, we can skip the copy here
@@ -61,7 +62,7 @@ def _into_tensor(
         input_tensor = torch.from_numpy(img).to(device, dtype)
         return input_tensor
     finally:
-        img.flags.writeable = False
+        img.flags.writeable = writeable
 
 
 @torch.inference_mode()

--- a/backend/src/nodes/impl/pytorch/auto_split.py
+++ b/backend/src/nodes/impl/pytorch/auto_split.py
@@ -72,9 +72,13 @@ def pytorch_auto_split(
         try:
             # convert to tensor
             img = np.ascontiguousarray(img)
-            if not img.flags.writeable:
+            if not img.flags.writeable and device == torch.device("cpu"):
                 img = np.copy(img)
+            else:
+                # since we are going to copy the image to the GPU, we can skip the copy here
+                img.flags.writeable = True
             input_tensor = torch.from_numpy(img).to(device, dtype)
+            img.flags.writeable = False
             input_tensor = _rgb_to_bgr(input_tensor)
             input_tensor = _into_batched_form(input_tensor)
 


### PR DESCRIPTION
Copying takes time and memory. Why waste this time and memory if we are just going to immediately copy the image to the GPU?

Now the copy will only happen if the user is upscaling with CPU. On anything else, the image is simply moved to a tensor (sharing the same memory) after being made writeable, then copied to the GPU. The image is then set back to readonly.

This made a significant cut to processing time.