### PR TITLE
Disable reloading for main process

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "electron-forge start -- --devtools",
     "frontend": "electron-forge start -- --remote-backend=http://127.0.0.1:8000 --devtools",
     "dev": "concurrently \"npm run dev:py\" \"electron-forge start -- --remote-backend=http://127.0.0.1:8000 --refresh --devtools\"",
+    "dev:reload": "concurrently \"npm run dev:py\" \"cross-env HOT_RESTART=1 electron-forge start -- --remote-backend=http://127.0.0.1:8000 --refresh --devtools\"",
     "dev:profile": "concurrently \"npm run dev:py:profile\" \"electron-forge start -- --remote-backend=http://127.0.0.1:8000 --refresh --devtools\"",
     "dev:py": "cd backend/src && cross-env CHECK_LEVEL=fix nodemon --exec \"python -m debugpy --listen 5678\" ./run.py 8000",
     "dev:py:profile": "cd backend/src && cross-env CHECK_LEVEL=fix nodemon --exec \"python ./run.py 8000 --trace",

--- a/vite/main.config.ts
+++ b/vite/main.config.ts
@@ -4,7 +4,6 @@ import ignore from 'rollup-plugin-ignore';
 import { defineConfig, mergeConfig } from 'vite';
 import { external, getBuildConfig, getBuildDefine } from './base.config';
 import type { ConfigEnv, UserConfig } from 'vite';
-
 import './forge-types';
 
 // https://vitejs.dev/config
@@ -29,7 +28,7 @@ export default defineConfig((env) => {
                 },
             },
         },
-        plugins: [...(os.platform() === 'darwin' ? [ignore(['fsevents'])] : [])],
+        plugins: os.platform() === 'darwin' ? [ignore(['fsevents'])] : [],
         define,
         resolve: {
             // Load the Node.js entry.

--- a/vite/main.config.ts
+++ b/vite/main.config.ts
@@ -2,9 +2,11 @@
 import os from 'os';
 import ignore from 'rollup-plugin-ignore';
 import { defineConfig, mergeConfig } from 'vite';
-import { external, getBuildConfig, getBuildDefine } from './base.config';
+import { external, getBuildConfig, getBuildDefine, pluginHotRestart } from './base.config';
 import type { ConfigEnv, UserConfig } from 'vite';
 import './forge-types';
+
+const restart = process.env.HOT_RESTART !== undefined;
 
 // https://vitejs.dev/config
 export default defineConfig((env) => {
@@ -28,7 +30,10 @@ export default defineConfig((env) => {
                 },
             },
         },
-        plugins: os.platform() === 'darwin' ? [ignore(['fsevents'])] : [],
+        plugins: [
+            ...(restart ? [pluginHotRestart('restart')] : []),
+            ...(os.platform() === 'darwin' ? [ignore(['fsevents'])] : []),
+        ],
         define,
         resolve: {
             // Load the Node.js entry.
@@ -39,6 +44,11 @@ export default defineConfig((env) => {
                 'electron-log/main': 'electron-log',
             },
             conditions: ['node', 'default'],
+        },
+        server: {
+            watch: {
+                ignored: ['**/translation.json'],
+            },
         },
     };
 

--- a/vite/main.config.ts
+++ b/vite/main.config.ts
@@ -2,7 +2,7 @@
 import os from 'os';
 import ignore from 'rollup-plugin-ignore';
 import { defineConfig, mergeConfig } from 'vite';
-import { external, getBuildConfig, getBuildDefine, pluginHotRestart } from './base.config';
+import { external, getBuildConfig, getBuildDefine } from './base.config';
 import type { ConfigEnv, UserConfig } from 'vite';
 
 import './forge-types';
@@ -29,10 +29,7 @@ export default defineConfig((env) => {
                 },
             },
         },
-        plugins: [
-            pluginHotRestart('restart'),
-            ...(os.platform() === 'darwin' ? [ignore(['fsevents'])] : []),
-        ],
+        plugins: [...(os.platform() === 'darwin' ? [ignore(['fsevents'])] : [])],
         define,
         resolve: {
             // Load the Node.js entry.
@@ -43,11 +40,6 @@ export default defineConfig((env) => {
                 'electron-log/main': 'electron-log',
             },
             conditions: ['node', 'default'],
-        },
-        server: {
-            watch: {
-                ignored: ['**/translation.json'],
-            },
         },
     };
 


### PR DESCRIPTION
As I said on Discord, the hot reloading of the main process gets in the way of my development workflow, because it restarts chainner completely and loses the current chain/state. This is a huge problem for me, because I frequently change files in `src/common` (e.g. type system stuff) that cause these reloads. So not having it is better.