### PR TITLE
Fixed passthrough state of nodes not being saved

### DIFF
--- a/src/main/SaveFile.ts
+++ b/src/main/SaveFile.ts
@@ -83,6 +83,7 @@ export class SaveFile {
                         isDisabled: n.data.isDisabled,
                         isLocked: n.data.isLocked,
                         isCollapsed: n.data.isCollapsed,
+                        isPassthrough: n.data.isPassthrough,
                         nodeName: n.data.nodeName,
                     },
                     id: n.id,


### PR DESCRIPTION
This was reported to us on Discord by GlitchBob:

> Noticed that chains with nodes set to "skip" are back to "enabled" if you reopen the program, even if you've saved the chain with the skips set.

Pretty simple bug. I forgot to add `isPassthrough` to the data being saved.