### PR TITLE
Increase font size for type tags

### DIFF
--- a/src/renderer/components/TypeTag.tsx
+++ b/src/renderer/components/TypeTag.tsx
@@ -261,16 +261,17 @@ export interface TypeTagProps {
 export const TypeTag = memo(
     forwardRef<TypeTagProps, 'span'>((props, ref) => {
         const { isOptional, ...rest } = props;
+        const height = '17px';
         return (
             <Tag
                 bgColor="var(--custom-tag-bg)"
                 color="var(--custom-tag-fg)"
                 display="inline-block"
-                fontSize="x-small"
+                fontSize="xs"
                 fontStyle={isOptional ? 'italic' : undefined}
-                height="15px"
+                height={height}
                 lineHeight="auto"
-                minHeight="15px"
+                minHeight={height}
                 minWidth={0}
                 ml={1}
                 px={1}


### PR DESCRIPTION
Despite how useful and important type tags are, we used a very small font for them, making them unreadable unless zoomed in.

This PR change the font size of type tags from 10px ("x-small") to 12px ("xs"). This is the same font size we use for input labels that are above their input.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/0c0e07cb-0e83-4d81-bb24-4970ca9fa15b) ![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/c420ca8a-4d90-4ad3-bdb9-dfc5cde31c0f)
