### PR TITLE
PR changes

### DIFF
--- a/backend/src/api/node_data.py
+++ b/backend/src/api/node_data.py
@@ -9,7 +9,15 @@ import navi
 from .group import NestedIdGroup
 from .input import BaseInput
 from .output import BaseOutput
-from .types import FeatureId, InputId, NodeKind, OutputId, RunFn
+from .types import (
+    FeatureId,
+    InputId,
+    IterInputId,
+    IterOutputId,
+    NodeKind,
+    OutputId,
+    RunFn,
+)
 
 
 class IteratorInputInfo:
@@ -18,6 +26,7 @@ class IteratorInputInfo:
         inputs: int | InputId | list[int] | list[InputId] | list[int | InputId],
         length_type: navi.ExpressionJson = "uint",
     ) -> None:
+        self.id: IterInputId = IterInputId(0)
         self.inputs: list[InputId] = (
             [InputId(x) for x in inputs]
             if isinstance(inputs, list)
@@ -27,8 +36,9 @@ class IteratorInputInfo:
 
     def to_dict(self):
         return {
+            "id": self.id,
             "inputs": self.inputs,
-            "lengthType": self.length_type,
+            "sequenceType": navi.named("Sequence", {"length": self.length_type}),
         }
 
 
@@ -38,6 +48,7 @@ class IteratorOutputInfo:
         outputs: int | OutputId | list[int] | list[OutputId] | list[int | OutputId],
         length_type: navi.ExpressionJson = "uint",
     ) -> None:
+        self.id: IterOutputId = IterOutputId(0)
         self.outputs: list[OutputId] = (
             [OutputId(x) for x in outputs]
             if isinstance(outputs, list)
@@ -47,8 +58,9 @@ class IteratorOutputInfo:
 
     def to_dict(self):
         return {
+            "id": self.id,
             "outputs": self.outputs,
-            "lengthType": self.length_type,
+            "sequenceType": navi.named("Sequence", {"length": self.length_type}),
         }
 
 

--- a/backend/src/api/types.py
+++ b/backend/src/api/types.py
@@ -5,6 +5,8 @@ from typing import Any, Callable, Literal, NewType
 NodeId = NewType("NodeId", str)
 InputId = NewType("InputId", int)
 OutputId = NewType("OutputId", int)
+IterInputId = NewType("IterInputId", int)
+IterOutputId = NewType("IterOutputId", int)
 FeatureId = NewType("FeatureId", str)
 
 

--- a/backend/src/packages/chaiNNer_standard/image/batch_processing/load_images.py
+++ b/backend/src/packages/chaiNNer_standard/image/batch_processing/load_images.py
@@ -76,11 +76,13 @@ def list_glob(directory: Path, globexpr: str, ext_filter: list[str]) -> list[Pat
                 "For information on how to use WCMatch glob expressions, see [here](https://facelessuser.github.io/wcmatch/glob/)."
             ),
         ),
-        BoolInput("Use limit", default=False),
+        BoolInput("Use limit", default=False).with_id(4),
         if_group(Condition.bool(4, True))(
-            NumberInput("Limit", default=10, min=1).with_docs(
+            NumberInput("Limit", default=10, min=1)
+            .with_docs(
                 "Limit the number of images to iterate over. This can be useful for testing the iterator without having to iterate over all images."
             )
+            .with_id(5)
         ),
         BoolInput("Stop on first error", default=False).with_docs(
             "Instead of collecting errors and throwing them at the end of processing, stop iteration and throw an error as soon as one occurs.",
@@ -97,7 +99,10 @@ def list_glob(directory: Path, globexpr: str, ext_filter: list[str]) -> list[Pat
             output_type="if Input4 { min(uint, Input5 - 1) } else { uint }",
         ),
     ],
-    iterator_outputs=IteratorOutputInfo(outputs=[0, 2, 3, 4]),
+    iterator_outputs=IteratorOutputInfo(
+        outputs=[0, 2, 3, 4],
+        length_type="if Input4 { min(uint, Input5) } else { uint }",
+    ),
     kind="generator",
 )
 def load_images_node(

--- a/backend/src/packages/chaiNNer_standard/image/video_frames/load_video.py
+++ b/backend/src/packages/chaiNNer_standard/image/video_frames/load_video.py
@@ -33,16 +33,18 @@ from .. import video_frames_group
     icon="MdVideoCameraBack",
     inputs=[
         VideoFileInput(primary_input=True),
-        BoolInput("Use limit", default=False),
+        BoolInput("Use limit", default=False).with_id(1),
         if_group(Condition.bool(1, True))(
-            NumberInput("Limit", default=10, min=1).with_docs(
+            NumberInput("Limit", default=10, min=1)
+            .with_docs(
                 "Limit the number of frames to iterate over. This can be useful for testing the iterator without having to iterate over all frames of the video."
                 " Will not copy audio if limit is used."
             )
+            .with_id(2)
         ),
     ],
     outputs=[
-        ImageOutput("Frame Image", channels=3),
+        ImageOutput("Frame", channels=3),
         NumberOutput(
             "Frame Index",
             output_type="if Input1 { min(uint, Input2 - 1) } else { uint }",
@@ -52,7 +54,9 @@ from .. import video_frames_group
         NumberOutput("FPS", output_type="0.."),
         AudioStreamOutput().suggest(),
     ],
-    iterator_outputs=IteratorOutputInfo(outputs=[0, 1]),
+    iterator_outputs=IteratorOutputInfo(
+        outputs=[0, 1], length_type="if Input1 { min(uint, Input2) } else { uint }"
+    ),
     node_context=True,
     kind="generator",
 )

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -16,6 +16,8 @@ export interface Size {
 export type SchemaId = string & { readonly __schemaId: never };
 export type InputId = number & { readonly __inputId: never };
 export type OutputId = number & { readonly __outputId: never };
+export type IteratorInputId = number & { readonly __iteratorInputId: never };
+export type IteratorOutputId = number & { readonly __iteratorOutputId: never };
 export type GroupId = number & { readonly __groupId: never };
 export type PackageId = string & { readonly __packageId: never };
 export type FeatureId = string & { readonly __featureId: never };
@@ -279,12 +281,14 @@ export type OutputHeight = Readonly<Record<OutputId, number>>;
 export type OutputTypes = Readonly<Partial<Record<OutputId, ExpressionJson | null>>>;
 
 export interface IteratorInputInfo {
+    readonly id: IteratorInputId;
     readonly inputs: readonly InputId[];
-    readonly lengthType: ExpressionJson;
+    readonly sequenceType: ExpressionJson;
 }
 export interface IteratorOutputInfo {
+    readonly id: IteratorOutputId;
     readonly outputs: readonly OutputId[];
-    readonly lengthType: ExpressionJson;
+    readonly sequenceType: ExpressionJson;
 }
 
 export type KeyInfo = EnumKeyInfo | NumberKeyInfo | TypeKeyInfo;

--- a/src/common/types/chainner-scope.ts
+++ b/src/common/types/chainner-scope.ts
@@ -26,6 +26,10 @@ import {
 const code = `
 struct null;
 
+struct Sequence {
+    length: uint,
+}
+
 struct Error { message: string }
 def error(message: invStrSet("")): Error {
     Error { message }

--- a/src/renderer/components/TypeTag.tsx
+++ b/src/renderer/components/TypeTag.tsx
@@ -3,6 +3,7 @@ import {
     IntIntervalType,
     IntervalType,
     NeverType,
+    NumberPrimitive,
     Type,
     intInterval,
     isNumericLiteral,
@@ -280,6 +281,68 @@ const getTypeText = (type: Type): TagValue[] => {
     return tags;
 };
 
+const getLengthTag = (length: NumberPrimitive): TagValue[] => {
+    if (isNumericLiteral(length))
+        return [
+            {
+                kind: 'literal',
+                value: `[${length.toString()}]`,
+                tooltip: `A sequence with exactly ${length.toString()} elements.`,
+            },
+        ];
+
+    const rangeType = getSimplifiedNumberRange(length);
+    if (rangeType) {
+        const { min, max } = rangeType;
+        if (min === 0) {
+            if (max === Infinity) {
+                return [
+                    {
+                        kind: 'literal',
+                        value: `[?]`,
+                        tooltip: `A sequence with an unknown number of elements.`,
+                    },
+                ];
+            }
+            return [
+                {
+                    kind: 'literal',
+                    value: `[≤${max}]`,
+                    tooltip: `A sequence with at most ${max} elements.`,
+                },
+            ];
+        }
+        if (max === Infinity) {
+            return [
+                {
+                    kind: 'literal',
+                    value: `[≥${min}]`,
+                    tooltip: `A sequence with at least ${min} elements.`,
+                },
+            ];
+        }
+        return [
+            {
+                kind: 'literal',
+                value: `[${min}..${max}]`,
+                tooltip: `A sequence with between ${min} and ${max} elements.`,
+            },
+        ];
+    }
+
+    return [];
+};
+const getSequenceTags = (type: Type): TagValue[] => {
+    if (!isStructInstance(type)) return [];
+
+    const length = type.getField('length') ?? NeverType.instance;
+    if (length.underlying === 'number') {
+        return getLengthTag(length);
+    }
+
+    return [];
+};
+
 export interface TypeTagProps {
     isOptional?: boolean;
 }
@@ -316,7 +379,7 @@ export interface TypeTagsProps {
     type: Type;
     isOptional: boolean;
     longText?: boolean;
-    lengthType?: Type;
+    sequenceType?: Type;
 }
 
 const Punctuation = memo(({ children }: React.PropsWithChildren<unknown>) => {
@@ -407,15 +470,11 @@ const TagRenderer = memo(({ tag, longText }: TagRendererProps) => {
 });
 
 export const TypeTags = memo(
-    ({ type, isOptional, longText = false, lengthType = undefined }: TypeTagsProps) => {
+    ({ type, isOptional, longText = false, sequenceType }: TypeTagsProps) => {
         const { t } = useTranslation();
         const tags = getTypeText(withoutNull(type));
-        if (lengthType) {
-            tags.push(
-                ...getTypeText(lengthType).map(
-                    (e) => ({ kind: 'string', value: `[${e.value}]` } as TagValue)
-                )
-            );
+        if (sequenceType) {
+            tags.push(...getSequenceTags(sequenceType));
         }
 
         return (

--- a/src/renderer/components/inputs/ColorInput.tsx
+++ b/src/renderer/components/inputs/ColorInput.tsx
@@ -300,7 +300,7 @@ export const ColorInput = memo(
         input,
         definitionType,
         isConnected,
-        lengthType,
+        sequenceType,
     }: InputProps<'color', string>) => {
         const { label, optional, def, channels } = input;
         const { conditionallyInactive } = useContext(InputContext);
@@ -363,7 +363,7 @@ export const ColorInput = memo(
                     <Center>
                         <TypeTags
                             isOptional={optional}
-                            lengthType={lengthType}
+                            sequenceType={sequenceType}
                             type={definitionType}
                         />
                     </Center>

--- a/src/renderer/components/inputs/GenericInput.tsx
+++ b/src/renderer/components/inputs/GenericInput.tsx
@@ -8,60 +8,64 @@ import { TypeTags } from '../TypeTag';
 import { WithoutLabel } from './InputContainer';
 import { InputProps } from './props';
 
-export const GenericInput = memo(({ input, definitionType, lengthType }: InputProps<'generic'>) => {
-    const { label, optional, hint, description } = input;
+export const GenericInput = memo(
+    ({ input, definitionType, sequenceType }: InputProps<'generic'>) => {
+        const { label, optional, hint, description } = input;
 
-    const { conditionallyInactive } = useContext(InputContext);
+        const { conditionallyInactive } = useContext(InputContext);
 
-    return (
-        <WithoutLabel>
-            <Box
-                display="flex"
-                flexDirection="row"
-            >
-                <Tooltip
-                    hasArrow
-                    borderRadius={8}
-                    label={
-                        hint ? <Markdown nonInteractive>{description ?? ''}</Markdown> : undefined
-                    }
-                    openDelay={500}
-                    px={2}
-                    py={1}
+        return (
+            <WithoutLabel>
+                <Box
+                    display="flex"
+                    flexDirection="row"
                 >
-                    <HStack
-                        m={0}
-                        p={0}
-                        spacing={0}
+                    <Tooltip
+                        hasArrow
+                        borderRadius={8}
+                        label={
+                            hint ? (
+                                <Markdown nonInteractive>{description ?? ''}</Markdown>
+                            ) : undefined
+                        }
+                        openDelay={500}
+                        px={2}
+                        py={1}
                     >
-                        <Text
-                            opacity={conditionallyInactive ? 0.7 : undefined}
-                            textDecoration={conditionallyInactive ? 'line-through' : undefined}
+                        <HStack
+                            m={0}
+                            p={0}
+                            spacing={0}
                         >
-                            {label}
-                        </Text>
-                        {hint && (
-                            <Center
-                                h="auto"
-                                m={0}
-                                p={0}
+                            <Text
+                                opacity={conditionallyInactive ? 0.7 : undefined}
+                                textDecoration={conditionallyInactive ? 'line-through' : undefined}
                             >
-                                <QuestionIcon
-                                    boxSize={3}
-                                    ml={1}
+                                {label}
+                            </Text>
+                            {hint && (
+                                <Center
+                                    h="auto"
+                                    m={0}
+                                    p={0}
+                                >
+                                    <QuestionIcon
+                                        boxSize={3}
+                                        ml={1}
+                                    />
+                                </Center>
+                            )}
+                            <Center>
+                                <TypeTags
+                                    isOptional={optional}
+                                    sequenceType={sequenceType}
+                                    type={definitionType}
                                 />
                             </Center>
-                        )}
-                        <Center>
-                            <TypeTags
-                                isOptional={optional}
-                                lengthType={lengthType}
-                                type={definitionType}
-                            />
-                        </Center>
-                    </HStack>
-                </Tooltip>
-            </Box>
-        </WithoutLabel>
-    );
-});
+                        </HStack>
+                    </Tooltip>
+                </Box>
+            </WithoutLabel>
+        );
+    }
+);

--- a/src/renderer/components/inputs/SchemaInput.tsx
+++ b/src/renderer/components/inputs/SchemaInput.tsx
@@ -95,7 +95,7 @@ export const SchemaInput = memo(({ input, nodeState, afterInput }: SingleInputPr
     );
 
     const inputType = type.instance?.inputs.get(inputId) ?? NeverType.instance;
-    const inputLength = type.instance?.inputLengths.get(inputId);
+    const inputLength = type.instance?.inputSequence.get(inputId);
 
     const InputType = InputComponents[kind];
     let inputElement = (
@@ -106,10 +106,10 @@ export const SchemaInput = memo(({ input, nodeState, afterInput }: SingleInputPr
             inputType={inputType}
             isConnected={connectedInputs.has(inputId)}
             isLocked={isLocked}
-            lengthType={inputLength}
             nodeId={nodeId}
             nodeSchemaId={schemaId}
             resetValue={resetValue}
+            sequenceType={inputLength}
             setSize={setSize}
             setValue={setValue}
             size={size}
@@ -143,7 +143,7 @@ export const SchemaInput = memo(({ input, nodeState, afterInput }: SingleInputPr
 
     if (fused) {
         const outputType = nodeState.type.instance?.outputs.get(fused.outputId);
-        const lengthType = nodeState.type.instance?.outputLengths.get(fused.outputId);
+        const sequenceType = nodeState.type.instance?.outputSequence.get(fused.outputId);
 
         const fusedOutputHandle = (
             <OutputHandle
@@ -170,7 +170,7 @@ export const SchemaInput = memo(({ input, nodeState, afterInput }: SingleInputPr
                     <Center pr="0.5em">
                         <TypeTags
                             isOptional={false}
-                            lengthType={lengthType}
+                            sequenceType={sequenceType}
                             type={outputType}
                         />
                     </Center>

--- a/src/renderer/components/inputs/props.ts
+++ b/src/renderer/components/inputs/props.ts
@@ -24,5 +24,5 @@ export interface InputProps<Kind extends InputKind, Value extends string | numbe
     readonly nodeId?: string;
     readonly nodeSchemaId?: SchemaId;
     readonly testCondition: (condition: Condition) => boolean;
-    readonly lengthType?: Type;
+    readonly sequenceType?: Type;
 }

--- a/src/renderer/components/node/NodeOutputs.tsx
+++ b/src/renderer/components/node/NodeOutputs.tsx
@@ -110,7 +110,7 @@ export const NodeOutputs = memo(({ nodeState, animated }: NodeOutputProps) => {
                 const definitionType = functions?.get(output.id) ?? NeverType.instance;
 
                 const type = nodeState.type.instance?.outputs.get(output.id);
-                const outputLength = nodeState.type.instance?.outputLengths.get(output.id);
+                const outputLength = nodeState.type.instance?.outputSequence.get(output.id);
 
                 const size =
                     outputHeight?.[output.id] && nodeWidth
@@ -130,17 +130,17 @@ export const NodeOutputs = memo(({ nodeState, animated }: NodeOutputProps) => {
                         isConnected={nodeState.connectedOutputs.has(output.id)}
                         isIterated={iteratedOutputs.has(output.id)}
                         key={`${id}-${output.id}`}
-                        lengthType={outputLength}
                         output={output}
+                        sequenceType={outputLength}
                         type={type}
                     >
                         <OutputType
                             animated={animated}
                             definitionType={definitionType}
                             id={id}
-                            lengthType={outputLength}
                             output={output}
                             schema={nodeState.schema}
+                            sequenceType={outputLength}
                             setSize={setSize}
                             size={size}
                             type={type ?? NeverType.instance}

--- a/src/renderer/components/outputs/GenericOutput.tsx
+++ b/src/renderer/components/outputs/GenericOutput.tsx
@@ -115,7 +115,7 @@ const isImageDefinition = lazyKeyed((type: Type) => {
 const isImage = lazyKeyed((type: Type) => isSubsetOf(type, getImageType()));
 
 export const GenericOutput = memo(
-    ({ output, type, id, schema, definitionType, lengthType }: OutputProps) => {
+    ({ output, type, id, schema, definitionType, sequenceType }: OutputProps) => {
         // We first check the definition type first, because it changes less, which makes it more efficient to cache.
         const viewImage = isImageDefinition(definitionType) ?? isImage(type);
 
@@ -138,7 +138,7 @@ export const GenericOutput = memo(
                 <TypeTags
                     longText
                     isOptional={false}
-                    lengthType={lengthType}
+                    sequenceType={sequenceType}
                     type={type}
                 />
                 <Text

--- a/src/renderer/components/outputs/OutputContainer.tsx
+++ b/src/renderer/components/outputs/OutputContainer.tsx
@@ -82,7 +82,7 @@ interface OutputContainerProps {
     generic: boolean;
     isConnected: boolean;
     isIterated: boolean;
-    lengthType?: Type;
+    sequenceType?: Type;
 }
 
 export const OutputContainer = memo(
@@ -95,7 +95,7 @@ export const OutputContainer = memo(
         generic,
         isConnected,
         isIterated,
-        lengthType,
+        sequenceType,
     }: React.PropsWithChildren<OutputContainerProps>) => {
         let contents = children;
         if (output.hasHandle) {
@@ -140,7 +140,7 @@ export const OutputContainer = memo(
                             >
                                 <TypeTags
                                     isOptional={false}
-                                    lengthType={lengthType}
+                                    sequenceType={sequenceType}
                                     type={type}
                                 />
                             </Center>

--- a/src/renderer/components/outputs/props.ts
+++ b/src/renderer/components/outputs/props.ts
@@ -20,5 +20,5 @@ export interface OutputProps {
     readonly animated: boolean;
     readonly size: Readonly<Size> | undefined;
     readonly setSize: (size: Readonly<Size>) => void;
-    readonly lengthType?: Type;
+    readonly sequenceType?: Type;
 }


### PR DESCRIPTION
PR changes for #2960

Changes:
- Added `struct Sequence { length: uint }` Navi type to hold the type information of a sequence. Everything now uses this type instead of just being a number. This has the advantage that it will be trivial to add more information in the future.
- Improved type tags for sequences.
- Added sequence length types for Load Images and Load Video to account for Use Limit.
- Major rework for how input/output types are ordered. Types for (iter) inputs/outputs just work.
- Iter input/output infos now have IDs. This just makes it easier to refer to them, because output types might depend on sequence lengths in the future. E.g. a Count node that returns the length of the input sequence. Since nodes can only have at most 1 input/output sequence rn, I just hard-coded the ID as 0 in the backend for now.