### PR TITLE
Add "Install All" button to dependency manager

### DIFF
--- a/src/common/Backend.ts
+++ b/src/common/Backend.ts
@@ -9,6 +9,7 @@ import {
     OutputData,
     OutputTypes,
     Package,
+    PackageId,
     PackageSettings,
     PyPiName,
     PythonInfo,
@@ -241,22 +242,12 @@ export class Backend {
         return this.fetchJson('/features', 'GET');
     }
 
-    installPackage(pkg: Package): Promise<void> {
-        return this.fetchJson('/packages/install', 'POST', {
-            package: pkg.id,
-        });
+    installPackages(packages: readonly PackageId[]): Promise<void> {
+        return this.fetchJson('/packages/install', 'POST', { packages });
     }
 
-    uninstallPackage(pkg: Package): Promise<void> {
-        return this.fetchJson('/packages/uninstall', 'POST', {
-            package: pkg.id,
-        });
-    }
-
-    updatePackage(pkg: Package): Promise<void> {
-        return this.fetchJson('/packages/install', 'POST', {
-            package: pkg.id,
-        });
+    uninstallPackages(packages: readonly PackageId[]): Promise<void> {
+        return this.fetchJson('/packages/uninstall', 'POST', { packages });
     }
 
     shutdown(): Promise<void> {


### PR DESCRIPTION
This PR adds a new button to the dependency manager that allows users to install/update all dependencies at once.

To implement this, I had to change all the code that worked on a one-package basis.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/871fda1f-fee3-4b19-a5dc-e99649c84bd6)

Other changes:
- Improved size formatting to be more precise. 