### PR TITLE
ONNX size requirements and more robust shape detection

### DIFF
--- a/backend/src/nodes/impl/onnx/auto_split.py
+++ b/backend/src/nodes/impl/onnx/auto_split.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import gc
+from typing import Callable
 
 import numpy as np
 import onnxruntime as ort
+
+from nodes.impl.onnx.model import SizeReq
 
 from ..upscale.auto_split import Tiler, auto_split
 
@@ -64,11 +67,40 @@ def _flip_r_b_channels(img: np.ndarray) -> np.ndarray:
     return img
 
 
+def _pad(
+    img: np.ndarray, req: SizeReq
+) -> tuple[np.ndarray, Callable[[np.ndarray], np.ndarray]]:
+    w = img.shape[1]
+    h = img.shape[0]
+
+    pad_w, pad_h = req.get_padding(w, h)
+
+    def remove_padding(i: np.ndarray) -> np.ndarray:
+        new_w = i.shape[1]
+        new_h = i.shape[0]
+        scale_w = new_w // (w + pad_w)
+        scale_h = new_h // (h + pad_h)
+        new_pad_w = int(pad_w * scale_w)
+        new_pad_h = int(pad_h * scale_h)
+        return i[: new_h - new_pad_h, : new_w - new_pad_w]
+
+    if pad_w or pad_h:
+        paddings = [(0, pad_h), (0, pad_w)]
+        if len(img.shape) == 3:
+            paddings.append((0, 0))
+        img = np.pad(img, paddings, "reflect")
+
+        return img, remove_padding
+    else:
+        return img, lambda i: i
+
+
 def onnx_auto_split(
     img: np.ndarray,
     session: ort.InferenceSession,
     change_shape: bool,
     tiler: Tiler,
+    size_req: SizeReq | None = None,
 ) -> np.ndarray:
     input_name = session.get_inputs()[0].name
     output_name = session.get_outputs()[0].name
@@ -78,6 +110,7 @@ def onnx_auto_split(
     def upscale(img: np.ndarray, _: object):
         try:
             lr_img = img.astype(np.float16) if is_fp16_model else img
+            lr_img, remove_pad = _pad(lr_img, size_req or SizeReq())
             lr_img = _flip_r_b_channels(lr_img)
             lr_img = _into_batched_form(lr_img, change_shape)
 
@@ -85,6 +118,7 @@ def onnx_auto_split(
 
             output = _into_standard_image_form(output, change_shape)
             output = _flip_r_b_channels(output)
+            output = remove_pad(output)
             return output.astype(np.float32)
         except Exception as e:
             if "ONNXRuntimeError" in str(e) and (

--- a/backend/src/nodes/impl/onnx/model.py
+++ b/backend/src/nodes/impl/onnx/model.py
@@ -8,6 +8,46 @@ from typing import Final, Literal, Union
 OnnxSubType = Literal["Generic", "RemBg"]
 
 
+def _ceil_div(a: int, b: int):
+    return -(a // -b)
+
+
+@dataclass(init=False)
+class SizeReq:
+    minimum: int
+    multiple_of: int
+
+    def __init__(self, minimum: int = 1, multiple_of: int = 1):
+        if minimum < 1:
+            raise ValueError("minimum must be at least 1")
+        if multiple_of < 1:
+            raise ValueError("multiple_of must be at least 1")
+
+        self.minimum = _ceil_div(minimum, multiple_of) * multiple_of
+        self.multiple_of = multiple_of
+
+    def get_padding(self, width: int, height: int) -> tuple[int, int]:
+        """
+        Given an image size, this returns the minimum amount of padding necessary to satisfy the size requirements. The returned padding is in the format `(pad_width, pad_height)` and is guaranteed to be non-negative.
+        """
+
+        def ceil_modulo(x: int, mod: int) -> int:
+            if x % mod == 0:
+                return x
+            return (x // mod + 1) * mod
+
+        w: int = max(self.minimum, width)
+        h: int = max(self.minimum, height)
+
+        w = ceil_modulo(w, self.multiple_of)
+        h = ceil_modulo(h, self.multiple_of)
+
+        return w - width, h - height
+
+
+NO_SIZE_REQ = SizeReq()
+
+
 @dataclass
 class OnnxInfo:
     opset: int
@@ -21,6 +61,8 @@ class OnnxInfo:
 
     input_channels: int | None = None
     output_channels: int | None = None
+
+    size_req: SizeReq = NO_SIZE_REQ
 
 
 class OnnxGeneric:

--- a/backend/src/nodes/impl/onnx/update_model_dims.py
+++ b/backend/src/nodes/impl/onnx/update_model_dims.py
@@ -1,0 +1,93 @@
+# Copyright (c) ONNX Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Include in chaiNNer with the following changes:
+# - Remove `dim_proto.dim_value != dim` for constant dimensions
+# - Improved type hints
+from __future__ import annotations
+
+from typing import Sequence
+
+import onnx.checker
+from onnx import ModelProto, ValueInfoProto
+
+
+def update_inputs_outputs_dims(
+    model: ModelProto,
+    input_dims: dict[str, Sequence[str | int]],
+    output_dims: dict[str, Sequence[str | int]],
+) -> ModelProto:
+    """This function updates the dimension sizes of the model's inputs and outputs to the values
+    provided in input_dims and output_dims. if the dim value provided is negative, a unique dim_param
+    will be set for that dimension.
+
+    Example. if we have the following shape for inputs and outputs:
+
+    * shape(input_1) = ('b', 3, 'w', 'h')
+    * shape(input_2) = ('b', 4)
+    * shape(output)  = ('b', 'd', 5)
+
+    The parameters can be provided as:
+
+    ::
+
+        input_dims = {
+            "input_1": ['b', 3, 'w', 'h'],
+            "input_2": ['b', 4],
+        }
+        output_dims = {
+            "output": ['b', -1, 5]
+        }
+
+    Putting it together:
+
+    ::
+
+        model = onnx.load('model.onnx')
+        updated_model = update_inputs_outputs_dims(model, input_dims, output_dims)
+        onnx.save(updated_model, 'model.onnx')
+    """
+    dim_param_set: set[str] = set()
+
+    def init_dim_param_set(
+        dim_param_set: set[str], value_infos: list[ValueInfoProto]
+    ) -> None:
+        for info in value_infos:
+            shape = info.type.tensor_type.shape
+            for dim in shape.dim:
+                if dim.HasField("dim_param"):
+                    dim_param_set.add(dim.dim_param)  # type: ignore
+
+    init_dim_param_set(dim_param_set, model.graph.input)  # type: ignore
+    init_dim_param_set(dim_param_set, model.graph.output)  # type: ignore
+    init_dim_param_set(dim_param_set, model.graph.value_info)  # type: ignore
+
+    def update_dim(tensor: ValueInfoProto, dim: str | int, j: int, name: str) -> None:
+        dim_proto = tensor.type.tensor_type.shape.dim[j]
+        if isinstance(dim, int):
+            if dim >= 0:
+                dim_proto.dim_value = dim
+            else:
+                generated_dim_param = name + "_" + str(j)
+                if generated_dim_param in dim_param_set:
+                    raise ValueError(
+                        f"Unable to generate unique dim_param for axis {j} of {name}. Please manually provide a dim_param value."
+                    )
+                dim_proto.dim_param = generated_dim_param
+        else:
+            dim_proto.dim_param = dim
+
+    for input_ in model.graph.input:
+        input_name = input_.name
+        input_dim_arr = input_dims[input_name]
+        for j, dim in enumerate(input_dim_arr):
+            update_dim(input_, dim, j, input_name)
+
+    for output in model.graph.output:
+        output_name = output.name
+        output_dim_arr = output_dims[output_name]
+        for j, dim in enumerate(output_dim_arr):
+            update_dim(output, dim, j, output_name)
+
+    onnx.checker.check_model(model)
+    return model

--- a/backend/src/nodes/properties/inputs/onnx_inputs.py
+++ b/backend/src/nodes/properties/inputs/onnx_inputs.py
@@ -1,7 +1,7 @@
 import navi
 from api import BaseInput
 
-from ...impl.onnx.model import OnnxModel, OnnxModels, OnnxRemBg
+from ...impl.onnx.model import OnnxGeneric, OnnxModel, OnnxModels, OnnxRemBg
 from .generic_inputs import DropDownInput
 
 
@@ -22,6 +22,7 @@ class OnnxGenericModelInput(OnnxModelInput):
         self, label: str = "Model", input_type: navi.ExpressionJson = "OnnxModel"
     ):
         super().__init__(label, navi.intersect(input_type, "OnnxGenericModel"))
+        self.associated_type = OnnxGeneric
 
     def enforce(self, value: object):
         assert isinstance(value, OnnxModels)

--- a/backend/src/packages/chaiNNer_onnx/onnx/utility/interpolate_models.py
+++ b/backend/src/packages/chaiNNer_onnx/onnx/utility/interpolate_models.py
@@ -49,6 +49,8 @@ def perform_interp(
 
 
 def check_will_upscale(context: NodeContext, model: OnnxModel):
+    if model.sub_type != "Generic":
+        return True
     fake_img = np.ones((3, 3, 3), dtype=np.float32, order="F")
     result = upscale_image_node(context, fake_img, model, NO_TILING, 0, False)
 


### PR DESCRIPTION
Fixes #2939

This changes 2 things: 
1. ONNX models now have size requirements.

    Size requirements are detected by testing different input sizes. If shape inference succeeds for a size, this size is assumed to be valid. Unfortunately, shape inference is too accepting of invalid inputs, so I start testing with size 16. 

    This means that the input images of ALL generic ONNX models will now be padded to multiples of 16 (or higher). While this is inefficient, I think that the small overhead is worth it compared to models not running at all.

2. Detecting input/output channels and fixed input sizes is now more robust by not relying on shape inference anymore.

Unfortunately, I had to include some code from the ONNX repo, because `update_inputs_outputs_dims` didn't have an option to overwrite dimensions.