### PR TITLE
Make nodes a bit more compact

### DIFF
--- a/src/renderer/components/node/NodeBody.tsx
+++ b/src/renderer/components/node/NodeBody.tsx
@@ -35,7 +35,6 @@ export const NodeBody = memo(({ nodeState, isCollapsed, animated }: NodeBodyProp
 
     return (
         <>
-            {!autoInput && inputs.length > 0 && <Box py={1} />}
             {!autoInput && (
                 <Box
                     bg="var(--bg-700)"
@@ -45,7 +44,7 @@ export const NodeBody = memo(({ nodeState, isCollapsed, animated }: NodeBodyProp
                 </Box>
             )}
 
-            {anyVisibleOutputs && <Box py={1} />}
+            {anyVisibleOutputs && <Box py={0.5} />}
             <Box
                 bg="var(--bg-700)"
                 w="full"

--- a/src/renderer/components/node/NodeHeader.tsx
+++ b/src/renderer/components/node/NodeHeader.tsx
@@ -244,9 +244,10 @@ export const NodeHeader = memo(
                     bgGradient={`linear(to-r, ${gradL}, ${gradR})`}
                     borderBottomColor={accentColor}
                     borderBottomWidth="2px"
+                    gap="2px"
                     h="auto"
                     minHeight={isCollapsed ? minHeight : undefined}
-                    p={1}
+                    p="2px"
                     verticalAlign="middle"
                     w="full"
                 >


### PR DESCRIPTION
This one might be a bit controversial. I'm not even sure if I'm fully sold on it yet

- Reduced padding in header
- Removed spacing between header and inputs
- Reduced height of space between inputs and outputs

Something feels a bit off about it but I can't quite figure out what

# After
![image](https://github.com/chaiNNer-org/chaiNNer/assets/34788790/dba6215f-99b6-4ce8-905c-b8a2e14a7688)

# Before
![image](https://github.com/chaiNNer-org/chaiNNer/assets/34788790/43a3bad6-5e99-48a9-9485-2cd2d27628a6)
