### PR TITLE
Add logic operation node

### DIFF
--- a/backend/src/packages/chaiNNer_standard/utility/math/logic_operation.py
+++ b/backend/src/packages/chaiNNer_standard/utility/math/logic_operation.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from enum import Enum
+
+from api import Lazy, SpecialSuggestion
+from nodes.groups import if_enum_group
+from nodes.properties.inputs import BoolInput, EnumInput
+from nodes.properties.outputs import BoolOutput
+
+from .. import math_group
+
+
+class LogicOperation(Enum):
+    AND = "and"
+    OR = "or"
+    XOR = "xor"
+    NOT = "not"
+
+
+OP_LABEL: dict[LogicOperation, str] = {
+    LogicOperation.AND: "AND: a & b",
+    LogicOperation.OR: "OR: a | b",
+    LogicOperation.XOR: "XOR: a ^ b",
+    LogicOperation.NOT: "NOT: !a",
+}
+
+
+@math_group.register(
+    schema_id="chainner:utility:logic_operation",
+    name="Logic Operation",
+    description="Perform logic operations on conditions.",
+    see_also=[
+        "chainner:utility:conditional",
+    ],
+    icon="MdCalculate",
+    inputs=[
+        EnumInput(
+            LogicOperation,
+            "Logic Operation",
+            option_labels=OP_LABEL,
+            label_style="hidden",
+        ).with_id(0),
+        BoolInput("A", has_handle=True).with_id(1),
+        if_enum_group(0, (LogicOperation.AND, LogicOperation.OR, LogicOperation.XOR))(
+            BoolInput("B", has_handle=True).with_id(2).make_lazy(),
+        ),
+    ],
+    outputs=[
+        BoolOutput(
+            label="Result",
+            output_type="""
+                let a = Input1;
+                let b = Input2;
+
+                match Input0 {
+                    LogicOperation::And => a and b,
+                    LogicOperation::Or  => a or b,
+                    LogicOperation::Xor => a != b,
+                    LogicOperation::Not => not a,
+                }
+            """,
+        )
+        .suggest()
+        .as_passthrough_of(1),
+    ],
+    suggestions=[
+        SpecialSuggestion(
+            "AND",
+            name="Logic Operation: AND",
+            inputs={0: LogicOperation.AND},
+        ),
+        SpecialSuggestion(
+            "&",
+            name="Logic Operation: AND",
+            inputs={0: LogicOperation.AND},
+        ),
+        SpecialSuggestion(
+            "OR",
+            name="Logic Operation: OR",
+            inputs={0: LogicOperation.OR},
+        ),
+        SpecialSuggestion(
+            "|",
+            name="Logic Operation: OR",
+            inputs={0: LogicOperation.OR},
+        ),
+        SpecialSuggestion(
+            "XOR",
+            name="Logic Operation: XOR",
+            inputs={0: LogicOperation.XOR},
+        ),
+        SpecialSuggestion(
+            "NOT",
+            name="Logic Operation: NOT",
+            inputs={0: LogicOperation.NOT},
+        ),
+        SpecialSuggestion(
+            "!",
+            name="Logic Operation: NOT",
+            inputs={0: LogicOperation.NOT},
+        ),
+    ],
+)
+def logic_operation_node(op: LogicOperation, a: bool, b: Lazy[bool]) -> bool:
+    if op == LogicOperation.AND:
+        return a and b.value
+    if op == LogicOperation.OR:
+        return a or b.value
+    if op == LogicOperation.XOR:
+        return a != b.value
+    if op == LogicOperation.NOT:
+        return not a

--- a/src/renderer/components/PaneNodeSearchMenu.tsx
+++ b/src/renderer/components/PaneNodeSearchMenu.tsx
@@ -226,11 +226,16 @@ function* getSpecialSuggestions(
     schemata: readonly NodeSchema[],
     searchQuery: string
 ): Iterable<SuggestionGroupItem> {
+    const equalIgnoreCase = (a: string, b: string) => {
+        // the length check isn't 100% correct, but it's good enough for our mostly-ASCII suggestions
+        return a.length === b.length && a.toLowerCase() === b.toLowerCase();
+    };
+
     const parse = (
         s: SpecialSuggestion,
         schema: NodeSchema
     ): { inputs: Partial<InputData> } | undefined => {
-        if (searchQuery === s.query) {
+        if (equalIgnoreCase(searchQuery, s.query)) {
             return { inputs: s.inputs };
         }
         if (s.parseInput != null && searchQuery.startsWith(s.query)) {


### PR DESCRIPTION
Fixes #2982

This adds a node to perform boolean operations. Supported operations are: and, or, xor, not. These operations are [functionally complete](https://en.wikipedia.org/wiki/Functional_completeness), but we may want to add more in the future if needed.

Just like for the Math node, I added suggestions, so users can quickly create specific operations. Since I wanted to support text, I also had to slightly adjust how search queries are matched.

![image](https://github.com/chaiNNer-org/chaiNNer/assets/20878432/165ac085-46ef-4ff1-a991-f295f89b3ae4)
