### PR TITLE
Add similarity check to ONNX model conversions

### DIFF
--- a/backend/src/packages/chaiNNer_onnx/onnx/utility/convert_to_ncnn.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/utility/convert_to_ncnn.py
@@ -11,8 +11,6 @@ from nodes.properties.outputs import NcnnModelOutput, TextOutput
 
 from .. import utility_group
 
-FP_MODE_32 = 0
-
 
 @utility_group.register(
     schema_id="chainner:onnx:convert_to_ncnn",


### PR DESCRIPTION
Closes #2585.

This adds a new check to ensure that the ONNX models of PyTorch models produce the same outputs. This new check is options and off by default, because it requires an ONNX runtime.

I also cleaned up some other code along the way.

To the reviewer: please test this. I don't really do ONNX conversions, so I just tested it on a few models and it seemed to work.