### PR TITLE
Switch to using total VRAM instead of free VRAM to estimate tile size

### DIFF
--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
@@ -68,10 +68,10 @@ def upscale(
                 if options.use_fp16:
                     model_bytes = model_bytes // 2
                 mem_info: tuple[int, int] = torch.cuda.mem_get_info(device)  # type: ignore
-                free, _total = mem_info
+                _free, total = mem_info
                 if options.budget_limit > 0:
-                    free = min(options.budget_limit * 1024**3, free)
-                budget = int(free * 0.8)
+                    total = min(options.budget_limit * 1024**3, total)
+                budget = int(total * 0.75)
 
                 return MaxTileSize(
                     estimate_tile_size(

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
@@ -69,9 +69,12 @@ def upscale(
                     model_bytes = model_bytes // 2
                 mem_info: tuple[int, int] = torch.cuda.mem_get_info(device)  # type: ignore
                 _free, total = mem_info
+                # only use 75% of the total memory
+                total = int(total * 0.75)
                 if options.budget_limit > 0:
                     total = min(options.budget_limit * 1024**3, total)
-                budget = int(total * 0.75)
+                # Estimate using 80% of the value to be more conservative
+                budget = int(total * 0.8)
 
                 return MaxTileSize(
                     estimate_tile_size(


### PR DESCRIPTION
We recently switched to not clearing out the cuda cache after each upscale and rather at the end of the chain. This means that pytorch now keeps VRAM usage somewhat high. This is fine though, because this is actually PyTorch's intended behavior to improve performance. Even though it is capturing this VRAM and it looks like its in use, PyTorch is able to reuse that memory for allocating tensors. In fact [users should not be using clear cache at all, apparently](https://discuss.pytorch.org/t/about-torch-cuda-empty-cache/34232).

However, since it _looks_ like this vram is in use and unable to be used, we need to switch to using total system VRAM for estimations rather than free VRAM, since otherwise we might be estimating incorrectly. 

Since the total amount is likely have some usage already, i lowered the budget calculation a bit to compensate.