### PR TITLE
Add IsGrayscale node to detect if images are grayscale

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/is_grayscale.py
+++ b/backend/src/packages/chaiNNer_standard/image_utility/miscellaneous/is_grayscale.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import numpy as np
+
+from nodes.properties.inputs import ImageInput, SliderInput
+from nodes.properties.outputs import BoolOutput
+
+from .. import miscellaneous_group
+
+
+@miscellaneous_group.register(
+    schema_id="chainner:image:is_grayscale",
+    name="Is Grayscale",
+    description="Checks if the input image is grayscale by checking if all color channels are identical within a given tolerance.",
+    icon="BsSquareHalf",
+    inputs=[
+        ImageInput().with_docs("Input image to check for grayscale."),
+        SliderInput(
+            "Tolerance", default=0, min=0, max=255, precision=0, step=1
+        ).with_docs("Tolerance for channel differences."),
+    ],
+    outputs=[
+        BoolOutput("Is Grayscale").with_docs(
+            "True if the image is grayscale within the specified tolerance, False otherwise."
+        ),
+    ],
+)
+def is_grayscale_node(img: np.ndarray, tolerance: int = 0) -> bool:
+    if img.ndim == 2 or img.shape[2] == 1:
+        return True
+
+    threshold = tolerance / 255.0
+
+    diff_rg = np.abs(img[:, :, 0] - img[:, :, 1])
+    diff_rb = np.abs(img[:, :, 0] - img[:, :, 2])
+
+    return bool(np.all(diff_rg <= threshold) and np.all(diff_rb <= threshold))


### PR DESCRIPTION
This PR provides a new node to detect if an image is grayscale or not. Most images from the web are not correctly labeled as such (i.e. limiting the amount of channels), therefore the `Image Statistics` node doesn't always come in clutch. When up scaling or editing a directory of images, it can happen that some images require different models to be loaded in based on if the image is grayscale or not.

This node provides such functionality by comparing the channels to a tolerance level. Due to noise or compression, it can happen that a seemingly grayscale image has some differing values within the channels, hence a tolerance input seemed as the right way to handle this bit of (unfortunate) logic.

This PR is always open for feedback and changes.