### PR TITLE
distance_transform: Add more algorithms and cut-off parameter

### DIFF
--- a/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/distance_to_alpha.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/distance_to_alpha.py
@@ -11,7 +11,7 @@ from .. import miscellaneous_group
 @miscellaneous_group.register(
     schema_id="chainner:image:distance_to_alpha",
     name="Distance to Alpha",
-    description="Converts a distance field to an alpha mask.",
+    description="Converts a distance field to an alpha mask by adjusting the image contrast.",
     icon="MdBlurOn",
     inputs=[
         ImageInput(channels=1),

--- a/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/distance_to_alpha.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/distance_to_alpha.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import numpy as np
+
+from nodes.properties.inputs import ImageInput, NumberInput, SliderInput
+from nodes.properties.outputs import ImageOutput
+
+from .. import miscellaneous_group
+
+
+@miscellaneous_group.register(
+    schema_id="chainner:image:distance_to_alpha",
+    name="Distance to Alpha",
+    description="Converts a distance field to an alpha mask.",
+    icon="MdBlurOn",
+    inputs=[
+        ImageInput(channels=1),
+        NumberInput("Spread", min=1, default=4),
+        SliderInput("Cutoff", min=0, default=0.5, max=1, precision=2),
+        SliderInput("Edge Width", min=0.01, default=0.5, max=4, precision=2),
+    ],
+    outputs=[ImageOutput(shape_as=0, assume_normalized=True)],
+)
+def distance_to_alpha_node(
+    img: np.ndarray,
+    spread: int,
+    cutoff: float,
+    width: float,
+) -> np.ndarray:
+    # This is essentially a pivoted contrast node
+    contrast = (spread * 2) / width
+    pivot = 1 - cutoff
+    return np.clip(pivot + (img - pivot) * contrast, 0, 1)

--- a/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/distance_transform.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/distance_transform.py
@@ -51,7 +51,7 @@ def binary_sdf(img: np.ndarray, spread: float, cutoff: float) -> np.ndarray:
     signed_distance[img1 == 0] = cutoff - white_dist.ravel()[img1 == 0] / spread / 2
 
     signed_distance = np.clip(signed_distance, 0, 1)
-    out[:, :, -1] = signed_distance.reshape(img.shape)[:, :, 0]
+    out[:, :, -1] = signed_distance.reshape(img.shape)
     return out
 
 

--- a/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/distance_transform.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/distance_transform.py
@@ -21,7 +21,8 @@ class DistanceAlgorithm(Enum):
 
 
 def binary_sdf(img: np.ndarray, spread: float, cutoff: float) -> np.ndarray:
-    img = as_3d(to_uint8(img, normalized=True))
+    out = as_3d(img.copy())
+    img = to_uint8(out[:, :, -1], normalized=True)
     img[img < 128] = 0
     img[img >= 128] = 255
 
@@ -50,8 +51,8 @@ def binary_sdf(img: np.ndarray, spread: float, cutoff: float) -> np.ndarray:
     signed_distance[img1 == 0] = cutoff - white_dist.ravel()[img1 == 0] / spread / 2
 
     signed_distance = np.clip(signed_distance, 0, 1)
-
-    return signed_distance.reshape(img.shape)
+    out[:, :, -1] = signed_distance.reshape(img.shape)[:, :, 0]
+    return out
 
 
 @miscellaneous_group.register(
@@ -60,7 +61,7 @@ def binary_sdf(img: np.ndarray, spread: float, cutoff: float) -> np.ndarray:
     description="Perform a distance transform on a monochrome bitmap image, producing a signed distance field.",
     icon="MdBlurOff",
     inputs=[
-        ImageInput(channels=1),
+        ImageInput(),
         NumberInput("Spread", min=1, default=4),
         SliderInput("Cutoff", min=0, default=0.5, max=1, precision=2),
         EnumInput(DistanceAlgorithm, option_labels={
@@ -71,7 +72,8 @@ def binary_sdf(img: np.ndarray, spread: float, cutoff: float) -> np.ndarray:
         ).with_docs(
             "If Binary is selected, then the image will be converted to binary (either black or white) before processing.",
             "Choosing ESDF or EDTAA will significantly improve the results of anti-aliased shapes, but it cannot be used on anything else. It assumes strictly binary shapes (with optional anti-aliasing), and will return incorrect results for e.g. blurry images. If you cannot guarantee binary image, use the `chainner:image:threshold` node with *Anti-aliasing* enabled.",
-            "Sub-pixel distance transform is implemented using the excellent [ESDF algorithm](https://acko.net/blog/subpixel-distance-transform/) by Steven Wittens.",
+            "If an RGBA image is passed in the ESDF and EDTAA algorithms will also use the results of the distance transform to generate an alpha-filled image in the RGB color channels"
+            "Sub-pixel distance transform is implemented using the excellent [ESDF algorithm](https://acko.net/blog/subpixel-distance-transform/) by Steven Wittens and [EDTAA algorithm](https://www.itn.liu.se/~stegu76/edtaa/) by Stefan Gustavson.",
         ),
     ],
     outputs=[ImageOutput(shape_as=0)],

--- a/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/distance_transform.py
+++ b/backend/src/packages/chaiNNer_standard/image_filter/miscellaneous/distance_transform.py
@@ -1,17 +1,26 @@
 from __future__ import annotations
 
+from enum import Enum
+
 import cv2
 import numpy as np
-from chainner_ext import esdf
+from chainner_ext import esdf, edtaa
 
 from nodes.impl.image_utils import as_3d, to_uint8
-from nodes.properties.inputs import BoolInput, ImageInput, NumberInput
+from nodes.properties.inputs import EnumInput, ImageInput, NumberInput, SliderInput
 from nodes.properties.outputs import ImageOutput
 
 from .. import miscellaneous_group
 
 
-def binary_sdf(img: np.ndarray, spread: float) -> np.ndarray:
+class DistanceAlgorithm(Enum):
+    BINARY = 1
+    ESDF = 2
+    EDTAA3 = 3
+    EDTAA4 = 4
+
+
+def binary_sdf(img: np.ndarray, spread: float, cutoff: float) -> np.ndarray:
     img = as_3d(to_uint8(img, normalized=True))
     img[img < 128] = 0
     img[img >= 128] = 255
@@ -37,8 +46,8 @@ def binary_sdf(img: np.ndarray, spread: float) -> np.ndarray:
     img1 = img.ravel()
     signed_distance = np.empty(shape=img.shape, dtype=np.float32).ravel()
 
-    signed_distance[img1 == 255] = black_dist.ravel()[img1 == 255] / spread / 2 + 0.5
-    signed_distance[img1 == 0] = 0.5 - white_dist.ravel()[img1 == 0] / spread / 2
+    signed_distance[img1 == 255] = black_dist.ravel()[img1 == 255] / spread / 2 + cutoff
+    signed_distance[img1 == 0] = cutoff - white_dist.ravel()[img1 == 0] / spread / 2
 
     signed_distance = np.clip(signed_distance, 0, 1)
 
@@ -53,9 +62,15 @@ def binary_sdf(img: np.ndarray, spread: float) -> np.ndarray:
     inputs=[
         ImageInput(channels=1),
         NumberInput("Spread", min=1, default=4),
-        BoolInput("Sub-pixel precision", default=False).with_docs(
-            "If enabled, then anti-aliasing will be accounted for. If not enabled, then the image will be converted to binary (either black or white) before processing.",
-            "Enabling this option will significantly improve the results of anti-aliased shapes, but it cannot be used on anything else. It assumes strictly binary shapes (with optional anti-aliasing), and will return incorrect results for e.g. blurry images. If you cannot guarantee binary image, use the `chainner:image:threshold` node with *Anti-aliasing* enabled.",
+        SliderInput("Cutoff", min=0, default=0.5, max=1, precision=2),
+        EnumInput(DistanceAlgorithm, option_labels={
+            DistanceAlgorithm.ESDF: 'ESDF',
+            DistanceAlgorithm.EDTAA3: 'EDTAA3',
+            DistanceAlgorithm.EDTAA4: 'EDTAA4',
+        }
+        ).with_docs(
+            "If Binary is selected, then the image will be converted to binary (either black or white) before processing.",
+            "Choosing ESDF or EDTAA will significantly improve the results of anti-aliased shapes, but it cannot be used on anything else. It assumes strictly binary shapes (with optional anti-aliasing), and will return incorrect results for e.g. blurry images. If you cannot guarantee binary image, use the `chainner:image:threshold` node with *Anti-aliasing* enabled.",
             "Sub-pixel distance transform is implemented using the excellent [ESDF algorithm](https://acko.net/blog/subpixel-distance-transform/) by Steven Wittens.",
         ),
     ],
@@ -64,8 +79,14 @@ def binary_sdf(img: np.ndarray, spread: float) -> np.ndarray:
 def distance_transform_node(
     img: np.ndarray,
     spread: int,
-    use_esdf: bool,
+    cutoff: float,
+    algorithm: DistanceAlgorithm,
 ) -> np.ndarray:
-    if use_esdf:
-        return esdf(img, spread * 2, 0.5, False, True)
-    return binary_sdf(img, spread)
+    if algorithm == DistanceAlgorithm.ESDF:
+        return esdf(img, spread * 2, cutoff, False, True)
+    if algorithm == DistanceAlgorithm.EDTAA3:
+        return edtaa(img, spread * 2, cutoff, True, False)
+    if algorithm == DistanceAlgorithm.EDTAA4:
+        return edtaa(img, spread * 2, cutoff, False, True)
+    else:
+        return binary_sdf(img, spread, cutoff)


### PR DESCRIPTION
This PR depends on the https://github.com/chaiNNer-org/chaiNNer-rs/pull/36 PR in chaiNNer-rs.

The following features are added for distance fields:
- Added the EDTAA3 and EDTAA4 algorithms
- Added cut-off parameter to Distance Transform node to adjust the pivot point of the signed-distance field
- Added dedicated distance-to-alpha node that increases the contrast of the contour edge to return to an alpha mask
- Added optional RGBA image input support
  - For Binary the RGB channels are simply passed through
  - For ESDF and EDTAA the RGB channels are alpha-filled using the results of the distance transform

These new features give the user more options for upscaling alpha masks using signed distance fields.