### PR TITLE
Fixed ONNX size req padding

### DIFF
--- a/backend/src/nodes/impl/pytorch/convert_to_onnx_impl.py
+++ b/backend/src/nodes/impl/pytorch/convert_to_onnx_impl.py
@@ -24,8 +24,8 @@ def convert_to_onnx_impl(
         input_name: {0: "batch_size", 2: "height", 3: "width"},
         output_name: {0: "batch_size", 2: "height", 3: "width"},
     }
-    size = max(model.size_requirements.minimum, 3)
-    size = size + (size % model.size_requirements.multiple_of)
+    size = 3
+    size += model.size_requirements.get_padding(size, size)[0]
     dummy_input = torch.rand(1, model.input_channels, size, size)
     dummy_input = dummy_input.to(device)
 


### PR DESCRIPTION
`size += size % model.size_requirements.multiple_of` does not make size a multiple of `multiple_of`. E.g. for `size=3` and `multiple_of=4`, this will result in a value of `6` for `size` at the end.

It was also wrong in that it didn't account for the minimum size.