### PR TITLE
fix: Fix SwinIR 4X being referenced with wrong name

### DIFF
--- a/backend/src/packages/chaiNNer_external/web_ui.py
+++ b/backend/src/packages/chaiNNer_external/web_ui.py
@@ -180,7 +180,7 @@ class UpscalerName(Enum):
     REAL_ESRGAN_4_ANIME6B = "R-ESRGAN 4x+ Anime6B"
     SCUNET_GAN = "ScuNET GAN"
     SCUNET_PSNR = "ScuNET PSNR"
-    SWIN_IR_4 = "SwinIR 4x"
+    SWIN_IR_4 = "SwinIR_4x"
 
 
 UPSCALE_NAME_LABELS = {


### PR DESCRIPTION
SwinIR is not properly named.

Add the underscore so the Automatic111 api properly picks it ups.

![image](https://github.com/user-attachments/assets/b190a1d1-858d-4637-bff8-8f1e81feef49)

As a workaround for now and without needing to rebuild the windows app, I have updated Automatic111
![image](https://github.com/user-attachments/assets/4e759c7f-eefe-4a16-adbc-029ecd0eed39)
