### PR TITLE
Support connected handles with multiple colors

### DIFF
--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -105,6 +105,28 @@ export const cacheLast = <K extends NonNullable<unknown>, T>(
     };
 };
 
+export interface CacheOptions {
+    readonly maxSize?: number;
+}
+export const cached = <K, T extends NonNullable<unknown>>(
+    fn: (arg: K) => T,
+    { maxSize = 100 }: CacheOptions = {}
+): ((arg: K) => T) => {
+    const cache = new Map<K, T>();
+    return (arg: K): T => {
+        let c = cache.get(arg);
+        if (c === undefined) {
+            if (cache.size >= maxSize && cache.size > 0) {
+                const firstKey = cache.keys().next().value as K;
+                cache.delete(firstKey);
+            }
+            c = fn(arg);
+            cache.set(arg, c);
+        }
+        return c;
+    };
+};
+
 export const debounce = (fn: () => void, delay: number): (() => void) => {
     let id: NodeJS.Timeout | undefined;
     return () => {

--- a/src/renderer/components/inputs/InputContainer.tsx
+++ b/src/renderer/components/inputs/InputContainer.tsx
@@ -9,8 +9,7 @@ import { assertNever, stringifyTargetHandle } from '../../../common/util';
 import { VALID, invalid } from '../../../common/Validity';
 import { GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { InputContext } from '../../contexts/InputContext';
-import { defaultColor } from '../../helpers/accentColors';
-import { useSourceTypeColor } from '../../hooks/useSourceTypeColor';
+import { useSourceTypeColors } from '../../hooks/useSourceTypeColor';
 import { useTypeColor } from '../../hooks/useTypeColor';
 import { Handle } from '../Handle';
 import { Markdown } from '../Markdown';
@@ -66,8 +65,7 @@ export const InputHandle = memo(
         }, [connectingFrom, id, targetHandle, isValidConnection]);
 
         const handleColors = useTypeColor(connectableType);
-
-        const sourceTypeColor = useSourceTypeColor(targetHandle);
+        const sourceTypeColor = useSourceTypeColors(targetHandle);
 
         return (
             <HStack
@@ -81,12 +79,7 @@ export const InputHandle = memo(
                     position="absolute"
                 >
                     <Handle
-                        connectedColor={
-                            isConnected
-                                ? (sourceTypeColor === defaultColor ? null : sourceTypeColor) ??
-                                  handleColors[0]
-                                : undefined
-                        }
+                        connectedColor={isConnected ? sourceTypeColor ?? handleColors : undefined}
                         handleColors={handleColors}
                         id={targetHandle}
                         isIterated={isIterated}

--- a/src/renderer/components/node/CollapsedHandles.tsx
+++ b/src/renderer/components/node/CollapsedHandles.tsx
@@ -7,9 +7,9 @@ import { Output } from '../../../common/common-types';
 import { FunctionDefinition } from '../../../common/types/function';
 import { stringifySourceHandle, stringifyTargetHandle } from '../../../common/util';
 import { BackendContext } from '../../contexts/BackendContext';
-import { createConicGradient } from '../../helpers/colorTools';
+import { defaultColor } from '../../helpers/accentColors';
 import { NodeState } from '../../helpers/nodeState';
-import { useSourceTypeColor } from '../../hooks/useSourceTypeColor';
+import { useSourceTypeColors } from '../../hooks/useSourceTypeColor';
 import { useTypeColor } from '../../hooks/useTypeColor';
 
 interface InputHandleProps {
@@ -18,7 +18,7 @@ interface InputHandleProps {
 }
 
 const InputHandle = memo(({ isIterated, targetHandle }: InputHandleProps) => {
-    const sourceTypeColor = useSourceTypeColor(targetHandle);
+    const sourceTypeColor = useSourceTypeColors(targetHandle)?.[0] ?? defaultColor;
 
     return (
         <Box
@@ -72,7 +72,7 @@ const OutputHandle = memo(
                     isConnectable={false}
                     position={Position.Right}
                     style={{
-                        borderColor: createConicGradient(handleColors),
+                        borderColor: handleColors[0],
                         borderRadius: isIterated ? '10%' : '50%',
                     }}
                     type="source"

--- a/src/renderer/components/outputs/OutputContainer.tsx
+++ b/src/renderer/components/outputs/OutputContainer.tsx
@@ -61,7 +61,7 @@ export const OutputHandle = memo(
                 right="-6px"
             >
                 <Handle
-                    connectedColor={isConnected ? handleColors[0] : undefined}
+                    connectedColor={isConnected ? handleColors : undefined}
                     handleColors={handleColors}
                     id={sourceHandle}
                     isIterated={isIterated}

--- a/src/renderer/hooks/useSourceTypeColor.ts
+++ b/src/renderer/hooks/useSourceTypeColor.ts
@@ -1,3 +1,4 @@
+import { NeverType } from '@chainner/navi';
 import { useMemo } from 'react';
 import { Node, useReactFlow } from 'reactflow';
 import { useContext } from 'use-context-selector';
@@ -7,7 +8,7 @@ import { BackendContext } from '../contexts/BackendContext';
 import { GlobalVolatileContext } from '../contexts/GlobalNodeState';
 import { useTypeColor } from './useTypeColor';
 
-export const useSourceTypeColor = (targetHandle: string) => {
+export const useSourceTypeColors = (targetHandle: string) => {
     const { functionDefinitions } = useContext(BackendContext);
     const { edgeChanges, typeState } = useContext(GlobalVolatileContext);
     const { getEdges, getNode } = useReactFlow();
@@ -34,7 +35,7 @@ export const useSourceTypeColor = (targetHandle: string) => {
         }
     }, [sourceHandle, functionDefinitions, typeState, getNode]);
 
-    const sourceTypeColor = useTypeColor(sourceType);
+    const colors = useTypeColor(sourceType ?? NeverType.instance);
 
-    return sourceTypeColor[0];
+    return sourceType ? colors : undefined;
 };

--- a/src/renderer/hooks/useTypeColor.ts
+++ b/src/renderer/hooks/useTypeColor.ts
@@ -1,10 +1,9 @@
 import { Type } from '@chainner/navi';
 import { useMemo } from 'react';
-import { defaultColor, getTypeAccentColors } from '../helpers/accentColors';
+import { getTypeAccentColors } from '../helpers/accentColors';
 import { useSettings } from './useSettings';
 
-export const useTypeColor = (type: Type | undefined) => {
+export const useTypeColor = (type: Type) => {
     const { theme } = useSettings();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    return useMemo(() => (type ? getTypeAccentColors(type) : [defaultColor]), [type, theme]);
+    return useMemo(() => getTypeAccentColors(type, theme), [type, theme]);
 };


### PR DESCRIPTION
This PR adds support for connected handles with multiple colors.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/dccf31ab-60a1-47a4-b4e5-5505143025a2)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/027164e3-1b34-45b5-b860-79e17e530ece)

The styling is done is an overly complex way, but it was the only good solution I found. I'm using the same conic gradient we use for non-connected handles, and an SVG background image is used to create the hole in the middle.

Why an SVG background image? Because nothing else worked as well.
- I first tried to just use border color, but this looked horrible. The colors were rotated compared to non-connected handles, 3 colors looked horrible, and >=5 colors weren't supported at all.
- I tried using a radial gradient on top of the conic gradient to make the hole. This worked, but didn't have antialiasing. It looked horribly jagged when zoomed out.

---

Other changes:
- Cache as much as possible in `getTypeAccentColors`.
- Fixed a bug with collapsed handles that made them white when the handle had multiple colors.
- Fixed a bug with connected input handles that caused them to use the colors of their definition type when the color of the incoming edge was the default color.