### PR TITLE
Better type errors for text nodes

### DIFF
--- a/src/common/types/chainner-scope.ts
+++ b/src/common/types/chainner-scope.ts
@@ -119,9 +119,9 @@ struct SplitFilePath {
     ext: string,
 }
 
-intrinsic def formatPattern(pattern: string, ...args: string | null): string;
-intrinsic def regexReplace(text: string, regex: string, replacement: string, count: uint | inf): string;
-intrinsic def regexFind(text: string, regex: string, pattern: string): string;
+intrinsic def formatPattern(pattern: string, ...args: string | null): string | Error;
+intrinsic def regexReplace(text: string, regex: string, replacement: string, count: uint | inf): string | Error;
+intrinsic def regexFind(text: string, regex: string, pattern: string): string | Error;
 intrinsic def padStart(text: string, width: uint, padding: string): string;
 intrinsic def padEnd(text: string, width: uint, padding: string): string;
 intrinsic def padCenter(text: string, width: uint, padding: string): string;
@@ -135,9 +135,9 @@ export const getChainnerScope = lazy((): Scope => {
     const builder = new ScopeBuilder('Chainner scope', globalScope);
 
     const intrinsic: Record<string, (scope: Scope, ...args: NeverType[]) => Type> = {
-        formatPattern: makeScoped(formatTextPattern),
-        regexReplace: makeScoped(regexReplace),
-        regexFind: makeScoped(regexFind),
+        formatPattern: formatTextPattern,
+        regexReplace,
+        regexFind,
         padStart: makeScoped(padStart),
         padEnd: makeScoped(padEnd),
         padCenter: makeScoped(padCenter),


### PR DESCRIPTION
This improves the error messages users get in text formatting and regex nodes.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/4cc3b210-0392-47cc-a363-71d35a3fd42b) ![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/e4217310-fa40-417e-966c-1a3c88c7fe8f)
