### PR TITLE
Fixed assignability for outputs with errors

### DIFF
--- a/src/common/types/util.ts
+++ b/src/common/types/util.ts
@@ -61,8 +61,8 @@ export const getFields = <N extends keyof KnownStructDefinitions>(
 };
 
 export const nullType = getStructDescriptor(getChainnerScope(), 'null').default;
+export const errorDescriptor = getStructDescriptor(getChainnerScope(), 'Error');
+export const errorType = errorDescriptor.default;
 
 export const withoutNull = (type: Type): Type => without(type, nullType);
-
-export const withoutError = (type: Type): Type =>
-    without(type, getStructDescriptor(getChainnerScope(), 'Error').default);
+export const withoutError = (type: Type): Type => without(type, errorType);


### PR DESCRIPTION
This is a follow-up to #2902. I failed to consider that nodes may return an error as part of their output type. This means that nodes that returned e.g. `Image | Error` could not connect to image inputs. This PR fixes this by removing the `Error` type from output types.