### PR TITLE
update spandrel to 0.4.0, spandrel_extra_arches to 0.2.0

### DIFF
--- a/backend/src/packages/chaiNNer_pytorch/__init__.py
+++ b/backend/src/packages/chaiNNer_pytorch/__init__.py
@@ -98,13 +98,13 @@ package = add_package(
         Dependency(
             display_name="Spandrel",
             pypi_name="spandrel",
-            version="0.3.4",
+            version="0.4.0",
             size_estimate=264 * KB,
         ),
         Dependency(
             display_name="Spandrel extra architectures",
             pypi_name="spandrel_extra_arches",
-            version="0.1.1",
+            version="0.2.0",
             size_estimate=83 * KB,
         ),
     ],


### PR DESCRIPTION
I tested PyTorch upscaling with MoSR and ESRGAN and didn't see any issues. Let me know if there's anything else I should test. 