### PR TITLE
Sequence item types for Load Video

### DIFF
--- a/backend/src/api/__init__.py
+++ b/backend/src/api/__init__.py
@@ -1,6 +1,7 @@
 from .api import *
 from .group import *
 from .input import *
+from .iter import *
 from .lazy import *
 from .node_context import *
 from .node_data import *

--- a/backend/src/api/api.py
+++ b/backend/src/api/api.py
@@ -7,7 +7,6 @@ from typing import (
     Any,
     Awaitable,
     Callable,
-    Generic,
     Iterable,
     TypeVar,
 )
@@ -504,66 +503,3 @@ def add_package(
             dependencies=dependencies or [],
         )
     )
-
-
-I = TypeVar("I")
-L = TypeVar("L")
-
-
-@dataclass
-class Generator(Generic[I]):
-    supplier: Callable[[], Iterable[I | Exception]]
-    expected_length: int
-    fail_fast: bool = True
-
-    def with_fail_fast(self, fail_fast: bool) -> Generator[I]:
-        return Generator(self.supplier, self.expected_length, fail_fast=fail_fast)
-
-    @staticmethod
-    def from_iter(
-        supplier: Callable[[], Iterable[I | Exception]], expected_length: int
-    ) -> Generator[I]:
-        return Generator(supplier, expected_length)
-
-    @staticmethod
-    def from_list(l: list[L], map_fn: Callable[[L, int], I]) -> Generator[I]:
-        """
-        Creates a new generator from a list that is mapped using the given
-        function. The iterable will be equivalent to `map(map_fn, l)`.
-        """
-
-        def supplier():
-            for i, x in enumerate(l):
-                try:
-                    yield map_fn(x, i)
-                except Exception as e:
-                    yield e
-
-        return Generator(supplier, len(l))
-
-    @staticmethod
-    def from_range(count: int, map_fn: Callable[[int], I]) -> Generator[I]:
-        """
-        Creates a new generator the given number of items where each item is
-        lazily evaluated. The iterable will be equivalent to `map(map_fn, range(count))`.
-        """
-        assert count >= 0
-
-        def supplier():
-            for i in range(count):
-                try:
-                    yield map_fn(i)
-                except Exception as e:
-                    yield e
-
-        return Generator(supplier, count)
-
-
-N = TypeVar("N")
-R = TypeVar("R")
-
-
-@dataclass
-class Collector(Generic[N, R]):
-    on_iterate: Callable[[N], None]
-    on_complete: Callable[[], R]

--- a/backend/src/api/iter.py
+++ b/backend/src/api/iter.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Generic, Iterable, TypeVar
+
+I = TypeVar("I")
+L = TypeVar("L")
+
+
+@dataclass
+class Generator(Generic[I]):
+    supplier: Callable[[], Iterable[I | Exception]]
+    expected_length: int
+    fail_fast: bool = True
+    metadata: object | None = None
+
+    def with_fail_fast(self, fail_fast: bool):
+        self.fail_fast = fail_fast
+        return self
+
+    def with_metadata(self, metadata: object):
+        self.metadata = metadata
+        return self
+
+    @staticmethod
+    def from_iter(
+        supplier: Callable[[], Iterable[I | Exception]], expected_length: int
+    ) -> Generator[I]:
+        return Generator(supplier, expected_length)
+
+    @staticmethod
+    def from_list(l: list[L], map_fn: Callable[[L, int], I]) -> Generator[I]:
+        """
+        Creates a new generator from a list that is mapped using the given
+        function. The iterable will be equivalent to `map(map_fn, l)`.
+        """
+
+        def supplier():
+            for i, x in enumerate(l):
+                try:
+                    yield map_fn(x, i)
+                except Exception as e:
+                    yield e
+
+        return Generator(supplier, len(l))
+
+    @staticmethod
+    def from_range(count: int, map_fn: Callable[[int], I]) -> Generator[I]:
+        """
+        Creates a new generator the given number of items where each item is
+        lazily evaluated. The iterable will be equivalent to `map(map_fn, range(count))`.
+        """
+        assert count >= 0
+
+        def supplier():
+            for i in range(count):
+                try:
+                    yield map_fn(i)
+                except Exception as e:
+                    yield e
+
+        return Generator(supplier, count)
+
+
+N = TypeVar("N")
+R = TypeVar("R")
+
+
+@dataclass
+class Collector(Generic[N, R]):
+    on_iterate: Callable[[N], None]
+    on_complete: Callable[[], R]

--- a/backend/src/events.py
+++ b/backend/src/events.py
@@ -5,7 +5,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Dict, Literal, TypedDict, Union
 
-from api import ErrorValue, InputId, IterOutputId, NodeId, OutputId
+import navi
+from api import BroadcastData, ErrorValue, InputId, IterOutputId, NodeId, OutputId
 
 # General events
 
@@ -87,9 +88,9 @@ class NodeProgressUpdateEvent(TypedDict):
 
 class NodeBroadcastData(TypedDict):
     nodeId: NodeId
-    data: dict[OutputId, object]
-    types: dict[OutputId, object]
-    sequenceTypes: dict[IterOutputId, object] | None
+    data: dict[OutputId, BroadcastData | None]
+    types: dict[OutputId, navi.ExpressionJson | None]
+    sequenceTypes: dict[IterOutputId, navi.ExpressionJson] | None
 
 
 class NodeBroadcastEvent(TypedDict):


### PR DESCRIPTION
This adds a way for node to (1) add metadata to a generator and (2) derive item types from that metadata. I don't think the API I made is ideal, but it works for now.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/86cd6af9-e3cd-481e-a02c-8d362852388d)
