### PR TITLE
Fix health check we use for waiting for server to start

### DIFF
--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -129,6 +129,12 @@ async def nodes_available():
 access_logger.addFilter(SSEFilter())
 
 
+@app.route("/health")
+async def health(_request: Request):
+    """Simple health check endpoint that doesn't require full setup"""
+    return json({"status": "ok"})
+
+
 @app.route("/nodes")
 async def nodes(_request: Request):
     """Gets a list of all nodes as well as the node information"""

--- a/backend/src/server_host.py
+++ b/backend/src/server_host.py
@@ -89,6 +89,12 @@ class SSEFilter(logging.Filter):
 access_logger.addFilter(SSEFilter())
 
 
+@app.route("/health")
+async def health(_request: Request):
+    """Simple health check endpoint that doesn't require full setup"""
+    return json({"status": "ok"})
+
+
 @app.route("/nodes")
 async def nodes(request: Request):
     worker = await AppContext.get(request.app).get_worker()

--- a/backend/src/server_process_helper.py
+++ b/backend/src/server_process_helper.py
@@ -188,7 +188,7 @@ class WorkerServer:
             return
 
         async def test_connection(session: aiohttp.ClientSession):
-            async with session.get("/nodes", timeout=5) as resp:
+            async with session.get("/health", timeout=5) as resp:
                 resp.raise_for_status()
 
         start = time.time()


### PR DESCRIPTION
This health check is used when we wait for the server to start, for things like installing dependencies in CI. We wait for the server to start, then immediately shut down. 

Since we were using the /nodes endpoint for this, the nodes endpoint was erroring every time it was hit, causing logs to get spammed. This made the CI take a lot longer and made looking at the output nearly impossible.