### PR TITLE
Remove assertNever assertion for Axios requests

### DIFF
--- a/src/common/Backend.ts
+++ b/src/common/Backend.ts
@@ -17,7 +17,6 @@ import {
     SchemaId,
     Version,
 } from './common-types';
-import { assertNever } from './util';
 
 export interface BackendSuccessResponse {
     type: 'success';
@@ -201,7 +200,6 @@ export class Backend {
                 if (axios.isCancel(error)) {
                     throw CancelError.fromCancel(error, error.config);
                 }
-                assertNever(error);
             }
             if (ServerError.isJson(error)) {
                 throw ServerError.fromJson(error);


### PR DESCRIPTION
There appears to be an error type that axios does not have a type for: Network errors. Because of this, the error value is not really never and therefore we cannot assertNever there.

This does not fix the initial issue though, as the error will still throw.

Should it throw? I'm not really sure what even causes the network error (i did get it myself once when working on a different PR), but it seems to have to do with the backend restarting from code changes, which regular users will not have to deal with.