### PR TITLE
Fixed converting indexed PIL images to numpy

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image/io/load_image.py
+++ b/backend/src/packages/chaiNNer_standard/image/io/load_image.py
@@ -89,6 +89,10 @@ def _read_pil(path: Path) -> np.ndarray | None:
         return None
 
     im = Image.open(path)
+    if im.mode == "P":
+        # convert color palette to actual colors
+        im = im.convert(im.palette.mode)
+
     img = np.array(im)
     _, _, c = get_h_w_c(img)
     if c == 3:


### PR DESCRIPTION
Fixes #2816
Fixes #2620

Turns out, when [the internet tells you how to convert a PIL image to numpy](https://stackoverflow.com/questions/384759/how-do-i-convert-a-pil-image-into-a-numpy-array), they are lying to you. When the PIL image in question uses a color palette (mode=P), then `np.array(im)` will give you the indexes into the color palette and not the colors. So we have to convert the image first.