### PR TITLE
Add support for ONNX type and tag broadcasting

### DIFF
--- a/backend/src/nodes/impl/onnx/load.py
+++ b/backend/src/nodes/impl/onnx/load.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import time
+
+import onnx
+import onnx.inliner
+import re2
+from sanic.log import logger
+
+from .model import OnnxGeneric, OnnxInfo, OnnxModel, OnnxRemBg
+from .utils import (
+    get_opset,
+    get_tensor_fp_datatype,
+    image_to_image_shape_inference,
+)
+
+re2_options = re2.Options()
+re2_options.dot_nl = True
+re2_options.encoding = re2.Options.Encoding.LATIN1
+
+U2NET_STANDARD = re2.compile(b"1959.+1960.+1961.+1962.+1963.+1964.+1965", re2_options)
+U2NET_CLOTH = re2.compile(
+    b"output.+d1.+Concat_1876.+Concat_1896.+Concat_1916.+Concat_1936.+Concat_1956",
+    re2_options,
+)
+U2NET_SILUETA = re2.compile(b"1808.+1827.+1828.+2296.+1831.+1850.+1958", re2_options)
+U2NET_ISNET = re2.compile(
+    b"/stage1/rebnconvin/conv_s1/Conv.+/stage1/rebnconvin/relu_s1/Relu", re2_options
+)
+
+
+def load_onnx_model(model: onnx.ModelProto) -> OnnxModel:
+    info = OnnxInfo(
+        opset=get_opset(model),
+        dtype=get_tensor_fp_datatype(model),
+    )
+
+    model_as_bytes = model.SerializeToString()
+
+    if (
+        U2NET_STANDARD.search(model_as_bytes[-1000:]) is not None
+        or U2NET_SILUETA.search(model_as_bytes[-600:]) is not None
+        or U2NET_ISNET.search(model_as_bytes[:10000]) is not None
+    ):
+        info.scale_width = 1
+        info.scale_height = 1
+        return OnnxRemBg(model_as_bytes, info)
+    elif U2NET_CLOTH.search(model_as_bytes[-1000:]) is not None:
+        info.scale_width = 1
+        info.scale_height = 3
+        return OnnxRemBg(model_as_bytes, info)
+    else:
+        start = time.time()
+        try:
+            i_hwc, o_hwc = image_to_image_shape_inference(model, (512, 512))
+            i_h, i_w, i_c = i_hwc
+            o_h, o_w, o_c = o_hwc
+
+            def get_scale(i: int | None, o: int | None) -> int | None:
+                if i is None or o is None:
+                    return None
+                if o % i != 0:
+                    return None
+                return o // i
+
+            info.scale_width = get_scale(i_w, o_w)
+            info.scale_height = get_scale(i_h, o_h)
+
+            info.input_channels = i_c
+            info.output_channels = o_c
+        except Exception:
+            pass
+
+        logger.info(f"Model info took {time.time() - start:.2f}s")
+        return OnnxGeneric(model_as_bytes, info)

--- a/backend/src/nodes/impl/onnx/load.py
+++ b/backend/src/nodes/impl/onnx/load.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-import time
-
 import onnx
 import onnx.inliner
 import re2
-from sanic.log import logger
 
 from .model import OnnxGeneric, OnnxInfo, OnnxModel, OnnxRemBg
 from .utils import (
@@ -55,7 +52,6 @@ def load_onnx_model(model_or_bytes: onnx.ModelProto | bytes) -> OnnxModel:
         info.scale_height = 3
         return OnnxRemBg(model_as_bytes, info)
     else:
-        start = time.time()
         try:
             i_hwc, o_hwc = image_to_image_shape_inference(model, (512, 512))
             i_h, i_w, i_c = i_hwc
@@ -76,5 +72,4 @@ def load_onnx_model(model_or_bytes: onnx.ModelProto | bytes) -> OnnxModel:
         except Exception:
             pass
 
-        logger.info(f"Model info took {time.time() - start:.2f}s")
         return OnnxGeneric(model_as_bytes, info)

--- a/backend/src/nodes/impl/onnx/load.py
+++ b/backend/src/nodes/impl/onnx/load.py
@@ -29,13 +29,18 @@ U2NET_ISNET = re2.compile(
 )
 
 
-def load_onnx_model(model: onnx.ModelProto) -> OnnxModel:
+def load_onnx_model(model_or_bytes: onnx.ModelProto | bytes) -> OnnxModel:
+    if isinstance(model_or_bytes, onnx.ModelProto):
+        model = model_or_bytes
+        model_as_bytes = model.SerializeToString()
+    else:
+        model_as_bytes = model_or_bytes
+        model = onnx.load_model_from_string(model_or_bytes)
+
     info = OnnxInfo(
         opset=get_opset(model),
         dtype=get_tensor_fp_datatype(model),
     )
-
-    model_as_bytes = model.SerializeToString()
 
     if (
         U2NET_STANDARD.search(model_as_bytes[-1000:]) is not None

--- a/backend/src/nodes/impl/onnx/model.py
+++ b/backend/src/nodes/impl/onnx/model.py
@@ -1,65 +1,45 @@
 # This class defines an interface.
 # It is important that is does not contain types that depend on ONNX.
-from typing import Union
+from __future__ import annotations
 
-import re2
+from dataclasses import dataclass
+from typing import Final, Literal, Union
 
-re2_options = re2.Options()
-re2_options.dot_nl = True
-re2_options.encoding = re2.Options.Encoding.LATIN1
+OnnxSubType = Literal["Generic", "RemBg"]
 
-U2NET_STANDARD = re2.compile(b"1959.+1960.+1961.+1962.+1963.+1964.+1965", re2_options)
-U2NET_CLOTH = re2.compile(
-    b"output.+d1.+Concat_1876.+Concat_1896.+Concat_1916.+Concat_1936.+Concat_1956",
-    re2_options,
-)
-U2NET_SILUETA = re2.compile(b"1808.+1827.+1828.+2296.+1831.+1850.+1958", re2_options)
-U2NET_ISNET = re2.compile(
-    b"/stage1/rebnconvin/conv_s1/Conv.+/stage1/rebnconvin/relu_s1/Relu", re2_options
-)
+
+@dataclass
+class OnnxInfo:
+    opset: int
+    dtype: str
+
+    scale_width: int | None = None
+    scale_height: int | None = None
+
+    fixed_input_width: int | None = None
+    fixed_input_height: int | None = None
+
+    input_channels: int | None = None
+    output_channels: int | None = None
 
 
 class OnnxGeneric:
-    def __init__(self, model_as_bytes: bytes):
+    def __init__(self, model_as_bytes: bytes, info: OnnxInfo):
         self.bytes: bytes = model_as_bytes
-        self.sub_type = "Generic"
-        self.scale_height = None
-        self.scale_width = None
+        self.sub_type: Final[Literal["Generic"]] = "Generic"
+        self.info: OnnxInfo = info
 
 
 class OnnxRemBg:
-    def __init__(self, model_as_bytes: bytes, scale_height: int = 1):
+    def __init__(
+        self,
+        model_as_bytes: bytes,
+        info: OnnxInfo,
+    ):
         self.bytes: bytes = model_as_bytes
-        self.sub_type = "RemBg"
-        self.scale_height = scale_height
-        self.scale_width = 1
+        self.sub_type: Final[Literal["RemBg"]] = "RemBg"
+        self.info: OnnxInfo = info
 
 
 OnnxModels = (OnnxGeneric, OnnxRemBg)
 OnnxModel = Union[OnnxGeneric, OnnxRemBg]
-
-
-def is_rembg_model(model_as_bytes: bytes) -> bool:
-    if (
-        U2NET_STANDARD.search(model_as_bytes[-600:]) is not None
-        or U2NET_CLOTH.search(model_as_bytes[-1000:]) is not None
-        or U2NET_SILUETA.search(model_as_bytes[-600:]) is not None
-        or U2NET_ISNET.search(model_as_bytes[:10000]) is not None
-    ):
-        return True
-    return False
-
-
-def load_onnx_model(model_as_bytes: bytes) -> OnnxModel:
-    if (
-        U2NET_STANDARD.search(model_as_bytes[-1000:]) is not None
-        or U2NET_SILUETA.search(model_as_bytes[-600:]) is not None
-        or U2NET_ISNET.search(model_as_bytes[:10000]) is not None
-    ):
-        model = OnnxRemBg(model_as_bytes)
-    elif U2NET_CLOTH.search(model_as_bytes[-1000:]) is not None:
-        model = OnnxRemBg(model_as_bytes, scale_height=3)
-    else:
-        model = OnnxGeneric(model_as_bytes)
-
-    return model

--- a/backend/src/nodes/impl/onnx/utils.py
+++ b/backend/src/nodes/impl/onnx/utils.py
@@ -1,49 +1,168 @@
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal, Tuple, Union
 
-import onnxoptimizer
-import onnxruntime as ort
-from onnx.onnx_pb import ModelProto
+import onnx
+from onnx.onnx_pb import ModelProto, ValueInfoProto
+from onnx.tools import update_model_dims
 
-OnnxInputShape = Literal["BCHW", "BHWC"]
+OnnxTensorFormat = Literal["BCHW", "BHWC"]
+OnnxTensorShape = Tuple[
+    Union[int, str],
+    Union[int, str],
+    Union[int, str],
+    Union[int, str],
+]
+OnnxParsedTensorShape = Tuple[
+    OnnxTensorFormat,
+    int,
+    Union[int, None],
+    Union[int, None],
+]
+"""
+The elements are:
+- The tensor format (BCHW or BHWC).
+- The number of channels.
+- The width (optional).
+- The height (optional).
+"""
 
 
-def as_int(value: object) -> int | None:
+def _as_int(value: object) -> int | None:
     if isinstance(value, int):
         return value
     return None
 
 
-def parse_onnx_shape(
-    shape: tuple[int | str, str | int, str | int, str | int],
-) -> tuple[OnnxInputShape, int, int | None, int | None]:
+def _or_else(value: int | None, default: int) -> int:
+    return value if value is not None else default
+
+
+def parse_onnx_shape(shape: OnnxTensorShape) -> OnnxParsedTensorShape:
     if isinstance(shape[1], int) and shape[1] <= 4:
-        return "BCHW", shape[1], as_int(shape[3]), as_int(shape[2])
+        return "BCHW", shape[1], _as_int(shape[3]), _as_int(shape[2])
     elif isinstance(shape[3], int) and shape[3] <= 4:
-        return "BHWC", shape[3], as_int(shape[2]), as_int(shape[1])
+        return "BHWC", shape[3], _as_int(shape[2]), _as_int(shape[1])
     else:
-        return "BCHW", 3, as_int(shape[3]), as_int(shape[2])
+        return "BCHW", 3, _as_int(shape[3]), _as_int(shape[2])
 
 
-def get_input_shape(
-    session: ort.InferenceSession,
-) -> tuple[OnnxInputShape, int, int | None, int | None]:
+def to_onnx_tensor_shape(
+    tensor: onnx.TypeProto.Tensor,
+) -> OnnxTensorShape:
+    shape = tuple(
+        dim.dim_param if dim.HasField("dim_param") else dim.dim_value
+        for dim in tensor.shape.dim
+    )
+    if len(shape) != 4:
+        raise ValueError(f"Expected 4 dimensions, got {len(shape)}")
+    return shape
+
+
+def is_tensor_input(input: ValueInfoProto) -> bool:
+    return input.type.HasField("tensor_type")
+
+
+def is_image_to_image(model: ModelProto) -> bool:
     """
-    Returns the input shape, input channels, input width (optional), and input height (optional).
+    Returns whether the model is an image to image model (single image input -> single image output).
     """
+    if len(model.graph.input) != 1 or len(model.graph.output) != 1:
+        return False
 
-    return parse_onnx_shape(session.get_inputs()[0].shape)
+    i = model.graph.input[0]
+    o = model.graph.output[0]
+    return is_tensor_input(i) and is_tensor_input(o)
 
 
-def get_output_shape(
-    session: ort.InferenceSession,
-) -> tuple[OnnxInputShape, int, int | None, int | None]:
+def image_to_image_shape_inference(
+    model: ModelProto, input_size: tuple[int, int]
+) -> tuple[
+    tuple[int | None, int | None, int | None],
+    tuple[int | None, int | None, int | None],
+]:
     """
-    Returns the output shape, output channels, output width (optional), and output height (optional).
-    """
+    input_shape: The size of the input tensors as width, height.
 
-    return parse_onnx_shape(session.get_outputs()[0].shape)
+    return: The shapes of the input and output tensors in HWC format.
+    """
+    i = model.graph.input[0]
+    o = model.graph.output[0]
+
+    if not is_tensor_input(i) or not is_tensor_input(o):
+        raise ValueError("Expected tensor inputs and outputs")
+
+    # modify model to have a fixed input size
+    input_shape = to_onnx_tensor_shape(i.type.tensor_type)
+    output_shape = to_onnx_tensor_shape(o.type.tensor_type)
+
+    parsed_input_shape = parse_onnx_shape(input_shape)
+    tensor_format = parsed_input_shape[0]
+
+    b = _or_else(_as_int(input_shape[0]), 1)
+    c = parsed_input_shape[1]
+    h = _or_else(parsed_input_shape[3], input_size[1])
+    w = _or_else(parsed_input_shape[2], input_size[0])
+
+    new_inputs: list[Any]
+    if tensor_format == "BCHW":
+        new_inputs = [b, c, h, w]
+    elif tensor_format == "BHWC":
+        new_inputs = [b, h, w, c]
+    else:
+        raise ValueError(f"Unknown tensor format: {tensor_format}")
+
+    update_model_dims.update_inputs_outputs_dims(
+        model,
+        {i.name: new_inputs},
+        {o.name: list(output_shape)},
+    )
+
+    # infer the output shape using the fixed input size
+    inferred_model = onnx.shape_inference.infer_shapes(model)
+    i = inferred_model.graph.input[0]
+    o = inferred_model.graph.output[0]
+
+    input_shape = to_onnx_tensor_shape(i.type.tensor_type)
+    output_shape = to_onnx_tensor_shape(o.type.tensor_type)
+
+    # output in HWC format
+    input_shape = input_shape[1:]
+    output_shape = output_shape[1:]
+
+    if tensor_format == "BCHW":
+        input_shape = input_shape[::-1]
+        output_shape = output_shape[::-1]
+
+    input_shape = tuple(_as_int(dim) for dim in input_shape)
+    output_shape = tuple(_as_int(dim) for dim in output_shape)
+
+    assert len(input_shape) == 3
+    assert len(output_shape) == 3
+
+    return input_shape[0:3], output_shape
+
+
+def get_tensor_fp_datatype(model: ModelProto) -> str:
+    for item in [*model.graph.input, *model.graph.output]:
+        if item.type.HasField("tensor_type"):
+            tensor = item.type.tensor_type
+            if tensor.elem_type == onnx.TensorProto.FLOAT16:
+                return "fp16"
+            if tensor.elem_type == onnx.TensorProto.FLOAT:
+                return "fp32"
+            if tensor.elem_type == onnx.TensorProto.DOUBLE:
+                return "fp64"
+            if tensor.elem_type == onnx.TensorProto.BFLOAT16:
+                return "bf16"
+    return "fp32"
+
+
+def get_opset(model: onnx.ModelProto) -> int:
+    for opset in model.opset_import:
+        if opset.domain == "":
+            return opset.version
+    return -1
 
 
 def safely_optimize_onnx_model(model_proto: ModelProto) -> ModelProto:
@@ -51,6 +170,8 @@ def safely_optimize_onnx_model(model_proto: ModelProto) -> ModelProto:
     Optimizes the model using onnxoptimizer. If onnxoptimizer is not installed, the model is returned as is.
     """
     try:
+        import onnxoptimizer
+
         passes = onnxoptimizer.get_fuse_and_elimination_passes()
         model_proto = onnxoptimizer.optimize(model_proto, passes)
     except Exception:

--- a/backend/src/nodes/impl/rembg/session_factory.py
+++ b/backend/src/nodes/impl/rembg/session_factory.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import onnxruntime as ort
 
-from ...impl.onnx.utils import get_input_shape
+from ..onnx.session import get_input_shape
 from .session_base import BaseSession
 from .session_cloth import ClothSession
 from .session_simple import SimpleSession

--- a/backend/src/nodes/properties/inputs/onnx_inputs.py
+++ b/backend/src/nodes/properties/inputs/onnx_inputs.py
@@ -1,7 +1,7 @@
 import navi
 from api import BaseInput
 
-from ...impl.onnx.model import OnnxModel, OnnxModels, OnnxRemBg, is_rembg_model
+from ...impl.onnx.model import OnnxModel, OnnxModels, OnnxRemBg
 from .generic_inputs import DropDownInput
 
 
@@ -25,7 +25,7 @@ class OnnxGenericModelInput(OnnxModelInput):
 
     def enforce(self, value: object):
         assert isinstance(value, OnnxModels)
-        assert not is_rembg_model(value.bytes), "Expected a non-rembg model"
+        assert value.sub_type == "Generic", "Expected a non-rembg model"
         return value
 
 
@@ -40,7 +40,7 @@ class OnnxRemBgModelInput(OnnxModelInput):
 
     def enforce(self, value: object):
         assert isinstance(value, OnnxModels)
-        assert is_rembg_model(value.bytes), "Expected a rembg model"
+        assert value.sub_type == "RemBg", "Expected a rembg model"
         return value
 
 

--- a/backend/src/nodes/properties/outputs/onnx_outputs.py
+++ b/backend/src/nodes/properties/outputs/onnx_outputs.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import navi
-from api import BaseOutput
+from api import BaseOutput, OutputKind
+from nodes.utils.format import format_channel_numbers
 
 from ...impl.onnx.model import OnnxModel
 
@@ -11,17 +14,35 @@ class OnnxModelOutput(BaseOutput):
         self,
         model_type: navi.ExpressionJson = "OnnxModel",
         label: str = "Model",
+        kind: OutputKind = "generic",
     ):
-        super().__init__(model_type, label, associated_type=OnnxModel)
+        super().__init__(model_type, label, kind=kind, associated_type=OnnxModel)
+
+    def get_broadcast_data(self, value: OnnxModel):
+        i = value.info
+
+        tags: list[str] = []
+        if i.input_channels is not None and i.output_channels is not None:
+            tags.append(format_channel_numbers(i.input_channels, i.output_channels))
+
+        tags.append(f"opset{i.opset}")
+        tags.append(i.dtype)
+
+        return {"tags": tags}
 
     def get_broadcast_type(self, value: OnnxModel):
         fields = {
             "subType": navi.literal(value.sub_type),
         }
 
-        if value.scale_width:
-            fields["scaleWidth"] = value.scale_width
-        if value.scale_height:
-            fields["scaleHeight"] = value.scale_height
+        i = value.info
+        if i.scale_width is not None:
+            fields["scaleWidth"] = i.scale_width
+        if i.scale_height is not None:
+            fields["scaleHeight"] = i.scale_height
+        if i.input_channels is not None:
+            fields["inputChannels"] = i.input_channels
+        if i.output_channels is not None:
+            fields["outputChannels"] = i.output_channels
 
         return navi.named("OnnxModel", fields)

--- a/backend/src/packages/chaiNNer_onnx/onnx/io/load_model.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/io/load_model.py
@@ -6,7 +6,8 @@ from pathlib import Path
 import onnx
 from sanic.log import logger
 
-from nodes.impl.onnx.model import OnnxModel, load_onnx_model
+from nodes.impl.onnx.load import load_onnx_model
+from nodes.impl.onnx.model import OnnxModel
 from nodes.properties.inputs import OnnxFileInput
 from nodes.properties.outputs import DirectoryOutput, FileNameOutput, OnnxModelOutput
 from nodes.utils.utils import split_file_path
@@ -25,7 +26,7 @@ from .. import io_group
     icon="ONNX",
     inputs=[OnnxFileInput(primary_input=True)],
     outputs=[
-        OnnxModelOutput().suggest(),
+        OnnxModelOutput(kind="tagged").suggest(),
         DirectoryOutput("Directory", of_input=0).with_id(2),
         FileNameOutput("Name", of_input=0).with_id(1),
     ],
@@ -41,7 +42,5 @@ def load_model_node(path: Path) -> tuple[OnnxModel, Path, str]:
     logger.debug(f"Reading onnx model from path: {path}")
     model = onnx.load_model(str(path))
 
-    model_as_string = model.SerializeToString()
-
     dirname, basename, _ = split_file_path(path)
-    return load_onnx_model(model_as_string), dirname, basename
+    return load_onnx_model(model), dirname, basename

--- a/backend/src/packages/chaiNNer_onnx/onnx/processing/upscale_image.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/processing/upscale_image.py
@@ -8,8 +8,7 @@ from api import NodeContext
 from nodes.groups import Condition, if_enum_group, if_group
 from nodes.impl.onnx.auto_split import onnx_auto_split
 from nodes.impl.onnx.model import OnnxModel
-from nodes.impl.onnx.session import get_onnx_session
-from nodes.impl.onnx.utils import get_input_shape, get_output_shape
+from nodes.impl.onnx.session import get_input_shape, get_onnx_session, get_output_shape
 from nodes.impl.upscale.auto_split_tiles import (
     CUSTOM,
     TILE_SIZE_256,
@@ -98,7 +97,12 @@ def upscale(
             )
         ),
     ],
-    outputs=[ImageOutput("Image")],
+    outputs=[
+        ImageOutput(
+            "Image",
+            image_type="convenientUpscaleOnnx(Input0, Input1)",
+        )
+    ],
     name="Upscale Image",
     icon="ONNX",
     node_context=True,

--- a/backend/src/packages/chaiNNer_onnx/onnx/utility/interpolate_models.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/utility/interpolate_models.py
@@ -10,7 +10,8 @@ from onnx.onnx_pb import TensorProto
 from sanic.log import logger
 
 from api import NodeContext
-from nodes.impl.onnx.model import OnnxModel, load_onnx_model
+from nodes.impl.onnx.load import load_onnx_model
+from nodes.impl.onnx.model import OnnxModel
 from nodes.impl.onnx.utils import safely_optimize_onnx_model
 from nodes.impl.upscale.auto_split_tiles import NO_TILING
 from nodes.properties.inputs import OnnxModelInput, SliderInput
@@ -116,9 +117,8 @@ def interpolate_models_node(
         # Assigning a new value or assigning to field index do not seem to work
         model_proto_interp.graph.initializer.pop()  # type: ignore
     model_proto_interp.graph.initializer.extend(interp_weights_list)  # type: ignore
-    model_interp = model_proto_interp.SerializeToString()  # type: ignore
 
-    model = load_onnx_model(model_interp)
+    model = load_onnx_model(model_proto_interp)
     if not check_will_upscale(context, model):
         raise ValueError(
             "These models are not compatible and not able to be interpolated together"

--- a/backend/src/packages/chaiNNer_onnx/onnx/utility/optimize_model.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/utility/optimize_model.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import onnx
 
-from nodes.impl.onnx.model import OnnxModel, load_onnx_model
+from nodes.impl.onnx.load import load_onnx_model
+from nodes.impl.onnx.model import OnnxModel
 from nodes.impl.onnx.utils import safely_optimize_onnx_model
 from nodes.properties.inputs import OnnxModelInput
 from nodes.properties.outputs import OnnxModelOutput
@@ -25,5 +26,4 @@ from .. import utility_group
 def optimize_model_node(model: OnnxModel) -> OnnxModel:
     model_proto = onnx.load_from_string(model.bytes)
     model_proto = safely_optimize_onnx_model(model_proto)
-    model_bytes = model_proto.SerializeToString()
-    return load_onnx_model(model_bytes)
+    return load_onnx_model(model_proto)

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/utility/convert_to_ncnn.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/utility/convert_to_ncnn.py
@@ -12,7 +12,7 @@ from spandrel_extra_arches.architectures.SRFormer import SRFormer
 
 from api import NodeContext
 from nodes.impl.ncnn.model import NcnnModelWrapper
-from nodes.impl.onnx.model import OnnxGeneric
+from nodes.impl.onnx.load import load_onnx_model
 from nodes.impl.pytorch.convert_to_onnx_impl import (
     convert_to_onnx_impl,
     is_onnx_supported,
@@ -68,7 +68,7 @@ def convert_to_ncnn_node(
     device = exec_options.device
 
     # Intermediate conversion to ONNX is always fp32
-    onnx_model = OnnxGeneric(
+    onnx_model = load_onnx_model(
         convert_to_onnx_impl(model, device, False, "data", "output")
     )
     ncnn_model, fp_mode = onnx_convert_to_ncnn_node(onnx_model, is_fp16)

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/utility/convert_to_onnx.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/utility/convert_to_onnx.py
@@ -5,6 +5,7 @@ from enum import Enum
 from spandrel import ImageModelDescriptor
 
 from api import NodeContext
+from nodes.impl.onnx.load import load_onnx_model
 from nodes.impl.onnx.model import OnnxGeneric
 from nodes.impl.pytorch.convert_to_onnx_impl import (
     convert_to_onnx_impl,
@@ -92,7 +93,9 @@ def convert_to_onnx_node(
         use_half,
         opset_version=opset.value,
     )
+    onnx_model = load_onnx_model(onnx_model_bytes)
+    assert onnx_model.sub_type == "Generic"
 
     fp_mode = "fp16" if use_half else "fp32"
 
-    return OnnxGeneric(onnx_model_bytes), fp_mode, f"opset{opset.value}"
+    return onnx_model, fp_mode, f"opset{opset.value}"

--- a/src/common/types/chainner-scope.ts
+++ b/src/common/types/chainner-scope.ts
@@ -76,6 +76,8 @@ struct OnnxModel {
     subType: string,
     scaleHeight: int(1..),
     scaleWidth: int(1..),
+    inputChannels: int(1..),
+    outputChannels: int(1..),
 }
 let OnnxRemBgModel = OnnxModel {
     subType: "RemBg",
@@ -105,6 +107,17 @@ def convenientUpscale(model: PyTorchModel | NcnnNetwork, image: Image) {
     Image {
         width: model.scale * image.width,
         height: model.scale * image.height,
+        channels: if model.inputChannels == model.outputChannels {
+            image.channels
+        } else {
+            model.outputChannels
+        }
+    }
+}
+def convenientUpscaleOnnx(model: OnnxModel, image: Image) {
+    Image {
+        width: model.scaleWidth * image.width,
+        height: model.scaleHeight * image.height,
         channels: if model.inputChannels == model.outputChannels {
             image.channels
         } else {

--- a/src/renderer/components/TypeTag.tsx
+++ b/src/renderer/components/TypeTag.tsx
@@ -240,6 +240,17 @@ const getTypeText = (type: Type): TagValue[] => {
             if (isNumericLiteral(scale)) {
                 tags.push({ kind: 'literal', value: `${scale.toString()}x` });
             }
+
+            const scaleWidth = type.getField('scaleWidth') ?? NeverType.instance;
+            const scaleHeight = type.getField('scaleHeight') ?? NeverType.instance;
+            if (
+                isNumericLiteral(scaleWidth) &&
+                isNumericLiteral(scaleHeight) &&
+                scaleWidth.value === scaleHeight.value
+            ) {
+                tags.push({ kind: 'literal', value: `${scaleWidth.toString()}x` });
+            }
+
             const subType = type.getField('subType') ?? NeverType.instance;
             if (isStringLiteral(subType)) {
                 tags.push({ kind: 'literal', value: subType.value });


### PR DESCRIPTION
Closes #1370

This adds support for type and tag broadcasting for all ONNX models. While we did have type broadcasting for ONNX models before, those broadcasts did not contain much information. Now they contain the model's input/output channels and scale, just like for PyTorch and NCNN models. This finally allows us to compute output types for ONNX's Upscale Image node.

A model's input/output channels and scale(s) are detected using `onnx.shape_inference` [[1]](https://onnx.ai/onnx/api/shape_inference.html) [[2]](https://github.com/onnx/onnx/blob/main/docs/ShapeInference.md). This allows us to statically determine the shape of the output tensor for a given input tensor shape without actually running the model (=no inference session). While this is roughly 10-100x faster than creating an `ort.InferenceSession`, it's still not free. Loading generic ONNX models will now take roughly 3-4x longer. This might sound bad, but it's not. E.g. an ESRGAN ONNX model previously took 0.11s and now it takes 0.38s. A lot slower, but not a problem.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/a504430f-78cb-465d-b1be-7e70f39e06b0)
![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/22b8cf50-01bf-48a0-84c9-6179f6ac9a0d)

---

Changes:
- Extract out loading ONNX models into its own file. This ensures that the type definitions for ONNX models don't depend on the ONNX package.
- Store ONNX model information in new `OnnxInfo` class.
- Removed `is_rembg_model` function, because it wasn't necessary.
- Refactored `create_inference_session`.