### PR TITLE
Fix "npm run dev" so that both processes close when one closes

### DIFF
--- a/backend/nodemon.json
+++ b/backend/nodemon.json
@@ -1,0 +1,30 @@
+{
+    "watch": [
+        "src/**/*.py"
+    ],
+    "ext": "py",
+    "ignore": [
+        "src/__pycache__/**",
+        "src/**/__pycache__/**",
+        "src/**/*.pyc",
+        "src/**/*.pyo",
+        "src/**/*.pyd",
+        "src/**/*.so",
+        "src/**/*.dll",
+        "src/**/*.dylib",
+        "src/**/*.whl",
+        "src/**/node_modules/**",
+        "src/**/venv/**",
+        "src/**/.git/**",
+        "src/**/logs/**",
+        "src/**/traces/**"
+    ],
+    "delay": 1000,
+    "signal": "SIGTERM",
+    "restartable": "rs",
+    "env": {
+        "NODE_ENV": "development"
+    },
+    "verbose": true,
+    "stdout": false
+}

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "scripts": {
     "start": "electron-forge start -- --devtools",
     "frontend": "electron-forge start -- --remote-backend=http://127.0.0.1:8000 --devtools",
-    "dev": "concurrently \"npm run dev:py\" \"electron-forge start -- --remote-backend=http://127.0.0.1:8000 --refresh --devtools\"",
-    "dev:reload": "concurrently \"npm run dev:py\" \"cross-env HOT_RESTART=1 electron-forge start -- --remote-backend=http://127.0.0.1:8000 --refresh --devtools\"",
-    "dev:profile": "concurrently \"npm run dev:py:profile\" \"electron-forge start -- --remote-backend=http://127.0.0.1:8000 --refresh --devtools\"",
+    "dev": "concurrently --kill-others \"npm run dev:py\" \"electron-forge start -- --remote-backend=http://127.0.0.1:8000 --refresh --devtools\"",
+    "dev:reload": "concurrently --kill-others \"npm run dev:py\" \"cross-env HOT_RESTART=1 electron-forge start -- --remote-backend=http://127.0.0.1:8000 --refresh --devtools\"",
+    "dev:profile": "concurrently --kill-others \"npm run dev:py:profile\" \"electron-forge start -- --remote-backend=http://127.0.0.1:8000 --refresh --devtools\"",
     "dev:py": "cd backend/src && cross-env CHECK_LEVEL=fix nodemon --exec \"python -m debugpy --listen 5678\" ./run.py 8000 --dev",
     "dev:py:profile": "cd backend/src && cross-env CHECK_LEVEL=fix nodemon --exec \"python ./run.py 8000 --trace --dev",
     "package": "cross-env NODE_ENV=production electron-forge package",


### PR DESCRIPTION
Since the initial creation of chaiNNer I've been annoyed at how `npm run dev` didn't fully close when I closed the electron window. Well, the time has finally come to fix this.