### PR TITLE
Fixed label for `!=` in Compare node

### DIFF
--- a/backend/src/packages/chaiNNer_standard/utility/math/compare.py
+++ b/backend/src/packages/chaiNNer_standard/utility/math/compare.py
@@ -29,7 +29,7 @@ class Comparison(Enum):
             label="Operation",
             option_labels={
                 Comparison.EQUAL: "L == R",
-                Comparison.NOT_EQUAL: "L == R",
+                Comparison.NOT_EQUAL: "L != R",
                 Comparison.GREATER: "L > R",
                 Comparison.LESS: "L < R",
                 Comparison.GREATER_EQUAL: "L >= R",


### PR DESCRIPTION
The label was wrong. I have no idea how we missed this until now.