### PR TITLE
Select best-matching node based on search query

### DIFF
--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -92,6 +92,18 @@ export const lazyKeyed = <K extends object, T extends {} | null>(
         return value;
     };
 };
+export const cacheLast = <K extends NonNullable<unknown>, T>(
+    fn: (arg: K) => T
+): ((arg: K) => T) => {
+    let lastArg: K | undefined;
+    let lastValue: T = undefined as T;
+    return (arg: K): T => {
+        if (lastArg === arg) return lastValue;
+        lastValue = fn(arg);
+        lastArg = arg;
+        return lastValue;
+    };
+};
 
 export const debounce = (fn: () => void, delay: number): (() => void) => {
     let id: NodeJS.Timeout | undefined;

--- a/src/renderer/helpers/nodeSearchFuncs.ts
+++ b/src/renderer/helpers/nodeSearchFuncs.ts
@@ -38,3 +38,78 @@ export const getMatchingNodes = (
 
     return matchingNodes;
 };
+
+const getMax = <T extends NonNullable<unknown>>(
+    iter: Iterable<T>,
+    selector: (t: T) => number
+): T | undefined => {
+    let max: T | undefined;
+    let maxVal = -Infinity;
+    for (const item of iter) {
+        const val = selector(item);
+        if (val > maxVal) {
+            maxVal = val;
+            max = item;
+        }
+    }
+    return max;
+};
+
+export const getBestMatch = (
+    searchQuery: string,
+    matchingSchemata: readonly NodeSchema[],
+    _categories: CategoryMap,
+    scoreMultiplier: (schema: NodeSchema) => number = () => 1
+): NodeSchema | undefined => {
+    // eslint-disable-next-line no-param-reassign
+    searchQuery = searchQuery.trim().toLowerCase();
+    if (searchQuery.length <= 1) {
+        // there's no point in matching against super short queries
+        return undefined;
+    }
+
+    const g2Points = 1;
+    const g3Points = 3;
+    const g4Points = 10;
+
+    const letter = isLetter();
+    const isBoundary = (s: string, index: number) => {
+        if (index === 0) return true;
+        const before = s[index - 1];
+        return !letter.isMatch(before);
+    };
+    interface Matches {
+        matches: number;
+        boundaryMatches: number;
+    }
+    const countNGramMatches = (name: string, n: number): Matches => {
+        let matches = 0;
+        let boundaryMatches = 0;
+        for (let i = 0; i <= searchQuery.length - n; i += 1) {
+            const index = name.indexOf(searchQuery.slice(i, i + n));
+            if (index !== -1) {
+                if (isBoundary(name, index)) {
+                    boundaryMatches += 1;
+                } else {
+                    matches += 1;
+                }
+            }
+        }
+        return { matches, boundaryMatches };
+    };
+
+    const scoreMatches = (matches: Matches, basePoints: number) => {
+        return matches.matches * basePoints + matches.boundaryMatches * basePoints * 3;
+    };
+
+    return getMax(matchingSchemata, (schema) => {
+        const name = schema.name.toLowerCase();
+
+        const points =
+            scoreMatches(countNGramMatches(name, 2), g2Points) +
+            scoreMatches(countNGramMatches(name, 3), g3Points) +
+            scoreMatches(countNGramMatches(name, 4), g4Points);
+
+        return (points / name.length) * scoreMultiplier(schema);
+    });
+};

--- a/src/renderer/hooks/usePaneNodeSearchMenu.tsx
+++ b/src/renderer/hooks/usePaneNodeSearchMenu.tsx
@@ -126,7 +126,7 @@ export const usePaneNodeSearchMenu = (): UsePaneNodeSearchMenuValue => {
     const useConnectingFrom = useContextSelector(GlobalVolatileContext, (c) => c.useConnectingFrom);
     const { createNode, createConnection } = useContext(GlobalContext);
     const { closeContextMenu } = useContext(ContextMenuContext);
-    const { schemata, functionDefinitions, categories } = useContext(BackendContext);
+    const { schemata, functionDefinitions, categories, featureStates } = useContext(BackendContext);
 
     const { favorites } = useNodeFavorites();
 
@@ -238,6 +238,7 @@ export const usePaneNodeSearchMenu = (): UsePaneNodeSearchMenuValue => {
         <Menu
             categories={categories}
             favorites={favorites}
+            featureStates={featureStates}
             schemata={menuSchemata}
             suggestions={suggestions}
             onSelect={onSchemaSelect}


### PR DESCRIPTION
This improves the UX of the context node selector by setting the selected index to the node that matches the search query the best. This should make it a lot easier to find common nodes such as Text, Number, and Color.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/2a74d33e-28a3-4efc-8a57-4af56db2f17a) ![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/363ff23f-5945-4440-a66d-aeb59cc45b4c) ![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/6939e99f-0a5a-4c28-a245-0772d83c715d) ![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/63c04b4b-d07f-4bb1-9b0f-931757567673) ![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/b1526784-9495-4071-8196-d6475a0dfa67) ![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/6b459db5-7f5c-4096-9934-312b621d2f2d)

