### PR TITLE
Change default formatter to eslint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -121,7 +121,7 @@
     "editor.formatOnSave": true,
   },
   "[typescript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint",
     "editor.formatOnSave": true,
   },
   "[javascript]": {


### PR DESCRIPTION
Not sure why this was changed to prettier when eslint runs both its rules and prettier's rules, but this has been annoying me for quite some time, so I'm, changing it.