### PR TITLE
Add status API to get executor status

### DIFF
--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -413,6 +413,27 @@ async def kill(request: Request):
         return json(error_response("Error killing execution!", exception), status=500)
 
 
+@app.route("/status")
+async def status(_request: Request):
+    await nodes_available()
+
+    ctx = AppContext.get(app)
+
+    executor_status: str
+    if ctx.executor:
+        e = ctx.executor
+        if e.progress.aborted:
+            executor_status = "killing"
+        elif e.progress.paused:
+            executor_status = "paused"
+        else:
+            executor_status = "running"
+    else:
+        executor_status = "ready"
+
+    return json({"executor": executor_status})
+
+
 @app.route("/packages", methods=["GET"])
 async def get_packages(request: Request):
     await nodes_available()

--- a/src/common/Backend.ts
+++ b/src/common/Backend.ts
@@ -80,6 +80,13 @@ export interface BackendRunIndividualRequest {
     schemaId: SchemaId;
     options: PackageSettings;
 }
+export interface BackendWorkerStatusResponse {
+    executor: 'running' | 'killing' | 'paused' | 'ready';
+}
+export interface BackendStatusResponse {
+    ready: boolean;
+    worker: null | BackendError | BackendWorkerStatusResponse;
+}
 
 export type BackendResult<T> = BackendSuccess<T> | BackendError;
 export interface BackendSuccess<T> {
@@ -256,7 +263,7 @@ export class Backend {
         return this.fetchJson('/shutdown', 'POST');
     }
 
-    status(): Promise<{ ready: boolean }> {
+    status(): Promise<BackendStatusResponse> {
         return this.fetchJson('/status', 'GET');
     }
 }

--- a/src/renderer/contexts/BackendContext.tsx
+++ b/src/renderer/contexts/BackendContext.tsx
@@ -12,7 +12,12 @@ import React, {
 import { useTranslation } from 'react-i18next';
 import { useQuery, useQueryClient } from 'react-query';
 import { createContext, useContext } from 'use-context-selector';
-import { Backend, BackendNodesResponse, getBackend } from '../../common/Backend';
+import {
+    Backend,
+    BackendNodesResponse,
+    BackendStatusResponse,
+    getBackend,
+} from '../../common/Backend';
 import { CategoryMap } from '../../common/CategoryMap';
 import {
     CategoryId,
@@ -304,7 +309,7 @@ export const BackendProvider = memo(
         }, [isBackendReady]);
         const statusQuery = useQuery({
             queryKey: ['status', backend.url],
-            queryFn: async (): Promise<{ ready: boolean }> => {
+            queryFn: async (): Promise<BackendStatusResponse> => {
                 try {
                     // spin until we're no longer restarting
                     while (backendDownRef.current) {
@@ -314,7 +319,7 @@ export const BackendProvider = memo(
 
                     return await backend.status();
                 } catch (error) {
-                    return { ready: false };
+                    return { ready: false, worker: null };
                 }
             },
             cacheTime: 0,


### PR DESCRIPTION
Fixes #2922

This fixes the issue by adding a status API and pulling it every 3s. This has the effect that the UI will always show the correct status after at most 3s.