### PR TITLE
Add UI for anchor/position dropdowns

### DIFF
--- a/backend/src/nodes/properties/inputs/generic_inputs.py
+++ b/backend/src/nodes/properties/inputs/generic_inputs.py
@@ -44,7 +44,7 @@ class DropDownOption(TypedDict):
     condition: NotRequired[ConditionJson | None]
 
 
-DropDownStyle = Literal["dropdown", "checkbox", "tabs", "icons"]
+DropDownStyle = Literal["dropdown", "checkbox", "tabs", "icons", "anchor"]
 """
 This specified the preferred style in which the frontend may display the dropdown.
 
@@ -53,6 +53,7 @@ This specified the preferred style in which the frontend may display the dropdow
   The first option will be interpreted as the yes/true option while the second option will be interpreted as the no/false option.
 - `tabs`: The options are displayed as tab list. The label of the input itself will *not* be displayed.
 - `icons`: The options are displayed as a list of icons. This is only available if all options have icons. Labels are still required for all options.
+- `anchor`: The options are displayed as a 3x3 grid where the user is allowed to select one of 9 anchor positions. This only works for dropdowns with 9 options.
 """
 
 
@@ -598,4 +599,48 @@ def RowOrderDropdown() -> DropDownInput:
         OrderEnum,
         label="Order",
         default=OrderEnum.ROW_MAJOR,
+    )
+
+
+class Anchor(Enum):
+    TOP_LEFT = "top_left"
+    TOP = "top_centered"
+    TOP_RIGHT = "top_right"
+    LEFT = "centered_left"
+    CENTER = "centered"
+    RIGHT = "centered_right"
+    BOTTOM_LEFT = "bottom_left"
+    BOTTOM = "bottom_centered"
+    BOTTOM_RIGHT = "bottom_right"
+
+
+def AnchorInput(label: str = "Anchor", icon: str = "BsFillImageFill") -> DropDownInput:
+    return EnumInput(
+        Anchor,
+        label=label,
+        label_style="inline",
+        option_labels={
+            Anchor.TOP_LEFT: "Top Left",
+            Anchor.TOP: "Top",
+            Anchor.TOP_RIGHT: "Top Right",
+            Anchor.LEFT: "Left",
+            Anchor.CENTER: "Center",
+            Anchor.RIGHT: "Right",
+            Anchor.BOTTOM_LEFT: "Bottom Left",
+            Anchor.BOTTOM: "Bottom",
+            Anchor.BOTTOM_RIGHT: "Bottom Right",
+        },
+        icons={
+            Anchor.TOP_LEFT: icon,
+            Anchor.TOP: icon,
+            Anchor.TOP_RIGHT: icon,
+            Anchor.LEFT: icon,
+            Anchor.CENTER: icon,
+            Anchor.RIGHT: icon,
+            Anchor.BOTTOM_LEFT: icon,
+            Anchor.BOTTOM: icon,
+            Anchor.BOTTOM_RIGHT: icon,
+        },
+        preferred_style="anchor",
+        default=Anchor.CENTER,
     )

--- a/backend/src/packages/chaiNNer_standard/image_utility/compositing/blend_images.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/compositing/blend_images.py
@@ -26,41 +26,41 @@ from .. import compositing_group
 
 class BlendOverlayPosition(Enum):
     TOP_LEFT = "top_left"
-    TOP_CENTERED = "top_centered"
+    TOP = "top_centered"
     TOP_RIGHT = "top_right"
-    CENTERED_LEFT = "centered_left"
-    CENTERED = "centered"
-    CENTERED_RIGHT = "centered_right"
+    LEFT = "centered_left"
+    CENTER = "centered"
+    RIGHT = "centered_right"
     BOTTOM_LEFT = "bottom_left"
-    BOTTOM_CENTERED = "bottom_centered"
+    BOTTOM = "bottom_centered"
     BOTTOM_RIGHT = "bottom_right"
     PERCENT_OFFSET = "percent_offset"
     PIXEL_OFFSET = "pixel_offset"
 
 
 BLEND_OVERLAY_POSITION_LABELS = {
-    BlendOverlayPosition.TOP_LEFT: "Top left",
-    BlendOverlayPosition.TOP_CENTERED: "Top centered",
-    BlendOverlayPosition.TOP_RIGHT: "Top right",
-    BlendOverlayPosition.CENTERED_LEFT: "Centered left",
-    BlendOverlayPosition.CENTERED: "Centered",
-    BlendOverlayPosition.CENTERED_RIGHT: "Centered right",
-    BlendOverlayPosition.BOTTOM_LEFT: "Bottom left",
-    BlendOverlayPosition.BOTTOM_CENTERED: "Bottom centered",
-    BlendOverlayPosition.BOTTOM_RIGHT: "Bottom right",
+    BlendOverlayPosition.TOP_LEFT: "Top Left",
+    BlendOverlayPosition.TOP: "Top",
+    BlendOverlayPosition.TOP_RIGHT: "Top Right",
+    BlendOverlayPosition.LEFT: "Left",
+    BlendOverlayPosition.CENTER: "Center",
+    BlendOverlayPosition.RIGHT: "Right",
+    BlendOverlayPosition.BOTTOM_LEFT: "Bottom Left",
+    BlendOverlayPosition.BOTTOM: "Bottom",
+    BlendOverlayPosition.BOTTOM_RIGHT: "Bottom Right",
     BlendOverlayPosition.PERCENT_OFFSET: "Offset (%)",
     BlendOverlayPosition.PIXEL_OFFSET: "Offset (pixels)",
 }
 
 BLEND_OVERLAY_X0_Y0_FACTORS = {
     BlendOverlayPosition.TOP_LEFT: np.array([0, 0]),
-    BlendOverlayPosition.TOP_CENTERED: np.array([0.5, 0]),
+    BlendOverlayPosition.TOP: np.array([0.5, 0]),
     BlendOverlayPosition.TOP_RIGHT: np.array([1, 0]),
-    BlendOverlayPosition.CENTERED_LEFT: np.array([0, 0.5]),
-    BlendOverlayPosition.CENTERED: np.array([0.5, 0.5]),
-    BlendOverlayPosition.CENTERED_RIGHT: np.array([1, 0.5]),
+    BlendOverlayPosition.LEFT: np.array([0, 0.5]),
+    BlendOverlayPosition.CENTER: np.array([0.5, 0.5]),
+    BlendOverlayPosition.RIGHT: np.array([1, 0.5]),
     BlendOverlayPosition.BOTTOM_LEFT: np.array([0, 1]),
-    BlendOverlayPosition.BOTTOM_CENTERED: np.array([0.5, 1]),
+    BlendOverlayPosition.BOTTOM: np.array([0.5, 1]),
     BlendOverlayPosition.BOTTOM_RIGHT: np.array([1, 1]),
     BlendOverlayPosition.PERCENT_OFFSET: np.array([1, 1]),
     BlendOverlayPosition.PIXEL_OFFSET: np.array([0, 0]),
@@ -81,7 +81,7 @@ BLEND_OVERLAY_X0_Y0_FACTORS = {
                 BlendOverlayPosition,
                 label="Overlay position",
                 option_labels=BLEND_OVERLAY_POSITION_LABELS,
-                default=BlendOverlayPosition.CENTERED,
+                default=BlendOverlayPosition.CENTER,
             ),
             if_enum_group(3, (BlendOverlayPosition.PERCENT_OFFSET))(
                 SliderInput("X offset", min=-200, max=200, default=0, unit="%"),

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -69,7 +69,7 @@ export interface InputOption {
     readonly condition?: Condition | null;
 }
 export type FileInputKind = 'image' | 'pth' | 'pt' | 'video' | 'bin' | 'param' | 'onnx';
-export type DropDownStyle = 'dropdown' | 'checkbox' | 'tabs' | 'icons';
+export type DropDownStyle = 'dropdown' | 'checkbox' | 'tabs' | 'icons' | 'anchor';
 export interface DropdownGroup {
     readonly label?: string | null;
     readonly startAt: InputSchemaValue;

--- a/src/renderer/components/groups/FromToDropdownsGroup.tsx
+++ b/src/renderer/components/groups/FromToDropdownsGroup.tsx
@@ -4,6 +4,7 @@ import { IoMdArrowForward } from 'react-icons/io';
 import { Input, InputData, InputId, InputValue, OfKind } from '../../../common/common-types';
 import { getInputValue } from '../../../common/util';
 import { getPassthroughIgnored } from '../../helpers/nodeState';
+import { useValidDropDownValue } from '../../hooks/useValidDropDownValue';
 import { DropDown } from '../inputs/elements/Dropdown';
 import { InputContainer } from '../inputs/InputContainer';
 import { GroupProps } from './props';
@@ -15,10 +16,14 @@ interface SmallDropDownProps {
     isLocked: boolean;
 }
 const SmallDropDown = memo(({ input, inputData, setInputValue, isLocked }: SmallDropDownProps) => {
-    const value = getInputValue<string | number>(input.id, inputData);
     const setValue = useCallback(
         (data?: string | number) => setInputValue(input.id, data ?? input.def),
         [setInputValue, input]
+    );
+    const value = useValidDropDownValue(
+        getInputValue<string | number>(input.id, inputData),
+        setValue,
+        input
     );
 
     return (

--- a/src/renderer/components/groups/MenuIconRowGroup.tsx
+++ b/src/renderer/components/groups/MenuIconRowGroup.tsx
@@ -1,11 +1,29 @@
 import { Box } from '@chakra-ui/react';
 import { memo } from 'react';
+import { DropDownInput, InputSchemaValue } from '../../../common/common-types';
 import { getUniqueKey } from '../../../common/group-inputs';
-import { getPassthroughIgnored } from '../../helpers/nodeState';
+import { NodeState, getPassthroughIgnored } from '../../helpers/nodeState';
+import { useValidDropDownValue } from '../../hooks/useValidDropDownValue';
 import { IconList } from '../inputs/elements/IconList';
 import { InputContainer, WithoutLabel } from '../inputs/InputContainer';
 import { IconSet } from './IconSetGroup';
 import { GroupProps } from './props';
+
+const IconListWrapper = memo(
+    ({ input, nodeState }: { input: DropDownInput; nodeState: NodeState }) => {
+        const setValue = (value: InputSchemaValue) => nodeState.setInputValue(input.id, value);
+        const value = useValidDropDownValue(nodeState.inputData[input.id], setValue, input);
+
+        return (
+            <IconList
+                isDisabled={nodeState.isLocked}
+                options={input.options}
+                value={value}
+                onChange={setValue}
+            />
+        );
+    }
+);
 
 export const MenuIconRowGroup = memo(({ inputs, nodeState }: GroupProps<'menu-icon-row'>) => {
     return (
@@ -30,13 +48,10 @@ export const MenuIconRowGroup = memo(({ inputs, nodeState }: GroupProps<'menu-ic
 
                         if (item.kind === 'dropdown' && item.preferredStyle === 'icons') {
                             return (
-                                <IconList
-                                    isDisabled={nodeState.isLocked}
+                                <IconListWrapper
+                                    input={item}
                                     key={key}
-                                    options={item.options}
-                                    reset={() => nodeState.setInputValue(item.id, item.def)}
-                                    value={nodeState.inputData[item.id]}
-                                    onChange={(value) => nodeState.setInputValue(item.id, value)}
+                                    nodeState={nodeState}
                                 />
                             );
                         }

--- a/src/renderer/components/inputs/DropDownInput.tsx
+++ b/src/renderer/components/inputs/DropDownInput.tsx
@@ -1,7 +1,9 @@
 import { QuestionIcon } from '@chakra-ui/icons';
 import { Tooltip } from '@chakra-ui/react';
 import { memo, useCallback } from 'react';
+import { useValidDropDownValue } from '../../hooks/useValidDropDownValue';
 import { Markdown } from '../Markdown';
+import { AnchorSelector } from './elements/AnchorSelector';
 import { Checkbox } from './elements/Checkbox';
 import { DropDown } from './elements/Dropdown';
 import { IconList } from './elements/IconList';
@@ -14,6 +16,9 @@ type DropDownInputProps = InputProps<'dropdown', string | number>;
 export const DropDownInput = memo(
     ({ value, setValue, input, isLocked, testCondition }: DropDownInputProps) => {
         const { options, def, label, preferredStyle, groups, hint, description } = input;
+
+        // eslint-disable-next-line no-param-reassign
+        value = useValidDropDownValue(value, setValue, input);
 
         const reset = useCallback(() => setValue(def), [setValue, def]);
 
@@ -46,7 +51,6 @@ export const DropDownInput = memo(
                         isDisabled={isLocked}
                         label={label}
                         no={options[1]}
-                        reset={reset}
                         value={value}
                         yes={options[0]}
                         onChange={setValue}
@@ -61,7 +65,6 @@ export const DropDownInput = memo(
                     <TabList
                         isDisabled={isLocked}
                         options={input.options}
-                        reset={reset}
                         value={value}
                         onChange={setValue}
                     />
@@ -75,7 +78,19 @@ export const DropDownInput = memo(
                     <IconList
                         isDisabled={isLocked}
                         options={input.options}
-                        reset={reset}
+                        value={value}
+                        onChange={setValue}
+                    />
+                </InlineLabel>
+            );
+        }
+
+        if (preferredStyle === 'anchor' && options.length === 9) {
+            return (
+                <InlineLabel input={input}>
+                    <AnchorSelector
+                        isDisabled={isLocked}
+                        options={input.options}
                         value={value}
                         onChange={setValue}
                     />

--- a/src/renderer/components/inputs/elements/AnchorSelector.tsx
+++ b/src/renderer/components/inputs/elements/AnchorSelector.tsx
@@ -1,0 +1,112 @@
+import { Button, HStack, Tooltip, VStack } from '@chakra-ui/react';
+import { memo } from 'react';
+import {
+    BsArrowDown,
+    BsArrowDownLeft,
+    BsArrowDownRight,
+    BsArrowLeft,
+    BsArrowRight,
+    BsArrowUp,
+    BsArrowUpLeft,
+    BsArrowUpRight,
+    BsDot,
+} from 'react-icons/bs';
+import { DropDownInput, InputSchemaValue } from '../../../../common/common-types';
+import { IconFactory } from '../../CustomIcons';
+
+const indexes = [0, 1, 2] as const;
+
+type OffsetKey = string & { __offsetKey: never };
+const getOffsetKey = (x: number, y: number) => `${y} ${x}` as OffsetKey;
+const otherIcons: Partial<Record<OffsetKey, JSX.Element>> = {
+    [getOffsetKey(-1, 0)]: <BsArrowLeft opacity={0.7} />,
+    [getOffsetKey(+1, 0)]: <BsArrowRight opacity={0.7} />,
+    [getOffsetKey(0, -1)]: <BsArrowUp opacity={0.7} />,
+    [getOffsetKey(0, +1)]: <BsArrowDown opacity={0.7} />,
+    [getOffsetKey(-1, -1)]: <BsArrowUpLeft opacity={0.7} />,
+    [getOffsetKey(+1, +1)]: <BsArrowDownRight opacity={0.7} />,
+    [getOffsetKey(+1, -1)]: <BsArrowUpRight opacity={0.7} />,
+    [getOffsetKey(-1, +1)]: <BsArrowDownLeft opacity={0.7} />,
+};
+
+export interface AnchorSelectorProps {
+    value: InputSchemaValue;
+    onChange: (value: InputSchemaValue) => void;
+    isDisabled?: boolean;
+    options: DropDownInput['options'];
+}
+
+export const AnchorSelector = memo(
+    ({ value, onChange, isDisabled, options }: AnchorSelectorProps) => {
+        let selectedIndex = options.findIndex((o) => o.value === value);
+        if (selectedIndex === -1) selectedIndex = 0;
+
+        const selectedY = Math.floor(selectedIndex / indexes.length);
+        const selectedX = selectedIndex % indexes.length;
+
+        return (
+            <VStack
+                className="nodrag"
+                display="inline-flex"
+                spacing={0}
+            >
+                {indexes.map((y) => (
+                    <HStack
+                        key={y}
+                        spacing={0}
+                    >
+                        {indexes.map((x) => {
+                            const o = options[y * indexes.length + x];
+                            const selected = value === o.value;
+
+                            let icon;
+                            if (selected) {
+                                icon = <IconFactory icon={o.icon} />;
+                            } else {
+                                icon = otherIcons[getOffsetKey(x - selectedX, y - selectedY)] ?? (
+                                    <BsDot opacity={0.7} />
+                                );
+                            }
+
+                            return (
+                                <Tooltip
+                                    closeOnClick
+                                    closeOnPointerDown
+                                    hasArrow
+                                    borderRadius={8}
+                                    isDisabled={isDisabled}
+                                    key={x}
+                                    label={o.option}
+                                    openDelay={1000}
+                                    placement="top"
+                                >
+                                    <Button
+                                        border={selected ? '1px solid' : undefined}
+                                        borderBottomLeftRadius={y === 2 && x === 0 ? 'md' : '0'}
+                                        borderBottomRightRadius={y === 2 && x === 2 ? 'md' : '0'}
+                                        borderBottomWidth={selectedY !== y + 1 ? '1px' : '0px'}
+                                        borderLeftWidth={selectedX === x || x === 0 ? '1px' : '0px'}
+                                        borderRightWidth={selectedX !== x + 1 ? '1px' : '0px'}
+                                        borderTopLeftRadius={y === 0 && x === 0 ? 'md' : '0'}
+                                        borderTopRightRadius={y === 0 && x === 2 ? 'md' : '0'}
+                                        borderTopWidth={selectedY === y || y === 0 ? '1px' : '0px'}
+                                        boxSizing="content-box"
+                                        height={7}
+                                        isDisabled={isDisabled}
+                                        minWidth={0}
+                                        px={2}
+                                        variant={selected ? 'solid' : 'outline'}
+                                        width={4}
+                                        onClick={() => onChange(o.value)}
+                                    >
+                                        {icon}
+                                    </Button>
+                                </Tooltip>
+                            );
+                        })}
+                    </HStack>
+                ))}
+            </VStack>
+        );
+    }
+);

--- a/src/renderer/components/inputs/elements/Checkbox.tsx
+++ b/src/renderer/components/inputs/elements/Checkbox.tsx
@@ -1,5 +1,5 @@
 import { Box, Checkbox as ChakraCheckbox } from '@chakra-ui/react';
-import { ReactNode, memo, useEffect } from 'react';
+import { ReactNode, memo } from 'react';
 import { DropDownInput, InputSchemaValue } from '../../../../common/common-types';
 import './Checkbox.scss';
 
@@ -7,9 +7,8 @@ type ArrayItem<T> = T extends readonly (infer I)[] ? I : never;
 type Option = ArrayItem<DropDownInput['options']>;
 
 export interface CheckboxProps {
-    value: InputSchemaValue | undefined;
+    value: InputSchemaValue;
     onChange: (value: InputSchemaValue) => void;
-    reset: () => void;
     isDisabled?: boolean;
     yes: Option;
     no: Option;
@@ -18,14 +17,7 @@ export interface CheckboxProps {
 }
 
 export const Checkbox = memo(
-    ({ value, onChange, reset, isDisabled, yes, no, label, afterText }: CheckboxProps) => {
-        // reset invalid values to default
-        useEffect(() => {
-            if (value === undefined || (yes.value !== value && no.value !== value)) {
-                reset();
-            }
-        }, [value, reset, yes, no]);
-
+    ({ value, onChange, isDisabled, yes, no, label, afterText }: CheckboxProps) => {
         return (
             <ChakraCheckbox
                 className="chainner-node-checkbox"

--- a/src/renderer/components/inputs/elements/Dropdown.tsx
+++ b/src/renderer/components/inputs/elements/Dropdown.tsx
@@ -9,7 +9,7 @@ import {
 import { EMPTY_ARRAY } from '../../../../common/util';
 
 export interface DropDownProps {
-    value: InputSchemaValue | undefined;
+    value: InputSchemaValue;
     onChange: (value: InputSchemaValue) => void;
     reset: () => void;
     isDisabled?: boolean;
@@ -20,13 +20,6 @@ export interface DropDownProps {
 
 export const DropDown = memo(
     ({ value, onChange, reset, isDisabled, options, groups, testCondition }: DropDownProps) => {
-        // reset invalid values to default
-        useEffect(() => {
-            if (value === undefined || options.every((o) => o.value !== value)) {
-                reset();
-            }
-        }, [value, reset, options]);
-
         let selection = options.findIndex((o) => o.value === value);
         if (selection === -1) selection = 0;
 
@@ -49,7 +42,7 @@ export const DropDown = memo(
         }, [options, testCondition]);
 
         useEffect(() => {
-            if (value !== undefined && unavailableOptions.includes(value)) {
+            if (unavailableOptions.includes(value)) {
                 // we can't use reset since the default value might be unavailable too
                 // so we search for the first available option
                 const firstAvailable = options.find((o) => !unavailableOptions.includes(o.value));

--- a/src/renderer/components/inputs/elements/IconList.tsx
+++ b/src/renderer/components/inputs/elements/IconList.tsx
@@ -1,24 +1,16 @@
 import { Button, ButtonGroup, Tooltip } from '@chakra-ui/react';
-import { memo, useEffect } from 'react';
+import { memo } from 'react';
 import { DropDownInput, InputSchemaValue } from '../../../../common/common-types';
 import { IconFactory } from '../../CustomIcons';
 
 export interface IconListProps {
-    value: InputSchemaValue | undefined;
+    value: InputSchemaValue;
     onChange: (value: InputSchemaValue) => void;
-    reset: () => void;
     isDisabled?: boolean;
     options: DropDownInput['options'];
 }
 
-export const IconList = memo(({ value, onChange, reset, isDisabled, options }: IconListProps) => {
-    // reset invalid values to default
-    useEffect(() => {
-        if (value === undefined || options.every((o) => o.value !== value)) {
-            reset();
-        }
-    }, [value, reset, options]);
-
+export const IconList = memo(({ value, onChange, isDisabled, options }: IconListProps) => {
     let selection = options.findIndex((o) => o.value === value);
     if (selection === -1) selection = 0;
 

--- a/src/renderer/components/inputs/elements/TabList.tsx
+++ b/src/renderer/components/inputs/elements/TabList.tsx
@@ -1,23 +1,15 @@
 import { TabList as ChakraTabList, Tab, TabIndicator, Tabs } from '@chakra-ui/react';
-import { memo, useEffect } from 'react';
+import { memo } from 'react';
 import { DropDownInput, InputSchemaValue } from '../../../../common/common-types';
 
 export interface TabListProps {
-    value: InputSchemaValue | undefined;
+    value: InputSchemaValue;
     onChange: (value: InputSchemaValue) => void;
-    reset: () => void;
     isDisabled?: boolean;
     options: DropDownInput['options'];
 }
 
-export const TabList = memo(({ value, onChange, reset, isDisabled, options }: TabListProps) => {
-    // reset invalid values to default
-    useEffect(() => {
-        if (value === undefined || options.every((o) => o.value !== value)) {
-            reset();
-        }
-    }, [value, reset, options]);
-
+export const TabList = memo(({ value, onChange, isDisabled, options }: TabListProps) => {
     let selection = options.findIndex((o) => o.value === value);
     if (selection === -1) selection = 0;
 

--- a/src/renderer/hooks/useValidDropDownValue.ts
+++ b/src/renderer/hooks/useValidDropDownValue.ts
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import { DropDownInput, InputSchemaValue } from '../../common/common-types';
+
+export const useValidDropDownValue = (
+    value: InputSchemaValue | undefined,
+    setValue: (value: InputSchemaValue) => void,
+    input: Pick<DropDownInput, 'options' | 'def'>
+) => {
+    let valid = value ?? input.def;
+    if (input.options.every((o) => o.value !== valid)) {
+        valid = input.def;
+    }
+
+    // reset to valid value
+    const resetTo = valid !== value ? valid : undefined;
+    useEffect(() => {
+        if (resetTo !== undefined) {
+            setValue(resetTo);
+        }
+    }, [resetTo, setValue]);
+
+    return valid;
+};


### PR DESCRIPTION
This PR adds a new preferred style for dropdowns that describe anchors or positions. The Text as Image node is that only node using this new style right now, but I plan to use it for #2933/#777 as well. We might even use it for Blend Images, but that needs some more work.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/281a41f6-3c10-4851-b914-4c5f7b9e3772) ![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/1b7ea1e4-47aa-42ab-a2d3-f3ef9372f083)

Other changes:
- Rename position options in Text As Image and Blend Images. The labels are now shorter.
- Add `useValidDropDownValue` hook to ensure valid dropdown values. This removes some code duplication.