### PR TITLE
Add type: ignore comments to avif import

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image/io/load_image.py
+++ b/backend/src/packages/chaiNNer_standard/image/io/load_image.py
@@ -7,7 +7,7 @@ from typing import Callable, Iterable, Union
 
 import cv2
 import numpy as np
-import pillow_avif  # noqa: F401
+import pillow_avif  # type: ignore # noqa: F401
 from PIL import Image
 from sanic.log import logger
 

--- a/backend/src/packages/chaiNNer_standard/image/io/save_image.py
+++ b/backend/src/packages/chaiNNer_standard/image/io/save_image.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 import cv2
 import numpy as np
-import pillow_avif  # noqa: F401
+import pillow_avif  # type: ignore # noqa: F401
 from PIL import Image
 from sanic.log import logger
 


### PR DESCRIPTION
This gets rid of the warnings from pyright about this.

what a bad way to register a plugin tbh