### PR TITLE
Update "Align Image to Reference" node to v3.0.0

### DIFF
--- a/backend/src/nodes/impl/pytorch/rife/IFNet_HDv3_v4_14_align.py
+++ b/backend/src/nodes/impl/pytorch/rife/IFNet_HDv3_v4_14_align.py
@@ -1,23 +1,33 @@
-# type: ignore
 # Original Rife Frame Interpolation by hzwer
 # https://github.com/megvii-research/ECCV2022-RIFE
 # https://github.com/hzwer/Practical-RIFE
 
-# Modifications to use Rife for Image Alignment by tepete/pifroggi ('Enhance Everything!' Discord Server)
+# Modifications to use Rife for Image Alignment by pifroggi
+# or tepete on the "Enhance Everything!" Discord Server
+# https://github.com/pifroggi/vs_align
 
 # Additional helpful github issues
 # https://github.com/megvii-research/ECCV2022-RIFE/issues/278
 # https://github.com/megvii-research/ECCV2022-RIFE/issues/344
 
+from __future__ import annotations
+
 import torch
-import torch.nn.functional as F  # noqa: N812
 from torch import nn
+from torch.nn import functional
 from torchvision import transforms
 
 from .warplayer import warp
 
 
-def conv(in_planes, out_planes, kernel_size=3, stride=1, padding=1, dilation=1):  # noqa: ANN001
+def conv(
+    in_planes: int,
+    out_planes: int,
+    kernel_size: int = 3,
+    stride: int = 1,
+    padding: int = 1,
+    dilation: int = 1,
+):
     return nn.Sequential(
         nn.Conv2d(
             in_planes,
@@ -32,7 +42,14 @@ def conv(in_planes, out_planes, kernel_size=3, stride=1, padding=1, dilation=1):
     )
 
 
-def conv_bn(in_planes, out_planes, kernel_size=3, stride=1, padding=1, dilation=1):  # noqa: ANN001
+def conv_bn(
+    in_planes: int,
+    out_planes: int,
+    kernel_size: int = 3,
+    stride: int = 1,
+    padding: int = 1,
+    dilation: int = 1,
+):
     return nn.Sequential(
         nn.Conv2d(
             in_planes,
@@ -57,7 +74,7 @@ class Head(nn.Module):
         self.cnn3 = nn.ConvTranspose2d(32, 8, 4, 2, 1)
         self.relu = nn.LeakyReLU(0.2, True)
 
-    def forward(self, x, feat=False):  # noqa: ANN001
+    def forward(self, x: torch.Tensor, feat: bool = False):
         x0 = self.cnn0(x)
         x = self.relu(x0)
         x1 = self.cnn1(x)
@@ -71,18 +88,18 @@ class Head(nn.Module):
 
 
 class ResConv(nn.Module):
-    def __init__(self, c, dilation=1):  # noqa: ANN001
+    def __init__(self, c: int, dilation: int = 1):
         super().__init__()
         self.conv = nn.Conv2d(c, c, 3, 1, dilation, dilation=dilation, groups=1)
         self.beta = nn.Parameter(torch.ones((1, c, 1, 1)), requires_grad=True)
         self.relu = nn.LeakyReLU(0.2, True)
 
-    def forward(self, x):  # noqa: ANN001
+    def forward(self, x: torch.Tensor):
         return self.relu(self.conv(x) * self.beta + x)
 
 
 class IFBlock(nn.Module):
-    def __init__(self, in_planes, c=64):  # noqa: ANN001
+    def __init__(self, in_planes: int, c: int = 64):
         super().__init__()
         self.conv0 = nn.Sequential(
             conv(in_planes, c // 2, 3, 2, 1),
@@ -102,14 +119,22 @@ class IFBlock(nn.Module):
             nn.ConvTranspose2d(c, 4 * 6, 4, 2, 1), nn.PixelShuffle(2)
         )
 
-    def forward(self, x, flow=None, scale=1):  # noqa: ANN001
-        x = F.interpolate(
+    def forward(
+        self,
+        x: torch.Tensor,
+        flow: torch.Tensor | None = None,
+        scale: int = 1,
+    ):
+        x = functional.interpolate(
             x, scale_factor=1.0 / scale, mode="bilinear", align_corners=False
         )
         if flow is not None:
             flow = (
-                F.interpolate(
-                    flow, scale_factor=1.0 / scale, mode="bilinear", align_corners=False
+                functional.interpolate(
+                    flow,
+                    scale_factor=1.0 / scale,
+                    mode="bilinear",
+                    align_corners=False,
                 )
                 * 1.0
                 / scale
@@ -118,7 +143,7 @@ class IFBlock(nn.Module):
         feat = self.conv0(x)
         feat = self.convblock(feat)
         tmp = self.lastconv(feat)
-        tmp = F.interpolate(
+        tmp = functional.interpolate(
             tmp, scale_factor=scale, mode="bilinear", align_corners=False
         )
         flow = tmp[:, :4] * scale
@@ -137,135 +162,371 @@ class IFNet(nn.Module):
 
     def align_images(
         self,
-        img0,  # noqa: ANN001
-        img1,  # noqa: ANN001
-        timestep,  # noqa: ANN001
-        scale_list,  # noqa: ANN001
-        blur_strength,  # noqa: ANN001
-        ensemble,  # noqa: ANN001
-        device,  # noqa: ANN001
+        fclip: torch.Tensor,
+        fref: torch.Tensor,
+        flowmask: torch.Tensor | None,
+        time: torch.Tensor,
+        scales: tuple[int, ...],
+        blur: int,
+        smooth: int,
+        ensemble: bool,
+        compensate: bool,
+        device: str,
+        fp16: bool,
+        fref_h_pad: int,
+        fref_w_pad: int,
+        flow2: torch.Tensor | None = None,
+        fref_pref: torch.Tensor | None = None,
     ):
-        # optional blur
-        if blur_strength is not None and blur_strength > 0:
-            blur = transforms.GaussianBlur(
-                kernel_size=(5, 5), sigma=(blur_strength, blur_strength)
+        def compute_flow(
+            fclip_pref: torch.Tensor,
+            fref_pref: torch.Tensor,
+            time: torch.Tensor,
+            fp16: bool,
+        ):
+            f0, f1 = self.encode(fclip_pref[:, :3]), self.encode(fref_pref[:, :3])
+            flow, mask, block = (
+                None,
+                None,
+                [self.block0, self.block1, self.block2, self.block3],
             )
-            img0_blurred = blur(img0)
-            img1_blurred = blur(img1)
-        else:
-            img0_blurred = img0
-            img1_blurred = img1
-
-        f0 = self.encode(img0_blurred[:, :3])
-        f1 = self.encode(img1_blurred[:, :3])
-        flow_list = []
-        mask_list = []
-        flow = None
-        mask = None
-        block = [self.block0, self.block1, self.block2, self.block3]
-        for i in range(4):
-            if flow is None:
-                flow, mask = block[i](
-                    torch.cat(
-                        (img0_blurred[:, :3], img1_blurred[:, :3], f0, f1, timestep), 1
-                    ),
-                    None,
-                    scale=scale_list[i],
+            for i in range(4):
+                inputs = torch.cat(
+                    (fclip_pref[:, :3], fref_pref[:, :3], f0, f1, time), 1
                 )
-                if ensemble:
-                    f_, m_ = block[i](
-                        torch.cat(
-                            (
-                                img1_blurred[:, :3],
-                                img0_blurred[:, :3],
-                                f1,
-                                f0,
-                                1 - timestep,
+                if flow is None:
+                    flow, mask = block[i](inputs, None, scale=scales[i])
+                    if ensemble:
+                        f_, m_ = block[i](
+                            torch.cat(
+                                (fref_pref[:, :3], fclip_pref[:, :3], f1, f0, 1 - time),
+                                1,
                             ),
-                            1,
-                        ),
-                        None,
-                        scale=scale_list[i],
-                    )
-                    flow = (flow + torch.cat((f_[:, 2:4], f_[:, :2]), 1)) / 2
-                    mask = (mask + (-m_)) / 2
-            else:
-                wf0 = warp(f0, flow[:, :2], device)
-                wf1 = warp(f1, flow[:, 2:4], device)
-                fd, m0 = block[i](
-                    torch.cat(
-                        (
-                            img0_blurred[:, :3],
-                            img1_blurred[:, :3],
-                            wf0,
-                            wf1,
-                            timestep,
-                            mask,
-                        ),
-                        1,
-                    ),
-                    flow,
-                    scale=scale_list[i],
-                )
-                if ensemble:
-                    f_, m_ = block[i](
-                        torch.cat(
-                            (
-                                img1_blurred[:, :3],
-                                img0_blurred[:, :3],
-                                wf1,
-                                wf0,
-                                1 - timestep,
-                                -mask,
-                            ),
-                            1,
-                        ),
-                        torch.cat((flow[:, 2:4], flow[:, :2]), 1),
-                        scale=scale_list[i],
-                    )
-                    fd = (fd + torch.cat((f_[:, 2:4], f_[:, :2]), 1)) / 2
-                    mask = (m0 + (-m_)) / 2
+                            None,
+                            scale=scales[i],
+                        )
+                        flow, mask = (
+                            (flow + torch.cat((f_[:, 2:4], f_[:, :2]), 1)) / 2,
+                            (mask + (-m_)) / 2,
+                        )
                 else:
-                    mask = m0
-                flow = flow + fd
-            mask_list.append(mask)
-            flow_list.append(flow)
+                    if fp16:
+                        wf0, wf1 = (
+                            warp(f0, flow[:, :2], device).half(),
+                            warp(f1, flow[:, 2:4], device).half(),
+                        )
+                    else:
+                        wf0, wf1 = (
+                            warp(f0, flow[:, :2], device),
+                            warp(f1, flow[:, 2:4], device),
+                        )
+                    fd, m0 = block[i](
+                        torch.cat(
+                            (fclip_pref[:, :3], fref_pref[:, :3], wf0, wf1, time, mask),
+                            1,
+                        ),
+                        flow,
+                        scale=scales[i],
+                    )
+                    if ensemble:
+                        f_, m_ = block[i](
+                            torch.cat(
+                                (
+                                    fref_pref[:, :3],
+                                    fclip_pref[:, :3],
+                                    wf1,
+                                    wf0,
+                                    1 - time,
+                                    -mask,
+                                ),
+                                1,
+                            ),
+                            torch.cat((flow[:, 2:4], flow[:, :2]), 1),
+                            scale=scales[i],
+                        )
+                        fd, mask = (
+                            (fd + torch.cat((f_[:, 2:4], f_[:, :2]), 1)) / 2,
+                            (m0 + (-m_)) / 2,
+                        )
+                    else:
+                        mask = m0
+                    flow += fd
+            return flow
 
-        # apply warp to original image
-        aligned_img0 = warp(img0, flow_list[-1][:, :2], device)
+        def inpaint_flow(
+            flow: torch.Tensor,
+            mask: torch.Tensor,
+            device: str,
+            max_steps: int = 100,
+            feather_inpaint: int = 3,
+        ):
+            # step_size and feather_inpaint should be odd
+            step_size = max(
+                (flow.shape[2] // 100) * 2 + 1, 3
+            )  # step_size = height/50 but odd and at least 3
+            flow_orig = flow.clone()
 
-        # add clamp here instead of in warplayer script, as it changes the output there
-        aligned_img0 = aligned_img0.clamp(min=0.0, max=1.0)
-        return aligned_img0, flow_list[-1]
+            # make sure mask is binarized and the same size as flow
+            mask = (mask > 0.5).float()
+            if mask.shape[-2:] != flow.shape[2:]:
+                mask = functional.interpolate(
+                    mask,
+                    size=(flow.shape[2], flow.shape[3]),
+                    mode="nearest",
+                    recompute_scale_factor=False,
+                )
+            mask_orig = mask.clone()
+
+            # kernels for inpainting and shrinking the inpaint mask
+            kernel_inpaint = torch.ones(2, 1, step_size, step_size, device=device)
+            kernel_norm = torch.ones(1, 1, step_size, step_size, device=device)
+            shrink_mask_kernel = torch.ones(
+                1, 1, step_size - 2, step_size - 2, device=device
+            )
+
+            # kernels to grow mask and feather mask
+            grow_mask_kernel = torch.ones(
+                1, 1, feather_inpaint, feather_inpaint, device=device
+            )
+            feather_inpaint_kernel = grow_mask_kernel / (feather_inpaint**2)
+
+            flow_down = flow
+            mask_down = mask
+
+            # use downscaling as a faster blur/averaging
+            for _step in range(max_steps):
+                # downscale inpaint step by 2 (each step it get 2 times smaller)
+                if (
+                    flow_down.shape[2] > 4 and flow_down.shape[3] > 4
+                ):  # make sure it doesn't get too small
+                    flow_down = functional.interpolate(
+                        flow_down,
+                        scale_factor=0.5,
+                        mode="bilinear",
+                        align_corners=False,
+                    )
+                    mask_down = functional.interpolate(
+                        mask_down, scale_factor=0.5, mode="nearest"
+                    )
+
+                # delete flow that will be inpainted
+                inv_mask = 1 - mask_down
+                masked_flow = flow_down * inv_mask
+
+                # do one inpaint step (no autocast due to occasional division artifacts)
+                with torch.amp.autocast(device.type, enabled=False):
+                    inpainted_flow = functional.conv2d(
+                        masked_flow.to(torch.float32),
+                        kernel_inpaint,
+                        padding="same",
+                        groups=2,
+                    )
+                    norm_mask = functional.conv2d(
+                        inv_mask.to(torch.float32), kernel_norm, padding="same"
+                    ).clamp_(min=1e-6)
+                    inpainted_flow /= norm_mask
+
+                # upscale to add inpaint step
+                flow_up = functional.interpolate(
+                    inpainted_flow,
+                    size=(flow.shape[2], flow.shape[3]),
+                    mode="bilinear",
+                    align_corners=False,
+                )
+                mask_up = functional.interpolate(
+                    mask_down, size=(flow.shape[2], flow.shape[3]), mode="nearest"
+                )
+
+                # add inpaint to flow
+                inv_mask_up = 1 - mask_up
+                flow.mul_(inv_mask_up).add_(flow_up * mask_up)
+
+                # shrink mask for next step
+                mask_down = (
+                    1
+                    - functional.conv2d(
+                        1 - mask_down, shrink_mask_kernel, padding="same"
+                    )
+                ).clamp(0, 1)
+
+                # check if mask is still present and if more steps are needed
+                if mask_down.sum() == 0:
+                    break
+
+            # blur flow
+            kernel_size = (
+                flow.shape[2] // 40
+            ) * 2 + 1  # blur radius = height/20 but odd
+            kernel_box = torch.ones((1, 1, kernel_size), device=device) / kernel_size
+            flow = functional.conv2d(
+                flow,
+                kernel_box.unsqueeze(2).expand(2, 1, 1, kernel_size),
+                padding=(0, kernel_size // 2),
+                groups=2,
+            )  # horizontal blur
+            flow = functional.conv2d(
+                flow,
+                kernel_box.unsqueeze(3).expand(2, 1, kernel_size, 1),
+                padding=(kernel_size // 2, 0),
+                groups=2,
+            )  # vertical blur
+
+            # feather mask
+            mask_orig = functional.interpolate(
+                mask_orig, scale_factor=1 / 8, mode="bilinear", align_corners=True
+            )
+            mask_grown = functional.conv2d(
+                mask_orig, grow_mask_kernel, padding=feather_inpaint // 2
+            ).clamp(0, 1)
+            mask_feather = functional.conv2d(
+                mask_grown, feather_inpaint_kernel, padding=feather_inpaint // 2
+            ).clamp(0, 1)
+            mask_feather = functional.interpolate(
+                mask_feather,
+                size=(flow_orig.shape[2], flow_orig.shape[3]),
+                mode="bilinear",
+                align_corners=True,
+            )
+
+            # make sure both tensor are the same dtype due to autocast
+            flow = flow.to(mask_feather.dtype)
+
+            # add inpaint to original flow
+            return flow_orig.lerp_(flow, mask_feather)
+
+        # check if fref_pref already available
+        fref_pref_none = fref_pref is None
+
+        # get dimensions
+        fref_h, fref_w = fref.shape[2], fref.shape[3]
+        fclip_h, fclip_w = fclip.shape[2], fclip.shape[3]
+
+        # resize to fref padded
+        if fclip_h != fref_h_pad or fclip_w != fref_w_pad:
+            fclip_pref = functional.interpolate(
+                fclip,
+                size=(fref_h_pad, fref_w_pad),
+                mode="bilinear",
+                align_corners=False,
+            )
+        else:
+            fclip_pref = fclip
+
+        # resize to fref padded
+        if fref_h != fref_h_pad or fref_w != fref_w_pad:
+            fref = functional.interpolate(
+                fref,
+                size=(fref_h_pad, fref_w_pad),
+                mode="bilinear",
+                align_corners=False,
+            )
+
+        # pre-blur fclip and fref
+        if blur is not None and blur > 0:
+            gaussblur = transforms.GaussianBlur(kernel_size=(5, 5), sigma=(blur, blur))
+            fclip_pref = gaussblur(fclip_pref)
+            if fref_pref_none:
+                fref_pref = gaussblur(fref)
+        elif fref_pref_none:
+            fref_pref = fref
+
+        # compute flow from fclip_pref to fref_pref
+        flow1 = compute_flow(fclip_pref, fref_pref, time, fp16)
+
+        # compute flow from fref_pref to itself
+        if compensate and flow2 is None:
+            flow2 = compute_flow(fref_pref, fref_pref, time, fp16)
+
+        # extract final flow and subtract flow2 from flow1
+        if compensate:
+            compensated_flow = flow1[:, :2] - flow2[:, :2]
+        else:
+            compensated_flow = flow1[:, :2]
+
+        # resize flow to fclip's size
+        compensated_flow = functional.interpolate(
+            compensated_flow,
+            size=(fref_h, fref_w),
+            mode="bilinear",
+            align_corners=False,
+        )
+        if fclip_w / fref_w_pad != 1:
+            flow_x = compensated_flow[:, 0:1, :, :] * (float(fclip_w) / fref_w_pad)
+            flow_y = compensated_flow[:, 1:2, :, :] * (float(fclip_h) / fref_h_pad)
+            compensated_flow = torch.cat([flow_x, flow_y], dim=1)
+
+        # inpaint flow based on mask
+        if flowmask is not None:
+            compensated_flow = inpaint_flow(compensated_flow, flowmask, device)
+
+        # post-smoothing flow
+        if smooth is not None and smooth > 0:
+            kernel_box = torch.ones((1, 1, smooth), device=device) / smooth
+            compensated_flow = functional.pad(
+                compensated_flow, (smooth // 2, smooth // 2, 0, 0), mode="reflect"
+            )
+            compensated_flow = functional.conv2d(
+                compensated_flow,
+                kernel_box.unsqueeze(2).expand(2, 1, 1, smooth),
+                groups=2,
+            )  # horizontal blur
+            compensated_flow = functional.pad(
+                compensated_flow, (0, 0, smooth // 2, smooth // 2), mode="reflect"
+            )
+            compensated_flow = functional.conv2d(
+                compensated_flow,
+                kernel_box.unsqueeze(3).expand(2, 1, smooth, 1),
+                groups=2,
+            )  # vertical blur
+
+        # warp fclip with compensated flow
+        if fp16:
+            aligned_fclip = warp(fclip, compensated_flow, device).half()
+        else:
+            aligned_fclip = warp(fclip, compensated_flow, device)
+
+        # clamp and return
+        return aligned_fclip.clamp_(0, 1), flow2, fref_pref
 
     def forward(
         self,
-        x,  # noqa: ANN001
-        timestep=1,  # noqa: ANN001
-        training=False,  # noqa: ANN001
-        fastmode=True,  # noqa: ANN001
-        ensemble=True,  # noqa: ANN001
-        num_iterations=1,  # noqa: ANN001
-        multiplier=0.5,  # noqa: ANN001
-        blur_strength=0,  # noqa: ANN001
-        device="cuda",  # noqa: ANN001
+        fclip: torch.Tensor,  # misaligned frame.
+        fref: torch.Tensor,  # reference frame.
+        flowmask: torch.Tensor | None = None,  # inpainting mask for flow.
+        scales: tuple[int, ...] = (8, 4, 2, 1),  # rife scale list.
+        pads: tuple[int, int] = (0, 0),  # heigth and width padding.
+        blur: int = 0,  # pre blurs input images.
+        smooth: int = 0,  # post smoothes flow before warping.
+        its: int = 1,  # runs alignment pass multiple times.
+        compensate: bool = True,  # if True, fref will be aligned to itself and subtracted from flow.
+        ensemble: bool = True,  # computed flow from clip to ref and ref to clip.
+        device: str = "cuda",  # cpu or cuda.
+        fp16: bool = False,  # if True, use half precision.
     ):
-        if not training:
-            channel = x.shape[1] // 2
-            img0 = x[:, :channel]
-            img1 = x[:, channel:]
-
-        scale_list = [multiplier * 8, multiplier * 4, multiplier * 2, multiplier]
-
-        if not torch.is_tensor(timestep):
-            timestep = (x[:, :1].clone() * 0 + 1) * timestep
-        else:
-            timestep = timestep.repeat(1, 1, img0.shape[2], img0.shape[3])  # type: ignore
-
-        for _iteration in range(num_iterations):
-            aligned_img0, flow = self.align_images(
-                img0, img1, timestep, scale_list, blur_strength, ensemble, device
+        fref_h_pad = fref.shape[2] + pads[0]
+        fref_w_pad = fref.shape[3] + pads[1]
+        time = torch.ones((1, 1, fref_h_pad, fref_w_pad), device=fref.device) * 1
+        flow2 = None
+        fref_pref = None
+        for _iteration in range(its):
+            aligned_fclip, flow2, fref_pref = self.align_images(
+                fclip,
+                fref,
+                flowmask,
+                time,
+                scales,
+                blur,
+                smooth,
+                ensemble,
+                compensate,
+                device,
+                fp16,
+                fref_h_pad,
+                fref_w_pad,
+                flow2,
+                fref_pref,
             )
-            img0 = aligned_img0  # use the aligned image as img0 for the next iteration
-
-        return aligned_img0, flow
+            fclip = (
+                aligned_fclip  # use the aligned image as fclip for the next iteration
+            )
+        return aligned_fclip

--- a/backend/src/nodes/impl/pytorch/rife/IFNet_HDv3_v4_14_align.py
+++ b/backend/src/nodes/impl/pytorch/rife/IFNet_HDv3_v4_14_align.py
@@ -1,3 +1,4 @@
+# type: ignore
 # Original Rife Frame Interpolation by hzwer
 # https://github.com/megvii-research/ECCV2022-RIFE
 # https://github.com/hzwer/Practical-RIFE

--- a/backend/src/nodes/impl/pytorch/rife/LICENSE
+++ b/backend/src/nodes/impl/pytorch/rife/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright  (c)  Megvii  Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/backend/src/nodes/impl/pytorch/xfeat/LICENSE
+++ b/backend/src/nodes/impl/pytorch/xfeat/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/backend/src/nodes/impl/pytorch/xfeat/xfeat_align.py
+++ b/backend/src/nodes/impl/pytorch/xfeat/xfeat_align.py
@@ -1,0 +1,233 @@
+# Original XFeat Accelerated Features for Lightweight Image Matching
+# https://www.verlab.dcc.ufmg.br/descriptors/xfeat_cvpr24/
+# https://github.com/verlab/accelerated_features
+
+# Modifications for homography alignment by pifroggi
+# or tepete on the "Enhance Everything!" Discord Server
+# https://github.com/pifroggi/vs_align
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F  # noqa: N812
+from torch import nn
+
+from .xfeat_arch import *
+from .xfeat_arch import XFeatModel
+
+
+def gen_grid(
+    homography: torch.Tensor,
+    src_h: int,
+    src_w: int,
+    out_h: int,
+    out_w: int,
+    device: str,
+):
+    # generates the grid from homograhpy to warp with grid_sample
+    grid_y, grid_x = torch.meshgrid(
+        torch.linspace(0, out_h - 1, out_h, device=device),
+        torch.linspace(0, out_w - 1, out_w, device=device),
+        indexing="ij",  # make sure first dimension is y and second is x
+    )
+    grid = torch.stack([grid_x, grid_y, torch.ones_like(grid_x)], dim=-1)  # stack grids
+    grid_flat = grid.view(-1, 3).T  # flatten grid
+    homography_inv = torch.inverse(homography)  # inverse homography
+    src_coords = homography_inv @ grid_flat  # apply homography to grid
+    src_coords = src_coords / src_coords[2:3, :]  # mormalize
+    src_coords = (
+        src_coords[:2, :].view(2, out_h, out_w).permute(1, 2, 0)
+    )  # reshape to (out_h, out_w, 2)
+    src_coords[..., 0] = (
+        2.0 * src_coords[..., 0] / (src_w - 1) - 1
+    )  # normalize to [-1, 1] for grid_sample
+    src_coords[..., 1] = (
+        2.0 * src_coords[..., 1] / (src_h - 1) - 1
+    )  # normalize to [-1, 1] for grid_sample
+    return src_coords.unsqueeze(0)
+
+
+class XFeat(nn.Module):
+    # XFeat inference module
+    def __init__(
+        self,
+        weights: dict | None = None,
+        top_k: int = 4096,
+        detection_threshold: float = 0.05,
+        height: int = 480,
+        width: int = 704,
+        device: str = "cuda",
+    ):
+        super().__init__()
+        self.dev = torch.device(device)
+        self.net = XFeatModel().to(self.dev).eval()
+        self.top_k = top_k
+        self.detection_threshold = detection_threshold
+        self.height = height
+        self.width = width
+        if weights is not None:
+            self.net.load_state_dict(weights)
+        self.interpolator = InterpolateSparse2d("bicubic")
+
+    @torch.inference_mode()
+    def detectAndCompute(  # noqa: N802
+        self,
+        x: torch.Tensor,
+        top_k: int | None = None,
+        detection_threshold: float | None = None,
+        height: int | None = None,
+        width: int | None = None,
+    ):
+        # computes sparse keypoints & descriptors
+        if top_k is None:
+            top_k = self.top_k
+        if detection_threshold is None:
+            detection_threshold = self.detection_threshold
+        if height is None:
+            height = self.height
+        if width is None:
+            width = self.width
+        x, rh1, rw1 = self.preprocess_tensor(x, height, width)
+        B, _, _H1, _W1 = x.shape  # noqa: N806
+        M1, K1, H1 = self.net(x)  # noqa: N806
+        M1 = F.normalize(M1, dim=1)  # noqa: N806
+
+        # convert logits to heatmap and extract kpts
+        K1h = self.get_kpts_heatmap(K1)  # noqa: N806
+        mkpts = self.NMS(K1h, threshold=detection_threshold, kernel_size=5)
+
+        # compute reliability scores
+        _nearest = InterpolateSparse2d("nearest")
+        _bilinear = InterpolateSparse2d("bilinear")
+        scores = (
+            _nearest(K1h, mkpts, _H1, _W1) * _bilinear(H1, mkpts, _H1, _W1)
+        ).squeeze(-1)
+        scores[torch.all(mkpts == 0, dim=-1)] = -1
+
+        # select top-k features
+        idxs = torch.argsort(-scores)
+        mkpts_x = torch.gather(mkpts[..., 0], -1, idxs)[:, :top_k]
+        mkpts_y = torch.gather(mkpts[..., 1], -1, idxs)[:, :top_k]
+        mkpts = torch.cat([mkpts_x[..., None], mkpts_y[..., None]], dim=-1)
+        scores = torch.gather(scores, -1, idxs)[:, :top_k]
+
+        feats = self.interpolator(M1, mkpts, H=_H1, W=_W1)
+        feats = F.normalize(feats, dim=-1)
+        mkpts = mkpts * torch.tensor([rw1, rh1], device=mkpts.device).view(1, 1, -1)
+        valid = scores > 0
+        return [
+            {
+                "keypoints": mkpts[b][valid[b]],
+                "scores": scores[b][valid[b]],
+                "descriptors": feats[b][valid[b]],
+            }
+            for b in range(B)
+        ]
+
+    def preprocess_tensor(
+        self,
+        x: torch.Tensor,
+        target_height: int = 480,
+        target_width: int = 704,
+    ):
+        # resize to common resolution (must be divisible by 32)
+        H, W = x.shape[-2:]  # noqa: N806
+        if H != target_height or W != target_width:
+            rh, rw = H / target_height, W / target_width
+            x = F.interpolate(
+                x, (target_height, target_width), mode="bilinear", align_corners=False
+            )
+        else:
+            rh, rw = 1.0, 1.0
+        return x, rh, rw
+
+    def get_kpts_heatmap(
+        self,
+        kpts: torch.Tensor,
+        softmax_temp: float = 1.0,
+    ):
+        scores = F.softmax(kpts * softmax_temp, 1)[:, :64]
+        B, _, H, W = scores.shape  # noqa: N806
+        heatmap = scores.permute(0, 2, 3, 1).reshape(B, H, W, 8, 8)
+        heatmap = heatmap.permute(0, 1, 3, 2, 4).reshape(B, 1, H * 8, W * 8)
+        return heatmap
+
+    def NMS(  # noqa: N802
+        self,
+        x: torch.Tensor,
+        threshold: float = 0.05,
+        kernel_size: int = 5,
+    ):
+        B, _, H, W = x.shape  # noqa: N806
+        pad = kernel_size // 2
+        local_max = nn.MaxPool2d(kernel_size=kernel_size, stride=1, padding=pad)(x)
+        pos = (x == local_max) & (x > threshold)
+        pos_batched = [k.nonzero()[..., 1:].flip(-1) for k in pos]
+
+        pad_val = max([len(x) for x in pos_batched])
+        pos_out = torch.zeros((B, pad_val, 2), dtype=torch.long, device=x.device)
+
+        # pad kpts and build (B, N, 2) tensor
+        for b in range(len(pos_batched)):
+            pos_out[b, : len(pos_batched[b]), :] = pos_batched[b]
+
+        return pos_out
+
+    @torch.inference_mode()
+    def match(
+        self,
+        feats1: torch.Tensor,
+        feats2: torch.Tensor,
+        min_cossim: float = 0.82,
+    ):
+        # matches two sets of points
+        cossim = feats1 @ feats2.t()
+        cossim_t = feats2 @ feats1.t()
+        _, match12 = cossim.max(dim=1)
+        _, match21 = cossim_t.max(dim=1)
+        idx0 = torch.arange(len(match12), device=match12.device)
+        mutual = match21[match12] == idx0
+
+        if min_cossim > 0:
+            cossim_vals, _ = cossim.max(dim=1)
+            good = cossim_vals > min_cossim
+            idx0 = idx0[mutual & good]
+            idx1 = match12[mutual & good]
+        else:
+            idx0 = idx0[mutual]
+            idx1 = match12[mutual]
+        return idx0, idx1
+
+
+class InterpolateSparse2d(nn.Module):
+    # interpolate tensor at given sparse 2D positions
+    def __init__(
+        self,
+        mode: str = "bicubic",
+        align_corners: bool = False,
+    ):
+        super().__init__()
+        self.mode = mode
+        self.align_corners = align_corners
+
+    def normgrid(
+        self,
+        x: torch.Tensor,
+        H: int,  # noqa: N803
+        W: int,  # noqa: N803
+    ):
+        return (
+            2.0 * (x / (torch.tensor([W - 1, H - 1], device=x.device, dtype=x.dtype)))
+            - 1.0
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        pos: torch.Tensor,
+        H: int,  # noqa: N803
+        W: int,  # noqa: N803
+    ):
+        grid = self.normgrid(pos, H, W).unsqueeze(-2).to(x.dtype)
+        x = F.grid_sample(x, grid, mode=self.mode, align_corners=False)
+        return x.permute(0, 2, 3, 1).squeeze(-2)

--- a/backend/src/nodes/impl/pytorch/xfeat/xfeat_align.py
+++ b/backend/src/nodes/impl/pytorch/xfeat/xfeat_align.py
@@ -22,7 +22,7 @@ def gen_grid(
     src_w: int,
     out_h: int,
     out_w: int,
-    device: str,
+    device: str | torch.device,
 ):
     # generates the grid from homograhpy to warp with grid_sample
     grid_y, grid_x = torch.meshgrid(
@@ -56,7 +56,7 @@ class XFeat(nn.Module):
         detection_threshold: float = 0.05,
         height: int = 480,
         width: int = 704,
-        device: str = "cuda",
+        device: str | torch.device = "cuda",
     ):
         super().__init__()
         self.dev = torch.device(device)
@@ -158,7 +158,7 @@ class XFeat(nn.Module):
         threshold: float = 0.05,
         kernel_size: int = 5,
     ):
-        B, _, H, W = x.shape  # noqa: N806
+        B, _, _, _ = x.shape  # noqa: N806
         pad = kernel_size // 2
         local_max = nn.MaxPool2d(kernel_size=kernel_size, stride=1, padding=pad)(x)
         pos = (x == local_max) & (x > threshold)

--- a/backend/src/nodes/impl/pytorch/xfeat/xfeat_arch.py
+++ b/backend/src/nodes/impl/pytorch/xfeat/xfeat_arch.py
@@ -1,0 +1,168 @@
+"""
+"XFeat: Accelerated Features for Lightweight Image Matching, CVPR 2024."
+https://www.verlab.dcc.ufmg.br/descriptors/xfeat_cvpr24/
+"""
+
+import torch
+import torch.nn.functional as f
+from torch import nn
+
+
+class BasicLayer(nn.Module):
+    """
+    Basic Convolutional Layer: Conv2d -> BatchNorm -> ReLU
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int = 3,
+        stride: int = 1,
+        padding: int = 1,
+        dilation: int = 1,
+        bias: bool = False,
+    ):
+        super().__init__()
+        self.layer = nn.Sequential(
+            nn.Conv2d(
+                in_channels,
+                out_channels,
+                kernel_size,
+                padding=padding,
+                stride=stride,
+                dilation=dilation,
+                bias=bias,
+            ),
+            nn.BatchNorm2d(out_channels, affine=False),
+            nn.ReLU(inplace=True),
+        )
+
+    def forward(self, x: torch.Tensor):
+        return self.layer(x)
+
+
+class XFeatModel(nn.Module):
+    """
+    Implementation of architecture described in
+    "XFeat: Accelerated Features for Lightweight Image Matching, CVPR 2024."
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.norm = nn.InstanceNorm2d(1)
+
+        ########### ⬇️ CNN Backbone & Heads ⬇️ ###########
+
+        self.skip1 = nn.Sequential(
+            nn.AvgPool2d(4, stride=4), nn.Conv2d(1, 24, 1, stride=1, padding=0)
+        )
+
+        self.block1 = nn.Sequential(
+            BasicLayer(1, 4, stride=1),
+            BasicLayer(4, 8, stride=2),
+            BasicLayer(8, 8, stride=1),
+            BasicLayer(8, 24, stride=2),
+        )
+
+        self.block2 = nn.Sequential(
+            BasicLayer(24, 24, stride=1),
+            BasicLayer(24, 24, stride=1),
+        )
+
+        self.block3 = nn.Sequential(
+            BasicLayer(24, 64, stride=2),
+            BasicLayer(64, 64, stride=1),
+            BasicLayer(64, 64, 1, padding=0),
+        )
+        self.block4 = nn.Sequential(
+            BasicLayer(64, 64, stride=2),
+            BasicLayer(64, 64, stride=1),
+            BasicLayer(64, 64, stride=1),
+        )
+
+        self.block5 = nn.Sequential(
+            BasicLayer(64, 128, stride=2),
+            BasicLayer(128, 128, stride=1),
+            BasicLayer(128, 128, stride=1),
+            BasicLayer(128, 64, 1, padding=0),
+        )
+
+        self.block_fusion = nn.Sequential(
+            BasicLayer(64, 64, stride=1),
+            BasicLayer(64, 64, stride=1),
+            nn.Conv2d(64, 64, 1, padding=0),
+        )
+
+        self.heatmap_head = nn.Sequential(
+            BasicLayer(64, 64, 1, padding=0),
+            BasicLayer(64, 64, 1, padding=0),
+            nn.Conv2d(64, 1, 1),
+            nn.Sigmoid(),
+        )
+
+        self.keypoint_head = nn.Sequential(
+            BasicLayer(64, 64, 1, padding=0),
+            BasicLayer(64, 64, 1, padding=0),
+            BasicLayer(64, 64, 1, padding=0),
+            nn.Conv2d(64, 65, 1),
+        )
+
+        ########### ⬇️ Fine Matcher MLP ⬇️ ###########
+
+        self.fine_matcher = nn.Sequential(
+            nn.Linear(128, 512),
+            nn.BatchNorm1d(512, affine=False),
+            nn.ReLU(inplace=True),
+            nn.Linear(512, 512),
+            nn.BatchNorm1d(512, affine=False),
+            nn.ReLU(inplace=True),
+            nn.Linear(512, 512),
+            nn.BatchNorm1d(512, affine=False),
+            nn.ReLU(inplace=True),
+            nn.Linear(512, 512),
+            nn.BatchNorm1d(512, affine=False),
+            nn.ReLU(inplace=True),
+            nn.Linear(512, 64),
+        )
+
+    def _unfold2d(self, x: torch.Tensor, ws: int = 2):
+        """
+        Unfolds tensor in 2D with desired ws (window size) and concat the channels
+        """
+        b, c, h, w = x.shape
+        x = x.unfold(2, ws, ws).unfold(3, ws, ws).reshape(b, c, h // ws, w // ws, ws**2)
+        return x.permute(0, 1, 4, 2, 3).reshape(b, -1, h // ws, w // ws)
+
+    def forward(self, x: torch.Tensor):
+        """
+        input:
+                x -> torch.Tensor(B, C, H, W) grayscale or rgb images
+        return:
+                feats     ->  torch.Tensor(B, 64, H/8, W/8) dense local features
+                keypoints ->  torch.Tensor(B, 65, H/8, W/8) keypoint logit map
+                heatmap   ->  torch.Tensor(B,  1, H/8, W/8) reliability map
+
+        """
+        # dont backprop through normalization
+        with torch.no_grad():
+            x = x.mean(dim=1, keepdim=True)
+            x = self.norm(x)
+
+        # main backbone
+        x1 = self.block1(x)
+        x2 = self.block2(x1 + self.skip1(x))
+        x3 = self.block3(x2)
+        x4 = self.block4(x3)
+        x5 = self.block5(x4)
+
+        # pyramid fusion
+        x4 = f.interpolate(x4, (x3.shape[-2], x3.shape[-1]), mode="bilinear")
+        x5 = f.interpolate(x5, (x3.shape[-2], x3.shape[-1]), mode="bilinear")
+        feats = self.block_fusion(x3 + x4 + x5)
+
+        # heads
+        heatmap = self.heatmap_head(feats)  # Reliability map
+        keypoints = self.keypoint_head(self._unfold2d(x, ws=8))  # Keypoint map logits
+
+        return feats, keypoints, heatmap

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/align_image_to_reference.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/align_image_to_reference.py
@@ -2,210 +2,442 @@
 # https://github.com/megvii-research/ECCV2022-RIFE
 # https://github.com/hzwer/Practical-RIFE
 
-# Modifications to use Rife for Image Alignment by tepete/pifroggi ('Enhance Everything!' Discord Server)
+# Original XFeat Accelerated Features for Lightweight Image Matching
+# https://www.verlab.dcc.ufmg.br/descriptors/xfeat_cvpr24/
+# https://github.com/verlab/accelerated_features
 
-# Additional helpful github issues
-# https://github.com/megvii-research/ECCV2022-RIFE/issues/278
-# https://github.com/megvii-research/ECCV2022-RIFE/issues/344
+# Modifications for image alignment by pifroggi
+# Node currently matches vs_align 3.0.0
+# https://github.com/pifroggi/vs_align
+from __future__ import annotations
 
 import zipfile
 from enum import Enum
 from pathlib import Path
 
+import cv2
 import numpy as np
 import requests
 import torch
+from torch.nn import functional
 
 from api import NodeContext
 from nodes.impl.pytorch.rife.IFNet_HDv3_v4_14_align import IFNet
 from nodes.impl.pytorch.utils import np2tensor, safe_cuda_cache_empty, tensor2np
-from nodes.impl.resize import ResizeFilter, resize
-from nodes.properties.inputs import EnumInput, ImageInput, NumberInput
+from nodes.impl.pytorch.xfeat.xfeat_align import XFeat, gen_grid
+from nodes.properties.inputs import BoolInput, EnumInput, ImageInput
 from nodes.properties.outputs import ImageOutput
-from nodes.utils.utils import get_h_w_c
 
-from ...settings import get_settings
+from ...settings import PyTorchSettings, get_settings
 from .. import processing_group
 
 
 class PrecisionMode(Enum):
-    FIFTY_PERCENT = 2000
-    ONE_HUNDRED_PERCENT = 1000
-    TWO_HUNDRED_PERCENT = 500
-    FOUR_HUNDRED_PERCENT = 250
-    EIGHT_HUNDRED_PERCENT = 125
+    FIFTY_PERCENT = 1
+    ONE_HUNDRED_PERCENT = 2
+    TWO_HUNDRED_PERCENT = 3
+    FOUR_HUNDRED_PERCENT = 4
 
 
-def calculate_padding(height: int, width: int, precision_mode: PrecisionMode):
-    if precision_mode == PrecisionMode.EIGHT_HUNDRED_PERCENT:
-        pad_value = 4
-    elif precision_mode == PrecisionMode.FOUR_HUNDRED_PERCENT:
-        pad_value = 8
-    elif precision_mode == PrecisionMode.TWO_HUNDRED_PERCENT:
-        pad_value = 16
-    elif precision_mode == PrecisionMode.ONE_HUNDRED_PERCENT:
-        pad_value = 32
-    else:
-        pad_value = 64
-
-    pad_height = (pad_value - height % pad_value) % pad_value
-    pad_width = (pad_value - width % pad_value) % pad_value
+def calculate_padding(height: int, width: int, modulus: int) -> tuple[int, int]:
+    pad_height = (modulus - height % modulus) % modulus
+    pad_width = (modulus - width % modulus) % modulus
     return pad_height, pad_width
 
 
 def download_model(
-    download_url: str, model_dir: Path, model_file: str, zip_inner_path: str
-):
+    download_url: str,
+    model_dir: Path,
+    model_file: str,
+    zip_inner_path: str | None = None,
+) -> Path:
     model_dir.mkdir(parents=True, exist_ok=True)
-    zip_path = model_dir / "model.zip"
     model_path = model_dir / model_file
 
-    if not model_path.exists():
+    # if the file already exists locally, return it
+    if model_path.exists():
+        return model_path
+
+    # download the file
+    try:
+        response = requests.get(download_url)
+        response.raise_for_status()
+    except requests.RequestException as e:
+        raise RuntimeError(
+            f"Failed to download the file from {download_url}. Error: {e}"
+        ) from e
+
+    # if zip_inner_path then unzip
+    if zip_inner_path is not None:
+        zip_path = model_dir / "model_temp.zip"
+        with open(zip_path, "wb") as f:
+            f.write(response.content)
+
+        with zipfile.ZipFile(zip_path, "r") as zip_ref:
+            zipped_file_path = f"{zip_inner_path}/{model_file}"
+            zip_ref.extract(zipped_file_path, model_dir)
+
+        extracted_file_path = model_dir / zipped_file_path
+        if extracted_file_path != model_path:
+            extracted_file_path.rename(model_path)
+
+        # clean up
+        zip_path.unlink(missing_ok=True)
+        subfolder = model_dir / zip_inner_path
         try:
-            response = requests.get(download_url)
-            response.raise_for_status()
-            with open(zip_path, "wb") as f:
-                f.write(response.content)
-            with zipfile.ZipFile(zip_path, "r") as zip_ref:
-                specific_file_path = zip_inner_path + "/" + model_file
-                zip_ref.extract(specific_file_path, model_dir)
-            extracted_file_path = model_dir / specific_file_path
-            final_path = model_path
-            if extracted_file_path != model_path:
-                extracted_file_path.rename(final_path)
-
-            # cleanup empty folder
-            train_log_dir = model_dir / zip_inner_path
-            train_log_dir.rmdir()
-
-            zip_path.unlink()
-        except requests.RequestException as e:
-            print(f"Failed to download the model. Error: {e}")
+            subfolder.rmdir()  # remove empty subfolder if possible
+        except OSError:
+            pass
+    else:
+        with open(model_path, "wb") as f:
+            f.write(response.content)
 
     return model_path
 
 
 def align_images(
     context: NodeContext,
-    target_img: np.ndarray,
-    source_img: np.ndarray,
-    precision_mode: PrecisionMode,
-    model_file: str = "flownet.pkl",
-    multiplier: float = 1,
-    alignment_passes: int = 1,
-    blur_strength: float = 0,
-    ensemble: bool = True,
+    fclip: np.ndarray,
+    ref: np.ndarray,
+    fmask: np.ndarray | None,
+    precision: PrecisionMode,
+    lq_input: bool,
+    wide_search: bool,
+    exec_options: PyTorchSettings,
 ) -> np.ndarray:
-    model_full_path = download_model(
+    # settings
+    device = exec_options.device
+    fp16 = exec_options.use_fp16
+    precision = precision.value
+    blur = 2 if lq_input else 0
+    smooth = 11 if lq_input else 0
+
+    # scales
+    s1 = (16, 8, 4, 2)  # needs mod64 pad
+    s2 = (8, 4, 2, 1)  # needs mod32 pad
+    s3 = (4, 2, 1, 0.5)  # needs mod16 pad
+    s4 = (2, 1, 0.5, 0.25)  # needs mod8  pad
+
+    # initialize rife_align model
+    rife_model_path = download_model(
         download_url="https://drive.usercontent.google.com/download?id=1BjuEY7CHZv1wzmwXSQP9ZTj0mLWu_4xy&export=download&authuser=0",
         model_dir=context.storage_dir / "rife_v4.14/weights",
-        model_file=model_file,
+        model_file="flownet.pkl",
         zip_inner_path="train_log",
     )
+    state_dict = torch.load(rife_model_path, map_location=device, weights_only=True)
+    state_dict = {k.replace("module.", ""): v for k, v in state_dict.items()}
+    rife_align = IFNet().to(device)
+    rife_align.load_state_dict(state_dict, strict=False)
+    rife_align.eval()
+    if fp16:
+        rife_align.half()
 
-    source_h, source_w, _ = get_h_w_c(source_img)
-
-    # resize, then shift reference left because rife shifts slightly to the right
-    target_img_resized = resize(
-        target_img, (source_w, source_h), filter=ResizeFilter.LANCZOS
-    )
-    target_img_resized = np.roll(target_img_resized, -1, axis=1)
-    target_img_resized[:, -1] = target_img_resized[:, -2]
-
-    # padding because rife can only work with multiples of 32 (changes with precision mode)
-    pad_h, pad_w = calculate_padding(source_h, source_w, precision_mode)
-    top_pad = pad_h // 2
-    bottom_pad = pad_h - top_pad
-    left_pad = pad_w // 2
-    right_pad = pad_w - left_pad
-    target_img_padded = np.pad(
-        target_img_resized,
-        ((top_pad, bottom_pad), (left_pad, right_pad), (0, 0)),
-        mode="edge",
-    )
-    source_img_padded = np.pad(
-        source_img, ((top_pad, bottom_pad), (left_pad, right_pad), (0, 0)), mode="edge"
-    )
-
-    exec_options = get_settings(context)
-    device = exec_options.device
-
-    # load model
-    model = IFNet().to(device)
-    state_dict = torch.load(model_full_path, map_location=device)
-    new_state_dict = {k.replace("module.", ""): v for k, v in state_dict.items()}
-    model.load_state_dict(new_state_dict)
-    model.eval()
+    # initialize xfeat model
+    if wide_search:
+        xfeat_model_path = download_model(
+            download_url="https://raw.githubusercontent.com/verlab/accelerated_features/e92685f57f8318b18725c5c8c0bd28c7fe188d9a/weights/xfeat.pt",
+            model_dir=context.storage_dir / "xfeat/weights",
+            model_file="xfeat.pt",
+        )
+        state_dict = torch.load(
+            xfeat_model_path, map_location=device, weights_only=True
+        )
+        descriptor = XFeat(
+            top_k=3000, weights=state_dict, height=480, width=704, device=device
+        )
+        matcher = XFeat(device=device)
+        if fp16:
+            descriptor.half()
+            matcher.half()
 
     # convert to tensors
-    target_tensor_padded = np2tensor(target_img_padded, change_range=True).to(device)
-    source_tensor_padded = np2tensor(source_img_padded, change_range=True).to(device)
+    fclip = np2tensor(fclip, change_range=True).to(device)
+    fref = np2tensor(ref, change_range=True).to(device)
+    if fmask is not None:
+        if fmask.ndim == 3:
+            fmask = fmask[:, :, 0]
+        fmask = np2tensor(fmask, change_range=True).to(device)
 
-    # concatenate images
-    img_pair = torch.cat((target_tensor_padded, source_tensor_padded), dim=1)
+    # convert to fp16 if needed
+    if fp16:
+        fclip = fclip.half()
+        fref = fref.half()
 
-    with torch.no_grad():
-        aligned_img, _ = model(
-            img_pair,
-            multiplier=multiplier,
-            num_iterations=alignment_passes,
-            blur_strength=blur_strength,
-            ensemble=ensemble,
-            device=device,
-        )
+    # align fclip to fref
+    with torch.inference_mode():
+        # homography alignment with xfeat and cv2
+        if wide_search:
+            # detect points
+            fref = functional.pad(
+                fref, (4, 4, 4, 4), mode="replicate"
+            )  # pad to reduce border artifacts
+            _, _, fref_h, fref_w = fref.shape  # update height and width due to padding
+            _, _, fclip_h, fclip_w = fclip.shape
+            fclip_points = descriptor.detectAndCompute(fclip)[0]  # compute points
+            fref_points = descriptor.detectAndCompute(fref)[0]  # compute points
+            kpts1, descs1 = fclip_points["keypoints"], fclip_points["descriptors"]
+            kpts2, descs2 = fref_points["keypoints"], fref_points["descriptors"]
+            points_found = len(kpts1) > 100 and len(kpts2) > 100
 
-    # convert back to numpy and crop
-    result_img = tensor2np(
-        aligned_img.squeeze(0).cpu(), change_range=False, imtype=np.float32
-    )
-    result_img = result_img[
-        top_pad : top_pad + source_h, left_pad : left_pad + source_w
-    ]
+            if points_found:  # only proceed if there are enough points
+                # match points between the two images
+                idx0, idx1 = matcher.match(descs1, descs2, 0.82)
+                match_found = len(idx0) > 50
 
-    return result_img
+                if match_found:  # only proceed if there are enough matched points
+                    # find homography from matched points with cv2
+                    pts1 = kpts1[idx0].cpu().numpy()
+                    pts2 = kpts2[idx1].cpu().numpy()
+                    homography, _ = cv2.findHomography(
+                        pts1,
+                        pts2,
+                        cv2.USAC_MAGSAC,
+                        10.0,
+                        maxIters=1000,
+                        confidence=0.995,
+                    )  # find homography on cpu
+                    homography_t = torch.tensor(
+                        homography, dtype=torch.float32, device=device
+                    )  # send back to gpu
+                    homography_t = gen_grid(
+                        homography_t, fclip_h, fclip_w, fref_h, fref_w, device
+                    )  # generate grid for grid sample
+                    if fp16:
+                        homography_t = homography_t.half()
+                    fclip = functional.grid_sample(
+                        fclip,
+                        homography_t,
+                        mode="bicubic",
+                        padding_mode="border",
+                        align_corners=True,
+                    )  # warp
+
+                    # mask area outside the warped image
+                    corners_src = np.float32(
+                        [
+                            [0, 0],
+                            [fclip_w - 1, 0],
+                            [fclip_w - 1, fclip_h - 1],
+                            [0, fclip_h - 1],
+                        ]
+                    ).reshape(-1, 1, 2)  # corners of source
+                    corners_dst = cv2.perspectiveTransform(
+                        corners_src, homography
+                    )  # transform corners with homography
+                    homography_mask = np.ones(
+                        (fref_h, fref_w), dtype=np.float32
+                    )  # create full white mask
+                    cv2.fillConvexPoly(
+                        homography_mask, np.int32(corners_dst), 0.0
+                    )  # fill inside corners with black
+
+                    # get bounding box
+                    corners = corners_dst.reshape(-1, 2)
+                    min_xy = np.floor(corners.min(axis=0)).astype(int)
+                    max_xy = np.ceil(corners.max(axis=0)).astype(int)
+                    min_x, min_y = np.maximum(min_xy, 0)
+                    max_x, max_y = np.minimum(max_xy, [fref_w, fref_h])
+
+                    # avoid cropping to small value
+                    if max_x - min_x < 16:
+                        min_x, max_x = 0, 16
+                    if max_y - min_y < 16:
+                        min_y, max_y = 0, 16
+
+                    # convert to tensor and combine homography_mask with fmask if it exists
+                    if fmask is not None:
+                        homography_mask = torch.from_numpy(homography_mask)[
+                            None, None
+                        ].to(device)
+                        if fmask.shape[2] != fref_h or fmask.shape[3] != fref_w:
+                            fmask = functional.interpolate(
+                                fmask, size=(fref_h - 8, fref_w - 8), mode="nearest"
+                            )  # resize but compensate for pad from earlier
+                            fmask = functional.pad(
+                                fmask, (4, 4, 4, 4), mode="replicate"
+                            )
+                        fmask = fmask + homography_mask
+                    else:
+                        fmask = torch.from_numpy(homography_mask)[None, None].to(device)
+
+                    # crop to bounding box
+                    fclip = fclip[:, :, min_y:max_y, min_x:max_x]
+                    fref = fref[:, :, min_y:max_y, min_x:max_x]
+                    if fmask is not None:
+                        fmask = fmask[:, :, min_y:max_y, min_x:max_x]
+
+        # padding for scales
+        _, _, fref_h_new, fref_w_new = fref.shape
+        if precision in (1, 2):
+            p1 = calculate_padding(fref_h_new, fref_w_new, 64)
+        if precision > 1:
+            p2 = calculate_padding(fref_h_new, fref_w_new, 32)
+        if precision > 2:
+            p3 = calculate_padding(fref_h_new, fref_w_new, 16)
+        if precision > 3:
+            p4 = calculate_padding(fref_h_new, fref_w_new, 8)
+
+        # flow based alignment with rife
+        with torch.amp.autocast(device.type, enabled=fp16):
+            if precision == 1:
+                fclip = rife_align(
+                    fclip,
+                    fref,
+                    fmask if fmask is not None else None,
+                    s1,
+                    p1,
+                    blur=blur,
+                    smooth=smooth * 3 if smooth > 0 else 11,
+                    compensate=True,
+                    device=device,
+                    fp16=fp16,
+                )
+            elif precision == 2:
+                fclip = rife_align(
+                    fclip,
+                    fref,
+                    fmask if fmask is not None else None,
+                    s1,
+                    p1,
+                    blur=9,
+                    smooth=91,
+                    compensate=False,
+                    device=device,
+                    fp16=fp16,
+                )
+                fclip = rife_align(
+                    fclip,
+                    fref,
+                    fmask if fmask is not None else None,
+                    s2,
+                    p2,
+                    blur=blur,
+                    smooth=smooth,
+                    compensate=True,
+                    device=device,
+                    fp16=fp16,
+                )
+            elif precision == 3:
+                fclip = rife_align(
+                    fclip,
+                    fref,
+                    fmask if fmask is not None else None,
+                    s2,
+                    p2,
+                    blur=9,
+                    smooth=15,
+                    compensate=False,
+                    device=device,
+                    fp16=fp16,
+                )
+                fclip = rife_align(
+                    fclip,
+                    fref,
+                    fmask if fmask is not None else None,
+                    s3,
+                    p3,
+                    blur=blur,
+                    smooth=smooth,
+                    compensate=True,
+                    device=device,
+                    fp16=fp16,
+                )
+            elif precision == 4:
+                fclip = rife_align(
+                    fclip,
+                    fref,
+                    fmask if fmask is not None else None,
+                    s2,
+                    p2,
+                    blur=9,
+                    smooth=15,
+                    compensate=False,
+                    device=device,
+                    fp16=fp16,
+                )
+                fclip = rife_align(
+                    fclip,
+                    fref,
+                    fmask if fmask is not None else None,
+                    s3,
+                    p3,
+                    blur=2,
+                    smooth=7,
+                    compensate=False,
+                    device=device,
+                    fp16=fp16,
+                )
+                fclip = rife_align(
+                    fclip,
+                    fref,
+                    fmask if fmask is not None else None,
+                    s4,
+                    p4,
+                    blur=blur,
+                    smooth=smooth,
+                    compensate=True,
+                    device=device,
+                    fp16=fp16,
+                )
+
+        if wide_search:
+            if points_found and match_found:
+                fclip = functional.pad(
+                    fclip,
+                    (min_x, fref_w - max_x, min_y, fref_h - max_y),
+                    mode="replicate",
+                )  # pad what was removed from boundry box crop
+            fclip = fclip[
+                :, :, 4:-4, 4:-4
+            ]  # crop padding used to reduce border artifacts
+
+    # convert back to numpy
+    return tensor2np(fclip.squeeze(0).cpu(), change_range=False, imtype=np.float32)
 
 
 @processing_group.register(
     schema_id="chainner:pytorch:image_align_rife",
     name="Align Image to Reference",
-    description="Aligns an Image with a Reference Image using Rife. Images should have vague alignment before using this Node. Output Image will have the same dimensions as Reference Image. Resize Reference Image to get desired output scale.",
+    description=[
+        "Aligns and removes distortions by warping an Image towards a Reference Image. Tips for best results:",
+        "- Always crop black bars or letterboxes on both images.",
+        "- If Image's brightness or colors are vastly different, make Reference Image roughly match.",
+    ],
     icon="BsRulers",
     inputs=[
         ImageInput("Image", channels=3),
         ImageInput("Reference Image", channels=3),
+        ImageInput("Mask")
+        .make_optional()
+        .with_docs(
+            "Optionally use a black & white mask to exclude areas in white from warping, like a watermark or text that is only on one image. Masked areas will instead be warped like the surroundings.",
+            "The masked areas correspond to the same areas on the Reference Image.",
+            hint=True,
+        ),
         EnumInput(
             PrecisionMode,
             label="Precision",
-            default=PrecisionMode.ONE_HUNDRED_PERCENT,
+            default=PrecisionMode.TWO_HUNDRED_PERCENT,
             option_labels={
                 PrecisionMode.FIFTY_PERCENT: "50%",
                 PrecisionMode.ONE_HUNDRED_PERCENT: "100%",
                 PrecisionMode.TWO_HUNDRED_PERCENT: "200%",
                 PrecisionMode.FOUR_HUNDRED_PERCENT: "400%",
-                PrecisionMode.EIGHT_HUNDRED_PERCENT: "800% (VRAM!)",
             },
         ).with_docs(
-            "If the Alignment is very close, try a **high** value.",
-            "If the Alignment is **not** very close, try a **low** value.",
-            "Higher values will internally align at higher resolutions to increase precision, which will in turn increase processing time and VRAM usage. Lower values are less precise, but can align over larger distances.",
+            "Speed/Quality tradeoff with higher meaning finer alignment up to a subpixel level. Higher is slower and requires more VRAM.",
+            "100% or 200% works great in most cases. 400% is only needed if both input images are very high quality.",
             hint=True,
         ),
-        NumberInput("Alignment Passes", min=1, max=1000, default=1, unit="#").with_docs(
-            "Runs the alignment multiple times.",
-            "With more than around 4 passes, artifacts can appear. Try to keep it low.",
+        BoolInput("Low Quality Input", default=False).with_docs(
+            "Enables better handling for low-quality input images. When turned on general shapes are prioritized over high-frequency details like noise, grain, or compression artifacts by averaging the warping across a small area.",
+            "Also fixes an issue sometimes noticeable in Anime images, where lines can get slightly thicker/thinner due to warping.",
             hint=True,
         ),
-        NumberInput(
-            "Blur Strength",
-            min=0,
-            max=100,
-            default=0,
-            precision=1,
-            step=1,
-            unit="⌀",
-        ).with_docs(
-            "Blur is only used internally and will not be visible on the Output Image. It will reduce accuracy, try to keep it **low**. The **best** alignment will be at **Blur 0**.",
-            "Blur can help to ignore strong degredations (like compression or noise). If the lines on the Output Image get thinner or thicker, try to increase the blur a little as well.",
+        BoolInput("Wide Search", default=False).with_docs(
+            "Enables a larger search radius at the cost of some speed. When turned on completely different crops like 4:3 and 16:9, shearing, and rotations up to 45° can be aligned.",
+            "Recommended if the misalignment is larger than about 20 pixel.",
             hint=True,
         ),
     ],
@@ -214,25 +446,26 @@ def align_images(
 )
 def align_image_to_reference_node(
     context: NodeContext,
-    target_img: np.ndarray,
-    source_img: np.ndarray,
+    fclip: np.ndarray,
+    ref: np.ndarray,
+    fmask: np.ndarray | None,
     precision: PrecisionMode,
-    alignment_passes: int,
-    blur_strength: float,
+    lq_input: bool,
+    wide_search: bool,
 ) -> np.ndarray:
     exec_options = get_settings(context)
     context.add_cleanup(
         safe_cuda_cache_empty,
         after="node" if exec_options.force_cache_wipe else "chain",
     )
-    multiplier = precision.value / 1000
+
     return align_images(
         context,
-        target_img,
-        source_img,
+        fclip,
+        ref,
+        fmask,
         precision,
-        multiplier=multiplier,
-        alignment_passes=alignment_passes,
-        blur_strength=blur_strength,
-        ensemble=True,
+        lq_input,
+        wide_search,
+        exec_options,
     )

--- a/backend/src/packages/chaiNNer_pytorch/pytorch/processing/align_image_to_reference.py
+++ b/backend/src/packages/chaiNNer_pytorch/pytorch/processing/align_image_to_reference.py
@@ -430,14 +430,14 @@ def align_images(
             "100% or 200% works great in most cases. 400% is only needed if both input images are very high quality.",
             hint=True,
         ),
-        BoolInput("Low Quality Input", default=False).with_docs(
-            "Enables better handling for low-quality input images. When turned on general shapes are prioritized over high-frequency details like noise, grain, or compression artifacts by averaging the warping across a small area.",
-            "Also fixes an issue sometimes noticeable in Anime images, where lines can get slightly thicker/thinner due to warping.",
-            hint=True,
-        ),
         BoolInput("Wide Search", default=False).with_docs(
             "Enables a larger search radius at the cost of some speed. When turned on completely different crops like 4:3 and 16:9, shearing, and rotations up to 45° can be aligned.",
             "Recommended if the misalignment is larger than about 20 pixel.",
+            hint=True,
+        ),
+        BoolInput("Low Quality Input", default=False).with_docs(
+            "Enables better handling for low-quality input images. When turned on general shapes are prioritized over high-frequency details like noise, grain, or compression artifacts by averaging the warping across a small area.",
+            "Also fixes an issue sometimes noticeable in Anime images, where lines can get slightly thicker/thinner due to warping.",
             hint=True,
         ),
     ],
@@ -450,8 +450,8 @@ def align_image_to_reference_node(
     ref: np.ndarray,
     fmask: np.ndarray | None,
     precision: PrecisionMode,
-    lq_input: bool,
     wide_search: bool,
+    lq_input: bool,
 ) -> np.ndarray:
     exec_options = get_settings(context)
     context.add_cleanup(


### PR DESCRIPTION
 This brings the node up to date to match the [Vapoursynth version](https://github.com/pifroggi/vs_align/tree/main).

Full changelog:
* Overhaul to how the alignment works, which makes it easier to get good results. Previously it could be hard to finetune the options. Sometimes higher precision was better, sometimes multiple passes were better, sometimes more blur, sometimes a combination of all. The new version should now consistently improve with a higher precision level and no longer require much time to find the right combination.
* `Precision` levels now produce different results. There are now 4 levels instead of 5. Alignment quality is better than before for a given precision level, but also slower.
* Added new optional `Mask` input. It takes a black & white image that can be used to exclude areas in white from warping, like a watermark or text that is only on one image. Masked areas will instead be warped like the surroundings.
* Added new `Wide Search` toggle and removed now obsolete `Alignment Passes` slider. This enables a larger search radius at the cost of some speed. When enabled completely different crops like 4:3 and 16:9, shearing, and rotations up to 45° can be aligned. It works by doing a fast homography alignment with the help of [XFeat](https://github.com/verlab/accelerated_features) first to move the corners of the image roughly into the right position before proceeding with the main alignment step. This is both better and faster than the old approach. 
* Added new `Low Quality Input` toggle and removed now obsolete `Blur Strength` slider.
This enables better handling for low-quality input images. When enabled general shapes are prioritized over high-frequency details like noise, grain, or compression artifacts by averaging the warping across a small area. This works better than the old approach and does not require finetuning.
* Added fp16 support.