### PR TITLE
Switch to using Axios for requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@fontsource/open-sans": "^4.5.10",
         "@octokit/rest": "^19.0.13",
         "@react-nano/use-event-source": "^0.12.0",
+        "axios": "^1.7.2",
         "bezier-js": "^6.1.4",
         "chakra-ui-markdown-renderer": "^4.1.0",
         "chokidar": "^3.5.3",
@@ -5803,6 +5804,11 @@
       "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==",
       "optional": true
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/at-least-node": {
       "version": "1.0.0",
       "dev": true,
@@ -5826,6 +5832,16 @@
       "peer": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -6645,6 +6661,17 @@
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.2",
       "license": "MIT",
@@ -7342,6 +7369,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/delegates": {
@@ -9226,6 +9261,19 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -13665,6 +13713,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "@fontsource/open-sans": "^4.5.10",
     "@octokit/rest": "^19.0.13",
     "@react-nano/use-event-source": "^0.12.0",
+    "axios": "^1.7.2",
     "bezier-js": "^6.1.4",
     "chakra-ui-markdown-renderer": "^4.1.0",
     "chokidar": "^3.5.3",

--- a/src/common/Backend.ts
+++ b/src/common/Backend.ts
@@ -174,8 +174,10 @@ export class Backend {
             return resp.data;
         } catch (error) {
             if (axios.isAxiosError(error)) {
-                if (ServerError.isJson(error.response?.data)) {
-                    throw ServerError.fromJson(error.response?.data);
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                const responseData = error.response?.data;
+                if (ServerError.isJson(responseData)) {
+                    throw ServerError.fromJson(responseData);
                 }
                 if (error.response?.data) {
                     return error.response.data as T;

--- a/src/common/Backend.ts
+++ b/src/common/Backend.ts
@@ -1,3 +1,4 @@
+import axios, { AxiosRequestConfig } from 'axios';
 import {
     BackendJsonNode,
     Category,
@@ -155,24 +156,36 @@ export class Backend {
     }
 
     private async fetchJson<T>(path: string, method: 'POST' | 'GET', json?: unknown): Promise<T> {
-        const options: RequestInit = {
+        const options: AxiosRequestConfig = {
             method,
-            cache: 'no-cache',
+            url: `${this.url}${path}`,
         };
         const { signal } = this.abortController;
         if (json !== undefined) {
-            options.body = JSON.stringify(json);
+            options.data = json;
             options.headers = {
                 'Content-Type': 'application/json',
             };
             options.signal = signal;
         }
-        const resp = await fetch(`${this.url}${path}`, options);
-        const result = (await resp.json()) as T;
-        if (ServerError.isJson(result)) {
-            throw ServerError.fromJson(result);
+
+        try {
+            const resp = await axios.request<T>(options);
+            return resp.data;
+        } catch (error) {
+            if (axios.isAxiosError(error)) {
+                if (ServerError.isJson(error.response?.data)) {
+                    throw ServerError.fromJson(error.response?.data);
+                }
+                if (error.response?.data) {
+                    return error.response.data as T;
+                }
+            }
+            if (ServerError.isJson(error)) {
+                throw ServerError.fromJson(error);
+            }
+            throw error;
         }
-        return result;
     }
 
     /**


### PR DESCRIPTION
Closes #2957 

IMO, the fact that the browser and nodejs implementations of fetch differ, and there is no way to natively specify timeout, is really stupid. So, I decided to just switch to using Axios instead of trying to use native fetch. Axios is able to work in both the browser and nodejs, and it defaults to having no timeout. So, we should expect this issue to never pop up again with this.