### PR TITLE
Disable MacOS code signing

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -97,14 +97,14 @@ const config = {
                 additionalDMGOptions: {
                     window: { size: { width: 660, height: 500 } },
                     filesystem: 'APFS',
-                    ...(process.argv.includes('--dry-run') || process.argv.includes('--no-sign')
-                        ? {}
-                        : {
-                              'code-sign': {
-                                  'signing-identity': process.env.APPLE_SIGNING_ID,
-                                  identifier: packageJson.appId,
-                              },
-                          }),
+                    // ...(process.argv.includes('--dry-run') || process.argv.includes('--no-sign')
+                    //     ? {}
+                    //     : {
+                    //           'code-sign': {
+                    //               'signing-identity': process.env.APPLE_SIGNING_ID,
+                    //               identifier: packageJson.appId,
+                    //           },
+                    //       }),
                 },
             },
         },


### PR DESCRIPTION
Commenting this out for now because our builds are failing due to it. I don't really care about this, since none of the other platforms are code signed anyway.