### PR TITLE
Unselect nodes for undo history

### DIFF
--- a/src/renderer/components/HistoryProvider.tsx
+++ b/src/renderer/components/HistoryProvider.tsx
@@ -102,7 +102,10 @@ export const HistoryProvider = memo(
             if (selfUpdate) return noop;
 
             const id = setTimeout(() => {
-                historyRef.current = historyRef.current.commit([getNodes(), getEdges()]);
+                historyRef.current = historyRef.current.commit([
+                    getNodes().map((n) => ({ ...n, selected: false })),
+                    getEdges(),
+                ]);
             }, 250);
             return () => clearTimeout(id);
             // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
This was suggested by kim. Apparently a node being selected can cause undos to get stuck, so this should fix it