### PR TITLE
Fix ref assignment in render

### DIFF
--- a/src/renderer/components/ReactFlowBox.tsx
+++ b/src/renderer/components/ReactFlowBox.tsx
@@ -86,8 +86,10 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
 
     const [nodes, setNodes, internalOnNodesChange] = useNodesState<NodeData>([]);
     const [edges, setEdges, internalOnEdgesChange] = useEdgesState<EdgeData>([]);
-    setNodesRef.current = setNodes;
-    setEdgesRef.current = setEdges;
+    useEffect(() => {
+        setNodesRef.current = setNodes;
+        setEdgesRef.current = setEdges;
+    }, [setNodes, setEdges, setNodesRef, setEdgesRef]);
 
     const altPressed = useKeyPress(['Alt', 'Option']);
 


### PR DESCRIPTION
Assigning refs during render is not allowed. It just happens to work in some React environments but not in others. Case in point, I get an error logged to console caused by this. Doing the assignment in an `useEffect` fixes the error.