### PR TITLE
Improve "Add Noise" node to support subtle noise generation (#3048)

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image_filter/noise/add_noise.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/noise/add_noise.py
@@ -45,7 +45,15 @@ class NoiseType(Enum):
                 NoiseColor.GRAY: "Monochrome",
             },
         ),
-        SliderInput("Amount", min=0, max=100, default=50),
+        SliderInput(
+            "Amount",
+            min=0.0,
+            max=100.0,
+            default=50.0,
+            precision=1,
+            step=0.1,
+            slider_step=0.1,
+        ),
         seed_group(SeedInput()),
     ],
     outputs=[
@@ -67,18 +75,18 @@ def add_noise_node(
     img: np.ndarray,
     noise_type: NoiseType,
     noise_color: NoiseColor,
-    amount: int,
+    amount: float,
     seed: Seed,
 ) -> np.ndarray:
     if noise_type == NoiseType.GAUSSIAN:
-        return gaussian_noise(img, amount / 100, noise_color, seed.value)
+        return gaussian_noise(img, amount / 100.0, noise_color, seed.value)
     elif noise_type == NoiseType.UNIFORM:
-        return uniform_noise(img, amount / 100, noise_color, seed.value)
+        return uniform_noise(img, amount / 100.0, noise_color, seed.value)
     elif noise_type == NoiseType.SALT_AND_PEPPER:
-        return salt_and_pepper_noise(img, amount / 100, noise_color, seed.value)
+        return salt_and_pepper_noise(img, amount / 100.0, noise_color, seed.value)
     elif noise_type == NoiseType.POISSON:
-        return poisson_noise(img, amount / 100, noise_color, seed.value)
+        return poisson_noise(img, amount / 100.0, noise_color, seed.value)
     elif noise_type == NoiseType.SPECKLE:
-        return speckle_noise(img, amount / 100, noise_color, seed.value)
+        return speckle_noise(img, amount / 100.0, noise_color, seed.value)
     else:
         raise ValueError(f"Unknown noise type: {noise_type}")


### PR DESCRIPTION
Implements fine-grained control over the noise amount, by switching to a float-based noise multiplier instead.

(The previous implementation was only able to generate noise in increments of +2.55 on the 0-255 pixel luminance scale.)

---

Detailed description:

- The node's previous noise implementation was not granular enough, causing huge jumps between the noise amounts generated by different slider values. The problem was the division factor (an integer scale of 0-100). Think about it in terms of the 0-255 range of normal uint8 image channels. The previous algorithm divided the input slider by 100, and the lowest input value was 1, meaning that the lowest possible noise amount "step" was `0.01`. Now let's look at what happens when we generate such noise: `0.01 * 255 = 2.55`. This means the smallest noise amount step was causing roughly 3 brightness steps for each pixel, which made the entire node very heavy-handed and not very useful. It was most noticeable when generating monochromatic noise on RGB images, where the equal impact on every RGB channel made the heavy noise very invasive (because ChaiNNer adds the same monochromatic noise texture equally to all 3 channels then).

- To fix the node in a backwards-compatible way, the slider has been changed to a float with a single decimal, ranging from `0.0` to `100.0`. By adding a single decimal to the slider, we thereby make the noise amount go in steps of `0.1 / 100 = 0.001` instead, which represents `0.001 * 255 = 0.255` on the regular uint8 scale. So to generate noise that adds +1 on the uint8 scale, you would now just need to go roughly +0.4 on the float slider.

This improvement finally makes the noise node granular enough to be useful for subtle, artistic noise.

---

Closes #3048