### PR TITLE
Stricter condition for type assignability

### DIFF
--- a/src/common/types/assign.ts
+++ b/src/common/types/assign.ts
@@ -1,0 +1,93 @@
+import {
+    NeverType,
+    NonNeverType,
+    NumberPrimitive,
+    StringPrimitive,
+    Type,
+    UnionType,
+    intersect,
+    isDisjointWith,
+} from '@chainner/navi';
+
+export type AssignmentResult = AssignmentOk | AssignmentError;
+export interface AssignmentOk {
+    readonly isOk: true;
+    readonly assignedType: NonNeverType;
+}
+export interface AssignmentError {
+    readonly isOk: false;
+    readonly assignedType: NeverType;
+    readonly errorType: Type;
+}
+
+/**
+ * We only want to split if there is at least one specific struct instance or there are no struct instances at all.
+ */
+const shouldSplit = (items: readonly Type[]): boolean => {
+    let noStructs = true;
+    for (const item of items) {
+        if (item.underlying === 'struct') {
+            noStructs = false;
+            if (item.type === 'instance') {
+                return true;
+            }
+        }
+    }
+    return noStructs;
+};
+const splitType = (t: Type): Type[] => {
+    if (t.underlying === 'union' && shouldSplit(t.items)) {
+        const numbers: NumberPrimitive[] = [];
+        const strings: StringPrimitive[] = [];
+        const result: Type[] = [];
+        for (const item of t.items) {
+            if (item.underlying === 'number') {
+                numbers.push(item);
+            } else if (item.underlying === 'string') {
+                strings.push(item);
+            } else {
+                result.push(item);
+            }
+        }
+
+        if (numbers.length === 1) {
+            result.push(numbers[0]);
+        } else if (numbers.length >= 2) {
+            result.push(new UnionType(numbers as never));
+        }
+        if (strings.length === 1) {
+            result.push(strings[0]);
+        } else if (strings.length >= 2) {
+            result.push(new UnionType(strings as never));
+        }
+        return result;
+    }
+    return [t];
+};
+
+/**
+ * Returns whether the type `t` can be assigned to an input of type `definitionType`.
+ */
+export const assign = (t: Type, definitionType: Type): AssignmentResult => {
+    const split = splitType(t);
+    if (split.length > 1) {
+        for (const item of split) {
+            if (isDisjointWith(item, definitionType)) {
+                return { isOk: false, assignedType: NeverType.instance, errorType: item };
+            }
+        }
+    }
+
+    const intersection = intersect(t, definitionType);
+    if (intersection.underlying === 'never') {
+        return { isOk: false, assignedType: intersection, errorType: t };
+    }
+    return { isOk: true, assignedType: intersection };
+};
+
+/**
+ * Equivalent to `assign(t, definitionType).isOk`, but faster.
+ */
+export const assignOk = (t: Type, definitionType: Type): boolean => {
+    return assign(t, definitionType).isOk;
+};

--- a/src/common/types/mismatch.ts
+++ b/src/common/types/mismatch.ts
@@ -8,6 +8,7 @@ import {
     isStructInstance,
 } from '@chainner/navi';
 import { assertNever } from '../util';
+import { assign } from './assign';
 import { getChainnerScope } from './chainner-scope';
 import { explain, formatChannelNumber } from './explain';
 import { prettyPrintType } from './pretty';
@@ -31,10 +32,14 @@ export const generateAssignmentErrorTrace = (
     assigned: Type,
     definition: Type
 ): AssignmentErrorTrace | undefined => {
-    if (!isDisjointWith(assigned, definition)) {
+    const assignmentResult = assign(assigned, definition);
+    if (assignmentResult.isOk) {
         // types compatible
         return undefined;
     }
+
+    // eslint-disable-next-line no-param-reassign
+    assigned = assignmentResult.errorType;
 
     if (
         isStructInstance(assigned) &&


### PR DESCRIPTION
This adds a new `assign` function that determines whether a type `T` is assignable to an input with some definition type `D`.

The old condition was "`T` and `D` overlap." This condition served as well to prevent connects that could not be valid, but it's not enough anymore. The new Conditional node causes problems in that regard, because it allows users to create the union of 2 types `A` and `B`. So users can e.g. create the type `Image | number` which is assignable to a number input under the old condition.

To fix this issue, I modified the condition slightly. Instead of checking with `T` for overlap, it will now split `T` into its unioned types and check with those items. So the condition is now: `split(T).every(item => overlap(item, D))`. The key here is how `T` is split. It's a little complex, because the `any` type should still be assignable to everything. `split` essentially works like this:

```ts
function split(T) {
  if (T.isAny) return [T]
  const num = T & number
  const str = T & string
  const structs = T.iterateStructInstances()
  return [num, str, ...structs]
}
```

2 things to note:
1. The is-any check is a little fuzzy to allow types very close to `any`. This is necessary, because nodes can't actually output `any`. There is special handling for the `Error` type, so nodes will output at most `any \ Error`.
2. Iterating struct instances means grouping them by their definition. E.g. `Image { width: 100 } | Image { width: 200 } | PyTorchModel` will be iterated as [ `Image { width: 100 } | Image { width: 200 }`, `PyTorchModel` ].

The new assignability condition fixes the issues the Conditional node causes, but I expect that we will likely need to revise it further in the future.

### Examples

Image or color:
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/2b359de0-4eee-4f49-9405-fe225191cb2a)

Image or number:
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/ab42865f-dca9-4ebf-a49e-5a5f3c2b381f)
