### PR TITLE
Fix for writeable flag error

### DIFF
--- a/backend/src/nodes/impl/pytorch/auto_split.py
+++ b/backend/src/nodes/impl/pytorch/auto_split.py
@@ -58,7 +58,11 @@ def _into_tensor(
             img = np.copy(img)
         else:
             # since we are going to copy the image to the GPU, we can skip the copy here
-            img.flags.writeable = True
+            try:
+                img.flags.writeable = True
+            except Exception:
+                # Some arrays cannot be made writeable, and we need to copy them
+                img = np.copy(img)
         input_tensor = torch.from_numpy(img).to(device, dtype)
         return input_tensor
     finally:


### PR DESCRIPTION
Some numpy arrays cannot be set to writeable -- this seems to include arrays that come from rust/chainner-ext. These would cause errors from attempting to make them writeable.

So, I just wrapped it with a try/except, and made it copy if it cannot be set to writeable. Easy fix, and we still get the optimization from it if it is able to be set to writeable