### PR TITLE
Fix colors of pane search icons

### DIFF
--- a/src/renderer/colors.scss
+++ b/src/renderer/colors.scss
@@ -99,6 +99,9 @@
     /* controls */
     --controls-bg: var(--theme-600-a50);
     --controls-bg-hover: var(--theme-600);
+
+    // pane search
+    --pane-icon: var(--theme-200);
 }
 
 :root[data-theme='light'] {
@@ -165,6 +168,9 @@
     --controls-bg-hover: var(--theme-400);
 
     --type-color-color: #000;
+
+    // pane search
+    --pane-icon: var(--theme-700);
 }
 
 // Default theme (copied from Chakra UI)

--- a/src/renderer/components/PaneNodeSearchMenu.tsx
+++ b/src/renderer/components/PaneNodeSearchMenu.tsx
@@ -81,7 +81,7 @@ const SchemaItem = memo(
                 onClick={onClick}
             >
                 <IconFactory
-                    accentColor="gray.500"
+                    accentColor="var(--pane-icon)"
                     icon={icon}
                 />
                 <Text


### PR DESCRIPTION
Wasn't a fan of how this looked with themes

# Before:
![image](https://github.com/chaiNNer-org/chaiNNer/assets/34788790/dbc35043-00da-4451-a153-abd6dcfb0cb4)


# After:
![image](https://github.com/chaiNNer-org/chaiNNer/assets/34788790/3349d1f2-95ca-4247-b4fc-2f8eadc723b7)
