### PR TITLE
Prevent log spam by not logging useless stack traces

### DIFF
--- a/src/renderer/components/SystemStats.tsx
+++ b/src/renderer/components/SystemStats.tsx
@@ -12,10 +12,9 @@ export const SystemStats = memo(() => {
         queryKey: 'systemUsage',
         queryFn: async () => {
             try {
-                const response = await backend.systemUsage();
-                return response;
+                return await backend.systemUsage();
             } catch (error) {
-                log.error(error);
+                log.error(`Failed to fetch system usage from backend: ${String(error)}`);
                 throw error;
             }
         },


### PR DESCRIPTION
Stack traces are completely useless for network errors, so I just log the message and a little context.