### PR TITLE
Add pip cache to backend type check workflow

### DIFF
--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -42,6 +42,7 @@ jobs:
             - uses: actions/setup-python@v4
               with:
                   python-version: '3.9'
+                  cache: 'pip'
             - uses: actions/cache@v3
               with:
                   path: ~/.cache/chainner_pip
@@ -78,6 +79,6 @@ jobs:
                   cache: 'pip'
             - uses: actions/cache@v3
               with:
-                path: ~/.cache/chainner_pip
-                key: chainner-pip-cache-${{ matrix.python-version }}
+                  path: ~/.cache/chainner_pip
+                  key: chainner-pip-cache-${{ matrix.python-version }}
             - run: python ./backend/src/run.py --close-after-start --install-builtin-packages --error-on-failed-node


### PR DESCRIPTION
Noticed this one was being a bit slow, so i checked and it wasn't caching pip. oops