### PR TITLE
Add a setting for clearing CUDA cache after each inference

### DIFF
--- a/backend/src/api/node_context.py
+++ b/backend/src/api/node_context.py
@@ -148,9 +148,11 @@ class NodeContext(Progress, ABC):
         """
 
     @abstractmethod
-    def add_cleanup(self, fn: Callable[[], None]) -> None:
+    def add_cleanup(
+        self, fn: Callable[[], None], after: Literal["node", "chain"] = "chain"
+    ) -> None:
         """
-        Registers a function that will be called when the chain execution is finished.
+        Registers a function that will be called when the chain execution is finished (if set to chain mode) or after node execution is finished (node mode).
 
         Registering the same function (object) twice will only result in the function being called once.
         """

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/align_image_to_reference.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/align_image_to_reference.py
@@ -221,14 +221,19 @@ def align_image_to_reference_node(
     blur_strength: float,
 ) -> np.ndarray:
     context.add_cleanup(safe_cuda_cache_empty)
+    exec_options = get_settings(context)
     multiplier = precision.value / 1000
-    return align_images(
-        context,
-        target_img,
-        source_img,
-        precision,
-        multiplier=multiplier,
-        alignment_passes=alignment_passes,
-        blur_strength=blur_strength,
-        ensemble=True,
-    )
+    try:
+        return align_images(
+            context,
+            target_img,
+            source_img,
+            precision,
+            multiplier=multiplier,
+            alignment_passes=alignment_passes,
+            blur_strength=blur_strength,
+            ensemble=True,
+        )
+    finally:
+        if exec_options.force_cache_wipe:
+            safe_cuda_cache_empty()

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/align_image_to_reference.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/align_image_to_reference.py
@@ -220,20 +220,19 @@ def align_image_to_reference_node(
     alignment_passes: int,
     blur_strength: float,
 ) -> np.ndarray:
-    context.add_cleanup(safe_cuda_cache_empty)
     exec_options = get_settings(context)
+    context.add_cleanup(
+        safe_cuda_cache_empty,
+        after="node" if exec_options.force_cache_wipe else "chain",
+    )
     multiplier = precision.value / 1000
-    try:
-        return align_images(
-            context,
-            target_img,
-            source_img,
-            precision,
-            multiplier=multiplier,
-            alignment_passes=alignment_passes,
-            blur_strength=blur_strength,
-            ensemble=True,
-        )
-    finally:
-        if exec_options.force_cache_wipe:
-            safe_cuda_cache_empty()
+    return align_images(
+        context,
+        target_img,
+        source_img,
+        precision,
+        multiplier=multiplier,
+        alignment_passes=alignment_passes,
+        blur_strength=blur_strength,
+        ensemble=True,
+    )

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/guided_upscale.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/guided_upscale.py
@@ -79,16 +79,15 @@ def guided_upscale_node(
     iterations: float,
     split_mode: SplitMode,
 ) -> np.ndarray:
-    context.add_cleanup(safe_cuda_cache_empty)
     exec_options = get_settings(context)
-    try:
-        return pix_transform_auto_split(
-            source=source,
-            guide=guide,
-            device=exec_options.device,
-            params=Params(iteration=int(iterations * 1000)),
-            split_mode=split_mode,
-        )
-    finally:
-        if exec_options.force_cache_wipe:
-            safe_cuda_cache_empty()
+    context.add_cleanup(
+        safe_cuda_cache_empty,
+        after="node" if exec_options.force_cache_wipe else "chain",
+    )
+    return pix_transform_auto_split(
+        source=source,
+        guide=guide,
+        device=exec_options.device,
+        params=Params(iteration=int(iterations * 1000)),
+        split_mode=split_mode,
+    )

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/guided_upscale.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/guided_upscale.py
@@ -80,10 +80,15 @@ def guided_upscale_node(
     split_mode: SplitMode,
 ) -> np.ndarray:
     context.add_cleanup(safe_cuda_cache_empty)
-    return pix_transform_auto_split(
-        source=source,
-        guide=guide,
-        device=get_settings(context).device,
-        params=Params(iteration=int(iterations * 1000)),
-        split_mode=split_mode,
-    )
+    exec_options = get_settings(context)
+    try:
+        return pix_transform_auto_split(
+            source=source,
+            guide=guide,
+            device=exec_options.device,
+            params=Params(iteration=int(iterations * 1000)),
+            split_mode=split_mode,
+        )
+    finally:
+        if exec_options.force_cache_wipe:
+            safe_cuda_cache_empty()

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/inpaint.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/inpaint.py
@@ -114,11 +114,9 @@ def inpaint_node(
     ), "Input image and mask must have the same resolution"
 
     exec_options = get_settings(context)
+    context.add_cleanup(
+        safe_cuda_cache_empty,
+        after="node" if exec_options.force_cache_wipe else "chain",
+    )
 
-    context.add_cleanup(safe_cuda_cache_empty)
-
-    try:
-        return inpaint(img, mask, model, exec_options)
-    finally:
-        if exec_options.force_cache_wipe:
-            safe_cuda_cache_empty()
+    return inpaint(img, mask, model, exec_options)

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/inpaint.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/inpaint.py
@@ -117,4 +117,8 @@ def inpaint_node(
 
     context.add_cleanup(safe_cuda_cache_empty)
 
-    return inpaint(img, mask, model, exec_options)
+    try:
+        return inpaint(img, mask, model, exec_options)
+    finally:
+        if exec_options.force_cache_wipe:
+            safe_cuda_cache_empty()

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
@@ -265,7 +265,10 @@ def upscale_image_node(
 ) -> np.ndarray:
     exec_options = get_settings(context)
 
-    context.add_cleanup(safe_cuda_cache_empty)
+    context.add_cleanup(
+        safe_cuda_cache_empty,
+        after="node" if exec_options.force_cache_wipe else "chain",
+    )
 
     in_nc = model.input_channels
     out_nc = model.output_channels
@@ -296,10 +299,4 @@ def upscale_image_node(
     if not use_custom_scale or scale == 1 or in_nc != out_nc:
         # no custom scale
         custom_scale = scale
-    try:
-        return custom_scale_upscale(
-            img, inner_upscale, scale, custom_scale, separate_alpha
-        )
-    finally:
-        if exec_options.force_cache_wipe:
-            safe_cuda_cache_empty()
+    return custom_scale_upscale(img, inner_upscale, scale, custom_scale, separate_alpha)

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/upscale_image.py
@@ -296,5 +296,10 @@ def upscale_image_node(
     if not use_custom_scale or scale == 1 or in_nc != out_nc:
         # no custom scale
         custom_scale = scale
-
-    return custom_scale_upscale(img, inner_upscale, scale, custom_scale, separate_alpha)
+    try:
+        return custom_scale_upscale(
+            img, inner_upscale, scale, custom_scale, separate_alpha
+        )
+    finally:
+        if exec_options.force_cache_wipe:
+            safe_cuda_cache_empty()

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/wavelet_color_fix.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/wavelet_color_fix.py
@@ -82,18 +82,24 @@ def wavelet_color_fix_node(
     context.add_cleanup(safe_cuda_cache_empty)
     device = exec_options.device
 
-    # convert to tensors
-    target_tensor = np2tensor(target_img, change_range=True).to(device)
-    source_tensor_resized = np2tensor(source_img_resized, change_range=True).to(device)
+    try:
+        # convert to tensors
+        target_tensor = np2tensor(target_img, change_range=True).to(device)
+        source_tensor_resized = np2tensor(source_img_resized, change_range=True).to(
+            device
+        )
 
-    # wavelet color fix
-    result_tensor = wavelet_reconstruction(
-        target_tensor, source_tensor_resized, levels=levels
-    )
+        # wavelet color fix
+        result_tensor = wavelet_reconstruction(
+            target_tensor, source_tensor_resized, levels=levels
+        )
 
-    # convert back to numpy array
-    result_img = tensor2np(
-        result_tensor.detach().cpu(), change_range=False, imtype=np.float32
-    )
+        # convert back to numpy array
+        result_img = tensor2np(
+            result_tensor.detach().cpu(), change_range=False, imtype=np.float32
+        )
 
-    return result_img
+        return result_img
+    finally:
+        if exec_options.force_cache_wipe:
+            safe_cuda_cache_empty()

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/wavelet_color_fix.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/wavelet_color_fix.py
@@ -79,27 +79,24 @@ def wavelet_color_fix_node(
     )
 
     exec_options = get_settings(context)
-    context.add_cleanup(safe_cuda_cache_empty)
+    context.add_cleanup(
+        safe_cuda_cache_empty,
+        after="node" if exec_options.force_cache_wipe else "chain",
+    )
     device = exec_options.device
 
-    try:
-        # convert to tensors
-        target_tensor = np2tensor(target_img, change_range=True).to(device)
-        source_tensor_resized = np2tensor(source_img_resized, change_range=True).to(
-            device
-        )
+    # convert to tensors
+    target_tensor = np2tensor(target_img, change_range=True).to(device)
+    source_tensor_resized = np2tensor(source_img_resized, change_range=True).to(device)
 
-        # wavelet color fix
-        result_tensor = wavelet_reconstruction(
-            target_tensor, source_tensor_resized, levels=levels
-        )
+    # wavelet color fix
+    result_tensor = wavelet_reconstruction(
+        target_tensor, source_tensor_resized, levels=levels
+    )
 
-        # convert back to numpy array
-        result_img = tensor2np(
-            result_tensor.detach().cpu(), change_range=False, imtype=np.float32
-        )
+    # convert back to numpy array
+    result_img = tensor2np(
+        result_tensor.detach().cpu(), change_range=False, imtype=np.float32
+    )
 
-        return result_img
-    finally:
-        if exec_options.force_cache_wipe:
-            safe_cuda_cache_empty()
+    return result_img

--- a/backend/src/packages/chaiNNer_pytorch/settings.py
+++ b/backend/src/packages/chaiNNer_pytorch/settings.py
@@ -75,6 +75,16 @@ package.add_setting(
     )
 )
 
+if nvidia.is_available:
+    package.add_setting(
+        ToggleSetting(
+            label="Force CUDA Cache Wipe (not recommended)",
+            key="force_cache_wipe",
+            description="Clears PyTorch's CUDA cache after each inference. This is NOT recommended, by us or PyTorch's developers, as it basically interferes with how PyTorch is intended to work and can significantly slow down inference time. Only enable this if you're experiencing issues with VRAM allocation.",
+            default=False,
+        )
+    )
+
 
 @dataclass(frozen=True)
 class PyTorchSettings:
@@ -82,6 +92,7 @@ class PyTorchSettings:
     use_fp16: bool
     gpu_index: int
     budget_limit: int
+    force_cache_wipe: bool = False
 
     # PyTorch 2.0 does not support FP16 when using CPU
     def __post_init__(self):
@@ -122,4 +133,5 @@ def get_settings(context: NodeContext) -> PyTorchSettings:
         use_fp16=settings.get_bool("use_fp16", False),
         gpu_index=settings.get_int("gpu_index", 0, parse_str=True),
         budget_limit=settings.get_int("budget_limit", 0, parse_str=True),
+        force_cache_wipe=settings.get_bool("force_cache_wipe", False),
     )


### PR DESCRIPTION
While I'd prefer for this to just not be an option, I admit it might be useful as a debugging tool for users or to potentially prevent issues. If users are fine with the slowdown and it stops an issue from happening, then it's probably useful to have this.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/34788790/449d9810-cfc6-4ed3-ba2d-e797934299cc)
