### PR TITLE
Slightly more space for text in dropdowns

### DIFF
--- a/src/renderer/components/inputs/elements/Dropdown.tsx
+++ b/src/renderer/components/inputs/elements/Dropdown.tsx
@@ -127,7 +127,7 @@ export const DropDown = memo(
                 disabled={isDisabled}
                 draggable={false}
                 size="sm"
-                style={{ contain: 'size' }}
+                style={{ contain: 'size', paddingRight: '1.75rem' }}
                 value={selection}
                 onChange={handleChange}
             >


### PR DESCRIPTION
This changes the right padding of dropdowns to display just a bit more text. This doesn't do much, but it can make space for one more character in some cases.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/3f68190b-c505-4ae9-9c7e-946dc288dfc7)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/74502adf-33cb-4d80-91b2-c5bfdfe94abb)
